### PR TITLE
Add a bunch of tokio metrics to prometheus

### DIFF
--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -25,7 +25,7 @@ use mz_http_util::DynamicFilterTarget;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
-use mz_ore::metrics::MetricsRegistry;
+use mz_ore::metrics::{register_runtime_metrics, MetricsRegistry};
 use mz_ore::netio::{Listener, SocketAddr};
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
@@ -38,6 +38,7 @@ use mz_storage::storage_state::StorageInstanceContext;
 use mz_storage_client::client::proto_storage_server::ProtoStorageServer;
 use mz_storage_types::connections::ConnectionContext;
 use mz_txn_wal::operator::TxnsContext;
+use tokio::runtime::Handle;
 use tower::Service;
 use tracing::{error, info};
 
@@ -184,6 +185,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         .await?;
 
     let tracing_handle = Arc::new(tracing_handle);
+    register_runtime_metrics("main", Handle::current().metrics(), &metrics_registry);
 
     // Keep this _after_ the mz_ore::tracing::configure call so that its panic
     // hook runs _before_ the one that sends things to sentry.

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -54,7 +54,7 @@ use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs, TracingOrches
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::error::ErrorExt;
 use mz_ore::metric;
-use mz_ore::metrics::MetricsRegistry;
+use mz_ore::metrics::{register_runtime_metrics, MetricsRegistry};
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task::RuntimeExt;
 use mz_ore::url::SensitiveUrl;
@@ -724,6 +724,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         },
         metrics_registry.clone(),
     ))?;
+    register_runtime_metrics("main", runtime.metrics(), &metrics_registry);
 
     let span = tracing::info_span!("environmentd::run").entered();
 

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -86,7 +86,8 @@ impl PersistClientCache {
             Arc::clone(&state_cache),
             pubsub_client.receiver,
         );
-        let isolated_runtime = IsolatedRuntime::new(cfg.isolated_runtime_worker_threads);
+        let isolated_runtime =
+            IsolatedRuntime::new(registry, Some(cfg.isolated_runtime_worker_threads));
 
         PersistClientCache {
             cfg,

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -223,7 +223,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
             .await?;
 
             if force_downgrade_upper {
-                let isolated_runtime = Arc::new(IsolatedRuntime::default());
+                let isolated_runtime = Arc::new(IsolatedRuntime::new(&metrics_registry, None));
                 let pubsub_sender: Arc<dyn PubSubSender> = Arc::new(NoopPubSubSender);
                 let shared_states = Arc::new(StateCache::new(
                     &cfg,

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -647,7 +647,7 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
     let consensus =
         make_consensus(&cfg, &args.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
     let blob = make_blob(&cfg, &args.blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
-    let isolated_runtime = Arc::new(IsolatedRuntime::default());
+    let isolated_runtime = Arc::new(IsolatedRuntime::new(&metrics_registry, None));
     let state_cache = Arc::new(StateCache::new(
         &cfg,
         Arc::clone(&metrics),


### PR DESCRIPTION
Specifically:
- Capturing for both the "main" and isolated Persist runtimes. (Some other binaries use Tokio, but I think we only care for `envd` and `clusterd`, so I have left the others alone.)
- Capturing only metrics that boil down to a single u64, partly for convenience and partly to limit cardinality. This excludes a bunch of per-worker metrics and some histograms, both of which are possible to support with some slightly more invasive code. (Let me know if [anything I'm missing](https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html) seems worth the effort?)

### Motivation

https://github.com/MaterializeInc/incidents-and-escalations/issues/194

### Tips for reviewer

This crate exists: https://crates.io/crates/tokio-metrics-collector

This didn't seem substantial enough to warrant a dependency, and I'm unsure how well it would integrate with our existing stack, but it is an option!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
