### PR TITLE
docs: Get errors in kubectl port-forward loop

### DIFF
--- a/doc/user/content/installation/install-on-aws.md
+++ b/doc/user/content/installation/install-on-aws.md
@@ -347,7 +347,7 @@ node instance type, etc.), see the
 
       ```shell
       while true;
-      do kubectl port-forward service/mzutd2fbabf5-console 8080:8080 -n materialize-environment 2>&1 |
+      do kubectl port-forward service/mzutd2fbabf5-console 8080:8080 -n materialize-environment 2>&1 | tee /dev/stderr |
       grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
       done;
       ```

--- a/doc/user/content/installation/install-on-azure.md
+++ b/doc/user/content/installation/install-on-azure.md
@@ -371,7 +371,7 @@ node instance type, etc.), see the
 
       ```shell
       while true;
-      do kubectl port-forward svc/mzl88mc8f6if-console 8080:8080 -n materialize-environment 2>&1 |
+      do kubectl port-forward svc/mzl88mc8f6if-console 8080:8080 -n materialize-environment 2>&1 | tee /dev/stderr |
       grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
       done;
       ```

--- a/doc/user/content/installation/install-on-gcp.md
+++ b/doc/user/content/installation/install-on-gcp.md
@@ -439,7 +439,7 @@ node instance type, etc.), see the
 
       ```shell
       while true;
-      do kubectl port-forward svc/mzpzk74xji8b-console 8080:8080 -n materialize-environment 2>&1 |
+      do kubectl port-forward svc/mzpzk74xji8b-console 8080:8080 -n materialize-environment 2>&1 | tee /dev/stderr |
       grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
       done;
       ```

--- a/doc/user/content/installation/install-on-local-kind.md
+++ b/doc/user/content/installation/install-on-local-kind.md
@@ -286,7 +286,7 @@ reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
 
       ```shell
       while true;
-      do kubectl port-forward svc/mz32bsnzerqo-console 8080:8080 -n materialize-environment 2>&1 |
+      do kubectl port-forward svc/mz32bsnzerqo-console 8080:8080 -n materialize-environment 2>&1 | tee /dev/stderr |
       grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
       done;
       ```

--- a/doc/user/content/installation/install-on-local-minikube.md
+++ b/doc/user/content/installation/install-on-local-minikube.md
@@ -291,7 +291,7 @@ reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
 
       ```shell
       while true;
-      do kubectl port-forward svc/mz10wiu7fyr7-console 8080:8080 -n materialize-environment 2>&1 |
+      do kubectl port-forward svc/mz10wiu7fyr7-console 8080:8080 -n materialize-environment 2>&1 | tee /dev/stderr |
       grep -q "portforward.go" && echo "Restarting port forwarding due to an error." || break;
       done;
       ```


### PR DESCRIPTION
Noted by Marty in https://materializeinc.slack.com/archives/C07PN7KSB0T/p1740756550623179?thread_ts=1740756449.640289&cid=C07PN7KSB0T
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
