### PR TITLE
bump-version: Make sure correct helm-docs version is used

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -65,6 +65,18 @@ cargo update --workspace
 bin/bazel gen
 
 bin/helm-chart-version-bump "v$version"
+
+helm_docs_version=1.14.3
+if ! helm-docs --help > /dev/null; then
+    echo "helm-docs is currently not installed"
+    echo "Install helm-docs $helm_docs_version from https://github.com/norwoodj/helm-docs/releases/tag/v$helm_docs_version"
+    exit 1
+fi
+if [ "$(helm-docs --version)" != "helm-docs version $helm_docs_version" ]; then
+    echo "helm-docs is installed, but has wrong version: $(helm-docs --version)"
+    echo "Install helm-docs $helm_docs_version from https://github.com/norwoodj/helm-docs/releases/tag/v$helm_docs_version"
+    exit 1
+fi
 helm-docs misc/helm-charts
 
 if $commit; then


### PR DESCRIPTION
To prevent lints from failing

See https://materializeinc.slack.com/archives/CTESPM7FU/p1740412689912119 for context
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
