### PR TITLE
[parser] Refactor the handling of complex expressions in casts

### DIFF
--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -324,7 +324,7 @@ http
 {"queries":[{"query":"select $1+$2::int as col","params":["1"]}]}
 ----
 200 OK
-{"results":[{"error":{"message":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2","code":"XX000"},"notices":[]}]}
+{"results":[{"error":{"message":"request supplied 1 parameters, but SELECT $1 + $2::int4 AS col requires 2","code":"XX000"},"notices":[]}]}
 
 # NaN
 http

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -122,7 +122,7 @@ ws-text
 {"queries": [{"query": "select $1::int", "params": []}]}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT ($1)::int4 requires 1","code":"XX000"}}
+{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT $1::int4 requires 1","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -321,34 +321,7 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 }
             }
             Expr::Cast { expr, data_type } => {
-                // We are potentially rewriting an expression like
-                //     CAST(<expr> OP <expr> AS <type>)
-                // to
-                //     <expr> OP <expr>::<type>
-                // which could incorrectly change the meaning of the expression
-                // as the `::` binds tightly. To be safe, we wrap the inner
-                // expression in parentheses
-                //    (<expr> OP <expr>)::<type>
-                // unless the inner expression is of a type that we know is
-                // safe to follow with a `::` to without wrapping.
-                let needs_wrap = !matches!(
-                    **expr,
-                    Expr::Nested(_)
-                        | Expr::Value(_)
-                        | Expr::Cast { .. }
-                        | Expr::Function { .. }
-                        | Expr::Identifier { .. }
-                        | Expr::Collate { .. }
-                        | Expr::HomogenizingFunction { .. }
-                        | Expr::NullIf { .. }
-                );
-                if needs_wrap {
-                    f.write_str('(');
-                }
                 f.write_node(&expr);
-                if needs_wrap {
-                    f.write_str(')');
-                }
                 f.write_str("::");
                 f.write_node(data_type);
             }

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -94,6 +94,17 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                         );
                     }
                 }
