### PR TITLE
Optimize some local crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,10 @@ gimli = { opt-level = 3 }
 miniz_oxide = { opt-level = 3 }
 object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
+timely = { opt-level = 3 }
+differential-dataflow = { opt-level = 3 }
+mz-compute = { opt-level = 3 }
+mz-transform = { opt-level = 3 }
 
 [profile.release]
 # Compile time seems similar to "lto = false", runtime ~10% faster


### PR DESCRIPTION
This doesn't seem to increase build times much, but comes with a dramatic
speed up of sqllogictest:

main:
```
bin/sqllogictest --build-only
	3677.11s user 382.87s system 1402% cpu 4:49.48 total
bin/sqllogictest test/sqllogictest/introspection
	1088.87s user 97.06s system 421% cpu 4:41.33 total
```

this:
```
bin/sqllogictest --build-only
	3906.03s user 390.20s system 1444% cpu 4:57.37 total
bin/sqllogictest test/sqllogictest/introspection
	206.07s user 5.38s system 260% cpu 1:21.13 total
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
