### PR TITLE
[storage] Fix and re-enable alter sink tests

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -823,6 +823,10 @@ class AlterKafkaSinkFromAction(Action):
                     if len(o.columns) == 1
                     and o.columns[0].data_type == old_object.columns[0].data_type
                 ]
+            elif sink.format in ["FORMAT JSON"]:
+                # We should be able to format all data types as JSON, and they have no
+                # particular backwards-compatiblility requirements.
+                objs = [o for o in exe.db.db_objects_without_views()]
             else:
                 # Avro schema migration checking can be quite strict, and we need to be not only
                 # compatible with the latest object's schema but all previous schemas.

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2293,7 +2293,7 @@ ddl_action_list = ActionList(
         # TODO: Reenable when database-issues#8813 is fixed.
         # (AlterTableAddColumnAction, 10),
         # TODO: Reenable when database-issues#8445 is fixed
-        # (AlterKafkaSinkFromAction, 8),
+        (AlterKafkaSinkFromAction, 8),
         # (TransactionIsolationAction, 1),
     ],
     autocommit=True,


### PR DESCRIPTION
From our docs:

> When using the Avro format with a schema registry, the generated Avro schema for the new relation must be compatible with the previously published schema. If that’s not the case, the ALTER SINK command will succeed, but the subsequent execution of the sink will result in errors and will not be able to make progress.

And the avro docs:

> [...] if both are records: the ordering of fields may be different: fields are matched by name.

So to check compatibility, we should check by name instead of by order.

### Motivation

Fixes: https://github.com/MaterializeInc/database-issues/issues/8445

### Tips for reviewer

I've opted out JSON from any checks, since I don't think any rules are enforced for that type of sink, and that should help get our test coverage up.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
