### PR TITLE
ci: Only run terraform tests in Nightly for now

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -742,51 +742,6 @@ steps:
       queue: hetzner-aarch64-4cpu-8gb
     skip: "Version upgrade skips are allowed for LTS releases now"
 
-  - group: E2E
-    key: e2e
-    steps:
-    - id: terraform-aws
-      label: "Terraform + Helm Chart E2E on AWS"
-      artifact_paths: [test/terraform/aws/terraform.tfstate]
-      depends_on: build-aarch64
-      timeout_in_minutes: 1200
-      concurrency: 1
-      concurrency_group: 'terraform-aws'
-      agents:
-        queue: linux-aarch64-small
-      plugins:
-        - ./ci/plugins/scratch-aws-access: ~
-        - ./ci/plugins/mzcompose:
-            composition: terraform
-            run: aws-temporary
-      # same test runs in nightly on main
-      inputs:
-        - misc/helm-charts/
-        - src/orchestratord/
-        - test/terraform/
-      branches: "!main !v*.* !self-managed/v*"
-
-    - id: terraform-gcp
-      label: "Terraform + Helm Chart E2E on GCP"
-      artifact_paths: [test/terraform/aws/terraform.tfstate]
-      depends_on: build-aarch64
-      timeout_in_minutes: 1200
-      concurrency: 1
-      concurrency_group: 'terraform-gcp'
-      agents:
-        queue: linux-aarch64-small
-      plugins:
-        - ./ci/plugins/scratch-aws-access: ~
-        - ./ci/plugins/mzcompose:
-            composition: terraform
-            run: gcp-temporary
-      # same test runs in nightly on main
-      inputs:
-        - misc/helm-charts/
-        - src/orchestratord/
-        - test/terraform/
-      branches: "!main !v*.* !self-managed/v*"
-
   - id: deploy-website
     label: Deploy website
     depends_on: lint-docs


### PR DESCRIPTION
They are running too often in Tests pipeline, for example when ci/ or src/ changes. Will have to think if there is a clean way to fix

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
