### PR TITLE
build: Remove unused tabled dependency in self-managed-debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6735,7 +6735,6 @@ dependencies = [
  "mz-ore",
  "serde",
  "serde_yaml",
- "tabled",
  "tokio",
  "tracing",
  "workspace-hack",

--- a/src/self-managed-debug/Cargo.toml
+++ b/src/self-managed-debug/Cargo.toml
@@ -21,7 +21,6 @@ mz-cloud-resources = { path = "../cloud-resources"}
 mz-ore = { path = "../ore", features = ["cli", "test"] }
 serde = "1.0.152"
 serde_yaml = "0.9.25"
-tabled = "0.10.0"
 tokio = "1.38.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31282

Seen in https://buildkite.com/materialize/nightly/builds/11226#019525eb-dd0e-4f66-8213-4e91673256b7

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
