### PR TITLE
build(deps): Downgrade pydantic again

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -41,7 +41,7 @@ psycopg==3.2.5
 psycopg-binary==3.2.5
 # pydantic >= 2.9 causes pdoc 15.0.1 to fail: UserWarning: Error parsing type annotation dict[str, Any] | None for pydantic.main.BaseModel.__pydantic_extra__: 'function' object is not subscriptable
 # See also https://github.com/mitmproxy/pdoc/issues/741
-pydantic==2.10.6
+pydantic==2.8.2
 pyelftools==0.32
 pyjwt==2.10.1
 PyMySQL==1.1.1

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -44,7 +44,7 @@ steps:
     key: linters
     steps:
       - id: closed-issues-detect
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         label: Detect references to already closed issues
         command: bin/ci-builder run stable bin/ci-closed-issues-detect
         depends_on: []
@@ -1513,7 +1513,7 @@ steps:
   - id: pubsub-disruption
     label: "PubSub disruption"
     depends_on: build-aarch64
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: hetzner-aarch64-8cpu-16gb
     plugins:
@@ -1524,7 +1524,7 @@ steps:
     label: "Check retain history"
     depends_on: build-aarch64
     skip: "database-issues#7310"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     agents:
       queue: hetzner-aarch64-8cpu-16gb
     plugins:
@@ -1845,7 +1845,7 @@ steps:
   - id: emulator
     label: Materialize Emulator
     depends_on: build-aarch64
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     plugins:
       - ./ci/plugins/mzcompose:
           composition: emulator
@@ -1883,7 +1883,7 @@ steps:
       - id: lang-csharp
         label: ":csharp: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         plugins:
           - ./ci/plugins/mzcompose:
               composition: csharp
@@ -1893,7 +1893,7 @@ steps:
       - id: lang-js
         label: ":js: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         plugins:
           - ./ci/plugins/mzcompose:
               composition: js
@@ -1903,7 +1903,7 @@ steps:
       - id: lang-java
         label: ":java: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         plugins:
           - ./ci/plugins/mzcompose:
               composition: java
@@ -1913,7 +1913,7 @@ steps:
       - id: lang-python
         label: ":python: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         plugins:
           - ./ci/plugins/mzcompose:
               composition: python
@@ -1923,7 +1923,7 @@ steps:
       - id: lang-ruby
         label: ":ruby: tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 20
+        timeout_in_minutes: 30
         plugins:
           - ./ci/plugins/mzcompose:
               composition: ruby


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/deploy/builds/17812#019536e9-5b47-431f-afe2-2bd10870dffe

I hope I have now managed to tell dependabot to stop trying to upgrade it
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
