### PR TITLE
ci: Fail CI when an unknown system parameter is set

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -173,6 +173,7 @@ IGNORE_RE = re.compile(
     | \ ANOM_ABEND\ .*\ exe="/usr/bin/qemu
     # This can happen in "K8s recovery: envd on failing node", but the test still succeeds, old environmentd will just be crashed, see database-issues#8749
     | \[pod/environmentd-0/environmentd\]\ .*\ (unable\ to\ confirm\ leadership|fenced\ out\ old\ deployment;\ rebooting\ as\ leader|this\ deployment\ has\ been\ fenced\ out)
+    | cannot\ load\ unknown\ system\ parameter
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -70,7 +70,6 @@ def get_default_system_parameters(
     return {
         # -----
         # Unsafe functions
-        "enable_unsafe_functions": "true",
         "unsafe_enable_unsafe_functions": "true",
         # -----
         # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
@@ -98,7 +97,6 @@ def get_default_system_parameters(
         ),
         "enable_alter_swap": "true",
         "enable_columnation_lgalloc": "true",
-        "enable_compute_chunked_stack": "true",
         "enable_compute_correction_v2": "true",
         "enable_connection_validation_syntax": "true",
         "enable_continual_task_builtins": (
@@ -123,7 +121,6 @@ def get_default_system_parameters(
         "enable_refresh_every_mvs": "true",
         "enable_cluster_schedule_refresh": "true",
         "enable_statement_lifecycle_logging": "true",
-        "enable_table_keys": "true",
         "unsafe_enable_table_keys": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
@@ -162,7 +159,6 @@ def get_default_system_parameters(
         "storage_statistics_collection_interval": "1000",
         "storage_statistics_interval": "2000",
         "storage_use_continual_feedback_upsert": "true",
-        "storage_use_reclock_v2": "true",
         "with_0dt_deployment_max_wait": "1800s",
         # End of list (ordered by name)
     }


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/8972
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
