### PR TITLE
Fix HIR explain's `count(*)` handling

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3336,15 +3336,10 @@ impl AggregateExpr {
     /// COUNT(*) to COUNT(true), making it indistinguishable from
     /// literal COUNT(true), but we prefer to consider this as the
     /// former.
+    ///
+    /// (HIR has the same `is_count_asterisk`.)
     pub fn is_count_asterisk(&self) -> bool {
-        match self {
-            AggregateExpr {
-                func: AggregateFunc::Count,
-                expr,
-                distinct: false,
-            } => expr.is_literal_true(),
-            _ => false,
-        }
+        self.func == AggregateFunc::Count && self.expr.is_literal_true() && !self.distinct
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3049,7 +3049,7 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!() => Operation::nullary(|_ecx| {
                 // COUNT(*) is equivalent to COUNT(true).
                 // This is mirrored in `AggregateExpr::is_count_asterisk`, so if you modify this,
-                // then attend to that code also.
+                // then attend to that code also (in both HIR and MIR).
                 Ok((HirScalarExpr::literal_true(), AggregateFunc::Count))
             }) => Int64, 2803;
             params!(Any) => AggregateFunc::Count => Int64, 2147;

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -3504,21 +3504,14 @@ impl AggregateExpr {
         self.func.output_type(self.expr.typ(outers, inner, params))
     }
 
+    /// Returns whether the expression is COUNT(*) or not.  Note that
+    /// when we define the count builtin in sql::func, we convert
+    /// COUNT(*) to COUNT(true), making it indistinguishable from
+    /// literal COUNT(true), but we prefer to consider this as the
+    /// former.
+    ///
+    /// (MIR has the same `is_count_asterisk`.)
     pub fn is_count_asterisk(&self) -> bool {
-        // This could be much less cumbersome if box/deref pattern
-        // syntax were stable: <https://github.com/rust-lang/rust/issues/29641>
-        if self.func != AggregateFunc::Count || self.distinct {
-            return false;
-        }
-        match &*self.expr {
-            HirScalarExpr::Literal(
-                row,
-                mz_repr::ColumnType {
-                    scalar_type: mz_repr::ScalarType::Bool,
-                    nullable: false,
-                },
-            ) => row.unpack_first() == mz_repr::Datum::True,
-            _ => false,
-        }
+        self.func == AggregateFunc::Count && self.expr.is_literal_true() && !self.distinct
     }
 }

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -3507,7 +3507,7 @@ impl AggregateExpr {
     pub fn is_count_asterisk(&self) -> bool {
         // This could be much less cumbersome if box/deref pattern
         // syntax were stable: <https://github.com/rust-lang/rust/issues/29641>
-        if self.func != AggregateFunc::Count {
+        if self.func != AggregateFunc::Count || self.distinct {
             return false;
         }
         match &*self.expr {

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -690,3 +690,55 @@ Project (#0, #1, #3)
       Get materialize.public.account_details
 
 EOF
+
+statement ok
+CREATE TABLE t5(
+    x int,
+    y int NOT NULL,
+    z int
+);
+
+# `count(*)` is planned as `count(true)`. We take care in EXPLAIN to show `count(true)` as `count(*)` to avoid confusing
+# users.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT count(*)
+FROM t5;
+----
+Reduce aggregates=[count(*)]
+  Get materialize.public.t5
+
+Target cluster: quickstart
+
+EOF
+
+query error DISTINCT \* not supported as function args
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT count(distinct *)
+FROM t5;
+
+# `count(true)` is currently also printed as `count(*)` in EXPLAIN, which I'd say is fine.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT count(true)
+FROM t5;
+----
+Reduce aggregates=[count(*)]
+  Get materialize.public.t5
+
+Target cluster: quickstart
+
+EOF
+
+# But `count(DISTINCT true)` means an entirely different thing, so EXPLAIN shouldn't conflate it with `count(*)`.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT count(DISTINCT true)
+FROM t5;
+----
+Reduce aggregates=[count(distinct true)]
+  Get materialize.public.t5
+
+Target cluster: quickstart
+
+EOF


### PR DESCRIPTION
Does the same for HIR as what https://github.com/MaterializeInc/materialize/pull/31402 did for MIR...

First commit just fixes the bug and adds tests, while the second commit is a minor refactoring to shorten the code and make it more uniform between HIR and MIR, and extend a comment to mention HIR.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
