### PR TITLE
Logical per-dataflow backpressure

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -97,6 +97,7 @@ def get_default_system_parameters(
         "enable_alter_swap": "true",
         "enable_columnation_lgalloc": "true",
         "enable_compute_correction_v2": "true",
+        "enable_compute_logical_backpressure": "true",
         "enable_connection_validation_syntax": "true",
         "enable_continual_task_builtins": (
             "true" if version > MzVersion.parse_mz("v0.127.0-dev") else "false"

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -929,7 +929,9 @@ impl Coordinator {
             read_holds,
             plan.source_imports
                 .into_iter()
-                .filter_map(|(id, (source, _))| source.arguments.operators.map(|mfp| (id, mfp))),
+                .filter_map(|(id, (source, _, _upper))| {
+                    source.arguments.operators.map(|mfp| (id, mfp))
+                }),
         )
         .await
     }

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -674,7 +674,7 @@ impl Coordinator {
                                             .desc
                                             .source_imports
                                             .into_iter()
-                                            .filter_map(|(id, (desc, _))| {
+                                            .filter_map(|(id, (desc, _, _upper))| {
                                                 desc.arguments.operators.map(|mfp| (id, mfp))
                                             })
                                             .collect(),

--- a/src/adapter/src/explain/mir.rs
+++ b/src/adapter/src/explain/mir.rs
@@ -151,7 +151,7 @@ impl<'a> Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
             .0
             .source_imports
             .iter_mut()
-            .map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _, _upper))| {
                 let op = source_desc.arguments.operators.as_ref();
                 ExplainSource::new(*id, op, context.config.filter_pushdown)
             })

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -290,7 +290,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
         );
         // Apply source monotonicity overrides.
         for id in self.force_source_non_monotonic.iter() {
-            if let Some((_desc, monotonic)) = df_desc.source_imports.get_mut(id) {
+            if let Some((_desc, monotonic, _upper)) = df_desc.source_imports.get_mut(id) {
                 *monotonic = false;
             }
         }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -1038,7 +1038,7 @@ mod tests {
                     storage_metadata: Default::default(),
                     typ: RelationType::empty(),
                 };
-                (id, (desc, Default::default()))
+                (id, (desc, Default::default(), Default::default()))
             })
             .collect();
         let index_imports = input_ids

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -88,7 +88,7 @@ mod sequential_hydration;
 pub mod error;
 
 type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
-type StorageCollections<T> = Arc<
+pub(crate) type StorageCollections<T> = Arc<
     dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = T> + Send + Sync,
 >;
 

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -29,6 +29,7 @@ message ProtoDataflowDescription {
     mz_repr.global_id.ProtoGlobalId id = 1;
     sources.ProtoSourceInstanceDesc source_instance_desc = 2;
     bool monotonic = 3;
+    mz_repr.antichain.ProtoU64Antichain upper = 4;
   }
 
   message ProtoIndexImport {

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -39,7 +39,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_types.dataflows.rs"));
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
     /// Sources instantiations made available to the dataflow pair with monotonicity information.
-    pub source_imports: BTreeMap<GlobalId, (SourceInstanceDesc<S>, bool)>,
+    pub source_imports: BTreeMap<GlobalId, (SourceInstanceDesc<S>, bool, Antichain<T>)>,
     /// Indexes made available to the dataflow.
     /// (id of index, import)
     pub index_imports: BTreeMap<GlobalId, IndexImport>,
@@ -185,6 +185,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
                     typ,
                 },
                 monotonic,
+                Antichain::new(),
             ),
         );
     }
