### PR TITLE
sql: don't re-write `CAST`s to 'list's with the `::` operator

### DIFF
--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -57,7 +57,7 @@ pub trait AstInfo: Clone {
     /// The type used for cluster names.
     type ClusterName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for data types.
-    type DataType: AstDisplay + Clone + Hash + Debug + Eq + Ord;
+    type DataType: AstDataType + AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type stored next to CTEs for their assigned ID.
     type CteId: Clone + Hash + Debug + Eq + Ord;
     /// The type used for role references.
@@ -66,6 +66,11 @@ pub trait AstInfo: Clone {
     type NetworkPolicyName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// They type used for any object names. Objects are the superset of all objects in Materialize.
     type ObjectName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
+}
+
+pub trait AstDataType {
+    /// Returns whether or not this type is the Materialize `list` type.
+    fn is_list(&self) -> bool;
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
@@ -221,6 +226,12 @@ pub enum RawDataType {
         /// Typ modifiers appended to the type name, e.g. `numeric(38,0)`.
         typ_mod: Vec<i64>,
     },
+}
+
+impl AstDataType for RawDataType {
+    fn is_list(&self) -> bool {
+        matches!(self, RawDataType::List(_))
+    }
 }
 
 impl AstDisplay for RawDataType {

--- a/src/sql-parser/tests/testdata/list
+++ b/src/sql-parser/tests/testdata/list
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# While maybe unexpected, list[] gets parsed as an array<list> type.
+
+parse-statement
+SELECT foo::uuid list[2] FROM fake_table;
+----
+SELECT foo::uuid list[] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Identifier([Ident("foo")]), data_type: Array(List(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] })) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT CAST(my_json->>'field' AS uuid list)[my_index] FROM fake_table;
+----
+SELECT CAST(my_json ->> 'field' AS uuid list)[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Cast { expr: Op { op: Op { namespace: None, op: "->>" }, expr1: Identifier([Ident("my_json")]), expr2: Some(Value(String("field"))) }, data_type: List(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }) }, positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -25,7 +25,9 @@ use mz_repr::role_id::RoleId;
 use mz_repr::{CatalogItemId, GlobalId, RelationVersion};
 use mz_repr::{ColumnName, RelationVersionSelector};
 use mz_sql_parser::ast::visit_mut::VisitMutNode;
-use mz_sql_parser::ast::{CreateContinualTaskStatement, Expr, RawNetworkPolicyName, Version};
+use mz_sql_parser::ast::{
+    AstDataType, CreateContinualTaskStatement, Expr, RawNetworkPolicyName, Version,
+};
 use mz_sql_parser::ident;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -676,6 +678,12 @@ pub enum ResolvedDataType {
         print_id: bool,
     },
     Error,
+}
+
+impl AstDataType for ResolvedDataType {
+    fn is_list(&self) -> bool {
+        matches!(self, ResolvedDataType::AnonymousList(_))
+    }
 }
 
 impl AstDisplay for ResolvedDataType {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -3027,3 +3027,13 @@ query T
 SELECT LIST[1,3,7,NULL] @> LIST[1,3,7,NULL] AS contains;
 ----
 false
+
+# Make sure we can index into a CAST-ed list.
+
+statement ok
+CREATE TABLE json_list (payload jsonb, random_index int, random_id uuid);
+
+statement ok
+CREATE MATERIALIZED VIEW json_mv AS (
+    SELECT * FROM json_list WHERE random_id = CAST(payload->>'my_field' AS uuid list)[random_index]
+)


### PR DESCRIPTION
This PR changes our SQL rendering to use the standard SQL `CAST` expression when a cast involves the `list` type, instead of rewriting the expression to use the Postgres `::` operator.

```
-- For example consider the following expression:
CAST(<field> AS <type> list)[index]
-- Today get's re-written as:
(<field>)::<type> list[index]

-- these two expressions are not the same!
```

The rewrite to the Postgres operator was originally introduced in https://github.com/MaterializeInc/materialize/pull/3149

I went back and forth on a number of different solutions to fix this panic, and what's in this PR is sort of the least bad. My major gripe with this implementation is adding the `AstDataType` trait, it feels like it breaks the abstraction of `AstInfo::DataType`, but maybe this isn't too bad?

Other changes I tried:
1. Parsing `int list[]` as indexing into a list as opposed to the type `Array<List<int>>`. We already don't support arrays of lists, but this behavior felt like a very big change.
2. Supporting wrapping parens around the type, e.g. `(int list)`. Also not a bad solution but the parser impl wasn't too straight forward, and given the root cause was re-writing the `CAST` statements, this felt like a bit of a hack?
3. Wrapping the entire `::` expression in parens, e.g. `((<field>)::<type> list)[index]`. But this also changes the semantics a bit because now the expression provided to the subscript operator is a nested expression. Concretely going from text -> AST -> text -> AST failed to roundtrip AST.

### Motivation

A customer hit this panic in their environment.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
