### PR TITLE
self_hosted: Update Persist's list of `LTS_VERSIONS`

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -37,8 +37,10 @@ use crate::project::OPTIMIZE_IGNORED_DATA_DECODE;
 use crate::read::READER_LEASE_DURATION;
 
 const LTS_VERSIONS: &[Version] = &[
-    // 25.1
-    Version::new(0, 130, 0),
+    // 25.1.0
+    Version::new(0, 130, 1),
+    // 25.1.1
+    Version::new(0, 130, 3),
 ];
 
 /// The tunable knobs for persist.


### PR DESCRIPTION
While debugging a legacy upgrade test I noticed that Persist's list of `LTS_VERSIONS` does not match the [list we maintain in Python](https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/version_list.py#L30-L34). This PR updates Persist's list to match Python.

This difference could be intentional! In which case please ignore me :) But figured I would toss up this PR in case it's a bug.

### Motivation

Fix missing LTS version in Persist

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
