### PR TITLE
Update lgalloc to 0.5, expose new parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "lgalloc"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194eb6220fcd2399f0342d2e8e24b8d41e22e037b2f34b1d4cf7cfba228f8cc6"
+checksum = "76a3c66aab975ca357cdecbc25eb804168ff50a9242a3d03e6087c91f3824dd0"
 dependencies = [
  "crossbeam-deque",
  "libc",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -50,6 +50,41 @@ pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
 /// Enable lgalloc.
 pub const ENABLE_LGALLOC: Config<bool> = Config::new("enable_lgalloc", true, "Enable lgalloc.");
 
+/// Enable lgalloc's eager memory return/reclamation feature.
+pub const ENABLE_LGALLOC_EAGER_RECLAMATION: Config<bool> = Config::new(
+    "enable_lgalloc_eager_reclamation",
+    true,
+    "Enable lgalloc's eager return behavior.",
+);
+
+/// The interval at which the background thread wakes.
+pub const LGALLOC_BACKGROUND_INTERVAL: Config<Duration> = Config::new(
+    "lgalloc_background_interval",
+    Duration::from_secs(1),
+    "Scheduling interval for lgalloc's background worker.",
+);
+
+/// Enable lgalloc's eager memory return/reclamation feature.
+pub const LGALLOC_FILE_GROWTH_DAMPENER: Config<usize> = Config::new(
+    "lgalloc_file_growth_dampener",
+    0,
+    "Lgalloc's file growth dampener parameter.",
+);
+
+/// Enable lgalloc's eager memory return/reclamation feature.
+pub const LGALLOC_LOCAL_BUFFER_BYTES: Config<usize> = Config::new(
+    "lgalloc_local_buffer_bytes",
+    32 << 20,
+    "Lgalloc's local buffer bytes parameter.",
+);
+
+/// The bytes to reclaim (slow path) per size class, for each background thread activation.
+pub const LGALLOC_SLOW_CLEAR_BYTES: Config<usize> = Config::new(
+    "lgalloc_slow_clear_bytes",
+    32 << 20,
+    "Clear byte size per size class for every invocation",
+);
+
 /// Enable lgalloc for columnation.
 pub const ENABLE_COLUMNATION_LGALLOC: Config<bool> = Config::new(
     "enable_columnation_lgalloc",
@@ -62,13 +97,6 @@ pub const ENABLE_COLUMNAR_LGALLOC: Config<bool> = Config::new(
     "enable_columnar_lgalloc",
     true,
     "Enable allocating aligned regions in columnar from lgalloc.",
-);
-
-/// Enable lgalloc's eager memory return/reclamation feature.
-pub const ENABLE_LGALLOC_EAGER_RECLAMATION: Config<bool> = Config::new(
-    "enable_lgalloc_eager_reclamation",
-    true,
-    "Enable lgalloc's eager return behavior.",
 );
 
 /// The interval at which the compute server performs maintenance tasks.
@@ -95,20 +123,6 @@ pub const DATAFLOW_MAX_INFLIGHT_BYTES_CC: Config<Option<usize>> = Config::new(
     None,
     "The maximum number of in-flight bytes emitted by persist_sources feeding \
      compute dataflows in cc clusters.",
-);
-
-/// The interval at which the background thread wakes.
-pub const LGALLOC_BACKGROUND_INTERVAL: Config<Duration> = Config::new(
-    "lgalloc_background_interval",
-    Duration::from_secs(1),
-    "Scheduling interval for lgalloc's background worker.",
-);
-
-/// The bytes to reclaim (slow path) per size class, for each background thread activation.
-pub const LGALLOC_SLOW_CLEAR_BYTES: Config<usize> = Config::new(
-    "lgalloc_slow_clear_bytes",
-    32 << 20,
-    "Clear byte size per size class for every invocation",
 );
 
 /// The term `n` in the growth rate `1 + 1/(n + 1)` for `ConsolidatingVec`.
@@ -193,14 +207,16 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CORRECTION_V2)
         .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)
