### PR TITLE
ci: Fix pydoc and make sure it doesn't break again

### DIFF
--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -31,4 +31,6 @@ try cargo --locked about generate ci/deploy/licenses.hbs > /dev/null
 
 try helm unittest misc/helm-charts/operator
 
+try bin/pydoc
+
 try_status_report

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 
-from materialize.zippy.all_actions import ValidateAll
+from materialize.zippy.all_actions import Action, ValidateAll  # noqa
 from materialize.zippy.backup_and_restore_actions import BackupAndRestore
 from materialize.zippy.balancerd_actions import (
     BalancerdRestart,
@@ -18,7 +18,7 @@ from materialize.zippy.balancerd_actions import (
 from materialize.zippy.blob_store_actions import BlobStoreRestart, BlobStoreStart
 from materialize.zippy.crdb_actions import CockroachRestart, CockroachStart
 from materialize.zippy.debezium_actions import CreateDebeziumSource, DebeziumStart
-from materialize.zippy.framework import ActionOrFactory
+from materialize.zippy.framework import ActionFactory, ActionOrFactory  # noqa
 from materialize.zippy.kafka_actions import (
     CreateTopicParameterized,
     Ingest,


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/deploy/builds/17842

It seems to be a pydoc bug, missing imports which aren't even required in the file

By running pydoc in the lints we will prevent this from happening in the future.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
