### PR TITLE
docs: Update release docs to callout recently released versions

### DIFF
--- a/doc/user/content/releases/v0.132.md
+++ b/doc/user/content/releases/v0.132.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.132"
 date: 2025-02-12
-released: false
+released: true
+patch: 2
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.133.md
+++ b/doc/user/content/releases/v0.133.md
@@ -1,0 +1,8 @@
+---
+title: "Materialize v0.133"
+date: 2025-02-19
+released: true
+patch: 1
+_build:
+  render: never
+---


### PR DESCRIPTION
Fixes the docs for v0.132 and v0.133

### Motivation

Fix docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