+
+                // Also check that the redacted version of the statement can be reparsed. This is
+                // important so that we are still able to pretty-print redacted statements, which
+                // helps during debugging.
+                let redacted = stmt.to_ast_string_redacted();
+                let res = parser::parse_statements(&redacted);
+                assert!(
+                    res.is_ok(),
+                    "redacted statement could not be reparsed: {res:?}\noriginal:\n{stmt}\nredacted:\n{redacted}"
+                );
+
                 if tc.args.contains_key("roundtrip") {
                     format!("{}\n", stmt)
                 } else {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -888,10 +888,38 @@ impl<'a> Parser<'a> {
         self.expect_keyword(AS)?;
         let data_type = self.parse_data_type()?;
         self.expect_token(&Token::RParen)?;
-        Ok(Expr::Cast {
-            expr: Box::new(expr),
-            data_type,
-        })
+        // We are potentially rewriting an expression like
+        //     CAST(<expr> OP <expr> AS <type>)
+        // to
+        //     <expr> OP <expr>::<type>
+        // (because we print Expr::Cast always as a Postgres-style cast, i.e. `::`)
+        // which could incorrectly change the meaning of the expression
+        // as the `::` binds tightly. To be safe, we wrap the inner
+        // expression in parentheses
+        //    (<expr> OP <expr>)::<type>
+        // unless the inner expression is of a kind that we know is
+        // safe to follow with a `::` without wrapping.
+        if !matches!(
+            expr,
+            Expr::Nested(_)
+                | Expr::Value(_)
+                | Expr::Cast { .. }
+                | Expr::Function { .. }
+                | Expr::Identifier { .. }
+                | Expr::Collate { .. }
+                | Expr::HomogenizingFunction { .. }
+                | Expr::NullIf { .. }
+        ) {
+            Ok(Expr::Cast {
+                expr: Box::new(Expr::Nested(Box::new(expr))),
+                data_type,
+            })
+        } else {
+            Ok(Expr::Cast {
+                expr: Box::new(expr),
+                data_type,
+            })
+        }
     }
 
     /// Parse a SQL EXISTS expression e.g. `WHERE EXISTS(SELECT ...)`.

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -910,6 +910,7 @@ impl<'a> Parser<'a> {
                 | Expr::HomogenizingFunction { .. }
                 | Expr::NullIf { .. }
                 | Expr::Subquery { .. }
+                | Expr::Parameter(..)
         ) {
             Ok(Expr::Cast {
                 expr: Box::new(Expr::Nested(Box::new(expr))),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -909,6 +909,7 @@ impl<'a> Parser<'a> {
                 | Expr::Collate { .. }
                 | Expr::HomogenizingFunction { .. }
                 | Expr::NullIf { .. }
+                | Expr::Subquery { .. }
         ) {
             Ok(Expr::Cast {
                 expr: Box::new(Expr::Nested(Box::new(expr))),

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -37,31 +37,8 @@ use mz_sql_parser::parser::{
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn datadriven() {
     walk("tests/testdata", |f| {
-        f.run(|tc| -> String {
-            if tc.directive == "parse-statement" {
-                // Verify that redacted statements can be parsed. This is important so that we are
-                // still able to pretty-print redacted statements which helps out during debugging.
-                verify_parse_redacted(&tc.input);
-            }
-            datadriven_testcase(tc)
-        })
+        f.run(|tc| -> String { datadriven_testcase(tc) })
     });
-}
-
-fn verify_parse_redacted(stmt: &str) {
-    let stmt = match parse_statements(stmt) {
-        Ok(stmt) => match stmt.into_iter().next() {
-            Some(stmt) => stmt.ast,
-            None => return,
-        },
-        Err(_) => return,
-    };
-    let redacted = stmt.to_ast_string_redacted();
-    let res = parse_statements(&redacted);
-    assert!(
-        res.is_ok(),
-        "redacted statement could not be parsed: {res:?}\noriginal:\n{stmt}\nredacted:\n{redacted}"
-    );
 }
 
 #[mz_ore::test]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1534,6 +1534,56 @@ SELECT round(1.5678, (SELECT n FROM nums)::int4)
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("round")])), args: Args { args: [Value(Number("1.5678")), Cast { expr: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("n")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("nums")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# Prepared statement parameter handling in casts. (Note: some extra wrapping parens here are currently not removed.)
+parse-statement
+select $2::int as col
+----
+SELECT $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select CAST($2 AS int) as col
+----
+SELECT $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select $1 + ($2)::int as col
+----
+SELECT $1 + ($2)::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Cast { expr: Nested(Parameter(2)), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }) }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select $1 + $2::int as col
+----
+SELECT $1 + $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }) }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ($1 + $2)::int as col
+----
+SELECT ($1 + $2)::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Parameter(2)) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ((($1)))::int as col
+----
+SELECT ((($1)))::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Nested(Nested(Parameter(1)))), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ((($1 + $2)))::int as col
+----
+SELECT ((($1 + $2)))::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Nested(Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Parameter(2)) }))), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1524,6 +1524,16 @@ SELECT (a + b)::int4 FROM fake_table
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# We should avoid inserting superfluous parenthesis, or it won't roundtrip after printing the cast in the Postgres
+# style, because some parser code paths eat superfluous parenthesis, including the code path that handles
+# Postgres-style casts.
+parse-statement
+SELECT round(1.5678, CAST((SELECT n FROM nums) AS integer));
+----
+SELECT round(1.5678, (SELECT n FROM nums)::int4)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("round")])), args: Args { args: [Value(Number("1.5678")), Cast { expr: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("n")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("nums")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1511,6 +1511,19 @@ SELECT (my_json::uuid)[my_index] FROM fake_table
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] } }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# Casts are always printed as Postgres-style casts, that is, with `::`. When going from `CAST` to `::`, we have to avoid
+# the daner of `::` binding to just part of the expression that was originally being cast. E.g. rewriting
+# CAST(a + b AS integer)
+# to
+# a + b::integer
+# without adding a parenthesis would be bad.
+parse-statement
+SELECT CAST(a + b AS integer) FROM fake_table;
+----
+SELECT (a + b)::int4 FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -596,22 +596,7 @@ pub fn doc_expr<T: AstInfo>(v: &Expr<T>) -> RcDoc {
             bracket_doc(RcDoc::text("CASE"), doc, RcDoc::text("END"), RcDoc::line())
         }
         Expr::Cast { expr, data_type } => {
-            // See AstDisplay for Expr for an explanation of this.
-            let needs_wrap = !matches!(
-                **expr,
-                Expr::Nested(_)
-                    | Expr::Value(_)
-                    | Expr::Cast { .. }
-                    | Expr::Function { .. }
-                    | Expr::Identifier { .. }
-                    | Expr::Collate { .. }
-                    | Expr::HomogenizingFunction { .. }
-                    | Expr::NullIf { .. }
-            );
-            let mut doc = doc_expr(expr);
-            if needs_wrap {
-                doc = bracket("(", doc, ")");
-            }
+            let doc = doc_expr(expr);
             RcDoc::concat([doc, RcDoc::text(format!("::{}", data_type.to_ast_string()))])
         }
         Expr::Nested(ast) => bracket("(", doc_expr(ast), ")"),

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -125,3 +125,16 @@ SELECT date('2000')
 
 query error db error: ERROR: function date\(unknown, unknown\) does not exist
 SELECT date('2000', 'a')
+
+query T
+SELECT CAST(5 + 3 AS text);
+----
+8
+
+query T
+SELECT (5 + 3)::text;
+----
+8
+
+query error db error: ERROR: operator does not exist: integer \+ text
+SELECT 5 + 3::text;


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/31705. When working on that PR, we noticed that if we fix precedence issues by adding parenthesis during the _printing_ of the AST, then the problem is that the AST won't roundtrip in parser tests. Therefore that PR fixed a precedence issue during AST parsing instead of printing. However, even before that PR, the AST printing already had an earlier precedence fix during printing. This was not causing a problem so far only because we hadn't had a parser test for it. So this PR moves that precedence fix also to the parsing, and adds a parser test for it. This is in the second commit.

The first commit is a related refactoring in the parser tests: When there was a parser roundtrip problem in tests, it would often manifest as an error msg complaining about the redacted query, even if the non-redacted query would also have the same roundtrip problem, which was sometimes misleading me into thinking that there is some issue specifically with the redaction. So, this refactoring moves the redacted reparse check to happen after the normal reparse checks. (See also commit msg.)

Edit: Note that the roundtrip problem that this PR is solving is only a problem in the sense that it's not an identical AST that we get back after reparsing, but the meaning of the AST is still the same. So, this is a test-only issue, as far as I can see.

Edit: I added a 3rd and 4th commit, each of which adds a case where the extra wrapping parens are not needed. If we have the extra wrapping, that can cause roundtrip failures, because the parser removes superfluous parens in some cases.

(Edit: In the long run, the cleanest solution would be to have a representation for both casting styles, and then both would trivially roundtrip. Then, if we still like the Postgres-style better, then an AST-transformation (like the ones in `transform_ast.rs`) could change from the standard to the Postgres style, and add Expr::Nested when needed.)

Nightly: https://buildkite.com/materialize/nightly/builds/11365

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
