### PR TITLE
ci: Reenable copy to s3 tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1812,7 +1812,6 @@ steps:
             run: nightly
       agents:
         queue: hetzner-aarch64-16cpu-32gb
-      skip: "Reenable when database-issues#8956 is fixed"
 
     - id: copy-to-s3-2-replicas
       label: "Copy To S3 (2 replicas)"
@@ -1825,7 +1824,6 @@ steps:
             args: [--default-size=2]
       agents:
         queue: hetzner-aarch64-16cpu-32gb
-      skip: "Reenable when database-issues#8956 is fixed"
 
   - id: backup-restore
     label: "CRDB / Persist backup and restore"


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31513

Noticed in https://buildkite.com/materialize/nightly/builds/11226#019525eb-dd0e-4855-96e2-14ccb54528cc

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
