### PR TITLE
ci: Bump timeouts for Maelstrom tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1143,7 +1143,7 @@ steps:
       - id: persist-maelstrom
         label: Maelstrom coverage of persist
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1155,7 +1155,7 @@ steps:
       - id: persist-maelstrom-single-node
         label: Long single-node Maelstrom coverage of persist
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 40
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
@@ -1167,7 +1167,7 @@ steps:
       - id: persist-maelstrom-multi-node
         label: Long multi-node Maelstrom coverage of persist with postgres consensus
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 40
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
@@ -1179,7 +1179,7 @@ steps:
       - id: txn-wal-maelstrom
         label: Maelstrom coverage of txn-wal
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31541

Seen timing out in https://buildkite.com/materialize/nightly/builds/11226#019525eb-dd5b-44e5-aa4f-a1bc602fecc8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
