### PR TITLE
Revert "build(deps): bump openssl-sys from 0.9.105 to 0.9.106"

### DIFF
--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -75,7 +75,7 @@ mz-tracing = { path = "../tracing", optional = true }
 nix = "0.26.1"
 num_cpus = "1.16.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
-openssl-sys = { version = "0.9.106", features = ["vendored"] }
+openssl-sys = { version = "0.9.80", features = ["vendored"] }
 opentelemetry = { version = "0.24.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
 pin-project = "1.1.9"

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -48,7 +48,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
-openssl-sys = { version = "0.9.106", features = ["vendored"] }
+openssl-sys = { version = "0.9.80", features = ["vendored"] }
 parquet = { version = "53.3.0", default-features = false, features = ["arrow", "brotli", "flate2", "snap", "lz4", "zstd"] }
 postgres-openssl = { version = "0.5.0" }
 postgres-protocol = { version = "0.6.5" }

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 openssl = { version = "0.10.48", features = ["vendored"] }
-openssl-sys = { version = "0.9.106", features = ["vendored"] }
+openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { version = "0.5.0" }
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
This reverts commit 9d8da1c6204d92fcc0fb45333f9960de70189fc2.

I'll check if this fixes https://github.com/MaterializeInc/database-issues/issues/8998
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
