### PR TITLE
[copy_from] Support specifying a column map in `COPY ... FROM <url>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7306,6 +7306,7 @@ dependencies = [
  "arrow",
  "async-compression",
  "async-stream",
+ "aws-sdk-s3",
  "aws-smithy-types",
  "aws-types",
  "bytes",

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -32,7 +32,7 @@ use mz_ore::result::ResultExt;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::thread::JoinOnDropHandle;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{CatalogItemId, Row, RowIterator, ScalarType};
+use mz_repr::{CatalogItemId, ColumnIndex, Row, RowIterator, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{EnvironmentId, SessionCatalog};
 use mz_sql::session::hint::ApplicationNameHint;
@@ -737,7 +737,7 @@ impl SessionClient {
     pub async fn insert_rows(
         &mut self,
         id: CatalogItemId,
-        columns: Vec<usize>,
+        columns: Vec<ColumnIndex>,
         rows: Vec<Row>,
         ctx_extra: ExecuteContextExtra,
     ) -> Result<ExecuteResponse, AdapterError> {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -22,7 +22,7 @@ use mz_ore::soft_assert_no_log;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, RowIterator};
+use mz_repr::{CatalogItemId, ColumnIndex, RowIterator};
 use mz_sql::ast::{FetchDirection, Raw, Statement};
 use mz_sql::catalog::ObjectType;
 use mz_sql::plan::{ExecuteTimeout, Plan, PlanKind};
@@ -256,7 +256,7 @@ pub enum ExecuteResponse {
     },
     CopyFrom {
         id: CatalogItemId,
-        columns: Vec<usize>,
+        columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'static>,
         ctx_extra: ExecuteContextExtra,
     },

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -7,7 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use aws_sdk_s3::config::Builder;
+use aws_sdk_s3::presigning::PresigningConfig;
 use aws_types::sdk_config::SdkConfig;
 use bytes::Bytes;
 
@@ -24,6 +27,12 @@ pub fn new_client(sdk_config: &SdkConfig) -> Client {
         .force_path_style(sdk_config.endpoint_url().is_some())
         .build();
     Client::from_conf(conf)
+}
+
+/// Returns a default [`PresigningConfig`] for tests.
+pub fn new_presigned_config() -> PresigningConfig {
+    // Expire the URL in 5 minutes.
+    PresigningConfig::expires_in(Duration::from_secs(5 * 60)).expect("known valid")
 }
 
 pub async fn list_bucket_path(

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -36,7 +36,8 @@ use mz_pgwire_common::{
     ConnectionCounter, ErrorResponse, Format, FrontendMessage, Severity, VERSIONS, VERSION_3,
 };
 use mz_repr::{
-    CatalogItemId, Datum, RelationDesc, RelationType, RowArena, RowIterator, RowRef, ScalarType,
+    CatalogItemId, ColumnIndex, Datum, RelationDesc, RelationType, RowArena, RowIterator, RowRef,
+    ScalarType,
 };
 use mz_server_core::TlsMode;
 use mz_sql::ast::display::AstDisplay;
@@ -2114,7 +2115,7 @@ where
     async fn copy_from(
         &mut self,
         id: CatalogItemId,
-        columns: Vec<usize>,
+        columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'_>,
         row_desc: RelationDesc,
         mut ctx_extra: ExecuteContextExtra,
@@ -2150,7 +2151,7 @@ where
     async fn copy_from_inner(
         &mut self,
         id: CatalogItemId,
-        columns: Vec<usize>,
+        columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'_>,
         row_desc: RelationDesc,
         ctx_extra: &mut ExecuteContextExtra,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -510,7 +510,11 @@ pub fn plan_copy_item(
     // should be simplified. The reason they are currently separate code paths is so we can roll
     // out `COPY ... FROM <url>` without touching the current `COPY ... FROM ... STDIN` behavior.
 
-    // If we're copying data into a table, then we generate an MFP.
+    // If we're copying data into a table that users can write into (e.g. not a `CREATE TABLE ...
+    // FROM SOURCE ...`), then we generate an MFP.
+    //
+    // Note: This method is called for both `COPY INTO <table> FROM` and `COPY <expr> TO <external>`
+    // so it's not always guaranteed that our `item` is a table.
     let mfp = if let Some(table_defaults) = item.writable_table_details() {
         let mut table_defaults = table_defaults.to_vec();
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -45,7 +45,9 @@ use std::{iter, mem};
 
 use itertools::Itertools;
 use mz_expr::virtual_syntax::AlgExcept;
-use mz_expr::{func as expr_func, Id, LetRecLimit, LocalId, MirScalarExpr, RowSetFinishing};
+use mz_expr::{
+    func as expr_func, Id, LetRecLimit, LocalId, MapFilterProject, MirScalarExpr, RowSetFinishing,
+};
 use mz_ore::assert_none;
 use mz_ore::collections::CollectionExt;
 use mz_ore::option::FallibleMapExt;
@@ -56,7 +58,7 @@ use mz_repr::adt::numeric::{NumericMaxScale, NUMERIC_DATUM_MAX_PRECISION};
 use mz_repr::adt::timestamp::TimestampPrecision;
 use mz_repr::adt::varchar::VarCharMaxLength;
 use mz_repr::{
-    strconv, CatalogItemId, ColumnName, ColumnType, Datum, RelationDesc, RelationType,
+    strconv, CatalogItemId, ColumnIndex, ColumnName, ColumnType, Datum, RelationDesc, RelationType,
     RelationVersionSelector, Row, RowArena, ScalarType,
 };
 use mz_sql_parser::ast::display::AstDisplay;
@@ -476,27 +478,93 @@ pub fn plan_insert_query(
     ))
 }
 
