### PR TITLE
k8s-orchestrator: create a StatefulSet per process

### DIFF
--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -153,7 +153,7 @@ is instantiated once per `pytest` invocation
 ```
 from materialize.cloudtest.util.wait import wait
 
-wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-u1-0")
+wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-gen-0-0")
 ```
 
 `wait` uses `kubectl wait` behind the scenes. Here is what the `kubectl wait`

--- a/misc/python/materialize/cloudtest/util/cluster.py
+++ b/misc/python/materialize/cloudtest/util/cluster.py
@@ -9,7 +9,7 @@
 
 
 def cluster_pod_name(cluster_id: str, replica_id: str, process: int = 0) -> str:
-    return f"pod/cluster-{cluster_id}-replica-{replica_id}-gen-0-{process}"
+    return f"pod/cluster-{cluster_id}-replica-{replica_id}-gen-0-{process}-0"
 
 
 def cluster_service_name(cluster_id: str, replica_id: str) -> str:

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -114,8 +114,8 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
     def get_replica() -> tuple[V1Pod, V1StatefulSet]:
         """Find the stateful set for the replica of the default cluster"""
-        compute_pod_name = "cluster-u1-replica-u1-gen-0-0"
-        ss_name = "cluster-u1-replica-u1-gen-0"
+        compute_pod_name = "cluster-u1-replica-u1-gen-0-0-0"
+        ss_name = "cluster-u1-replica-u1-gen-0-0"
         compute_pod = mz.environmentd.api().read_namespaced_pod(
             compute_pod_name, mz.environmentd.namespace()
         )

--- a/test/cloudtest/test_system_clusters.py
+++ b/test/cloudtest/test_system_clusters.py
@@ -31,5 +31,5 @@ def test_system_clusters(mz: MaterializeApplication) -> None:
     """Confirm that the system clusters have the expected labels and selectors"""
     mz.wait_replicas()
 
-    assert_pod_properties(mz, "cluster-s1-replica-s1-gen-0-0")
-    assert_pod_properties(mz, "cluster-s2-replica-s2-gen-0-0")
+    assert_pod_properties(mz, "cluster-s1-replica-s1-gen-0-0-0")
+    assert_pod_properties(mz, "cluster-s2-replica-s2-gen-0-0-0")


### PR DESCRIPTION
This PR changes the k8s orchestrator to create a separate statefulset for each process requested, instead of using a single statefulset with multiple replicas.

This is to allow us to supply different configurations to different cluster processes. In particular, we want to be able to provide each process with its index through a command line argument.

### Motivation

  * This PR refactors existing code.

Having the process ID as a command line argument to clusterd processes lets us use it for the Timely cluster initialization. See [thread](https://materializeinc.slack.com/archives/C08AENAP691/p1740413822244849) and [thread](https://materializeinc.slack.com/archives/CL68GT3AT/p1740572254878829).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
