### PR TITLE
self-managed-debug: Add port forwarding functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6761,6 +6761,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,6 +6763,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "tracing-subscriber",
  "workspace-hack",
 ]
 

--- a/src/self-managed-debug/Cargo.toml
+++ b/src/self-managed-debug/Cargo.toml
@@ -24,6 +24,7 @@ serde_yaml = "0.9.25"
 tokio = "1.38.0"
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "fmt"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/self-managed-debug/Cargo.toml
+++ b/src/self-managed-debug/Cargo.toml
@@ -15,13 +15,14 @@ chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 futures = "0.3.25"
 k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
-kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
+kube = { version = "0.92.1", default-features = false, features = ["client", "runtime"] }
 mz-build-info = { path = "../build-info" }
 mz-cloud-resources = { path = "../cloud-resources"}
 mz-ore = { path = "../ore", features = ["cli", "test"] }
 serde = "1.0.218"
 serde_yaml = "0.9.25"
 tokio = "1.38.0"
+tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/self-managed-debug/src/k8s_resource_dumper.rs
+++ b/src/self-managed-debug/src/k8s_resource_dumper.rs
@@ -40,6 +40,7 @@ use mz_cloud_resources::crd::gen::cert_manager::certificates::Certificate;
 use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 use mz_ore::task::JoinHandle;
 use serde::{de::DeserializeOwned, Serialize};
+use tracing::{error, info};
 
 use crate::Context;
 
@@ -83,7 +84,7 @@ where
             if let Some(namespace) = &self.namespace {
                 err_msg = format!("{} for namespace {}", err_msg, namespace);
             }
-            println!("{}", err_msg);
+            info!("{}", err_msg);
             return Ok(());
         }
         let file_path = format_resource_path(
@@ -111,7 +112,7 @@ where
                 serde_yaml::to_writer(&mut file, &item)?;
             }
 
-            println!("Exported {}", file_name.display());
+            info!("Exported {}", file_name.display());
         }
 
         Ok(())
@@ -119,7 +120,7 @@ where
 
     async fn dump(&self) {
         if let Err(e) = self._dump().await {
-            eprintln!("Failed to write k8s {}: {}", self.resource_type, e);
+            error!("Failed to write k8s {}: {}", self.resource_type, e);
         }
     }
 }
@@ -163,13 +164,13 @@ async fn _dump_k8s_pod_logs(
                 .await?;
 
             if logs.is_empty() {
-                eprintln!("No {} logs found for pod {}", suffix, pod_name);
+                error!("No {} logs found for pod {}", suffix, pod_name);
                 return Ok(());
             }
 
             let mut file = File::create(&file_name)?;
             file.write_all(logs.as_bytes())?;
-            println!("Exported {}", file_name.display());
+            info!("Exported {}", file_name.display());
 
             Ok(())
         }