+/// Determines the mapping between some external data and a Materialize relation.
+///
+/// Returns the following:
+/// * [`CatalogItemId`] for the destination table.
+/// * [`RelationDesc`] representing the shape of the __input__ data we are copying from.
+/// * The [`ColumnIndex`]es that the source data maps to. TODO(cf2): We don't need this mapping
+///   since we now return a [`MapFilterProject`].
+/// * [`MapFilterProject`] which will map and project the input data to match the shape of the
+///   destination table.
+///
 pub fn plan_copy_item(
     scx: &StatementContext,
     item_name: ResolvedItemName,
     columns: Vec<Ident>,
-) -> Result<(CatalogItemId, RelationDesc, Vec<usize>), PlanError> {
+) -> Result<
+    (
+        CatalogItemId,
+        RelationDesc,
+        Vec<ColumnIndex>,
+        Option<MapFilterProject>,
+    ),
+    PlanError,
+> {
     let item = scx.get_item_by_resolved_name(&item_name)?;
-
-    let mut desc = item
-        .desc(&scx.catalog.resolve_full_name(item.name()))?
-        .into_owned();
-
+    let fullname = scx.catalog.resolve_full_name(item.name());
+    let table_desc = item.desc(&fullname)?.into_owned();
     let mut ordering = Vec::with_capacity(columns.len());
 
-    if columns.is_empty() {
-        ordering.extend(0..desc.arity());
+    // TODO(cf2): The logic here to create the `source_desc` and the MFP are a bit duplicated and
+    // should be simplified. The reason they are currently separate code paths is so we can roll
+    // out `COPY ... FROM <url>` without touching the current `COPY ... FROM ... STDIN` behavior.
+
+    // If we're copying data into a table, then we generate an MFP.
+    let mfp = if let Some(table_defaults) = item.writable_table_details() {
+        let mut table_defaults = table_defaults.to_vec();
+
+        for default in &mut table_defaults {
+            transform_ast::transform(scx, default)?;
+        }
+
+        // Fill in any omitted columns and rearrange into correct order
+        let source_column_names: Vec<_> = columns
+            .iter()
+            .cloned()
+            .map(normalize::column_name)
+            .collect();
+
+        let mut default_exprs = Vec::new();
+        let mut project_keys = Vec::with_capacity(table_desc.arity());
+
+        // For each column in the destination table, either project it from the source data, or provide
+        // an expression to fill in a default value.
+        let column_details = table_desc.iter().zip_eq(table_defaults);
+        for ((col_name, col_type), col_default) in column_details {
+            let maybe_src_idx = source_column_names.iter().position(|name| name == col_name);
+            if let Some(src_idx) = maybe_src_idx {
+                project_keys.push(src_idx);
+            } else {
+                // If one a column from the table does not exist in the source data, then a default
+                // value will get appended to the end of the input Row from the source data.
+                let hir = plan_default_expr(scx, &col_default, &col_type.scalar_type)?;
+                let mir = hir.lower_uncorrelated()?;
+                project_keys.push(source_column_names.len() + default_exprs.len());
+                default_exprs.push(mir);
+            }
+        }
+
+        let mfp = MapFilterProject::new(source_column_names.len())
+            .map(default_exprs)
+            .project(project_keys);
+        Some(mfp)
+    } else {
+        None
+    };
+
+    // Create a mapping from input data to the table we're copying into.
+    let source_desc = if columns.is_empty() {
+        let indexes = (0..table_desc.arity()).map(ColumnIndex::from_raw);
+        ordering.extend(indexes);
+
+        // The source data should be in the same order as the table.
+        table_desc
     } else {
         let columns: Vec<_> = columns.into_iter().map(normalize::column_name).collect();
-        let column_by_name: BTreeMap<&ColumnName, (usize, &ColumnType)> = desc
-            .iter()
-            .enumerate()
-            .map(|(idx, (name, typ))| (name, (idx, typ)))
+        let column_by_name: BTreeMap<&ColumnName, (ColumnIndex, &ColumnType)> = table_desc
+            .iter_all()
+            .map(|(idx, name, typ)| (name, (*idx, typ)))
             .collect();
 
         let mut names = Vec::with_capacity(columns.len());
@@ -519,17 +587,29 @@ pub fn plan_copy_item(
             sql_bail!("column {} specified more than once", dup.as_str().quoted());
         }
 
-        desc = RelationDesc::new(RelationType::new(source_types), names);
+        // The source data is a different shape than the destination table.
+        RelationDesc::new(RelationType::new(source_types), names)
     };
 
-    Ok((item.id(), desc, ordering))
+    Ok((item.id(), source_desc, ordering, mfp))
 }
 
+/// See the doc comment on [`plan_copy_item`] for the details of what this function returns.
+///
+/// TODO(cf3): Merge this method with [`plan_copy_item`].
 pub fn plan_copy_from(
     scx: &StatementContext,
     table_name: ResolvedItemName,
     columns: Vec<Ident>,
-) -> Result<(CatalogItemId, RelationDesc, Vec<usize>), PlanError> {
+) -> Result<
+    (
+        CatalogItemId,
+        RelationDesc,
+        Vec<ColumnIndex>,
+        Option<MapFilterProject>,
+    ),
+    PlanError,
+> {
     let table = scx.get_item_by_resolved_name(&table_name)?;
 
     // Validate the target of the insert.
@@ -554,9 +634,9 @@ pub fn plan_copy_from(
             table_name.full_name_str()
         );
     }
-    let (id, desc, ordering) = plan_copy_item(scx, table_name, columns)?;
+    let (id, desc, ordering, mfp) = plan_copy_item(scx, table_name, columns)?;
 
-    Ok((id, desc, ordering))
+    Ok((id, desc, ordering, mfp))
 }
 
 /// Builds a plan that adds the default values for the missing columns and re-orders
