### PR TITLE
Fix `EXPLAIN` for constant views

### DIFF
--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -78,6 +78,8 @@ impl Optimize<HirRelationExpr> for Optimizer {
         // MIR ⇒ MIR optimization (local)
         let expr = if expr.as_const().is_some() {
             // No need to optimize further, because we already have a constant.
+            // But trace this at "local", so that `EXPLAIN LOCALLY OPTIMIZED PLAN` can pick it up.
+            trace_plan!(at: "local", &expr);
             OptimizedMirRelationExpr(expr)
         } else {
             // Call the real optimization.

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1309,7 +1309,7 @@ pub struct View {
     pub global_id: GlobalId,
     /// Unoptimized high-level expression from parsing the `create_sql`.
     pub raw_expr: Arc<HirRelationExpr>,
-    /// Optimized mid-level expression from optimizing the `raw_expr`.
+    /// Optimized mid-level expression from (locally) optimizing the `raw_expr`.
     pub optimized_expr: Arc<OptimizedMirRelationExpr>,
     /// Columns of this view.
     pub desc: RelationDesc,

--- a/test/sqllogictest/explain/locally_optimized_plan.slt
+++ b/test/sqllogictest/explain/locally_optimized_plan.slt
@@ -32,19 +32,6 @@ WHERE
 
 mode cockroach
 
-# Must explain the "Raw Plan".
-query T multiline
-EXPLAIN RAW PLAN FOR
-VIEW v;
-----
-Project (#0, #1, #3)
-  Filter (#1 = 100)
-    LeftOuterJoin (integer_to_bigint(#0) = #2)
-      Get materialize.public.accounts
-      Get materialize.public.account_details
-
-EOF
-
 # Must explain the "Locally Optimized Plan".
 query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR
@@ -158,7 +145,7 @@ FROM
 WHERE
   balance = 100;
 
-# Ensure that flag whas used during planning.
+# Ensure that flag was used during planning.
 query T multiline
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 VIEW v;

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1718,3 +1718,20 @@ Source materialize.public.t5
 Target cluster: no_replicas
 
 EOF
+
+# EXPLAIN statement without an explicit stage or format, so that we test the default
+# (Currently defaults to `EXPLAIN OPTIMIZED PLAN AS TEXT FOR`.)
+query T multiline
+EXPLAIN
+SELECT a+b FROM t4;
+----
+Explained Query:
+  Project (#3)
+    Map ((#0 + #1))
+      ReadStorage materialize.public.t4
+
+Source materialize.public.t4
+
+Target cluster: no_replicas
+
+EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -661,3 +661,32 @@ Return
 Target cluster: mz_catalog_server
 
 EOF
+
+statement ok
+CREATE TABLE accounts(id int, balance int);
+
+statement ok
+CREATE TABLE account_details(id bigint, address string);
+
+statement ok
+CREATE OR REPLACE VIEW v AS
+SELECT
+  *
+FROM
+  accounts a
+  LEFT JOIN account_details ad USING(id)
+WHERE
+  balance = 100;
+
+# Must explain the "Raw Plan".
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+VIEW v;
+----
+Project (#0, #1, #3)
+  Filter (#1 = 100)
+    LeftOuterJoin (integer_to_bigint(#0) = #2)
+      Get materialize.public.accounts
+      Get materialize.public.account_details
+
+EOF

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -220,3 +220,51 @@ Return
             Get l1
 
 EOF
+
+## Constant views
+## (Regression tests for https://github.com/MaterializeInc/database-issues/issues/8985 )
+
+statement ok
+CREATE VIEW v2 AS SELECT 1;
+
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+REPLAN VIEW v2
+----
+Constant
+  - (1)
+
+EOF
+
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+CREATE VIEW v3 AS SELECT 5;
+----
+Constant
+  - (5)
+
+EOF
+
+# LOCALLY OPTIMIZED PLAN FOR constant MV
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+CREATE MATERIALIZED VIEW v3 AS SELECT 5;
+----
+Constant
+  - (5)
+
+Target cluster: quickstart
+
+EOF
+
+# LOCALLY OPTIMIZED PLAN FOR constant peek
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+SELECT 5;
+----
+Constant
+  - (5)
+
+Target cluster: mz_catalog_server
+
+EOF


### PR DESCRIPTION
The first commit fixes `EXPLAIN LOCALLY OPTIMIZED PLAN` (https://github.com/MaterializeInc/database-issues/issues/8985).

The second commit renames `explain/view.slt` to `explain/locally_optimized_plan.slt`, because now the file is explaining not just views. Also, it moves out the one `EXPLAIN RAW PLAN` statement from it to `explain/raw_plan_as_text.slt`.

The third commit is somewhat unrelated: just adds a test for `EXPLAIN` without an explicit stage or format, so that we test the default. (Currently defaults to `EXPLAIN OPTIMIZED PLAN AS TEXT FOR`.) This is to prevent issues like the one fixed in https://github.com/MaterializeInc/materialize/pull/31482 (cc @def-, @mgree)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8985

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
