### PR TITLE
use the last path component for finding the image name

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -896,11 +896,10 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         };
 
         let container_name = image
-            .splitn(2, '/')
-            .skip(1)
-            .next()
-            .and_then(|name_version| name_version.splitn(2, ':').next())
+            .rsplit_once('/')
+            .and_then(|(_, name_version)| name_version.rsplit_once(':'))
             .context("`image` is not ORG/NAME:VERSION")?
+            .0
             .to_string();
 
         let container_security_context = if scheduling_config.security_context_enabled {


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/cloud/issues/10806

### Tips for reviewer

orchestratord already handles this correctly

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
