### PR TITLE
ci: Disable some Azurite-based tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -320,17 +320,6 @@ steps:
               composition: testdrive
               args: [--azurite]
 
-      - id: azurite-testdrive-replicas-4
-        label: ":racing_car: testdrive 4 replicas with :azure: blob store"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: testdrive
-              args: [--replicas=4, --azurite]
-
       - id: azurite-testdrive-size-8
         label: ":racing_car: testdrive with SIZE 8 and :azure: blob store"
         depends_on: build-aarch64
@@ -860,18 +849,6 @@ steps:
               composition: platform-checks
               args: [--scenario=RestartEntireMz, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-parallel-restart-entire-mz-azurite
-        label: "Checks parallel + restart of the entire Mz with :azure: blob store"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        parallelism: 2
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=RestartEntireMz, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID", --azurite]
-
       - id: checks-parallel-restart-environmentd-clusterd-storage
         label: "Checks parallel + restart of environmentd & storage clusterd"
         depends_on: build-aarch64
@@ -956,8 +933,8 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-0dt-restart-entire-mz-forced-migrations-azurite
-        label: "Checks 0dt restart of the entire Mz with forced migrations with :azure: blob store"
+      - id: checks-0dt-restart-entire-mz-forced-migrations
+        label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -966,7 +943,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID", --azurite]
+              args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"


### PR DESCRIPTION
Went OoM in https://buildkite.com/materialize/nightly/builds/11223#019524a5-b21c-45bd-8927-83bd6916f3de

We still have other Azurite-based tests, but because of Azurite's low performance and https://github.com/MaterializeInc/database-issues/issues/8892 we can't use it for as many scenarios as initially hoped

An alternative would be to increase the agent size further for these, but I'm not sure if there is enough value to justify.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