@@ -228,7 +229,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
 
     /// The number of columns associated with an identifier in the dataflow.
     pub fn arity_of(&self, id: &GlobalId) -> usize {
-        for (source_id, (source, _monotonic)) in self.source_imports.iter() {
+        for (source_id, (source, _monotonic, _upper)) in self.source_imports.iter() {
             if source_id == id {
                 return source.typ.arity();
             }
@@ -255,7 +256,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
         for BuildDesc { plan, .. } in &mut self.objects_to_build {
             r(plan)?;
         }
-        for (source_instance_desc, _) in self.source_imports.values_mut() {
+        for (source_instance_desc, _, _upper) in self.source_imports.values_mut() {
             let Some(mfp) = source_instance_desc.arguments.operators.as_mut() else {
                 continue;
             };
@@ -514,9 +515,9 @@ where
     /// Returns a `DataflowDescription` that has the same structure as `self` and can be
     /// structurally compared to other `DataflowDescription`s.
     ///
-    /// For now this method performs a single normalization only: It replaces transient `GlobalId`s
+    /// The function normalizes several properties. It replaces transient `GlobalId`s
     /// that are only used internally (i.e. not imported nor exported) with consecutive IDs
-    /// starting from `t1`.
+    /// starting from `t1`. It replaces the source import's `upper` by a dummy value.
     fn as_comparable(&self) -> Self {
         let external_ids: BTreeSet<_> = self.import_ids().chain(self.export_ids()).collect();
 
@@ -533,6 +534,11 @@ where
                 id
             }
         };
+
+        let mut source_imports = self.source_imports.clone();
+        for (_source, _monotonic, upper) in source_imports.values_mut() {
+            *upper = Antichain::new();
+        }
 
         let mut objects_to_build = self.objects_to_build.clone();
         for object in &mut objects_to_build {
@@ -551,7 +557,7 @@ where
         }
 
         DataflowDescription {
-            source_imports: self.source_imports.clone(),
+            source_imports,
             index_imports: self.index_imports.clone(),
             objects_to_build,
             index_exports,
@@ -607,29 +613,54 @@ impl RustType<ProtoDataflowDescription> for DataflowDescription<RenderPlan, Coll
     }
 }
 
-impl ProtoMapEntry<GlobalId, (SourceInstanceDesc<CollectionMetadata>, bool)> for ProtoSourceImport {
+impl
+    ProtoMapEntry<
+        GlobalId,
+        (
+            SourceInstanceDesc<CollectionMetadata>,
+            bool,
+            Antichain<mz_repr::Timestamp>,
+        ),
+    > for ProtoSourceImport
+{
     fn from_rust<'a>(
         entry: (
             &'a GlobalId,
-            &'a (SourceInstanceDesc<CollectionMetadata>, bool),
+            &'a (
+                SourceInstanceDesc<CollectionMetadata>,
+                bool,
+                Antichain<mz_repr::Timestamp>,
+            ),
         ),
     ) -> Self {
         ProtoSourceImport {
             id: Some(entry.0.into_proto()),
-            source_instance_desc: Some(entry.1 .0.into_proto()),
-            monotonic: entry.1 .1.into_proto(),
+            source_instance_desc: Some((entry.1).0.into_proto()),
+            monotonic: (entry.1).1.into_proto(),
+            upper: Some((entry.1).2.into_proto()),
         }
     }
 
     fn into_rust(
         self,
-    ) -> Result<(GlobalId, (SourceInstanceDesc<CollectionMetadata>, bool)), TryFromProtoError> {
+    ) -> Result<
+        (
+            GlobalId,
+            (
+                SourceInstanceDesc<CollectionMetadata>,
+                bool,
+                Antichain<mz_repr::Timestamp>,
+            ),
+        ),
+        TryFromProtoError,
+    > {
         Ok((
             self.id.into_rust_if_some("ProtoSourceImport::id")?,
             (
                 self.source_instance_desc
                     .into_rust_if_some("ProtoSourceImport::source_instance_desc")?,
                 self.monotonic.into_rust()?,
+                self.upper.into_rust_if_some("ProtoSourceImport::upper")?,
             ),
         ))
     }
@@ -740,7 +771,7 @@ impl Arbitrary for DataflowDescription<Plan, (), mz_repr::Timestamp> {
 }
 
 fn any_dataflow_description<P, S, T>(
-    any_source_import: impl Strategy<Value = (GlobalId, (SourceInstanceDesc<S>, bool))>,
+    any_source_import: impl Strategy<Value = (GlobalId, (SourceInstanceDesc<S>, bool, Antichain<T>))>,
 ) -> impl Strategy<Value = DataflowDescription<P, S, T>>
 where
     P: Arbitrary,
@@ -812,16 +843,35 @@ where
         )
 }
 
-fn any_source_import_collection_metadata(
-) -> impl Strategy<Value = (GlobalId, (SourceInstanceDesc<CollectionMetadata>, bool))> {
+fn any_source_import_collection_metadata() -> impl Strategy<
+    Value = (
+        GlobalId,
+        (
+            SourceInstanceDesc<CollectionMetadata>,
+            bool,
+            Antichain<mz_repr::Timestamp>,
+        ),
+    ),
+> {
     (
         any::<GlobalId>(),
-        any::<(SourceInstanceDesc<CollectionMetadata>, bool)>(),
+        any::<(SourceInstanceDesc<CollectionMetadata>, bool)>().prop_map(
+            |(source_instance_desc, monotonic)| (source_instance_desc, monotonic, Antichain::new()),
+        ),
     )
 }
 
-fn any_source_import() -> impl Strategy<Value = (GlobalId, (SourceInstanceDesc<()>, bool))> {
-    (any::<GlobalId>(), any::<(SourceInstanceDesc<()>, bool)>())
+fn any_source_import() -> impl Strategy<
+    Value = (
+        GlobalId,
+        (SourceInstanceDesc<()>, bool, Antichain<mz_repr::Timestamp>),
+    ),
+> {
+    (any::<GlobalId>(), any::<(SourceInstanceDesc<()>, bool)>()).prop_map(
+        |(id, (source_instance_desc, monotonic))| {
+            (id, (source_instance_desc, monotonic, Antichain::new()))
+        },
+    )
 }
 
 proptest::prop_compose! {

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -190,6 +190,38 @@ pub const ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION: Config<bool> = Co
     "When enabled, renders `as_specific_collection` using a fueled flat-map operator.",
 );
 
+/// Whether to apply logical backpressure in compute dataflows.
+pub const ENABLE_COMPUTE_LOGICAL_BACKPRESSURE: Config<bool> = Config::new(
+    "enable_compute_logical_backpressure",
+    false,
+    "When enabled, compute dataflows will apply logical backpressure.",
+);
+
+/// Maximal number of capabilities retained by the logical backpressure operator.
+///
+/// Selecting this value is subtle. If it's too small, it'll diminish the effectiveness of the
+/// logical backpressure operators. If it's too big, we can slow down hydration and cause state
+/// in the operator's implementation to build up.
+///
+/// The default value represents a compromise between these two extremes. We retain some metrics
+/// for 30 days, and the metrics update every minute. The default is exactly this number.
+pub const COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES: Config<Option<usize>> =
+    Config::new(
+        "compute_logical_backpressure_max_retained_capabilities",
+        Some(30 * 24 * 60),
+        "The maximum number of capabilities retained by the logical backpressure operator.",
+    );
+
+/// The slack to round observed timestamps up to.
+///
+/// The default corresponds to Mz's default tick interval, but does not need to do so. Ideally,
+/// it is not smaller than the tick interval, but it can be larger.
+pub const COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK: Config<Duration> = Config::new(
+    "compute_logical_backpressure_inflight_slack",
+    Duration::from_secs(1),
+    "Round observed timestamps to slack.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -216,4 +248,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COMPUTE_APPLY_COLUMN_DEMANDS)
         .add(&CONSOLIDATING_VEC_GROWTH_DAMPENER)
         .add(&ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION)
+        .add(&ENABLE_COMPUTE_LOGICAL_BACKPRESSURE)
+        .add(&COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES)
+        .add(&COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK)
 }

--- a/src/compute-types/src/explain.rs
+++ b/src/compute-types/src/explain.rs
@@ -78,7 +78,7 @@ impl<'a> DataflowDescription<Plan> {
         let sources = self
             .source_imports
             .iter_mut()
-            .map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _, _upper))| {
                 let op = source_desc.arguments.operators.as_ref();
                 ExplainSource::new(*id, op, context.config.filter_pushdown)
             })
