### PR TITLE
ENABLE_LGALLOC_REGION static, not const

### DIFF
--- a/src/ore/src/region.rs
+++ b/src/ore/src/region.rs
@@ -20,7 +20,7 @@ use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
 /// Enable allocations through `new_auto` to use lgalloc. `new_mmap` will always use lgalloc.
-pub const ENABLE_LGALLOC_REGION: std::sync::atomic::AtomicBool =
+pub static ENABLE_LGALLOC_REGION: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 /// A region allocator which holds items at stable memory locations.


### PR DESCRIPTION
Const has the undesired effect that the atomic is not, contrary to the
intention, a global variable. Consts are inlined, and hence setting the
const to a value doesn't have much of an effect globally. Fix it by
declaring the variable _static_, which was the intention all along.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