@@ -177,10 +178,10 @@ async fn _dump_k8s_pod_logs(
         if let Err(e) = export_pod_logs(&pods, &pod_name, &file_path, true).await {
             match e.downcast_ref::<kube::Error>() {
                 Some(kube::Error::Api(e)) if e.code == 400 => {
-                    eprintln!("No previous logs available for pod {}", pod_name);
+                    error!("No previous logs available for pod {}", pod_name);
                 }
                 _ => {
-                    eprintln!(
+                    error!(
                         "Failed to export previous logs for pod {}: {}",
                         &pod_name, e
                     );
@@ -189,7 +190,7 @@ async fn _dump_k8s_pod_logs(
         }
 
         if let Err(e) = export_pod_logs(&pods, &pod_name, &file_path, false).await {
-            eprintln!("Failed to export current logs for pod {}: {}", &pod_name, e);
+            error!("Failed to export current logs for pod {}: {}", &pod_name, e);
         }
     }
     Ok(())
@@ -198,7 +199,7 @@ async fn _dump_k8s_pod_logs(
 /// Write k8s pod logs to a yaml file per pod.
 async fn dump_k8s_pod_logs(context: &Context, client: Client, namespace: &String) {
     if let Err(e) = _dump_k8s_pod_logs(context, client, namespace).await {
-        eprintln!("Failed to dump k8s pod logs: {}", e);
+        error!("Failed to dump k8s pod logs: {}", e);
     }
 }
 
@@ -325,7 +326,7 @@ where
         if let Some(namespace) = namespace {
             err_msg = format!("{} for namespace {}", err_msg, namespace);
         }
-        eprintln!("{}", err_msg);
+        error!("{}", err_msg);
         return Ok(());
     }
 
@@ -335,7 +336,7 @@ where
     let mut file = File::create(&file_name)?;
     file.write_all(&output.stdout)?;
 
-    println!("Exported {}", file_name.display());
+    info!("Exported {}", file_name.display());
 
     Ok(())
 }
@@ -351,7 +352,7 @@ where
 {
     mz_ore::task::spawn(|| "dump-kubectl-describe", async move {
         if let Err(e) = dump_kubectl_describe::<K>(&context, namespace.as_ref()).await {
-            eprintln!(
+            error!(
                 "Failed to dump kubectl describe for {}: {}",
                 K::plural(&()).into_owned(),
                 e

--- a/src/self-managed-debug/src/k8s_resource_dumper.rs
+++ b/src/self-managed-debug/src/k8s_resource_dumper.rs
@@ -341,6 +341,7 @@ where
 }
 
 /// Spawns a new task to run `kubectl describe` for a given resource type K and writes the output to a file.
+#[must_use]
 pub fn spawn_dump_kubectl_describe_process<K>(
     context: Context,
     namespace: Option<String>,

--- a/src/self-managed-debug/src/main.rs
+++ b/src/self-managed-debug/src/main.rs
@@ -216,12 +216,12 @@ async fn run(context: Context) -> Result<(), anyhow::Error> {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     }
 
-    // TODO: Use the forwarded port to dump the system catalog.
+    // TODO(debug_tool1): Use the forwarded port to dump the system catalog.
 
     // Wait for all the describe processes to finish.
     join_all(describe_handles).await;
 
-    // TODO: Compress files to ZIP
+    // TODO(debug_tool1): Compress files to ZIP
     Ok(())
 }
 

--- a/src/self-managed-debug/src/system_catalog_dumper.rs
+++ b/src/self-managed-debug/src/system_catalog_dumper.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use k8s_openapi::api::core::v1::Service;
 use kube::{Api, Client};
 use mz_ore::retry::{self, RetryResult};
-use mz_ore::task::{self, AbortOnDropHandle};
+use mz_ore::task::{self, JoinHandle};
 use tracing::{error, info};
 
 use crate::Args;
@@ -39,43 +39,74 @@ pub async fn get_sql_port_forwarding_info(
 ) -> Result<SqlPortForwardingInfo, anyhow::Error> {
     for namespace in &args.k8s_namespaces {
         let services: Api<Service> = Api::namespaced(client.clone(), namespace);
-        for service in services.list(&Default::default()).await? {
+
+        // If override for target service and port is provided, verify that the
+        // service exists and has the port.
+        let maybe_service_and_port_override = match (&args.sql_target_service, args.sql_target_port)
+        {
+            (Some(service), Some(port)) => Some((service, port)),
+            _ => None,
+        };
+
+        if let Some((service_override, port_override)) = maybe_service_and_port_override {
+            let service = services.get(service_override).await?;
             if let Some(spec) = service.spec {
-                if service.metadata.name.is_none() {
-                    continue;
-                }
-                let service_name = service.metadata.name.expect("checked above");
+                let contains_port = spec
+                    .ports
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|port_info| port_info.port == port_override);
 
-                for port_info in spec.ports.unwrap_or_default() {
-                    let port = port_info.port;
-                    // Look for port with the target port specified in the CLI
-                    if args.sql_target_port.is_some()
-                        && args.sql_target_port.expect("checked above") == port
-                    {
-                        return Ok(SqlPortForwardingInfo {
-                            namespace: namespace.clone(),
-                            service_name,
-                            target_port: port,
-                            local_port: args.sql_local_port.unwrap_or(port),
-                        });
-                    }
-
-                    // Look for port named "internal-sql" or similar
-                    // By default, we use the internal SQL port.
-                    if let Some(port_name) = port_info.name {
-                        if port_name.to_lowercase().contains("internal")
-                            && port_name.to_lowercase().contains("sql")
-                        {
-                            return Ok(SqlPortForwardingInfo {
-                                namespace: namespace.clone(),
-                                service_name,
-                                target_port: port,
-                                local_port: args.sql_local_port.unwrap_or(port),
-                            });
-                        }
-                    }
+                if contains_port {
+                    return Ok(SqlPortForwardingInfo {
+                        namespace: namespace.clone(),
+                        service_name: service_override.clone(),
+                        target_port: port_override,
+                        local_port: args.sql_local_port.unwrap_or(port_override),
+                    });
                 }
             }
+
+            return Err(anyhow::anyhow!(
+                "Service {} with port {} not found",
+                service_override,
+                port_override
+            ));
+        }
+        let services = services.list(&Default::default()).await?;
+        // Check if any service contains a port with name "internal-sql"
+        let maybe_port_info = services
+            .iter()
+            .filter_map(|service| {
+                let spec = service.spec.as_ref()?;
+                let service_name = service.metadata.name.as_ref()?;
+                Some((spec, service_name))
+            })
+            .flat_map(|(spec, service_name)| {
+                spec.ports
+                    .iter()
+                    .flatten()
+                    .map(move |port| (port, service_name))
+            })
+            .find_map(|(port_info, service_name)| {
+                if let Some(port_name) = &port_info.name {
+                    if port_name.to_lowercase().contains("internal")
+                        && port_name.to_lowercase().contains("sql")
+                    {
+                        return Some(SqlPortForwardingInfo {
+                            namespace: namespace.clone(),
+                            service_name: service_name.to_owned(),
+                            target_port: port_info.port,
+                            local_port: args.sql_local_port.unwrap_or(port_info.port),
+                        });
+                    }
+                }
+
+                None
+            });
+
+        if let Some(port_info) = maybe_port_info {
+            return Ok(port_info);
         }
     }
 
@@ -86,12 +117,14 @@ pub async fn get_sql_port_forwarding_info(
 /// The process will retry if the port-forwarding fails and
 /// will terminate once the port forwarding reaches the max number of retries.
 /// We retry since kubectl port-forward is flaky.
-#[must_use]
 pub fn spawn_sql_port_forwarding_process(
     port_forwarding_info: &SqlPortForwardingInfo,
-    k8s_context: Option<String>,
-) -> AbortOnDropHandle<()> {
+    args: &Args,
+) -> JoinHandle<()> {
     let port_forwarding_info = port_forwarding_info.clone();
+
+    let k8s_context = args.k8s_context.clone();
+    let local_address = args.sql_local_address.clone();
 
     task::spawn(|| "port-forwarding", async move {
         if let Err(err) = retry::Retry::default()
@@ -100,13 +133,17 @@ pub fn spawn_sql_port_forwarding_process(
                 let k8s_context = k8s_context.clone();
                 let namespace = port_forwarding_info.namespace.clone();
                 let service_name = port_forwarding_info.service_name.clone();
+                let local_address = local_address.clone();
                 let local_port = port_forwarding_info.local_port;
                 let target_port = port_forwarding_info.target_port;
+                let local_address_or_default =
+                    local_address.clone().unwrap_or("localhost".to_string());
 
                 info!(
-                    "Spawning port forwarding process for {} from ports {} -> {}",
-                    service_name, local_port, target_port
+                    "Spawning port forwarding process for {} from ports {}:{} -> {}",
+                    service_name, local_address_or_default, local_port, target_port
                 );
+
                 async move {
                     let port_arg_str = format!("{}:{}", &local_port, &target_port);
                     let service_name_arg_str = format!("services/{}", &service_name);
@@ -120,6 +157,10 @@ pub fn spawn_sql_port_forwarding_process(
 
                     if let Some(k8s_context) = &k8s_context {
                         args.extend(["--context", k8s_context]);
+                    }
+
+                    if let Some(local_address) = &local_address {
+                        args.extend(["--address", local_address]);
                     }
 
                     match tokio::process::Command::new("kubectl")
@@ -164,5 +205,4 @@ pub fn spawn_sql_port_forwarding_process(
             error!("{}", err);
         }
     })
-    .abort_on_drop()
 }

--- a/src/self-managed-debug/src/system_catalog_dumper.rs
+++ b/src/self-managed-debug/src/system_catalog_dumper.rs
@@ -21,6 +21,7 @@ use k8s_openapi::api::core::v1::Service;
 use kube::{Api, Client};
 use mz_ore::retry::{self, RetryResult};
 use mz_ore::task::{self, AbortOnDropHandle};
+use tracing::{error, info};
 
 use crate::Args;
 
@@ -102,7 +103,7 @@ pub fn spawn_sql_port_forwarding_process(
                 let local_port = port_forwarding_info.local_port;
                 let target_port = port_forwarding_info.target_port;
 
-                println!(
+                info!(
                     "Spawning port forwarding process for {} from ports {} -> {}",
                     service_name, local_port, target_port
                 );
@@ -140,7 +141,7 @@ pub fn spawn_sql_port_forwarding_process(
                                     ),
                                     String::from_utf8_lossy(&output.stderr)
                                 );
-                                eprintln!("{}", retry_err_msg);
+                                error!("{}", retry_err_msg);
 
                                 return RetryResult::RetryableErr(anyhow::anyhow!(retry_err_msg));
                             }
@@ -160,7 +161,7 @@ pub fn spawn_sql_port_forwarding_process(
             })
             .await
         {
-            eprintln!("{}", err);
+            error!("{}", err);
         }
     })
     .abort_on_drop()

--- a/src/self-managed-debug/src/system_catalog_dumper.rs
+++ b/src/self-managed-debug/src/system_catalog_dumper.rs
@@ -1,0 +1,167 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Dumps catalog information to files.
+
+use std::time::Duration;
+
+use k8s_openapi::api::core::v1::Service;
+use kube::{Api, Client};
+use mz_ore::retry::{self, RetryResult};
+use mz_ore::task::{self, AbortOnDropHandle};
+
+use crate::Args;
+
+#[derive(Debug, Clone)]
+pub struct SqlPortForwardingInfo {
+    pub namespace: String,
+    pub service_name: String,
+    pub target_port: i32,
+    pub local_port: i32,
+}
+
+pub async fn get_sql_port_forwarding_info(
+    client: &Client,
+    args: &Args,
+) -> Result<SqlPortForwardingInfo, anyhow::Error> {
+    for namespace in &args.k8s_namespaces {
+        let services: Api<Service> = Api::namespaced(client.clone(), namespace);
+        for service in services.list(&Default::default()).await? {
+            if let Some(spec) = service.spec {
+                if service.metadata.name.is_none() {
+                    continue;
+                }
+                let service_name = service.metadata.name.expect("checked above");
+
+                for port_info in spec.ports.unwrap_or_default() {
+                    let port = port_info.port;
+                    // Look for port with the target port specified in the CLI
+                    if args.sql_target_port.is_some()
+                        && args.sql_target_port.expect("checked above") == port
+                    {
+                        return Ok(SqlPortForwardingInfo {
+                            namespace: namespace.clone(),
+                            service_name,
+                            target_port: port,
+                            local_port: args.sql_local_port.unwrap_or(port),
+                        });
+                    }
+
+                    // Look for port named "internal-sql" or similar
+                    // By default, we use the internal SQL port.
+                    if let Some(port_name) = port_info.name {
+                        if port_name.to_lowercase().contains("internal")
+                            && port_name.to_lowercase().contains("sql")
+                        {
+                            return Ok(SqlPortForwardingInfo {
+                                namespace: namespace.clone(),
+                                service_name,
+                                target_port: port,
+                                local_port: args.sql_local_port.unwrap_or(port),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!("No SQL port forwarding info found"))
+}
+
+/// Spawns a port forwarding process for the given k8s service.
+/// The process will retry if the port-forwarding fails and
+/// will terminate once the port forwarding reaches the max number of retries.
+/// We retry since kubectl port-forward is flaky.
+#[must_use]
+pub fn spawn_sql_port_forwarding_process(
+    port_forwarding_info: &SqlPortForwardingInfo,
+    k8s_context: Option<String>,
+) -> AbortOnDropHandle<()> {
+    let port_forwarding_info = port_forwarding_info.clone();
+
+    task::spawn(|| "port-forwarding", async move {
+        if let Err(err) = retry::Retry::default()
+            .max_duration(Duration::from_secs(60))
+            .retry_async(|retry_state| {
+                let k8s_context = k8s_context.clone();
+                let namespace = port_forwarding_info.namespace.clone();
+                let service_name = port_forwarding_info.service_name.clone();
+                let local_port = port_forwarding_info.local_port;
+                let target_port = port_forwarding_info.target_port;
+
+                println!(
+                    "Spawning port forwarding process for {} from ports {} -> {}",
+                    service_name, local_port, target_port
+                );
+                async move {
+                    let port_arg_str = format!("{}:{}", &local_port, &target_port);
+                    let service_name_arg_str = format!("services/{}", &service_name);
+                    let mut args = vec![
+                        "port-forward",
+                        &service_name_arg_str,
+                        &port_arg_str,
+                        "-n",
+                        &namespace,
+                    ];
+
+                    if let Some(k8s_context) = &k8s_context {
+                        args.extend(["--context", k8s_context]);
+                    }
+
+                    match tokio::process::Command::new("kubectl")
+                        .args(args)
+                        // Silence stdout/stderr
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .kill_on_drop(true)
+                        .output()
+                        .await
+                    {
+                        Ok(output) => {
+                            if !output.status.success() {
+                                let retry_err_msg = format!(
+                                    "Failed to port-forward{}: {}",
+                                    retry_state.next_backoff.map_or_else(
+                                        || "".to_string(),
+                                        |d| format!(", retrying in {:?}", d)
+                                    ),
+                                    String::from_utf8_lossy(&output.stderr)
+                                );
+                                eprintln!("{}", retry_err_msg);
+
+                                return RetryResult::RetryableErr(anyhow::anyhow!(retry_err_msg));
+                            }
+                        }
+                        Err(err) => {
+                            return RetryResult::RetryableErr(anyhow::anyhow!(
+                                "Failed to port-forward: {}",
+                                err
+                            ));
+                        }
+                    }
+                    // The kubectl subprocess's future will only resolve on error, thus the
+                    // code here is unreachable. We return RetryResult::Ok to satisfy
+                    // the type checker.
+                    RetryResult::Ok(())
+                }
+            })
+            .await
+        {
+            eprintln!("{}", err);
+        }
+    })
+    .abort_on_drop()
+}


### PR DESCRIPTION
- Add `system_catalog_dumper.rs` module for internal SQL port forwarding
- Update `Cargo.toml` to include `tokio-postgres`
- Modify `main.rs` to include new command-line arguments and initial port forwarding call
- Implement `spawn_internal_sql_port_forwarding_process` function for Kubernetes port forwarding

TODO: Spawn tasks to scrape the catalog using tokio-postgres
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/8908

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
