### PR TITLE
platform-checks: Try waiting longer in alter sink tests

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1202,6 +1202,9 @@ class AlterSinkPgSource(Check):
                 > SELECT COUNT(*) > ${running_count} FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'sink_alter_pg';
                 true
 
+                # Still needs to sleep some before the sink is updated
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="10s"
+
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO pg_table2 VALUES (2);
                 """,
@@ -1223,6 +1226,9 @@ class AlterSinkPgSource(Check):
 
                 > SELECT COUNT(*) > ${running_count} FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON mz_internal.mz_sink_status_history.sink_id = mz_sinks.id WHERE name = 'sink_alter_pg';
                 true
+
+                # Still needs to sleep some before the sink is updated
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="10s"
 
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO pg_table3 VALUES (3);


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11337#019549f8-14ed-4564-97cd-25993208f2be

@petrosagg Maybe this approach is not perfect somehow?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
