### PR TITLE
ci: Bump parallelism for platform-checks in release qualification

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -324,7 +324,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
-        parallelism: 2
+        parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
           queue: hetzner-aarch64-16cpu-32gb
@@ -337,7 +337,7 @@ steps:
         label: "Checks backup + restore between the two manipulate()"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -349,7 +349,7 @@ steps:
         label: "Checks backup + restore after manipulate()"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -361,7 +361,7 @@ steps:
         label: "Checks + multiple backups/restores"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -373,7 +373,7 @@ steps:
         label: "Checks preflight-check and continue upgrade"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -385,7 +385,7 @@ steps:
         label: "Platform checks upgrade, restarting compute clusterd first"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -397,7 +397,7 @@ steps:
         label: "Platform checks upgrade, restarting compute clusterd last"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -409,7 +409,7 @@ steps:
         label: "Checks + kill storage clusterd"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -432,7 +432,7 @@ steps:
         label: "Checks + restart clusterd compute"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -444,7 +444,7 @@ steps:
         label: "Checks + DROP/CREATE replica"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           # Seems to require more memory on aarch64
           queue: hetzner-aarch64-16cpu-32gb
@@ -457,7 +457,7 @@ steps:
         label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
         timeout_in_minutes: 120
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/release-qualification/builds/748#01952cb8-b4e3-467e-8aea-cfc77dbf325e

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
