### PR TITLE
Disable lgalloc in sqllogictest

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -297,10 +297,12 @@ def main() -> int:
             if args.monitoring:
                 command += ["--opentelemetry-endpoint=http://localhost:4317"]
         elif args.program == "sqllogictest":
+            # sqllogictest creates the scratch directory in a tmpfs mount, which doesn't work well with lgalloc
+            # https://github.com/MaterializeInc/database-issues/issues/8989
             formatted_params = [
                 f"{key}={value}"
                 for key, value in get_default_system_parameters().items()
-            ]
+            ] + ["enable_lgalloc=false"]
             system_parameter_default = ";".join(formatted_params)
             # Connect to the database to ensure it exists.
             _connect_sql(args.postgres)

--- a/misc/python/materialize/mzcompose/services/sql_logic_test.py
+++ b/misc/python/materialize/mzcompose/services/sql_logic_test.py
@@ -31,8 +31,11 @@ class SqlLogicTest(Service):
         environment += [
             "MZ_SYSTEM_PARAMETER_DEFAULT="
             + ";".join(
-                f"{key}={value}"
-                for key, value in get_default_system_parameters().items()
+                [
+                    f"{key}={value}"
+                    for key, value in get_default_system_parameters().items()
+                ]
+                + ["enable_lgalloc=false"]
             )
         ]
 


### PR DESCRIPTION
Sqllogictest uses the temp directory to create the scratch directories. On
some Linux distributions, it's mounted as a tmpfs file system, which
apparently isn't 100% compatible with lgalloc. Until lgalloc supports it,
disable lgalloc in sqllogictest.

Fixes MaterializeInc/database-issues#8989

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
