### PR TITLE
Prefix the environment role, rolebinding, and serviceaccount

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -161,15 +161,15 @@ pub mod v1alpha1 {
         }
 
         pub fn service_account_name(&self) -> String {
-            self.name_unchecked()
+            self.name_prefixed(&self.name_unchecked())
         }
 
         pub fn role_name(&self) -> String {
-            self.name_unchecked()
+            self.name_prefixed(&self.name_unchecked())
         }
 
         pub fn role_binding_name(&self) -> String {
-            self.name_unchecked()
+            self.name_prefixed(&self.name_unchecked())
         }
 
         pub fn environmentd_statefulset_name(&self, generation: u64) -> String {

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -320,6 +320,16 @@ impl Resources {
         )
         .await?;
 
+        // These three had their names changed right before GA, and some prospects were already
+        // testing Materialize self-hosted. So, we have to clean up the un-prefixed names.
+        let role_api: Api<Role> = Api::namespaced(client.clone(), &mz.namespace());
+        let rolebinding_api: Api<RoleBinding> = Api::namespaced(client.clone(), &mz.namespace());
+        let serviceaccount_api: Api<ServiceAccount> =
+            Api::namespaced(client.clone(), &mz.namespace());
+        delete_resource(&role_api, &mz.name_unchecked()).await?;
+        delete_resource(&rolebinding_api, &mz.name_unchecked()).await?;
+        delete_resource(&serviceaccount_api, &mz.name_unchecked()).await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Prefix the environment role, rolebinding, and serviceaccount with the `mz{resource_id}-` like all other objects created by orchestratord.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a previously unreported bug.

These objects were missed when adding prefixes earlier. Without the prefixes, there can be conflicts when running multiple materialize installations in the same namespace.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  No changes needed currently, but may need to be included in my upcoming migration to reconciling Materialize CRs.
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
