### PR TITLE
terraform test: Try bumping timeout for Azure

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -1354,7 +1354,7 @@ def workflow_azure_temporary(c: Composition, parser: WorkflowArgumentParser) -> 
                 raise ValueError("Never completed")
 
             # Can take a while for balancerd to come up
-            for i in range(240):
+            for i in range(600):
                 try:
                     status = spawn.capture(
                         [


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/nightly/builds/11319#0195466f-418c-438b-b846-4db74d9e605d

Logs indicate storage might not be ready yet:
> 2025-02-27T08:33:02.935514888Z {"timestamp":"2025-02-27T08:33:02.935388Z","level":"INFO","fields":{"message":"external operation consensus::open failed, retrying in 16s: indeterminate: error performing TLS handshake: unexpected EOF: self-signed certificate in certificate chain: unexpected EOF: self-signed certificate in certificate chain: unexpected EOF: error:80000002:system library:file_open:reason(2):providers/implementations/storemgmt/file_store.c:263:calling stat(/dev/shm/bazel-sandbox.1cdf88d3e065fde810147162da94bf638da928ae3ef64710600a4cb1f06f3ee2/processwrapper-sandbox/2753/execroot/__main__/bazel-out/aarch64-opt/bin/external/openssl/openssl.build_tmpdir/openssl/ssl/certs), error:80000002:system library:file_open:reason(2):providers/implementations/storemgmt/file_store.c:263:calling stat(/dev/shm/bazel-sandbox.1cdf88d3e065fde810147162da94bf638da928ae3ef64710600a4cb1f06f3ee2/processwrapper-sandbox/2753/execroot/__main__/bazel-out/aarch64-opt/bin/external/openssl/openssl.build_tmpdir/openssl/ssl/certs), error:80000002:system library:file_open:reason(2):providers/implementations/storemgmt/file_store.c:263:calling stat(/dev/shm/bazel-sandbox.1cdf88d3e065fde810147162da94bf638da928ae3ef64710600a4cb1f06f3ee2/processwrapper-sandbox/2753/execroot/__main__/bazel-out/aarch64-opt/bin/external/openssl/openssl.build_tmpdir/openssl/ssl/certs), error:80000002:system library:file_open:reason(2):providers/implementations/storemgmt/file_store.c:263:calling stat(/dev/shm/bazel-sandbox.1cdf88d3e065fde810147162da94bf638da928ae3ef64710600a4cb1f06f3ee2/processwrapper-sandbox/2753/execroot/__main__/bazel-out/aarch64-opt/bin/external/openssl/openssl.build_tmpdir/openssl/ssl/certs), error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2092:"},"target":"mz_persist_client::internal::machine","span":{"name":"environmentd::serve"},"spans":[{"name":"environmentd::run"},{"name":"environmentd::serve"}]}

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
