### PR TITLE
ci: Reenable incident-70 test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1697,8 +1697,7 @@ steps:
   - id: incident-70
     label: "Test for incident 70"
     depends_on: build-aarch64
-    timeout_in_minutes: 15
-    skip: "Affected by incidents-and-escalations#72"
+    timeout_in_minutes: 30
     agents:
       queue: hetzner-aarch64-8cpu-16gb
     plugins:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -62,6 +62,7 @@ SERVICES = [
     Clusterd(name="clusterd3"),
     Clusterd(name="clusterd4"),
     Mz(app_password=""),
+    Minio(),
     Materialized(
         # We use mz_panic() in some test scenarios, so environmentd must stay up.
         propagate_crashes=False,


### PR DESCRIPTION
Since https://github.com/MaterializeInc/incidents-and-escalations/issues/72 is closed

Noticed in https://buildkite.com/materialize/nightly/builds/11203#01951ba1-ed91-4a34-8d84-43ea6d2075dd

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
