### PR TITLE
Add support for helm values files to bin/orchestratord

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -47,6 +47,7 @@ def main():
     parser_run = subparsers.add_parser("run")
     parser_run.add_argument("--dev", action="store_true")
     parser_run.add_argument("--namespace", default="materialize")
+    parser_run.add_argument("--values")
     parser_run.set_defaults(func=run)
 
     parser_reset = subparsers.add_parser("reset")
@@ -82,18 +83,19 @@ def run(args: argparse.Namespace):
         dev=args.dev,
         cluster=args.kind_cluster_name,
     )
-    subprocess.check_call(
-        [
-            "helm",
-            "install",
-            "orchestratord",
-            "misc/helm-charts/operator",
-            "--atomic",
-            f"--set=operator.image.tag={DEV_IMAGE_TAG}",
-            "--create-namespace",
-            f"--namespace={args.namespace}",
-        ]
-    )
+    helm_args = [
+        "helm",
+        "install",
+        "orchestratord",
+        "misc/helm-charts/operator",
+        "--atomic",
+        f"--set=operator.image.tag={DEV_IMAGE_TAG}",
+        "--create-namespace",
+        f"--namespace={args.namespace}",
+    ]
+    if args.values is not None:
+        helm_args.extend(["--values", args.values])
+    subprocess.check_call(helm_args)
 
 
 def reset(args: argparse.Namespace):


### PR DESCRIPTION
Add support for helm values files to bin/orchestratord.

### Motivation

  * This PR adds a feature that has not yet been specified.
Makes it easier to run orchestratord without needing to manually edit the helm values.yaml file. Instead, you can define the overrides in a separate yaml file.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
