### PR TITLE
ci: Bump all terraform versions

### DIFF
--- a/test/terraform/aws-persistent/main.tf
+++ b/test/terraform/aws-persistent/main.tf
@@ -27,7 +27,7 @@ variable "orchestratord_version" {
 }
 
 module "materialize_infrastructure" {
-  source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.2.5"
+  source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.2.7"
 
   # Basic settings
   namespace    = "aws-persistent"

--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -27,7 +27,7 @@ variable "orchestratord_version" {
 }
 
 module "materialize_infrastructure" {
-  source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.2.5"
+  source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.2.7"
 
   # Basic settings
   # The namespace and environment variables are used to construct the names of the resources

--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -34,9 +34,7 @@ resource "azurerm_resource_group" "materialize" {
 }
 
 module "materialize" {
-  # TODO: Use ref when v0.1.3 is released
-  # source = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=v0.1.3"
-  source = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=c751b1f1345c961156b9253622b27774dd1d8d93"
+  source = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=v0.1.4"
   resource_group_name = azurerm_resource_group.materialize.name
   location            = "eastus2"
   prefix              = "tf-test"

--- a/test/terraform/gcp-temporary/main.tf
+++ b/test/terraform/gcp-temporary/main.tf
@@ -24,7 +24,7 @@ provider "google" {
 }
 
 module "materialize" {
-  source = "github.com/MaterializeInc/terraform-google-materialize?ref=v0.1.1"
+  source = "github.com/MaterializeInc/terraform-google-materialize?ref=v0.1.7"
 
   project_id = var.project_id
   region     = var.region

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -1032,6 +1032,14 @@ def workflow_gcp_temporary(c: Composition, parser: WorkflowArgumentParser) -> No
         )
         time.sleep(10)
 
+        with psycopg.connect(
+            "postgres://mz_system:materialize@127.0.0.1:6877/materialize",
+            autocommit=True,
+        ) as conn:
+            with conn.cursor() as cur:
+                # Required for some testdrive tests
+                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)")
+
         with c.override(
             Testdrive(
                 materialize_url="postgres://materialize@127.0.0.1:6875/materialize",
@@ -1441,6 +1449,14 @@ def workflow_azure_temporary(c: Composition, parser: WorkflowArgumentParser) -> 
             env=venv_env,
         )
         time.sleep(10)
+
+        with psycopg.connect(
+            "postgres://mz_system:materialize@127.0.0.1:6877/materialize",
+            autocommit=True,
+        ) as conn:
+            with conn.cursor() as cur:
+                # Required for some testdrive tests
+                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)")
 
         with c.override(
             Testdrive(


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
