### PR TITLE
Bump k8s-controller to 0.4.0 and k8s-openapi feature to v1_30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,13 +3887,12 @@ dependencies = [
 
 [[package]]
 name = "k8s-controller"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5da4d3249c4ebd1e6de32134fb82a720db3e7a978ad38e576d64e6a22c6e308"
+checksum = "eb25ca386c8032623bce5240a949eccb1f90fb309ece7d98f74276196a55020d"
 dependencies = [
  "async-trait",
  "futures",
- "k8s-openapi",
  "kube",
  "kube-runtime",
  "rand 0.8.5",

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.95"
 chrono = { version = "0.4.39", default-features = false }
 futures = "0.3.25"
-k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_29"] }
+k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
 mz-ore = { path = "../ore", default-features = false }
 rand = "0.8.5"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -22,7 +22,7 @@ mz-orchestrator = { path = "../orchestrator", default-features = false }
 mz-ore = { path = "../ore", default-features = false, features = ["async"]  }
 mz-secrets = { path = "../secrets", default-features = false }
 mz-repr = { path = "../repr", default-features = false }
-k8s-openapi = { version = "0.22.0", features = ["v1_29"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.125"

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -17,8 +17,8 @@ chrono = { version = "0.4.39", default-features = false }
 clap = { version = "4.5.23", features = ["derive"] }
 futures = "0.3.25"
 http = "1.2.0"
-k8s-controller = "0.3.3"
-k8s-openapi = { version = "0.22.0", features = ["v1_29"] }
+k8s-controller = "0.4.0"
+k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 maplit = "1.0.2"
 mz-alloc = { path = "../alloc", default-features = false }

--- a/src/self-managed-debug/Cargo.toml
+++ b/src/self-managed-debug/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.66"
 chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 futures = "0.3.25"
-k8s-openapi = { version = "0.22.0", features = ["v1_29"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 mz-build-info = { path = "../build-info" }
 mz-cloud-resources = { path = "../cloud-resources"}

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -71,7 +71,7 @@ hyper-dff4ba8e3ae991db = { package = "hyper", version = "1.4.1", features = ["cl
 hyper-util = { version = "0.1.6", features = ["client-legacy", "server-auto", "service"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.41.1", features = ["json"] }
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_29"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
@@ -207,7 +207,7 @@ hyper-dff4ba8e3ae991db = { package = "hyper", version = "1.4.1", features = ["cl
 hyper-util = { version = "0.1.6", features = ["client-legacy", "server-auto", "service"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.41.1", features = ["json"] }
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_29"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_30"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }


### PR DESCRIPTION
Bump k8s-controller to 0.4.0 and k8s-openapi feature to v1_30

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

We're running Kubernetes 1.30 in production now, and 1.29 leaves support in a few days.

Version 0.4.0 of k8s-controller no longer depends directly on k8s-openapi, so allows us to independently update the k8s-openapi feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
