### PR TITLE
Change catalog server default size to 25cc

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -130,7 +130,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.defaultReplicationFactor.support` |  | ``0`` |
 | `operator.clusters.defaultReplicationFactor.system` |  | ``0`` |
 | `operator.clusters.defaultSizes.analytics` |  | ``"25cc"`` |
-| `operator.clusters.defaultSizes.catalogServer` |  | ``"50cc"`` |
+| `operator.clusters.defaultSizes.catalogServer` |  | ``"25cc"`` |
 | `operator.clusters.defaultSizes.default` |  | ``"25cc"`` |
 | `operator.clusters.defaultSizes.probe` |  | ``"mz_probe"`` |
 | `operator.clusters.defaultSizes.support` |  | ``"25cc"`` |

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -173,7 +173,7 @@ operator:
       system: 25cc
       probe: mz_probe
       support: 25cc
-      catalogServer: 50cc
+      catalogServer: 25cc
       analytics: 25cc
     defaultReplicationFactor:
       system: 0


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

We've discussed that we want to halve the size of `mz_catalog_server` https://github.com/MaterializeInc/cloud/issues/10285. I've tested this on local-kind with few "realistic" dataflows https://www.notion.so/materialize/DDL-for-Mocking-Realistic-Use-cases-19e13f48d37b8092ab3fd66cea453b05 and the Console seems to be working well. Planning to stress test with this new size too when scraping the catalog using the debug tool. Also added a section in our docs https://github.com/MaterializeInc/materialize/pull/31545 on how to actually increase the cluster size if push comes to shove.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->
