### PR TITLE
canary-environment: index removed

### DIFF
--- a/test/canary-environment/models/loadgen/schema.yml
+++ b/test/canary-environment/models/loadgen/schema.yml
@@ -20,8 +20,9 @@ sources:
         data_tests:
           - makes_progress
       - name: sales_large
-        data_tests:
-          - makes_progress
+        # TODO: Reenable once we have the index for sales_large again, currently fails to rehydrate
+        #data_tests:
+        #  - makes_progress
       - name: sales_large_progress
         data_tests:
           - makes_progress


### PR DESCRIPTION
Related to https://materializeinc.slack.com/archives/C08AENAP691/p1740405815492579
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
