### PR TITLE
Refactor soft assertion enablement checks

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -14,7 +14,6 @@ use std::cmp::max;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
 use std::str::FromStr;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -23,7 +22,6 @@ use differential_dataflow::lattice::Lattice;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_audit_log::VersionedEvent;
-use mz_ore::assert::SOFT_ASSERTIONS;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::{
@@ -455,7 +453,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
 
         // This awkward code allows us to perform an expensive soft assert that requires cloning
         // `updates` twice, after `updates` has been consumed.
-        let contains_fence = if SOFT_ASSERTIONS.load(Ordering::Relaxed) {
+        let contains_fence = if mz_ore::assert::soft_assertions_enabled() {
             let updates: Vec<_> = updates.clone();
             let parsed_updates: Vec<_> = updates
                 .clone()

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -11,9 +11,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::atomic::Ordering;
 
-use mz_ore::assert::SOFT_ASSERTIONS;
 use mz_ore::soft_assert_eq_or_log;
 use mz_ore::str::{closure_to_display, separated, Indent, IndentLike, StrExt};
 use mz_repr::explain::text::DisplayText;
@@ -1058,7 +1056,7 @@ pub trait HumanizerMode: Sized + Clone {
     /// This will produce a [`HumanizerMode`] instance that redacts output in
     /// production deployments, but not in debug builds and in CI.
     fn default() -> Self {
-        let redacted = !SOFT_ASSERTIONS.load(Ordering::Relaxed);
+        let redacted = !mz_ore::assert::soft_assertions_enabled();
         Self::new(redacted)
     }
 

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -74,6 +74,7 @@ pub static SOFT_ASSERTIONS: AtomicBool = {
 pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);
 
 /// Returns if soft assertions are enabled.
+#[inline(always)]
 pub fn soft_assertions_enabled() -> bool {
     SOFT_ASSERTIONS.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -85,7 +86,7 @@ pub fn soft_assertions_enabled() -> bool {
 #[macro_export]
 macro_rules! soft_assert_no_log {
     ($cond:expr $(, $($arg:tt)+)?) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert!($cond$(, $($arg)+)?);
         }
     }}
@@ -98,7 +99,7 @@ macro_rules! soft_assert_no_log {
 #[macro_export]
 macro_rules! soft_assert_eq_no_log {
     ($cond:expr, $($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_eq!($cond, $($arg)+);
         }
     }}
@@ -111,7 +112,7 @@ macro_rules! soft_assert_eq_no_log {
 #[macro_export]
 macro_rules! soft_assert_ne_no_log {
     ($cond:expr, $($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_ne!($cond, $($arg)+);
         }
     }}
@@ -122,7 +123,7 @@ macro_rules! soft_assert_ne_no_log {
 #[macro_export]
 macro_rules! soft_assert_or_log {
     ($cond:expr, $($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert!($cond, $($arg)+);
         } else if !$cond {
             ::tracing::error!($($arg)+)
@@ -136,7 +137,7 @@ macro_rules! soft_assert_or_log {
 #[macro_export]
 macro_rules! soft_assert_eq_or_log {
     ($left:expr, $right:expr) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_eq!($left, $right);
         } else {
             // Borrowed from [`std::assert_eq`].
@@ -153,7 +154,7 @@ macro_rules! soft_assert_eq_or_log {
         }
     }};
     ($left:expr, $right:expr, $($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_eq!($left, $right, $($arg)+);
         } else {
             // Borrowed from [`std::assert_eq`].
@@ -177,7 +178,7 @@ macro_rules! soft_assert_eq_or_log {
 #[macro_export]
 macro_rules! soft_assert_ne_or_log {
     ($left:expr, $right:expr) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_ne!($left, $right);
         } else {
             // Borrowed from [`std::assert_ne`].
@@ -194,7 +195,7 @@ macro_rules! soft_assert_ne_or_log {
         }
     }};
     ($left:expr, $right:expr, $($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             assert_ne!($left, $right, $($arg)+);
         } else {
             // Borrowed from [`std::assert_ne`].
@@ -217,7 +218,7 @@ macro_rules! soft_assert_ne_or_log {
 #[macro_export]
 macro_rules! soft_panic_or_log {
     ($($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             panic!($($arg)+);
         } else {
             ::tracing::error!($($arg)+)
@@ -229,7 +230,7 @@ macro_rules! soft_panic_or_log {
 #[macro_export]
 macro_rules! soft_panic_no_log {
     ($($arg:tt)+) => {{
-        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+        if $crate::assert::soft_assertions_enabled() {
             panic!($($arg)+);
         }
     }}

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -14,7 +14,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -880,7 +879,7 @@ pub(crate) fn validate_schema<K: Codec, V: Codec>(
 ) {
     // Attempt to catch any bad schema usage in CI. This is probably too
     // expensive to run in prod.
-    if !mz_ore::assert::SOFT_ASSERTIONS.load(Ordering::Relaxed) {
+    if !mz_ore::assert::soft_assertions_enabled() {
         return;
     }
     let key_valid = K::validate(decoded_key, &stats_schemas.key);

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -37,9 +37,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::sync::atomic::Ordering;
 
-use mz_ore::assert::SOFT_ASSERTIONS;
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::{bracketed, separated, Indent};
 
@@ -208,7 +206,7 @@ impl Default for ExplainConfig {
     fn default() -> Self {
         Self {
             // Don't redact in debug builds and in CI.
-            redacted: !SOFT_ASSERTIONS.load(Ordering::Relaxed),
+            redacted: !mz_ore::assert::soft_assertions_enabled(),
             arity: false,
             cardinality: false,
             column_names: false,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -385,9 +385,6 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
     type Error = PlanError;
 
     fn try_from(mut v: ExplainPlanOptionExtracted) -> Result<Self, Self::Error> {
-        use mz_ore::assert::SOFT_ASSERTIONS;
-        use std::sync::atomic::Ordering;
-
         // If `WITH(raw)` is specified, ensure that the config will be as
         // representative for the original plan as possible.
         if v.raw {
@@ -397,7 +394,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
 
         // Certain config should default to be enabled in release builds running on
         // staging or prod (where SOFT_ASSERTIONS are turned off).
-        let enable_on_prod = !SOFT_ASSERTIONS.load(Ordering::Relaxed);
+        let enable_on_prod = !mz_ore::assert::soft_assertions_enabled();
 
         Ok(ExplainConfig {
             arity: v.arity.unwrap_or(enable_on_prod),


### PR DESCRIPTION
Recently, https://github.com/MaterializeInc/materialize/pull/31309 added a function for checking whether soft assertions are enabled, and called it in one place. There are many other places where we are doing the same check, so this PR modifies these places to also call this function.

I also added `#[inline(always)]` to `soft_assertions_enabled()` to avoid accidentally regressing performance by switching to function calls.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
