### PR TITLE
persist: Cleanup some long enabled LD flags

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -80,7 +80,6 @@ def get_default_system_parameters(
         # Persist internals changes: advance coverage
         "persist_enable_arrow_lgalloc_noncc_sizes": "true",
         "persist_enable_s3_lgalloc_noncc_sizes": "true",
-        "persist_enable_one_alloc_per_request": "true",
         # -----
         # Others (ordered by name)
         "allow_real_time_recency": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1045,7 +1045,6 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_optimize_ignored_data_decode"] = (
             BOOLEAN_FLAG_VALUES
         )
-        self.flags_with_values["persist_write_diffs_sum"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_variadic_left_join_lowering"] = (
             BOOLEAN_FLAG_VALUES
         )

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -60,7 +60,7 @@ use crate::internal::metrics::{BatchWriteMetrics, Metrics, RetryMetrics, ShardMe
 use crate::internal::paths::{PartId, PartialBatchKey, WriterKey};
 use crate::internal::state::{
     BatchPart, HollowBatch, HollowBatchPart, HollowRun, HollowRunRef, ProtoInlineBatchPart,
-    RunMeta, RunOrder, RunPart, WRITE_DIFFS_SUM,
+    RunMeta, RunOrder, RunPart,
 };
 use crate::stats::{untrimmable_columns, STATS_BUDGET_BYTES, STATS_COLLECTION_ENABLED};
 use crate::{PersistConfig, ShardId};
@@ -350,7 +350,6 @@ pub struct BatchBuilderConfig {
     pub(crate) stats_collection_enabled: bool,
     pub(crate) stats_budget: usize,
     pub(crate) stats_untrimmable_columns: Arc<UntrimmableColumns>,
-    pub(crate) write_diffs_sum: bool,
     pub(crate) encoding_config: EncodingConfig,
     pub(crate) preferred_order: RunOrder,
     pub(crate) structured_encoding: bool,
@@ -484,7 +483,6 @@ impl BatchBuilderConfig {
             stats_collection_enabled: STATS_COLLECTION_ENABLED.get(value),
             stats_budget: STATS_BUDGET_BYTES.get(value),
             stats_untrimmable_columns: Arc::new(untrimmable_columns(value)),
-            write_diffs_sum: WRITE_DIFFS_SUM.get(value),
             encoding_config: EncodingConfig {
                 use_dictionary: ENCODING_ENABLE_DICTIONARY.get(value),
                 compression: CompressionFormat::from_str(&ENCODING_COMPRESSION_FORMAT.get(value)),
@@ -1367,7 +1365,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
             structured_key_lower,
             stats,
             ts_rewrite,
-            diffs_sum: cfg.write_diffs_sum.then_some(diffs_sum),
+            diffs_sum: Some(diffs_sum),
             format: Some(cfg.batch_columnar_format),
             schema_id,
             // Field has been deprecated but kept around to roundtrip state.

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -367,7 +367,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
         .add(&crate::internal::machine::RECORD_COMPACTIONS)
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
-        .add(&crate::internal::state::WRITE_DIFFS_SUM)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_DECODE)
         .add(&crate::project::OPTIMIZE_IGNORED_DATA_FETCH)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -320,7 +320,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
-        .add(&crate::batch::RECORD_SCHEMA_ID)
         .add(&crate::batch::STRUCTURED_ORDER)
         .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -88,12 +88,6 @@ pub(crate) const ROLLUP_THRESHOLD: Config<usize> = Config::new(
     "The number of seqnos between rollups.",
 );
 
-pub(crate) const WRITE_DIFFS_SUM: Config<bool> = Config::new(
-    "persist_write_diffs_sum",
-    true,
-    "CYA to skip writing the diffs_sum field on HollowBatchPart",
-);
-
 /// A token to disambiguate state commands that could not otherwise be
 /// idempotent.
 #[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -36,7 +36,6 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
-        .add(&crate::s3::ENABLE_ONE_ALLOC_PER_REQUEST)
 }
 
 /// Config for an implementation of [Blob].


### PR DESCRIPTION
This PR removes a few dyncfgs/LaunchDarkly flags that have been enabled for multiple months and are no longer needed.

### Motivation

Code cleanup

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
