### PR TITLE
platform-checks: Bump sleep duration in ALTER SINK ... SET FROM

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1174,7 +1174,7 @@ class AlterSinkPgSource(Check):
                 > ALTER SINK sink_alter_pg SET FROM pg2;
 
                 # Wait for the actual restart to have occurred before inserting
-                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=20s
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=30s
 
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO pg_table2 VALUES (2);
@@ -1192,7 +1192,7 @@ class AlterSinkPgSource(Check):
                 > ALTER SINK sink_alter_pg SET FROM pg3;
 
                 # Wait for the actual restart to have occurred before inserting
-                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=20s
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=30s
 
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO pg_table3 VALUES (3);


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/nightly/builds/11269#01953fab-4258-4a58-a258-8b4c79fecfa7

@petrosagg @bkirwi  I feel like there should be a better way to check that we have cut over, just sleeping longer and longer will make our tests run slow, and still flaky.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