@@ -155,7 +155,7 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
         let sources = self
             .source_imports
             .iter_mut()
-            .map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _, _upper))| {
                 let op = source_desc.arguments.operators.as_ref();
                 ExplainSource::new(*id, op, context.config.filter_pushdown)
             })

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -802,7 +802,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
             let monotonic_ids = dataflow
                 .source_imports
                 .iter()
-                .filter_map(|(id, (_, monotonic))| if *monotonic { Some(id) } else { None })
+                .filter_map(|(id, (_, monotonic, _upper))| if *monotonic { Some(id) } else { None })
                 .chain(
                     dataflow
                         .index_imports
@@ -859,7 +859,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
     fn refine_source_mfps(dataflow: &mut DataflowDescription<Self>) {
         // Extract MFPs from Get operators for sources, and extract what we can for the source.
         // For each source, we want to find `&mut MapFilterProject` for each `Get` expression.
-        for (source_id, (source, _monotonic)) in dataflow.source_imports.iter_mut() {
+        for (source_id, (source, _monotonic, _upper)) in dataflow.source_imports.iter_mut() {
             let mut identity_present = false;
             let mut mfps = Vec::new();
             for build_desc in dataflow.objects_to_build.iter_mut() {

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -9,6 +9,10 @@
 
 //! Logic related to the creation of dataflow sinks.
 
+use std::any::Any;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::{Rc, Weak};
+
 use columnar::Columnar;
 use differential_dataflow::Collection;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc};
@@ -16,13 +20,11 @@ use mz_expr::{permutation_for_arrangement, EvalError, MapFilterProject};
 use mz_ore::soft_assert_or_log;
 use mz_ore::str::StrExt;
 use mz_ore::vec::PartialOrdVecExt;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
-use std::any::Any;
-use std::collections::{BTreeMap, BTreeSet};
-use std::rc::{Rc, Weak};
+use mz_timely_util::probe::Handle;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
@@ -50,6 +52,7 @@ where
         sink: &ComputeSinkDesc<CollectionMetadata>,
         start_signal: StartSignal,
         ct_times: Option<Collection<G, (), Diff>>,
+        output_probe: &Handle<Timestamp>,
     ) {
         soft_assert_or_log!(
             sink.non_null_assertions.is_strictly_sorted(),
@@ -172,6 +175,7 @@ where
                     ok_collection.enter_region(inner),
                     err_collection.enter_region(inner),
                     ct_times.map(|x| x.enter_region(inner)),
+                    output_probe,
                 );
 
                 if let Some(sink_token) = sink_token {
@@ -201,6 +205,7 @@ where
         // TODO(ct2): Figure out a better way to smuggle this in, potentially by
         // removing the `SinkRender` trait entirely.
         ct_times: Option<Collection<G, (), Diff>>,
+        output_probe: &Handle<Timestamp>,
     ) -> Option<Rc<dyn Any>>;
 }
 

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -13,12 +13,13 @@ use std::ops::DerefMut;
 use std::rc::Rc;
 
 use differential_dataflow::consolidation::consolidate_updates;
-use differential_dataflow::Collection;
+use differential_dataflow::{AsCollection, Collection};
 use mz_compute_client::protocol::response::{SubscribeBatch, SubscribeResponse};
 use mz_compute_types::sinks::{ComputeSinkDesc, SubscribeSinkConnection};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
+use mz_timely_util::probe::{Handle, ProbeNotify};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::Scope;
@@ -43,6 +44,7 @@ where
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
         _ct_times: Option<Collection<G, (), Diff>>,
+        output_probe: &Handle<Timestamp>,
     ) -> Option<Rc<dyn Any>> {
         // An encapsulation of the Subscribe response protocol.
         // Used to send rows and progress messages,
@@ -55,7 +57,10 @@ where
             poison: None,
         })));
         let subscribe_protocol_weak = Rc::downgrade(&subscribe_protocol_handle);
