### PR TITLE
Clarify properties of GlobalIds

### DIFF
--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -25,19 +25,9 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.global_id.rs"));
 
 /// The identifier for an item/object.
 ///
-/// WARNING: `GlobalId`'s `Ord` implementation has at various times expressed:
-/// - Dependency ordering (items with greater `GlobalId`s can depend on those
-/// lesser but never the other way around)
-/// - Nothing at all regarding dependencies
-///
-/// Currently, `GlobalId`s express a dependency ordering. We hope to keep it
-/// that way.
-///
-/// Before breaking this invariant, you should strongly consider alternative
-/// designs, i.e. it is an intense "smell" if you need to allow inverted
-/// `GlobalId` dependencies. Most likely, at some point in the future, you will
-/// need to invert the dependency structure again and will regret having broken
-/// it in the first place.
+/// WARNING: `GlobalId`'s `Ord` implementation does not express a dependency order.
+/// One should explicitly topologically sort objects by their dependencies, rather
+/// than rely on the order of identifiers.
 #[derive(
     Arbitrary,
     Clone,


### PR DESCRIPTION
Our documentation for `GlobalId` implied that one could rely on the `Ord` implementation for dependence order, but this is neither part of `formalism.md` nor accurate about the current codebase. Correct the documentation.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
