### PR TITLE
[dnm] test disabling epoch checking

### DIFF
--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -286,22 +286,23 @@ async fn start_connection(
                 let peer_epoch = ClusterStartupEpoch::from_bytes(buffer);
                 debug!("start: received peer epoch {peer_epoch}");
 
-                match my_epoch.cmp(&peer_epoch) {
-                    Ordering::Less => {
-                        return Err(EpochMismatch {
-                            mine: my_epoch,
-                            peer: peer_epoch,
-                        }
-                        .into());
-                    }
-                    Ordering::Greater => {
-                        warn!(
-                            process = my_index,
-                            "peer at address {address} gave older epoch ({peer_epoch}) than ours ({my_epoch})"
-                        );
-                    }
-                    Ordering::Equal => return Ok(s),
-                }
+                return Ok(s);
+                //match my_epoch.cmp(&peer_epoch) {
+                //    Ordering::Less => {
+                //        return Err(EpochMismatch {
+                //            mine: my_epoch,
+                //            peer: peer_epoch,
+                //        }
+                //        .into());
+                //    }
+                //    Ordering::Greater => {
+                //        warn!(
+                //            process = my_index,
+                //            "peer at address {address} gave older epoch ({peer_epoch}) than ours ({my_epoch})"
+                //        );
+                //    }
+                //    Ordering::Equal => return Ok(s),
+                //}
             }
             Err(err) => {
                 info!(
@@ -341,21 +342,22 @@ async fn await_connection(
         use tokio::io::AsyncWriteExt;
         s.write_all(&my_epoch.to_bytes()[..]).await?;
 
-        match my_epoch.cmp(&peer_epoch) {
-            Ordering::Less => {
-                return Err(EpochMismatch {
-                    mine: my_epoch,
-                    peer: peer_epoch,
-                }
-                .into());
-            }
-            Ordering::Greater => {
-                warn!(
-                    process = my_index,
-                    "peer {peer_index} gave older epoch ({peer_epoch}) than ours ({my_epoch})"
-                );
-            }
-            Ordering::Equal => return Ok((s, peer_index)),
-        }
+        return Ok((s, peer_index));
+        //match my_epoch.cmp(&peer_epoch) {
+        //    Ordering::Less => {
+        //        return Err(EpochMismatch {
+        //            mine: my_epoch,
+        //            peer: peer_epoch,
+        //        }
+        //        .into());
+        //    }
+        //    Ordering::Greater => {
+        //        warn!(
+        //            process = my_index,
+        //            "peer {peer_index} gave older epoch ({peer_epoch}) than ours ({my_epoch})"
+        //        );
+        //    }
+        //    Ordering::Equal => return Ok((s, peer_index)),
+        //}
     }
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
