### PR TITLE
dev docs: Update RUSTFLAGS with --cfg tokio_unstable

### DIFF
--- a/doc/developer/fast-compiles.md
+++ b/doc/developer/fast-compiles.md
@@ -43,7 +43,7 @@ you don't use a Debian-based distribution.
 To tell Rust to use mold, set the following environment variable:
 
 ```shell
-export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+export RUSTFLAGS="-C link-arg=-fuse-ld=mold --cfg tokio_unstable"
 ```
 
 Alternatively, you can configure the linker through a
@@ -61,7 +61,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 The fastest known way to compile is with mold and disabling debug info:
 
 ```shell
-export RUSTFLAGS="-C link-arg=-fuse-ld=mold -C debuginfo=0"
+export RUSTFLAGS="-C link-arg=-fuse-ld=mold -C debuginfo=0 --cfg tokio_unstable"
 ```
 
 Ideally, set that in your `~/.bashrc` or equivalent so that it applies


### PR DESCRIPTION
Otherwise compilation can fail, see https://materializeinc.slack.com/archives/CM7ATT65S/p1740776443473949

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