-
+        let sinked_collection = sinked_collection
+            .inner
+            .probe_notify_with(vec![output_probe.clone()])
+            .as_collection();
         subscribe(
             sinked_collection,
             err_collection,

--- a/src/timely-util/src/probe.rs
+++ b/src/timely-util/src/probe.rs
@@ -22,6 +22,7 @@ use timely::dataflow::operators::{CapabilitySet, InspectCore};
 use timely::dataflow::{Scope, Stream, StreamCore};
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::Timestamp;
+use timely::scheduling::Activator;
 use timely::{Container, Data, PartialOrder};
 use tokio::sync::Notify;
 
@@ -67,6 +68,8 @@ pub struct Handle<T: Timestamp> {
     /// The private frontier containing the changes produced by this handle only
     handle_frontier: Antichain<T>,
     notify: Rc<Notify>,
+    /// Activators to notify when the frontier progresses
+    activators: Rc<RefCell<Vec<Activator>>>,
 }
 
 impl<T: Timestamp> Default for Handle<T> {
@@ -78,6 +81,7 @@ impl<T: Timestamp> Default for Handle<T> {
             frontier: Rc::new(RefCell::new(MutableAntichain::new())),
             handle_frontier: Antichain::new(),
             notify: Rc::new(Notify::new()),
+            activators: Rc::default(),
         }
     }
 }
