### PR TITLE
[poc] cluster/communication: turmoil test for create_sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,10 +5095,13 @@ dependencies = [
  "mz-cluster-client",
  "mz-ore",
  "mz-service",
+ "rand 0.8.5",
  "regex",
  "timely",
  "tokio",
  "tracing",
+ "tracing-subscriber",
+ "turmoil",
  "workspace-hack",
 ]
 
@@ -6134,6 +6137,7 @@ dependencies = [
  "tracing-capture",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "turmoil",
  "url",
  "uuid",
  "workspace-hack",
@@ -8954,6 +8958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11145,6 +11159,21 @@ dependencies = [
  "sha1",
  "thiserror 1.0.61",
  "utf-8",
+]
+
+[[package]]
+name = "turmoil"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4bf3407e4cded7fa5c1f8083ccc0f38fb58c2640ea3c45dacd26ee8b15a91d"
+dependencies = [
+ "bytes",
+ "indexmap 2.2.6",
+ "rand 0.8.5",
+ "rand_distr",
+ "scoped-tls",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -24,6 +24,12 @@ tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
+[dev-dependencies]
+mz-ore = { path = "../ore", features = ["turmoil"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
+tracing-subscriber = "0.3.19"
+turmoil = "0.6.5"
+
 [package.metadata.cargo-udeps.ignore]
 # only used on linux
 normal = ["inotify", "workspace-hack", "rocksdb"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -93,6 +93,7 @@ opentelemetry_sdk = { version = "0.24.1", features = [
 ], optional = true }
 console-subscriber = { version = "0.4.0", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
+turmoil = { version = "0.6.5", optional = true }
 yansi = { version = "0.5.1", optional = true }
 
 [dev-dependencies]

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -519,6 +519,7 @@ where
                 let path = addr.as_pathname().unwrap().as_ref();
                 builder.server_addr(path)
             }
+            SocketAddr::Turmoil(_) => unimplemented!(),
         };
         Some(builder.spawn())
     } else {
@@ -618,6 +619,7 @@ where
         let endpoint = match console_config.listen_addr {
             SocketAddr::Inet(addr) => format!("http://{addr}"),
             SocketAddr::Unix(addr) => format!("file://localhost{addr}"),
+            SocketAddr::Turmoil(_) => unimplemented!(),
         };
         tracing::info!("starting tokio console on {endpoint}");
     }

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -123,6 +123,7 @@ where
                     }))
                     .await?
             }
+            SocketAddrType::Turmoil => unimplemented!(),
         };
         let service = InterceptedService::new(channel, VersionAttachInterceptor::new(version));
         let mut client = BidiProtoClient::new(service, G::URL, metrics);


### PR DESCRIPTION
This PR adds a chaos simulation for `create_sockets` using the [turmoil](https://github.com/tokio-rs/turmoil) library. The test runs a number of processes and instructs them to connect to each other, while simulating multiple controller reconnects with increasing epochs.

Run the test once with `cargo test -p mz-cluster`. Or use it for fuzzing with `cargo test -p mz-cluster -- --ignored fuzz`.

Note that the test is currently unreliable. Dropping the `create_sockets` future in a process can make other processes hang attempting to connect to that process. It's unclear whether this is a bug in turmoil or something we should expect given the absence of network timeouts in `create_sockets`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
