### PR TITLE
Fix EXPLAIN's humanization/redaction of the equivalences analysis

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -1095,6 +1095,15 @@ pub trait HumanizerMode: Sized + Clone {
             write!(f, "{}", datum)
         }
     }
+
+    /// Wrap the given `exprs` (with `cols`) into [`HumanizedExpr`] with the current `mode`.
+    fn seq<'i, T>(
+        &self,
+        exprs: &'i [T],
+        cols: Option<&'i Vec<String>>,
+    ) -> impl Iterator<Item = HumanizedExpr<'i, T, Self>> + Clone {
+        exprs.iter().map(move |expr| self.expr(expr, cols))
+    }
 }
 
 /// A [`HumanizerMode`] that is ambiguous but allows us to print valid SQL
@@ -1103,21 +1112,6 @@ pub trait HumanizerMode: Sized + Clone {
 /// The inner parameter is `true` iff literals should be redacted.
 #[derive(Debug, Clone)]
 pub struct HumanizedNotice(bool);
-
-impl HumanizedNotice {
-    // TODO: move to `HumanizerMode` once we start using a Rust version with the
-    // corresponding Rust stabilization issue:
-    //
-    // https://github.com/rust-lang/rust/pull/115822
-    pub fn seq<'i, T>(
-        &self,
-        exprs: &'i [T],
-        cols: Option<&'i Vec<String>>,
-    ) -> impl Iterator<Item = HumanizedExpr<'i, T, Self>> + Clone {
-        let mode = self.clone();
-        exprs.iter().map(move |expr| mode.expr(expr, cols))
-    }
-}
 
 impl HumanizerMode for HumanizedNotice {
     fn new(redacted: bool) -> Self {
@@ -1139,21 +1133,6 @@ impl HumanizerMode for HumanizedNotice {
 /// The inner parameter is `true` iff literals should be redacted.
 #[derive(Debug, Clone)]
 pub struct HumanizedExplain(bool);
-
-impl HumanizedExplain {
-    // TODO: move to `HumanizerMode` once we start using a Rust version with the
-    // corresponding Rust stabilization issue:
-    //
-    // https://github.com/rust-lang/rust/pull/115822
-    pub fn seq<'i, T>(
-        &self,
-        exprs: &'i [T],
-        cols: Option<&'i Vec<String>>,
-    ) -> impl Iterator<Item = HumanizedExpr<'i, T, Self>> + Clone {
-        let mode = self.clone();
-        exprs.iter().map(move |expr| mode.expr(expr, cols))
-    }
-}
 
 impl HumanizerMode for HumanizedExplain {
     fn new(redacted: bool) -> Self {

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -1297,7 +1297,7 @@ where
 /// Render a literal value represented as a single-element [`Row`] or an
 /// [`EvalError`].
 ///
-/// The default implemntation calls [`HumanizerMode::humanize_datum`] for
+/// The default implementation calls [`HumanizerMode::humanize_datum`] for
 /// the former and handles the error case (including redaction) directly for
 /// the latter.
 impl<'a, M> fmt::Display for HumanizedExpr<'a, Result<Row, EvalError>, M>

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -1203,12 +1203,12 @@ mod explain {
 
     use std::collections::BTreeMap;
 
-    use mz_expr::explain::ExplainContext;
+    use mz_expr::explain::{ExplainContext, HumanizedExplain, HumanizerMode};
     use mz_expr::MirRelationExpr;
     use mz_ore::stack::RecursionLimitError;
     use mz_repr::explain::{Analyses, AnnotatedPlan};
 
-    use crate::analysis::equivalences::Equivalences;
+    use crate::analysis::equivalences::{Equivalences, HumanizedEquivalenceClasses};
 
     // Analyses should have shortened paths when exported.
     use super::DerivedBuilder;
@@ -1346,7 +1346,12 @@ mod explain {
                 ) {
                     let analyses = annotations.entry(expr).or_default();
                     analyses.equivalences = Some(match equivs.as_ref() {
-                        Some(equivs) => equivs.to_string(),
+                        Some(equivs) => HumanizedEquivalenceClasses {
+                            equivalence_classes: equivs,
+                            cols: analyses.column_names.as_ref(),
+                            mode: HumanizedExplain::new(config.redacted),
+                        }
+                        .to_string(),
                         None => "<empty collection>".to_string(),
                     });
                 }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1626,6 +1626,31 @@ Target cluster: no_replicas
 
 EOF
 
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(EQUIVALENCES, HUMANIZED EXPRESSIONS) FOR
+SELECT *
+FROM t5, t6
+WHERE x = a AND b IN (8,9);
+----
+Explained Query:
+  Project (#0{x}..=#2{z}, #0{x}, #4{b}) // { equivs: "[[#0{x}, #3{x}], [false, (#0{x}) IS NULL, (#1{y}) IS NULL], [true, ((#4{b} = 8) OR (#4{b} = 9))]]" }
+    Join on=(#0{x} = #3{a}) type=differential // { equivs: "[[#0{x}, #3{a}], [false, (#0{x}) IS NULL, (#1{y}) IS NULL], [true, ((#4{b} = 8) OR (#4{b} = 9))]]" }
+      ArrangeBy keys=[[#0{x}]] // { equivs: "[[false, (#0{x}) IS NULL, (#1{y}) IS NULL]]" }
+        Filter (#0{x}) IS NOT NULL // { equivs: "[[false, (#0{x}) IS NULL, (#1{y}) IS NULL]]" }
+          ReadStorage materialize.public.t5 // { equivs: "[[false, (#1{y}) IS NULL]]" }
+      ArrangeBy keys=[[#0{a}]] // { equivs: "[[false, (#0{a}) IS NULL], [true, ((#1{b} = 8) OR (#1{b} = 9))]]" }
+        Filter ((#1{b} = 8) OR (#1{b} = 9)) // { equivs: "[[false, (#0{a}) IS NULL], [true, ((#1{b} = 8) OR (#1{b} = 9))]]" }
+          ReadStorage materialize.public.t6 // { equivs: "[[false, (#0{a}) IS NULL]]" }
+
+Source materialize.public.t5
+  filter=((#0{x}) IS NOT NULL)
+Source materialize.public.t6
+  filter=(((#1{b} = 8) OR (#1{b} = 9)))
+
+Target cluster: no_replicas
+
+EOF
+
 # `count(*)` is planned as `count(true)`. We take care in EXPLAIN to show `count(true)` as `count(*)` to avoid confusing
 # users.
 query T multiline

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -349,6 +349,57 @@ Target cluster: quickstart
 
 EOF
 
+# Test redaction with the equivalences analysis.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted, equivalences) AS TEXT FOR
+SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
+----
+Explained Query:
+  With
+    cte l0 =
+      Project (#0{a}, #1{b}) // { equivs: "[[█, (#0{a}) IS NULL]]" }
+        Join on=(#0{a} = #2{a}) type=differential // { equivs: "[[#0{a}, #2{a}], [█, (#0{a}) IS NULL]]" }
+          ArrangeBy keys=[[#0{a}]] // { equivs: "[]" }
+            ReadIndex on=t t_a_idx=[differential join] // { equivs: "[]" }
+          ArrangeBy keys=[[#0{a}]] // { equivs: "[[█, (#0{a}) IS NULL]]" }
+            Distinct project=[#0{a}] // { equivs: "[[█, (#0{a}) IS NULL]]" }
+              Project (#0{a}) // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                Filter (#0{a} < #1{a}) // { equivs: "[[█, (#0{a}) IS NULL, (#1{a}) IS NULL], [█, (#0{a} < #1{a})]]" }
+                  CrossJoin type=differential // { equivs: "[[█, (#1{a}) IS NULL]]" }
+                    ArrangeBy keys=[[]] // { equivs: "[]" }
+                      Distinct project=[#0{a}] // { equivs: "[]" }
+                        Project (#0{a}) // { equivs: "[]" }
+                          ReadIndex on=t t_a_idx=[*** full scan ***] // { equivs: "[]" }
+                    ArrangeBy keys=[[]] // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                      Project (#0{a}) // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                        ReadStorage materialize.public.mv // { equivs: "[[█, (#0{a}) IS NULL]]" }
+  Return // { equivs: "[[█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
+    Project (#0{a}, #1{b}) // { equivs: "[[█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
+      Join on=(#1{b} = #2{b}) type=differential // { equivs: "[[#1{b}, #2{b}], [█, (#0{a}) IS NULL, (#1{b}) IS NULL]]" }
+        ArrangeBy keys=[[#1{b}]] // { equivs: "[[█, (#0{a}) IS NULL]]" }
+          Get l0 // { equivs: "[[█, (#0{a}) IS NULL]]" }
+        ArrangeBy keys=[[#0{b}]] // { equivs: "[[█, (#0{b}) IS NULL]]" }
+          Distinct project=[#0{b}] // { equivs: "[[█, (#0{b}) IS NULL]]" }
+            Project (#0{b}) // { equivs: "[[█, (#0{b}) IS NULL]]" }
+              Filter (#0{b} > #1{b}) // { equivs: "[[█, (#0{b}) IS NULL, (#1{b}) IS NULL], [█, (#0{b} > #1{b})]]" }
+                CrossJoin type=differential // { equivs: "[]" }
+                  ArrangeBy keys=[[]] // { equivs: "[]" }
+                    Distinct project=[#0{b}] // { equivs: "[]" }
+                      Project (#1{b}) // { equivs: "[]" }
+                        Get l0 // { equivs: "[[█, (#0{a}) IS NULL]]" }
+                  ArrangeBy keys=[[]] // { equivs: "[]" }
+                    Project (#1{b}) // { equivs: "[]" }
+                      ReadStorage materialize.public.mv // { equivs: "[[█, (#0{a}) IS NULL]]" }
+
+Source materialize.public.mv
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***, differential join)
+
+Target cluster: quickstart
+
+EOF
+
 # Test outer joins (ON syntax).
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted) AS TEXT FOR


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/8987, by wiring up the humanization infrastructure to the printing of the `Equivalences` analysis. (Besides fixing the redaction issue, the humanization also adds column names when available.)

The first commit is a minor refactoring, and the second commit is the actual fix.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/8987

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
