### PR TITLE
terraform: Use new version for Azure

### DIFF
--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_resource_group" "materialize" {
 }
 
 module "materialize" {
-  source = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=v0.1.4"
+  source = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=d348fea526ed9815451a4d27ccd312a61dc59f68"
   resource_group_name = azurerm_resource_group.materialize.name
   location            = "eastus2"
   prefix              = "tf-test"

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -133,6 +133,7 @@ def get_tag(tag: str) -> str:
 
 
 def mz_self_managed_debug(env: dict[str, str] | None = None) -> None:
+    print("-- Running self-managed-debug")
     run_ignore_error(
         [
             "cargo",


### PR DESCRIPTION
Might fix https://github.com/MaterializeInc/database-issues/issues/8998
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
