### PR TITLE
sql: Wrap subscripted expression in parens when it ends with a type name

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1453,6 +1453,64 @@ SELECT MAP[1 => a, b => 1 + 2, a || 'b' => (SELECT 1), c => LIST[4, 5]]
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Map([MapEntry { key: Value(Number("1")), value: Identifier([Ident("a")]) }, MapEntry { key: Identifier([Ident("b")]), value: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) } }, MapEntry { key: Op { op: Op { namespace: None, op: "||" }, expr1: Identifier([Ident("a")]), expr2: Some(Value(String("b"))) }, value: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }) }, MapEntry { key: Identifier([Ident("c")]), value: List([Value(Number("4")), Value(Number("5"))]) }]), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# While maybe unexpected, list[] gets parsed as an array<list> type.
+
+parse-statement
+SELECT foo::uuid list[2] FROM fake_table;
+----
+SELECT foo::uuid list[] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Identifier([Ident("foo")]), data_type: Array(List(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] })) }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# Subscripting after a cast. The danger here is that if the cast is to list or array, then the subscript could melt into
+# the type as if it were creating an array type if the parser and/or AST printer is not careful.
+
+parse-statement
+SELECT CAST(my_json AS uuid list)[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid list)[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: List(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }) }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT CAST(my_json AS uuid[])[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid[])[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Array(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }) }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# This would not plan, because we are subscripting into a uuid, but it's still nice if it roundtrips through the parser.
+parse-statement
+SELECT CAST(my_json AS uuid)[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid)[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] } }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# Same as above, but with Postgres-style casts.
+
+parse-statement
+SELECT (my_json::uuid list)[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid list)[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: List(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }) }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT (my_json::uuid[])[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid[])[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Array(Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] }) }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# This would not plan, because we are subscripting into a uuid, but it's still nice if it roundtrips through the parser.
+parse-statement
+SELECT (my_json::uuid)[my_index] FROM fake_table;
+----
+SELECT (my_json::uuid)[my_index] FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] } }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -1450,3 +1450,13 @@ query T
 SELECT ARRAY[1,3,7,NULL] @> ARRAY[1,3,7,NULL] AS contains;
 ----
 false
+
+# Make sure we can index into a CAST-ed array.
+
+statement ok
+CREATE TABLE jsons (payload jsonb, random_index int, random_id uuid);
+
+statement ok
+CREATE MATERIALIZED VIEW json_mv AS (
+    SELECT * FROM jsons WHERE random_id = CAST(payload->>'my_field' AS uuid[])[random_index]
+)

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -3027,3 +3027,13 @@ query T
 SELECT LIST[1,3,7,NULL] @> LIST[1,3,7,NULL] AS contains;
 ----
 false
+
+# Make sure we can index into a CAST-ed list.
+
+statement ok
+CREATE TABLE jsons (payload jsonb, random_index int, random_id uuid);
+
+statement ok
+CREATE MATERIALIZED VIEW json_mv AS (
+    SELECT * FROM jsons WHERE random_id = CAST(payload->>'my_field' AS uuid list)[random_index]
+)


### PR DESCRIPTION
This is an alternative approach for solving the problem mentioned in https://github.com/MaterializeInc/materialize/pull/31696. The advantages of this approach are:
- Roundtrips through the parser even if the cast is not to a list or array type. [Details.](https://github.com/MaterializeInc/materialize/pull/31696/files#r1975213111)
- Does not break the abstraction of `AstInfo::DataType`. ([Breaking into `AstInfo::DataType` might be non-trivial for arrays.](https://github.com/MaterializeInc/materialize/pull/31696/files#r1975238697))
- Future-proof against the same problem occurring again if we add subscripting for more types at some point.
- ([The same approach can be used to solve the `needs_wrap` roundtripping problem](https://github.com/MaterializeInc/materialize/pull/31696/files#r1975321220) in a follow-up PR.)

Nightly: https://buildkite.com/materialize/nightly/builds/11348

### Motivation

[A customer encountered this.](https://materializeinc.slack.com/archives/C08ACQNGSQK/p1740675512403819?thread_ts=1740674779.093879&cid=C08ACQNGSQK)

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
