### PR TITLE
[core] Conditionally compile unstable metrics

### DIFF
--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -801,30 +801,33 @@ pub fn register_runtime_metrics(
         global_queue_depth,
         "The number of tasks currently scheduled in the runtime's global queue."
     );
-    register!(
-        num_blocking_threads,
-        "The number of additional threads spawned by the runtime."
-    );
-    register!(
-        num_idle_blocking_threads,
-        "The number of idle threads which have spawned by the runtime for spawn_blocking calls."
-    );
-    register!(
-        spawned_tasks_count,
-        "The number of tasks spawned in this runtime since it was created."
-    );
-    register!(
-        remote_schedule_count,
-        "The number of tasks scheduled from outside of the runtime."
-    );
-    register!(
-        budget_forced_yield_count,
-        "The number of times that tasks have been forced to yield back to the scheduler after exhausting their task budgets."
-    );
-    register!(
-        blocking_queue_depth,
-        "The number of tasks currently scheduled in the blocking thread pool, spawned using spawn_blocking."
-    );
+    #[cfg(tokio_unstable)]
+    {
+        register!(
+            num_blocking_threads,
+            "The number of additional threads spawned by the runtime."
+        );
+        register!(
+            num_idle_blocking_threads,
+            "The number of idle threads which have spawned by the runtime for spawn_blocking calls."
+        );
+        register!(
+            spawned_tasks_count,
+            "The number of tasks spawned in this runtime since it was created."
+        );
+        register!(
+            remote_schedule_count,
+            "The number of tasks scheduled from outside of the runtime."
+        );
+        register!(
+            budget_forced_yield_count,
+            "The number of times that tasks have been forced to yield back to the scheduler after exhausting their task budgets."
+        );
+        register!(
+            blocking_queue_depth,
+            "The number of tasks currently scheduled in the blocking thread pool, spawned using spawn_blocking."
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

Make local dev a little easier, if a bit less representative.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
