### PR TITLE
cloudtest: Fix test_disk_label

### DIFF
--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -135,7 +135,7 @@ def test_disk_label(mz: MaterializeApplication) -> None:
 
     for value in ("true", "false"):
         mz.environmentd.sql(
-            f"CREATE CLUSTER disk_{value} MANAGED, SIZE = '2-1', DISK = {value}"
+            f"CREATE CLUSTER disk_{value} MANAGED, SIZE = '2-no-disk', DISK = {value}"
         )
 
         (cluster_id, replica_id) = mz.environmentd.sql_query(
@@ -147,8 +147,7 @@ def test_disk_label(mz: MaterializeApplication) -> None:
         node_selectors = get_node_selector(mz, cluster_id, replica_id)
         if value == "true":
             assert (
-                node_selectors
-                == '\'{"materialize.cloud/disk":"true"} {"materialize.cloud/disk":"true"}\''
+                node_selectors == '\'{"materialize.cloud/disk":"true"}\''
             ), node_selectors
         else:
             assert node_selectors == "''"

--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -26,7 +26,7 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
 
             > CREATE CLUSTER testdrive_no_reset_disk_cluster1
                 REPLICAS (r1 (
-                    SIZE '1', DISK = true
+                    SIZE '1-no-disk', DISK = true
                 ))
 
             > CREATE CONNECTION IF NOT EXISTS kafka TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
@@ -100,7 +100,7 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
             key2:val2
 
             > CREATE CLUSTER disk_cluster2
-                REPLICAS (r1 (SIZE '1'))
+                REPLICAS (r1 (SIZE '1-no-disk'))
 
             > CREATE CONNECTION IF NOT EXISTS kafka TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 
@@ -168,7 +168,7 @@ def test_no_disk_replica(mz: MaterializeApplication) -> None:
 
             > CREATE CLUSTER no_disk_cluster1
                 REPLICAS (r1 (
-                    SIZE '1', DISK = false
+                    SIZE '1-no-disk', DISK = false
                 ))
 
             > CREATE CONNECTION IF NOT EXISTS kafka


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31511/

Failure seen in https://buildkite.com/materialize/nightly/builds/11196#019519fc-29b8-48ac-87db-4cb4c19b0758

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