@@ -565,7 +645,7 @@ pub fn plan_copy_from_rows(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
-    columns: Vec<usize>,
+    columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<HirRelationExpr, PlanError> {
     let scx = StatementContext::new(Some(pcx), catalog);
@@ -587,7 +667,7 @@ pub fn plan_copy_from_rows(
 
     let column_types = columns
         .iter()
-        .map(|x| desc.typ().column_types[*x].clone())
+        .map(|x| desc.get_type(x).clone())
         .map(|mut x| {
             // Null constraint is enforced later, when inserting the row in the table.
             // Without this, an assert is hit during lowering.
@@ -606,7 +686,7 @@ pub fn plan_copy_from_rows(
     // more easily, as at every stage we know this expression is nothing more than
     // a constant (as opposed to e.g. a constant with with an identity map and identity
     // projection).
-    let default: Vec<_> = (0..desc.arity()).collect();
+    let default: Vec<_> = (0..desc.arity()).map(ColumnIndex::from_raw).collect();
     if columns == default {
         return Ok(expr);
     }
@@ -618,8 +698,8 @@ pub fn plan_copy_from_rows(
     // Maps from table column index to position in the source query
     let col_to_source: BTreeMap<_, _> = columns.iter().enumerate().map(|(a, b)| (b, a)).collect();
 
-    let column_details = desc.iter_types().zip_eq(defaults).enumerate();
-    for (col_idx, (col_typ, default)) in column_details {
+    let column_details = desc.iter_all().zip_eq(defaults);
+    for ((col_idx, _col_name, col_typ), default) in column_details {
         if let Some(src_idx) = col_to_source.get(&col_idx) {
             project_key.push(*src_idx);
         } else {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -15,7 +15,9 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
 use mz_repr::namespaces::is_system_schema;
-use mz_repr::{CatalogItemId, ColumnType, RelationDesc, RelationVersionSelector, ScalarType};
+use mz_repr::{
+    CatalogItemId, ColumnIndex, ColumnType, RelationDesc, RelationVersionSelector, ScalarType,
+};
 use mz_sql_parser::ast::{
     ColumnDef, ColumnName, ConnectionDefaultAwsPrivatelink, CreateMaterializedViewStatement,
     RawItemName, ShowStatement, StatementKind, TableConstraint, UnresolvedDatabaseName,
@@ -437,7 +439,7 @@ pub fn plan_copy_from(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
-    columns: Vec<usize>,
+    columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<super::HirRelationExpr, PlanError> {
     query::plan_copy_from_rows(pcx, catalog, id, columns, rows)

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1213,7 +1213,7 @@ fn plan_copy_from(
     let (id, source_desc, columns, maybe_mfp) = query::plan_copy_from(scx, table_name, columns)?;
 
     let Some(mfp) = maybe_mfp else {
-        bail_unsupported!("COPY FROM ... expects an MFP to be produced");
+        sql_bail!("[internal error] COPY FROM ... expects an MFP to be produced");
     };
 
     Ok(Plan::CopyFrom(CopyFromPlan {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -990,7 +990,7 @@ pub fn describe_copy_from_table(
     table_name: <Aug as AstInfo>::ItemName,
     columns: Vec<Ident>,
 ) -> Result<StatementDesc, PlanError> {
-    let (_, desc, _) = query::plan_copy_from(scx, table_name, columns)?;
+    let (_, desc, _, _) = query::plan_copy_from(scx, table_name, columns)?;
     Ok(StatementDesc::new(Some(desc)))
 }
 
@@ -999,7 +999,7 @@ pub fn describe_copy_item(
     object_name: <Aug as AstInfo>::ItemName,
     columns: Vec<Ident>,
 ) -> Result<StatementDesc, PlanError> {
-    let (_, desc, _) = query::plan_copy_item(scx, object_name, columns)?;
+    let (_, desc, _, _) = query::plan_copy_item(scx, object_name, columns)?;
     Ok(StatementDesc::new(Some(desc)))
 }
 
@@ -1210,11 +1210,18 @@ fn plan_copy_from(
         bail_unsupported!("COPY FROM ... WITH (FILES ...) only supported from a URL")
     }
 
-    let (id, _, columns) = query::plan_copy_from(scx, table_name, columns)?;
+    let (id, source_desc, columns, maybe_mfp) = query::plan_copy_from(scx, table_name, columns)?;
+
+    let Some(mfp) = maybe_mfp else {
+        bail_unsupported!("COPY FROM ... expects an MFP to be produced");
+    };
+
     Ok(Plan::CopyFrom(CopyFromPlan {
         id,
         source,
         columns,
+        source_desc,
+        mfp,
         params,
         filter,
     }))

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -840,6 +840,8 @@ fn generate_rbac_requirements(
             id,
             source: _,
             columns: _,
+            source_desc: _,
+            mfp: _,
             params: _,
             filter: _,
         }) => RbacRequirements {

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -16,6 +16,7 @@ async-compression = { version = "0.4.11", features = ["bzip2", "gzip", "tokio", 
 async-stream = "0.3.3"
 aws-types = "1.1.1"
 aws-smithy-types = "1.1.8"
+aws-sdk-s3 = { version = "1.23.0", default-features = false }
 bytes = "1.10.1"
 bytesize = "1.3.0"
 csv-async = { version = "1.3.0", features = ["tokio"] }

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -482,8 +482,9 @@ where
                         match result {
                             Ok(Some(row)) => row_handle.give(&capability, Ok(row)),
                             Ok(None) => {
-                                let err = StorageErrorXKind::MfpFiltered.with_context("decode");
-                                row_handle.give(&capability, Err(err))
+                                // We only expect the provided MFP to map rows from the source data
+                                // and project default values.
+                                mz_ore::soft_panic_or_log!("oneshot source MFP filtered out data!");
                             }
                             Err(e) => {
                                 let err = StorageErrorXKind::MfpEvalError(e.to_string().into())
@@ -1030,8 +1031,6 @@ pub enum StorageErrorXKind {
     MissingSize,
     #[error("object is missing the required '{0}' field")]
     MissingField(Arc<str>),
-    #[error("[internal error] the supplied mfp filtered out a row, it is only supposed to map and project")]
-    MfpFiltered,
     #[error("failed while evaluating the provided mfp: '{0}'")]
     MfpEvalError(Arc<str>),
     #[error("something went wrong: {0}")]

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -1030,7 +1030,7 @@ pub enum StorageErrorXKind {
     MissingSize,
     #[error("object is missing the required '{0}' field")]
     MissingField(Arc<str>),
-    #[error("the supplied mfp filtered out a row, it is only supposed to map and project")]
+    #[error("[internal error] the supplied mfp filtered out a row, it is only supposed to map and project")]
     MfpFiltered,
     #[error("failed while evaluating the provided mfp: '{0}'")]
     MfpEvalError(Arc<str>),

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -69,12 +69,13 @@ use bytes::Bytes;
 use differential_dataflow::Hashable;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
+use mz_expr::SafeMfpPlan;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
-use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::oneshot_sources::{
@@ -143,6 +144,7 @@ where
         source,
         format,
         filter,
+        shape,
     } = request;
 
     let source = match source {
@@ -163,11 +165,11 @@ where
 
     let format = match format {
         ContentFormat::Csv(params) => {
-            let format = CsvDecoder::new(params, &collection_meta.relation_desc);
+            let format = CsvDecoder::new(params, &shape.source_desc);
             FormatKind::Csv(format)
         }
         ContentFormat::Parquet => {
-            let format = ParquetFormat::new(collection_meta.relation_desc.clone());
+            let format = ParquetFormat::new(shape.source_desc);
             FormatKind::Parquet(format)
         }
     };
@@ -192,8 +194,12 @@ where
         &work_stream,
     );
     // Parse chunks of records into Rows.
-    let (rows_stream, decode_token) =
-        render_decode_chunk(scope.clone(), format.clone(), &records_stream);
+    let (rows_stream, decode_token) = render_decode_chunk(
+        scope.clone(),
+        format.clone(),
+        &records_stream,
+        shape.source_mfp,
+    );
     // Stage the Rows in Persist.
     let (batch_stream, batch_token) = render_stage_batches_operator(
         scope.clone(),
@@ -434,6 +440,7 @@ pub fn render_decode_chunk<G, F>(
     scope: G,
     format: F,
     record_chunks: &TimelyStream<G, Result<F::RecordChunk, StorageErrorX>>,
+    mfp: SafeMfpPlan,
 ) -> (
     TimelyStream<G, Result<Row, StorageErrorX>>,
     PressOnDropButton,
@@ -449,6 +456,10 @@ where
 
     let shutdown = builder.build(move |caps| async move {
         let [_row_cap] = caps.try_into().unwrap();
+
+        let mut datum_vec = DatumVec::default();
+        let row_arena = RowArena::default();
+        let mut row_buf = Row::default();
 
         while let Some(event) = record_chunk_handle.next().await {
             let (capability, maybe_chunks) = match event {
@@ -468,9 +479,27 @@ where
             .context("decode chunk");
 
             match result {
-                Ok(rows) => rows
-                    .into_iter()
-                    .for_each(|row| row_handle.give(&capability, Ok(row))),
+                Ok(rows) => {
+                    // For each row of source data, we pass it through an MFP to re-arrange column
+                    // orders and/or fill in default values for missing columns.
+                    for row in rows {
+                        let mut datums = datum_vec.borrow_with(&row);
+                        let result = mfp.evaluate_into(&mut *datums, &row_arena, &mut row_buf);
+
+                        match result {
+                            Ok(Some(row)) => row_handle.give(&capability, Ok(row)),
+                            Ok(None) => {
+                                let err = StorageErrorXKind::MfpFiltered.with_context("decode");
+                                row_handle.give(&capability, Err(err))
+                            }
+                            Err(e) => {
+                                let err = StorageErrorXKind::MfpEvalError(e.to_string().into())
+                                    .with_context("decode");
+                                row_handle.give(&capability, Err(err))
+                            }
+                        }
+                    }
+                }
                 Err(err) => row_handle.give(&capability, Err(err)),
             }
         }
@@ -998,6 +1027,10 @@ pub enum StorageErrorXKind {
     MissingSize,
     #[error("object is missing the required '{0}' field")]
     MissingField(Arc<str>),
+    #[error("the supplied mfp filtered out a row, it is only supposed to map and project")]
+    MfpFiltered,
+    #[error("failed while evaluating the provided mfp: '{0}'")]
+    MfpEvalError(Arc<str>),
     #[error("something went wrong: {0}")]
     Generic(String),
 }

--- a/src/storage-operators/src/oneshot_source/aws_source.rs
+++ b/src/storage-operators/src/oneshot_source/aws_source.rs
@@ -120,6 +120,10 @@ impl OneshotObject for S3Object {
         &self.name
     }
 
+    fn path(&self) -> &str {
+        &self.key
+    }
+
     fn size(&self) -> usize {
         self.size
     }
@@ -200,7 +204,7 @@ impl OneshotSource for AwsS3Source {
             // TODO(cf1): Validate our checksum.
             let client = self.client().await.map_err(StorageErrorXKind::generic)?;
 
-            let mut request = client.get_object().bucket(&self.bucket).key(&object.name);
+            let mut request = client.get_object().bucket(&self.bucket).key(&object.key);
             if let Some(range) = range {
                 let value = range.into_range_header_value();
                 request = request.range(value);
@@ -215,7 +219,7 @@ impl OneshotSource for AwsS3Source {
                 .err_into()
                 .boxed();
 
-            Ok::<_, StorageErrorXKind>(stream)
+            Ok::<_, StorageErrorX>(stream)
         };
 
         futures::stream::once(initial_response)

--- a/src/storage-operators/src/oneshot_source/http_source.rs
+++ b/src/storage-operators/src/oneshot_source/http_source.rs
@@ -55,6 +55,10 @@ impl OneshotObject for HttpObject {
         &self.filename
     }
 
+    fn path(&self) -> &str {
+        &self.filename
+    }
+
     fn size(&self) -> usize {
         self.size
     }

--- a/src/storage-types/src/oneshot_sources.proto
+++ b/src/storage-types/src/oneshot_sources.proto
@@ -11,9 +11,11 @@ syntax = "proto3";
 
 package mz_storage_types.oneshot_sources;
 
+import "expr/src/linear.proto";
 import "google/protobuf/empty.proto";
 import "pgcopy/src/copy.proto";
 import "repr/src/catalog_item_id.proto";
+import "repr/src/relation_and_scalar.proto";
 import "storage-types/src/connections/aws.proto";
 
 message ProtoOneshotIngestionRequest {
@@ -32,6 +34,8 @@ message ProtoOneshotIngestionRequest {
     ProtoFilterFiles files = 6;
     ProtoFilterPattern pattern = 7;
   }
+
+  ProtoContentShape shape = 8;
 }
 
 message ProtoHttpContentSource {
@@ -56,4 +60,9 @@ message ProtoFilterFiles {
 
 message ProtoFilterPattern {
   string pattern = 1;
+}
+
+message ProtoContentShape {
+  mz_repr.relation_and_scalar.ProtoRelationDesc source_desc = 1;
+  mz_expr.linear.ProtoSafeMfpPlan source_mfp = 2;
 }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.95"
-async-compression = { version = "0.4.11", features = ["tokio", "gzip"] }
+async-compression = { version = "0.4.11", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 async-trait = "0.1.83"
 aws-credential-types = { version = "1.2.1", features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -805,6 +805,8 @@ impl Run for PosCommand {
                     "psql-execute" => psql::run_execute(builtin, state).await,
                     "s3-verify-data" => s3::run_verify_data(builtin, state).await,
                     "s3-verify-keys" => s3::run_verify_keys(builtin, state).await,
+                    "s3-file-upload" => s3::run_upload(builtin, state).await,
+                    "s3-set-presigned-url" => s3::run_set_presigned_url(builtin, state).await,
                     "schema-registry-publish" => schema_registry::run_publish(builtin, state).await,
                     "schema-registry-verify" => schema_registry::run_verify(builtin, state).await,
                     "schema-registry-wait" => schema_registry::run_wait(builtin, state).await,

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -7,15 +7,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::pin::Pin;
 use std::str;
 use std::thread;
 use std::time::Duration;
 
 use anyhow::bail;
+use anyhow::Context;
 use arrow::util::display::ArrayFormatter;
 use arrow::util::display::FormatOptions;
+use async_compression::tokio::bufread::{BzEncoder, GzipEncoder, XzEncoder, ZstdEncoder};
 use regex::Regex;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
+use crate::action::file::build_compression;
+use crate::action::file::build_contents;
+use crate::action::file::Compression;
 use crate::action::{ControlFlow, State};
 use crate::parser::BuiltinCommand;
 
@@ -176,4 +183,76 @@ fn rows_from_parquet(bytes: bytes::Bytes) -> Vec<String> {
         }
     }
     ret
+}
+
+pub async fn run_upload(
+    mut cmd: BuiltinCommand,
+    state: &State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let key = cmd.args.string("key")?;
+    let bucket = cmd.args.string("bucket")?;
+
+    let compression = build_compression(&mut cmd)?;
+    let content = build_contents(&mut cmd)?;
+
+    let aws_client = mz_aws_util::s3::new_client(&state.aws_config);
+
+    // TODO(parkmycar): Stream data to S3. The ByteStream type from the AWS config is a bit
+    // cumbersome to work with, so for now just stick with this.
+    let mut body = vec![];
+    for line in content {
+        body.extend(&line);
+        body.push(b'\n');
+    }
+
+    let mut reader: Pin<Box<dyn AsyncRead + Send + Sync>> = match compression {
+        Compression::None => Box::pin(&body[..]),
+        Compression::Gzip => Box::pin(GzipEncoder::new(&body[..])),
+        Compression::Bzip2 => Box::pin(BzEncoder::new(&body[..])),
+        Compression::Xz => Box::pin(XzEncoder::new(&body[..])),
+        Compression::Zstd => Box::pin(ZstdEncoder::new(&body[..])),
+    };
+    let mut content = vec![];
+    reader
+        .read_to_end(&mut content)
+        .await
+        .context("compressing")?;
+
+    println!("Uploading file to S3 bucket {bucket}/{key}");
+
+    // Upload the file to S3.
+    aws_client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(content.into())
+        .send()
+        .await
+        .context("s3 put")?;
+
+    Ok(ControlFlow::Continue)
+}
+
+pub async fn run_set_presigned_url(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let key = cmd.args.string("key")?;
+    let bucket = cmd.args.string("bucket")?;
+    let var_name = cmd.args.string("var-name")?;
+
+    let aws_client = mz_aws_util::s3::new_client(&state.aws_config);
+    let presign_config = mz_aws_util::s3::new_presigned_config();
+    let request = aws_client
+        .get_object()
+        .bucket(&bucket)
+        .key(&key)
+        .presigned(presign_config)
+        .await
+        .context("s3 presign")?;
+
+    println!("Setting '{var_name}' to presigned URL for {bucket}/{key}");
+    state.cmd_vars.insert(var_name, request.uri().to_string());
+
+    Ok(ControlFlow::Continue)
 }

--- a/test/testdrive/copy-from-s3-minio.td
+++ b/test/testdrive/copy-from-s3-minio.td
@@ -1,0 +1,160 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for COPY FROM expr.
+
+# COPY FROM expressions should immediately succeed or fail on their first runs
+$ set-max-tries max-tries=1
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_copy_from_remote = true;
+
+# Prepare the table we want to COPY INTO.
+> CREATE TABLE t1 (a text, b text);
+
+$ s3-file-upload bucket=copytos3 key=csv/1.csv repeat=2
+none,100
+
+$ s3-set-presigned-url bucket=copytos3 key=csv/1.csv var-name=1_csv_url
+
+> COPY INTO t1 FROM '${1_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t1;
+none 100
+none 100
+
+# gzip Compression.
+
+$ s3-file-upload bucket=copytos3 key=csv/2.csv.gz repeat=2 compression=gzip
+gzip,200
+
+$ s3-set-presigned-url bucket=copytos3 key=csv/2.csv.gz var-name=2_csv_url
+
+> COPY INTO t1 FROM '${2_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t1;
+gzip 200
+gzip 200
+none 100
+none 100
+
+# bzip2 Compression.
+
+$ s3-file-upload bucket=copytos3 key=csv/3.csv.bz2 repeat=2 compression=bzip2
+bzip2,300
+
+$ s3-set-presigned-url bucket=copytos3 key=csv/3.csv.bz2 var-name=3_csv_url
+
+> COPY INTO t1 FROM '${3_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t1;
+bzip2 300
+bzip2 300
+gzip 200
+gzip 200
+none 100
+none 100
+
+# xz Compression.
+
+$ s3-file-upload bucket=copytos3 key=csv/4.csv.xz repeat=2 compression=xz
+xz,400
+
+$ s3-set-presigned-url bucket=copytos3 key=csv/4.csv.xz var-name=4_csv_url
+
+> COPY INTO t1 FROM '${4_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t1;
+bzip2 300
+bzip2 300
+gzip 200
+gzip 200
+none 100
+none 100
+xz 400
+xz 400
+
+# zstd Compression.
+
+$ s3-file-upload bucket=copytos3 key=csv/5.csv.zst repeat=2 compression=zstd
+zstd,500
+
+$ s3-set-presigned-url bucket=copytos3 key=csv/5.csv.zst var-name=5_csv_url
+
+> COPY INTO t1 FROM '${5_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t1;
+bzip2 300
+bzip2 300
+gzip 200
+gzip 200
+none 100
+none 100
+xz 400
+xz 400
+zstd 500
+zstd 500
+
+# Map and Project.
+
+> CREATE TABLE t2 (a text DEFAULT 'hello', b text, c text);
+
+$ s3-file-upload bucket=copytos3 key=default_vals.csv repeat=5
+world
+
+$ s3-set-presigned-url bucket=copytos3 key=default_vals.csv var-name=default_vals_csv_url
+
+> COPY INTO t2 (b) FROM '${default_vals_csv_url}' (FORMAT CSV);
+
+> SELECT * FROM t2;
+hello world <null>
+hello world <null>
+hello world <null>
+hello world <null>
+hello world <null>
+
+# Test the AWS Source.
+
+> CREATE SECRET aws_secret AS '${arg.aws-secret-access-key}'
+
+> CREATE CONNECTION aws_conn
+  TO AWS (
+    ACCESS KEY ID = '${arg.aws-access-key-id}',
+    SECRET ACCESS KEY = SECRET aws_secret,
+    ENDPOINT = '${arg.aws-endpoint}',
+    REGION = 'us-east-1'
+  );
+
+# Test glob patterns.
+
+> CREATE TABLE t3 (a text, b text);
+
+> COPY INTO t3 FROM 's3://copytos3' (FORMAT CSV, AWS CONNECTION = aws_conn, PATTERN = "csv/**");
+
+> SELECT * FROM t3;
+bzip2 300
+bzip2 300
+gzip 200
+gzip 200
+none 100
+none 100
+xz 400
+xz 400
+zstd 500
+zstd 500
+
+# Test explicit file lists.
+
+> CREATE TABLE t4 (a text, b text);
+
+> COPY INTO t4 FROM 's3://copytos3/csv' (FORMAT CSV, AWS CONNECTION = aws_conn, FILES = ["csv/1.csv"]);
+
+> SELECT * FROM t4;
+none 100
+none 100


### PR DESCRIPTION
This PR adds support for specifying a column mapping and filling in default values for `COPY ... FROM <url>` (aka `OneshotSource`).

Let's say we ran `CREATE TABLE t1 (c1 text, c2 text, c3 text DEFAULT 'apple')`, so our table has 3 columns, but the file we're copying into Materialize only has 2 columns. After this PR you could run `COPY INTO t1 (c2, c1) FROM <url>` and it would map the first column of the data to `t1.c2`, the second column to `t1.c1`, and it would fill in the default value of `'apple'` for all values in `t1.c3`.

We do this by planning a `MapFilterProject`, converting it into a `SafeMfpPlan`, and then in `clusterd` when decoding data evaluating the `SafeMfpPlan` for every row.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/8858

### Tips for reviewer

There are no tests in this PR, they are included as part of https://github.com/MaterializeInc/materialize/pull/31581

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