-        .add(&ENABLE_COLUMNATION_LGALLOC)
+        .add(&LGALLOC_BACKGROUND_INTERVAL)
+        .add(&LGALLOC_FILE_GROWTH_DAMPENER)
+        .add(&LGALLOC_LOCAL_BUFFER_BYTES)
+        .add(&LGALLOC_SLOW_CLEAR_BYTES)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
+        .add(&ENABLE_COLUMNATION_LGALLOC)
         .add(&ENABLE_COLUMNAR_LGALLOC)
         .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
-        .add(&LGALLOC_BACKGROUND_INTERVAL)
-        .add(&LGALLOC_SLOW_CLEAR_BYTES)
         .add(&HYDRATION_CONCURRENCY)
         .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
         .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -20,7 +20,7 @@ differential-dataflow = "0.13.6"
 differential-dogs3 = "0.1.6"
 futures = "0.3.25"
 itertools = "0.12.1"
-lgalloc = "0.4"
+lgalloc = "0.5"
 mz-cluster = { path = "../cluster" }
 mz-compute-client = { path = "../compute-client" }
 mz-compute-types = { path = "../compute-types" }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -272,12 +272,19 @@ impl ComputeState {
 
         if ENABLE_LGALLOC.get(config) {
             if let Some(path) = &self.context.scratch_directory {
-                let eager_return = ENABLE_LGALLOC_EAGER_RECLAMATION.get(config);
-                let interval = LGALLOC_BACKGROUND_INTERVAL.get(config);
                 let clear_bytes = LGALLOC_SLOW_CLEAR_BYTES.get(config);
+                let eager_return = ENABLE_LGALLOC_EAGER_RECLAMATION.get(config);
+                let file_growth_dampener = LGALLOC_FILE_GROWTH_DAMPENER.get(config);
+                let interval = LGALLOC_BACKGROUND_INTERVAL.get(config);
+                let local_buffer_bytes = LGALLOC_LOCAL_BUFFER_BYTES.get(config);
                 info!(
                     ?path,
-                    eager_return, backgrund_interval=?interval, clear_bytes, "enabling lgalloc"
+                    backgrund_interval=?interval,
+                    clear_bytes,
+                    eager_return,
+                    file_growth_dampener,
+                    local_buffer_bytes,
+                    "enabling lgalloc"
                 );
                 let background_worker_config = lgalloc::BackgroundWorkerConfig {
                     interval,
@@ -288,7 +295,9 @@ impl ComputeState {
                         .enable()
                         .with_path(path.clone())
                         .with_background_config(background_worker_config)
-                        .eager_return(eager_return),
+                        .eager_return(eager_return)
+                        .file_growth_dampener(file_growth_dampener)
+                        .local_buffer_bytes(local_buffer_bytes),
                 );
             } else {
                 debug!("not enabling lgalloc, scratch directory not specified");

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-lgalloc = "0.4"
+lgalloc = "0.5"
 libc = "0.2.170"
 mz-ore = { path = "../ore", features = ["metrics"] }
 paste = "1.0"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -33,7 +33,7 @@ flatcontainer = { version = "0.5.0", optional = true }
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
 itertools = "0.12.1"
-lgalloc = { version = "0.4", optional = true }
+lgalloc = { version = "0.5", optional = true }
 libc = { version = "0.2.170", optional = true }
 mz-ore-proc = { path = "../ore-proc", default-features = false }
 num = "0.4.3"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -18,7 +18,7 @@ columnation = "0.1.0"
 differential-dataflow = "0.13.6"
 either = "1"
 futures-util = "0.3.31"
-lgalloc = "0.4"
+lgalloc = "0.5"
 mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] }
 num-traits = "0.2"
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
Updates the lgalloc dependency to 0.5, and exposes lgalloc's new parameters
as dyncfgs. Specifically, it allows us to set the local_buffer_bytes and
the file_growth_dampener. The first is the size of the per-thread per-size-
class buffer, the second is a dampener controlling how files per size class
grow as we need more capacity.

The default values correspond to lgalloc's own defaults.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
