### PR TITLE
testdrive: Bump version for kafka-sink-multi-partition.td

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/kafka-sink-multi-partition.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-sink-multi-partition.td
@@ -14,7 +14,7 @@
 # Records are expected to be routed to the same partition, regardless of comment.
 
 $ skip-if
-SELECT mz_version_num() < 13300;
+SELECT mz_version_num() < 13400;
 
 $ kafka-create-topic topic=v1 partitions=100
 


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31463

Failed in https://buildkite.com/materialize/nightly/builds/11337#019549f8-14e1-4c1c-a3cb-750331f8518f

My interpretation is that the PR was merged too late and we were already on version 0.134.0-dev by that time, so it's expected for the test not to work when migrating from an older version. @martykulma Does this track?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