@@ -135,7 +139,15 @@ impl<T: Timestamp> Handle<T> {
         self.handle_frontier.extend(new_frontier.iter().cloned());
         if changes.count() > 0 {
             self.notify.notify_waiters();
+            for activator in self.activators.borrow().iter() {
+                activator.activate();
+            }
         }
+    }
+
+    /// Register an activator to be notified when the frontier progresses
+    pub fn activate(&self, activator: Activator) {
+        self.activators.borrow_mut().push(activator);
     }
 }
 
@@ -154,6 +166,7 @@ impl<T: Timestamp> Clone for Handle<T> {
             frontier: Rc::clone(&self.frontier),
             handle_frontier: Antichain::new(),
             notify: Rc::clone(&self.notify),
+            activators: Rc::clone(&self.activators),
         }
     }
 }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -358,7 +358,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
     )?;
 
     // Push predicate information into the SourceDesc.
-    for (source_id, (source, _monotonic)) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source, _monotonic, _upper)) in dataflow.source_imports.iter_mut() {
         if let Some(list) = predicates.remove(&Id::Global(*source_id)) {
             if !list.is_empty() {
                 // Canonicalize the order of predicates, for stable plans.
@@ -417,7 +417,7 @@ pub fn optimize_dataflow_monotonic(
     ctx: &mut TransformCtx,
 ) -> Result<(), TransformError> {
     let mut monotonic_ids = BTreeSet::new();
-    for (source_id, (_source, is_monotonic)) in dataflow.source_imports.iter() {
+    for (source_id, (_source, is_monotonic, _upper)) in dataflow.source_imports.iter() {
         if *is_monotonic {
             monotonic_ids.insert(source_id.clone());
         }


### PR DESCRIPTION
Logical back pressure for dataflows.

This PR implements logical backpressure for dataflows. Logical backpressure is a mechanism that holds back time (not data), and reveals time stepwise as the downstream dataflow makes progress.

The implementation is conservative in what times it holds back. We cannot hold back all times because joins release resources as time ticks forward, and holding back time longer than necessary can cause regressions against current state. For this reason, we only hold back times until the input's write frontier (upper) at the time of creating the dataflow, but not beyond. This will allow us to apply logical backpressure while a dataflow is catching up, but it will not hold back any times in steady-state.

It is important that we do not hold back times in steady-state to ensure we permit maximum compaction of arrangements that we use in a dataflow. Holding back times before the current input's upper can result in slightly less compaction, but we know that the inputs are available up to that point and should soon advance the dataflow's output to the upper of the inputs.


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
