### PR TITLE
kakfa-sink-multi-partition test should skip versions below 0.135

### DIFF
--- a/test/testdrive-old-kafka-src-syntax/kafka-sink-multi-partition.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-sink-multi-partition.td
@@ -14,7 +14,7 @@
 # Records are expected to be routed to the same partition, regardless of comment.
 
 $ skip-if
-SELECT mz_version_num() < 13400;
+SELECT mz_version_num() < 13500;
 
 $ kafka-create-topic topic=v1 partitions=100
 


### PR DESCRIPTION
The partition strategy changes are available starting v0.135, I thought they were already in.

### Motivation

fix the release

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
