### PR TITLE
DNM: Run Nightly with extra parser roundtrip checks

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2611,6 +2611,7 @@ mod tests {
 
             let parsed = mz_sql_parser::parser::parse_statements(
                 "create view public.foo as select 1 as bar",
+                true,
             )
             .expect("")
             .into_element()
@@ -2641,7 +2642,7 @@ mod tests {
         let columns = iter::repeat(column).take(column_count).join("");
         let create_sql = format!("{view_def}{columns})");
         let create_sql_check = create_sql.clone();
-        assert_ok!(mz_sql_parser::parser::parse_statements(&create_sql));
+        assert_ok!(mz_sql_parser::parser::parse_statements(&create_sql, true));
         assert_err!(mz_sql_parser::parser::parse_statements_with_limit(
             &create_sql
         ));

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -861,7 +861,7 @@ impl CatalogState {
         table: &Table,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         let redacted = table.create_sql.as_ref().map(|create_sql| {
-            mz_sql::parse::parse(create_sql)
+            mz_sql::parse::parse(create_sql, true)
                 .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", create_sql))
                 .into_element()
                 .ast
@@ -924,7 +924,7 @@ impl CatalogState {
         create_sql: Option<&String>,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         let redacted = create_sql.map(|create_sql| {
-            let create_stmt = mz_sql::parse::parse(create_sql)
+            let create_stmt = mz_sql::parse::parse(create_sql, true)
                 .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", create_sql))
                 .into_element()
                 .ast;
@@ -1067,7 +1067,7 @@ impl CatalogState {
         connection: &Connection,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let create_stmt = mz_sql::parse::parse(&connection.create_sql)
+        let create_stmt = mz_sql::parse::parse(&connection.create_sql, true)
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", connection.create_sql))
             .into_element()
             .ast;
@@ -1279,7 +1279,7 @@ impl CatalogState {
         view: &View,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let create_stmt = mz_sql::parse::parse(&view.create_sql)
+        let create_stmt = mz_sql::parse::parse(&view.create_sql, true)
             .unwrap_or_else(|e| {
                 panic!(
                     "create_sql cannot be invalid: `{}` --- error: `{}`",
@@ -1326,7 +1326,7 @@ impl CatalogState {
         mview: &MaterializedView,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let create_stmt = mz_sql::parse::parse(&mview.create_sql)
+        let create_stmt = mz_sql::parse::parse(&mview.create_sql, true)
             .unwrap_or_else(|e| {
                 panic!(
                     "create_sql cannot be invalid: `{}` --- error: `{}`",
@@ -1437,7 +1437,7 @@ impl CatalogState {
         ct: &ContinualTask,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let create_stmt = mz_sql::parse::parse(&ct.create_sql)
+        let create_stmt = mz_sql::parse::parse(&ct.create_sql, true)
             .unwrap_or_else(|e| {
                 panic!(
                     "create_sql cannot be invalid: `{}` --- error: `{}`",
@@ -1510,7 +1510,7 @@ impl CatalogState {
             }
         };
 
-        let create_stmt = mz_sql::parse::parse(&sink.create_sql)
+        let create_stmt = mz_sql::parse::parse(&sink.create_sql, true)
             .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", sink.create_sql))
             .into_element()
             .ast;
@@ -1558,7 +1558,7 @@ impl CatalogState {
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         let mut updates = vec![];
 
-        let create_stmt = mz_sql::parse::parse(&index.create_sql)
+        let create_stmt = mz_sql::parse::parse(&index.create_sql, true)
             .unwrap_or_else(|e| {
                 panic!(
                     "create_sql cannot be invalid: `{}` --- error: `{}`",
@@ -1643,7 +1643,7 @@ impl CatalogState {
         let mut out = vec![];
 
         let redacted = typ.create_sql.as_ref().map(|create_sql| {
-            mz_sql::parse::parse(create_sql)
+            mz_sql::parse::parse(create_sql, true)
                 .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", create_sql))
                 .into_element()
                 .ast

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -502,7 +502,7 @@ impl CatalogState {
                             entry_name: entry.name().clone(),
                         });
                     }
-                    let statement = match mz_sql::parse::parse(entry.create_sql()) {
+                    let statement = match mz_sql::parse::parse(entry.create_sql(), true) {
                         Ok(mut statements) if statements.len() == 1 => {
                             let statement = statements.pop().expect("checked length");
                             statement.ast

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -42,7 +42,9 @@ where
     let mut updated_items = BTreeMap::new();
 
     for mut item in tx.get_items() {
-        let mut stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
+        let mut stmt = mz_sql::parse::parse(&item.create_sql, true)?
+            .into_element()
+            .ast;
         f(tx, item.id, &mut stmt)?;
 
         item.create_sql = stmt.to_ast_string_stable();
@@ -69,7 +71,9 @@ where
     let mut updated_items = BTreeMap::new();
     let items = tx.get_items();
     for mut item in items {
-        let mut stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
+        let mut stmt = mz_sql::parse::parse(&item.create_sql, true)?
+            .into_element()
+            .ast;
 
         f(tx, &cat, item.id, &mut stmt)?;
 
@@ -255,7 +259,9 @@ fn ast_rewrite_sources_to_tables(
     let items_with_statements = tx
         .get_items()
         .map(|item| {
-            let stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
+            let stmt = mz_sql::parse::parse(&item.create_sql, true)?
+                .into_element()
+                .ast;
             Ok((item, stmt))
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -945,7 +945,7 @@ impl CatalogState {
             let pcx = Some(&pcx);
             let session_catalog = state.for_system_session();
 
-            let stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
+            let stmt = mz_sql::parse::parse(create_sql, true)?.into_element().ast;
             let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
             let plan =
                 mz_sql::plan::plan(pcx, &session_catalog, stmt, &Params::empty(), &resolved_ids)?;
@@ -961,7 +961,7 @@ impl CatalogState {
         pcx: Option<&PlanContext>,
         catalog: &ConnCatalog,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
-        let stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
+        let stmt = mz_sql::parse::parse(create_sql, true)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, stmt)?;
         let plan = mz_sql::plan::plan(pcx, catalog, stmt, &Params::empty(), &resolved_ids)?;
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -371,7 +371,7 @@ Issue a SQL query to get started. Need help?
         let mut session_client = self.startup(session).await?;
 
         // Parse the SQL statement.
-        let stmts = mz_sql::parse::parse(sql)?;
+        let stmts = mz_sql::parse::parse(sql, true)?;
         if stmts.len() != 1 {
             bail!("must supply exactly one query");
         }

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -520,7 +520,7 @@ pub(super) struct SubscribeSpec {
 
 impl SubscribeSpec {
     fn to_plan(&self, catalog: &dyn SessionCatalog) -> Result<SubscribePlan, anyhow::Error> {
-        let parsed = mz_sql::parse::parse(self.sql)?.into_element();
+        let parsed = mz_sql::parse::parse(self.sql, true)?.into_element();
         let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, parsed.ast)?;
         let plan = mz_sql::plan::plan(None, catalog, stmt, &Params::empty(), &resolved_ids)?;
         match plan {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3505,7 +3505,7 @@ impl Coordinator {
 
         // Re-resolve items in the altered statement
         // Parse statement.
-        let create_sink_stmt = match mz_sql::parse::parse(&plan.sink.create_sql)
+        let create_sink_stmt = match mz_sql::parse::parse(&plan.sink.create_sql, true)
             .expect("invalid create sink sql")
             .into_element()
             .ast
@@ -3692,7 +3692,7 @@ impl Coordinator {
 
         let inner = || -> Result<Connection, AdapterError> {
             // Parse statement.
-            let create_conn_stmt = match mz_sql::parse::parse(&cur_conn.create_sql)
+            let create_conn_stmt = match mz_sql::parse::parse(&cur_conn.create_sql, true)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
                 .ast
@@ -3740,7 +3740,7 @@ impl Coordinator {
             };
 
             // Parse statement.
-            let create_conn_stmt = match mz_sql::parse::parse(&plan.connection.create_sql)
+            let create_conn_stmt = match mz_sql::parse::parse(&plan.connection.create_sql, true)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
                 .ast
@@ -3958,7 +3958,7 @@ impl Coordinator {
 
         let create_sql_to_stmt_deps = |coord: &Coordinator, err_cx, create_source_sql| {
             // Parse statement.
-            let create_source_stmt = match mz_sql::parse::parse(create_source_sql)
+            let create_source_stmt = match mz_sql::parse::parse(create_source_sql, true)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
                 .ast

--- a/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_continual_task.rs
@@ -307,7 +307,7 @@ fn update_create_sql(
         }
     }
 
-    let mut ast = mz_sql_parser::parser::parse_statements(create_sql)
+    let mut ast = mz_sql_parser::parser::parse_statements(create_sql, true)
         .expect("non-system items must be parseable")
         .into_element()
         .ast;

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -610,7 +610,7 @@ impl Coordinator {
         // This has to be the `storage_as_of`, because bootstrapping uses this in
         // `bootstrap_storage_collections`.
         if let Some(storage_as_of_ts) = storage_as_of.as_option() {
-            let stmt = mz_sql::parse::parse(&create_sql)
+            let stmt = mz_sql::parse::parse(&create_sql, true)
                 .map_err(|_| {
                     AdapterError::internal(
                         "create materialized view",

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -323,7 +323,7 @@ impl Coordinator {
                 let mut to_item = entry.item;
                 match &mut to_item {
                     CatalogItem::Connection(c) => {
-                        let mut stmt = match mz_sql::parse::parse(&c.create_sql)
+                        let mut stmt = match mz_sql::parse::parse(&c.create_sql, true)
                             .expect("invalid create sql persisted to catalog")
                             .into_element()
                             .ast

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1777,7 +1777,7 @@ impl CatalogItem {
         new_schema_name: &str,
     ) -> Result<CatalogItem, (String, String)> {
         let do_rewrite = |create_sql: String| -> Result<String, (String, String)> {
-            let mut create_stmt = mz_sql::parse::parse(&create_sql)
+            let mut create_stmt = mz_sql::parse::parse(&create_sql, true)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
                 .ast;
@@ -1859,7 +1859,7 @@ impl CatalogItem {
         rename_self: bool,
     ) -> Result<CatalogItem, String> {
         let do_rewrite = |create_sql: String| -> Result<String, String> {
-            let mut create_stmt = mz_sql::parse::parse(&create_sql)
+            let mut create_stmt = mz_sql::parse::parse(&create_sql, true)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
                 .ast;
@@ -2053,7 +2053,7 @@ impl CatalogItem {
         let Some(create_sql) = create_sql else {
             return Err(());
         };
-        let mut ast = mz_sql_parser::parser::parse_statements(create_sql)
+        let mut ast = mz_sql_parser::parser::parse_statements(create_sql, true)
             .expect("non-system items must be parseable")
             .into_element()
             .ast;

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -324,7 +324,7 @@ http
 {"queries":[{"query":"select $1+$2::int as col","params":["1"]}]}
 ----
 200 OK
-{"results":[{"error":{"message":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2","code":"XX000"},"notices":[]}]}
+{"results":[{"error":{"message":"request supplied 1 parameters, but SELECT $1 + $2::int4 AS col requires 2","code":"XX000"},"notices":[]}]}
 
 # NaN
 http

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -122,7 +122,7 @@ ws-text
 {"queries": [{"query": "select $1::int", "params": []}]}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT ($1)::int4 requires 1","code":"XX000"}}
+{"type":"Error","payload":{"message":"request supplied 0 parameters, but SELECT $1::int4 requires 1","code":"XX000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text

--- a/src/lsp-server/src/backend.rs
+++ b/src/lsp-server/src/backend.rs
@@ -306,7 +306,7 @@ impl LanguageServer for Backend {
                 if let Some(json_args) = json_args {
                     let args = serde_json::from_value::<String>(json_args.clone())
                         .map_err(|_| build_error("Error deserializing parse args as String."))?;
-                    let statements = parse_statements(&args)
+                    let statements = parse_statements(&args, true)
                         .map_err(|_| build_error("Error parsing the statements."))?;
 
                     // Transform raw statements to splitted statements
@@ -520,7 +520,7 @@ impl Backend {
         let mut parse_results = self.parse_results.lock().await;
 
         // Parse the text
-        let parse_result = mz_sql_parser::parser::parse_statements(&params.text);
+        let parse_result = mz_sql_parser::parser::parse_statements(&params.text, true);
 
         match parse_result {
             // The parser will return Ok when everything is well written.

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -321,34 +321,7 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 }
             }
             Expr::Cast { expr, data_type } => {
-                // We are potentially rewriting an expression like
-                //     CAST(<expr> OP <expr> AS <type>)
-                // to
-                //     <expr> OP <expr>::<type>
-                // which could incorrectly change the meaning of the expression
-                // as the `::` binds tightly. To be safe, we wrap the inner
-                // expression in parentheses
-                //    (<expr> OP <expr>)::<type>
-                // unless the inner expression is of a type that we know is
-                // safe to follow with a `::` to without wrapping.
-                let needs_wrap = !matches!(
-                    **expr,
-                    Expr::Nested(_)
-                        | Expr::Value(_)
-                        | Expr::Cast { .. }
-                        | Expr::Function { .. }
-                        | Expr::Identifier { .. }
-                        | Expr::Collate { .. }
-                        | Expr::HomogenizingFunction { .. }
-                        | Expr::NullIf { .. }
-                );
-                if needs_wrap {
-                    f.write_str('(');
-                }
                 f.write_node(&expr);
-                if needs_wrap {
-                    f.write_str(')');
-                }
                 f.write_str("::");
                 f.write_node(data_type);
             }

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -87,7 +87,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let sql = "SELECT (SELECT 1) FROM (SELECT 1) WHERE EXISTS (SELECT (SELECT 1))";
-//!     let stmts = mz_sql_parser::parser::parse_statements(sql.into())?;
+//!     let stmts = mz_sql_parser::parser::parse_statements(sql.into(), true)?;
 //!
 //!     let mut counter = SubqueryCounter { count: 0 };
 //!     for stmt in &stmts {
@@ -131,7 +131,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let sql = "SELECT a FROM b.c WHERE 1 + d(e)";
-//!     let stmts = mz_sql_parser::parser::parse_statements(sql.into())?;
+//!     let stmts = mz_sql_parser::parser::parse_statements(sql.into(), true)?;
 //!
 //!     let mut collector = IdentCollector { idents: vec![] };
 //!     for stmt in &stmts {

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -31,7 +31,7 @@
 //!            WHERE a > b AND b < 100 \
 //!            ORDER BY a DESC, b";
 //!
-//! let ast = parser::parse_statements(sql).unwrap();
+//! let ast = parser::parse_statements(sql, true).unwrap();
 //! println!("AST: {:?}", ast);
 //! ```
 
@@ -69,11 +69,11 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
 
     fn parse_statement(tc: &TestCase) -> String {
         let input = tc.input.strip_suffix('\n').unwrap_or(&tc.input);
-        match parser::parse_statements(input) {
+        match parser::parse_statements(input, false) {
             Ok(s) => {
                 let stmt = s.into_element().ast;
                 for printed in [stmt.to_ast_string(), stmt.to_ast_string_stable()] {
-                    let mut parsed = match parser::parse_statements(&printed) {
+                    let mut parsed = match parser::parse_statements(&printed, false) {
                         Ok(parsed) => parsed.into_element().ast,
                         Err(err) => panic!("reparse failed: {}: {}\n", stmt, err),
                     };
@@ -99,7 +99,7 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                 // important so that we are still able to pretty-print redacted statements, which
                 // helps during debugging.
                 let redacted = stmt.to_ast_string_redacted();
-                let res = parser::parse_statements(&redacted);
+                let res = parser::parse_statements(&redacted, false);
                 assert!(
                     res.is_ok(),
                     "redacted statement could not be reparsed: {res:?}\noriginal:\n{stmt}\nredacted:\n{redacted}"

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -94,6 +94,17 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                         );
                     }
                 }
+
+                // Also check that the redacted version of the statement can be reparsed. This is
+                // important so that we are still able to pretty-print redacted statements, which
+                // helps during debugging.
+                let redacted = stmt.to_ast_string_redacted();
+                let res = parser::parse_statements(&redacted);
+                assert!(
+                    res.is_ok(),
+                    "redacted statement could not be reparsed: {res:?}\noriginal:\n{stmt}\nredacted:\n{redacted}"
+                );
+
                 if tc.args.contains_key("roundtrip") {
                     format!("{}\n", stmt)
                 } else {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -888,10 +888,38 @@ impl<'a> Parser<'a> {
         self.expect_keyword(AS)?;
         let data_type = self.parse_data_type()?;
         self.expect_token(&Token::RParen)?;
-        Ok(Expr::Cast {
-            expr: Box::new(expr),
-            data_type,
-        })
+        // We are potentially rewriting an expression like
+        //     CAST(<expr> OP <expr> AS <type>)
+        // to
+        //     <expr> OP <expr>::<type>
+        // (because we print Expr::Cast always as a Postgres-style cast, i.e. `::`)
+        // which could incorrectly change the meaning of the expression
+        // as the `::` binds tightly. To be safe, we wrap the inner
+        // expression in parentheses
+        //    (<expr> OP <expr>)::<type>
+        // unless the inner expression is of a kind that we know is
+        // safe to follow with a `::` without wrapping.
+        if !matches!(
+            expr,
+            Expr::Nested(_)
+                | Expr::Value(_)
+                | Expr::Cast { .. }
+                | Expr::Function { .. }
+                | Expr::Identifier { .. }
+                | Expr::Collate { .. }
+                | Expr::HomogenizingFunction { .. }
+                | Expr::NullIf { .. }
+        ) {
+            Ok(Expr::Cast {
+                expr: Box::new(Expr::Nested(Box::new(expr))),
+                data_type,
+            })
+        } else {
+            Ok(Expr::Cast {
+                expr: Box::new(expr),
+                data_type,
+            })
+        }
     }
 
     /// Parse a SQL EXISTS expression e.g. `WHERE EXISTS(SELECT ...)`.

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -910,6 +910,7 @@ impl<'a> Parser<'a> {
                 | Expr::HomogenizingFunction { .. }
                 | Expr::NullIf { .. }
                 | Expr::Subquery { .. }
+                | Expr::Parameter(..)
         ) {
             Ok(Expr::Cast {
                 expr: Box::new(Expr::Nested(Box::new(expr))),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -909,6 +909,7 @@ impl<'a> Parser<'a> {
                 | Expr::Collate { .. }
                 | Expr::HomogenizingFunction { .. }
                 | Expr::NullIf { .. }
+                | Expr::Subquery { .. }
         ) {
             Ok(Expr::Cast {
                 expr: Box::new(Expr::Nested(Box::new(expr))),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -26,6 +26,7 @@ use std::fmt;
 
 use bytesize::ByteSize;
 use itertools::Itertools;
+use mz_ore::assert::soft_assertions_enabled;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::option::OptionExt;
@@ -121,17 +122,20 @@ pub fn parse_statements_with_limit(
             ByteSize::b(u64::cast_from(MAX_STATEMENT_BATCH_SIZE))
         ));
     }
-    Ok(parse_statements(sql))
+    Ok(parse_statements(sql, true))
 }
 
 /// Parses a SQL string containing zero or more SQL statements.
 #[mz_ore::instrument(target = "compiler", level = "trace", name = "sql_to_ast")]
-pub fn parse_statements(sql: &str) -> Result<Vec<StatementParseResult>, ParserStatementError> {
+pub fn parse_statements(
+    sql: &str,
+    assert_roundtrip: bool,
+) -> Result<Vec<StatementParseResult>, ParserStatementError> {
     let tokens = lexer::lex(sql).map_err(|error| ParserStatementError {
         error: error.into(),
         statement: None,
     })?;
-    let res = Parser::new(sql, tokens).parse_statements();
+    let res = Parser::new(sql, tokens).parse_statements(assert_roundtrip);
     // Don't trace sensitive raw sql, so we can only trace after parsing, and then can only output
     // redacted statements.
     debug!("{:?}", {
@@ -342,7 +346,10 @@ impl<'a> Parser<'a> {
         ParserError { pos, message }
     }
 
-    fn parse_statements(&mut self) -> Result<Vec<StatementParseResult<'a>>, ParserStatementError> {
+    fn parse_statements(
+        &mut self,
+        assert_roundtrip: bool,
+    ) -> Result<Vec<StatementParseResult<'a>>, ParserStatementError> {
         let mut stmts = Vec::new();
         let mut expecting_statement_delimiter = false;
         loop {
@@ -359,7 +366,7 @@ impl<'a> Parser<'a> {
                     .map_no_statement_parser_err();
             }
 
-            let s = self.parse_statement()?;
+            let s = self.parse_statement(assert_roundtrip)?;
             stmts.push(s);
             expecting_statement_delimiter = true;
         }
@@ -368,10 +375,41 @@ impl<'a> Parser<'a> {
     /// Parse a single top-level statement (such as SELECT, INSERT, CREATE, etc.),
     /// stopping before the statement separator, if any. Returns the parsed statement and the SQL
     /// fragment corresponding to it.
-    fn parse_statement(&mut self) -> Result<StatementParseResult<'a>, ParserStatementError> {
+    fn parse_statement(
+        &mut self,
+        assert_roundtrip: bool,
+    ) -> Result<StatementParseResult<'a>, ParserStatementError> {
         let before = self.peek_pos();
         let statement = self.parse_statement_inner()?;
         let after = self.peek_pos();
+
+        if assert_roundtrip && soft_assertions_enabled() {
+            // If we successfully parsed it, then it should also roundtrip through printing and then
+            // parsing it again.
+            for printed in [statement.to_ast_string(), statement.to_ast_string_stable()] {
+                let mut parsed = match parse_statements(&printed, false) {
+                    Ok(parsed) => parsed.into_element().ast,
+                    Err(err) => panic!("reparse failed: {}: {}\n", statement, err),
+                };
+                match (&mut parsed, &statement) {
+                    // DECLARE remembers the original SQL. Erase that here so it can differ if
+                    // needed (for example, quoting identifiers vs not). This is ok because we
+                    // still compare that the resulting ASTs are identical, and it's valid for
+                    // those to come from different original strings.
+                    (Statement::Declare(parsed), Statement::Declare(stmt)) => {
+                        parsed.sql.clone_from(&stmt.sql);
+                    }
+                    _ => {}
+                }
+                if parsed != statement {
+                    panic!(
+                        "reparse comparison failed:\n{:?}\n!=\n{:?}\n{printed}\n",
+                        statement, parsed
+                    );
+                }
+            }
+        }
+
         Ok(StatementParseResult::new(
             statement,
             self.sql[before..after].trim(),
@@ -3737,7 +3775,7 @@ impl<'a> Parser<'a> {
                 self.expected(self.peek_pos(), "end of statement", self.peek_token())?
             }
 
-            let stmt = self.parse_statement().map_err(|err| err.error)?.ast;
+            let stmt = self.parse_statement(true).map_err(|err| err.error)?.ast;
             match stmt {
                 Statement::Delete(stmt) => stmts.push(ContinualTaskStmt::Delete(stmt)),
                 Statement::Insert(stmt) => stmts.push(ContinualTaskStmt::Insert(stmt)),
@@ -6397,7 +6435,7 @@ impl<'a> Parser<'a> {
         };
 
         let relation = if self.consume_token(&Token::LParen) {
-            let query = self.parse_statement()?.ast;
+            let query = self.parse_statement(true)?.ast;
             self.expect_token(&Token::RParen)
                 .map_parser_err(StatementKind::Copy)?;
             match query {
@@ -8839,7 +8877,7 @@ impl<'a> Parser<'a> {
         let _ = self.parse_keywords(&[WITHOUT, HOLD]);
         self.expect_keyword(FOR)
             .map_parser_err(StatementKind::Declare)?;
-        let StatementParseResult { ast, sql } = self.parse_statement()?;
+        let StatementParseResult { ast, sql } = self.parse_statement(true)?;
         Ok(Statement::Declare(DeclareStatement {
             name,
             stmt: Box::new(ast),
@@ -8864,7 +8902,7 @@ impl<'a> Parser<'a> {
             .map_parser_err(StatementKind::Prepare)?;
         let pos = self.peek_pos();
         //
-        let StatementParseResult { ast, sql } = self.parse_statement()?;
+        let StatementParseResult { ast, sql } = self.parse_statement(true)?;
         if !matches!(
             ast,
             Statement::Select(_)

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -192,6 +192,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         COMMIT;
         ROLLBACK;
 "#,
+        true,
     )?;
 
     #[rustfmt::skip]  // rustfmt loses the structure of the expected vector by wrapping all lines
@@ -235,5 +236,5 @@ fn test_max_statement_batch_size() {
     let statements = format!("{statements}{statement}");
     let err = parse_statements_with_limit(&statements).expect_err("statements should be too big");
     assert!(err.contains("statement batch size cannot exceed "));
-    assert_ok!(parse_statements(&statements));
+    assert_ok!(parse_statements(&statements, true));
 }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -37,31 +37,8 @@ use mz_sql_parser::parser::{
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn datadriven() {
     walk("tests/testdata", |f| {
-        f.run(|tc| -> String {
-            if tc.directive == "parse-statement" {
-                // Verify that redacted statements can be parsed. This is important so that we are
-                // still able to pretty-print redacted statements which helps out during debugging.
-                verify_parse_redacted(&tc.input);
-            }
-            datadriven_testcase(tc)
-        })
+        f.run(|tc| -> String { datadriven_testcase(tc) })
     });
-}
-
-fn verify_parse_redacted(stmt: &str) {
-    let stmt = match parse_statements(stmt) {
-        Ok(stmt) => match stmt.into_iter().next() {
-            Some(stmt) => stmt.ast,
-            None => return,
-        },
-        Err(_) => return,
-    };
-    let redacted = stmt.to_ast_string_redacted();
-    let res = parse_statements(&redacted);
-    assert!(
-        res.is_ok(),
-        "redacted statement could not be parsed: {res:?}\noriginal:\n{stmt}\nredacted:\n{redacted}"
-    );
 }
 
 #[mz_ore::test]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1534,6 +1534,56 @@ SELECT round(1.5678, (SELECT n FROM nums)::int4)
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("round")])), args: Args { args: [Value(Number("1.5678")), Cast { expr: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("n")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("nums")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# Prepared statement parameter handling in casts. (Note: some extra wrapping parens here are currently not removed.)
+parse-statement
+select $2::int as col
+----
+SELECT $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select CAST($2 AS int) as col
+----
+SELECT $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select $1 + ($2)::int as col
+----
+SELECT $1 + ($2)::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Cast { expr: Nested(Parameter(2)), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }) }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select $1 + $2::int as col
+----
+SELECT $1 + $2::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Cast { expr: Parameter(2), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }) }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ($1 + $2)::int as col
+----
+SELECT ($1 + $2)::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Parameter(2)) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ((($1)))::int as col
+----
+SELECT ((($1)))::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Nested(Nested(Parameter(1)))), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select ((($1 + $2)))::int as col
+----
+SELECT ((($1 + $2)))::int4 AS col
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Nested(Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Parameter(1), expr2: Some(Parameter(2)) }))), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: Some(Ident("col")) }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1524,6 +1524,16 @@ SELECT (a + b)::int4 FROM fake_table
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# We should avoid inserting superfluous parenthesis, or it won't roundtrip after printing the cast in the Postgres
+# style, because some parser code paths eat superfluous parenthesis, including the code path that handles
+# Postgres-style casts.
+parse-statement
+SELECT round(1.5678, CAST((SELECT n FROM nums) AS integer));
+----
+SELECT round(1.5678, (SELECT n FROM nums)::int4)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("round")])), args: Args { args: [Value(Number("1.5678")), Cast { expr: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("n")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("nums")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1511,6 +1511,19 @@ SELECT (my_json::uuid)[my_index] FROM fake_table
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Subscript { expr: Nested(Cast { expr: Identifier([Ident("my_json")]), data_type: Other { name: Name(UnresolvedItemName([Ident("uuid")])), typ_mod: [] } }), positions: [SubscriptPosition { start: Some(Identifier([Ident("my_index")])), end: None, explicit_slice: false }] }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# Casts are always printed as Postgres-style casts, that is, with `::`. When going from `CAST` to `::`, we have to avoid
+# the daner of `::` binding to just part of the expression that was originally being cast. E.g. rewriting
+# CAST(a + b AS integer)
+# to
+# a + b::integer
+# without adding a parenthesis would be bad.
+parse-statement
+SELECT CAST(a + b AS integer) FROM fake_table;
+----
+SELECT (a + b)::int4 FROM fake_table
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Cast { expr: Nested(Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b")])) }), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] } }, alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("fake_table")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Map subqueries
 parse-statement
 SELECT MAP[]

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -596,22 +596,7 @@ pub fn doc_expr<T: AstInfo>(v: &Expr<T>) -> RcDoc {
             bracket_doc(RcDoc::text("CASE"), doc, RcDoc::text("END"), RcDoc::line())
         }
         Expr::Cast { expr, data_type } => {
-            // See AstDisplay for Expr for an explanation of this.
-            let needs_wrap = !matches!(
-                **expr,
-                Expr::Nested(_)
-                    | Expr::Value(_)
-                    | Expr::Cast { .. }
-                    | Expr::Function { .. }
-                    | Expr::Identifier { .. }
-                    | Expr::Collate { .. }
-                    | Expr::HomogenizingFunction { .. }
-                    | Expr::NullIf { .. }
-            );
-            let mut doc = doc_expr(expr);
-            if needs_wrap {
-                doc = bracket("(", doc, ")");
-            }
+            let doc = doc_expr(expr);
             RcDoc::concat([doc, RcDoc::text(format!("::{}", data_type.to_ast_string()))])
         }
         Expr::Nested(ast) => bracket("(", doc_expr(ast), ")"),

--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -44,13 +44,13 @@ pub fn to_pretty<T: AstInfo>(stmt: &Statement<T>, width: usize) -> String {
 
 /// Parses `str` into SQL statements and pretty prints them.
 pub fn pretty_strs(str: &str, width: usize) -> Result<Vec<String>, Error> {
-    let stmts = parse_statements(str)?;
+    let stmts = parse_statements(str, true)?;
     Ok(stmts.iter().map(|s| to_pretty(&s.ast, width)).collect())
 }
 
 /// Parses `str` into a single SQL statement and pretty prints it.
 pub fn pretty_str(str: &str, width: usize) -> Result<String, Error> {
-    let stmts = parse_statements(str)?;
+    let stmts = parse_statements(str, true)?;
     if stmts.len() != 1 {
         return Err(Error::ExpectedOne);
     }

--- a/src/sql-pretty/tests/parser.rs
+++ b/src/sql-pretty/tests/parser.rs
@@ -55,7 +55,7 @@ fn verify_pretty_expr(expr: &str) {
 }
 
 fn verify_pretty_statement(stmt: &str) {
-    let original = match parse_statements(stmt) {
+    let original = match parse_statements(stmt, true) {
         Ok(stmt) => match stmt.into_iter().next() {
             Some(stmt) => stmt,
             None => return,
@@ -65,7 +65,7 @@ fn verify_pretty_statement(stmt: &str) {
     for n in &[1, 40, 1000000] {
         let n = *n;
         let pretty1 = to_pretty(&original.ast, n);
-        let prettied = parse_statements(&pretty1)
+        let prettied = parse_statements(&pretty1, true)
             .unwrap_or_else(|_| panic!("could not parse: {pretty1}, original: {stmt}"))
             .into_iter()
             .next()

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -424,7 +424,7 @@ fn sql_impl_table_func_inner(
     sql: &'static str,
     feature_flag: Option<&'static vars::FeatureFlag>,
 ) -> Operation<TableFuncPlan> {
-    let query = match mz_sql_parser::parser::parse_statements(sql)
+    let query = match mz_sql_parser::parser::parse_statements(sql, true)
         .expect("static function definition failed to parse")
         .expect_element(|| "static function definition must have exactly one statement")
         .ast

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4419,7 +4419,7 @@ pub fn plan_create_cluster(
         let stmt = unplan_create_cluster(scx, plan.clone())
             .map_err(|e| PlanError::Replan(e.to_string()))?;
         let create_sql = stmt.to_ast_string_stable();
-        let stmt = parse::parse(&create_sql)
+        let stmt = parse::parse(&create_sql, true)
             .map_err(|e| PlanError::Replan(e.to_string()))?
             .into_element()
             .ast;
@@ -6837,7 +6837,7 @@ pub fn plan_alter_sink(
         AlterSinkAction::ChangeRelation(new_from) => {
             // First we reconstruct the original CREATE SINK statement
             let create_sql = item.create_sql();
-            let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
+            let stmts = mz_sql_parser::parser::parse_statements(create_sql, true)?;
             let [stmt]: [StatementParseResult; 1] = stmts
                 .try_into()
                 .expect("create sql of sink was not exactly one statement");

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -931,7 +931,7 @@ impl<'a> ShowSelect<'a> {
             filter,
             order.unwrap_or("q.*")
         );
-        let stmts = parse::parse(&query).expect("ShowSelect::new called with invalid SQL");
+        let stmts = parse::parse(&query, true).expect("ShowSelect::new called with invalid SQL");
         let stmt = match stmts.into_element().ast {
             Statement::Select(select) => select,
             _ => panic!("ShowSelect::new called with non-SELECT statement"),
@@ -1002,7 +1002,7 @@ fn humanize_sql_for_show_create(
 ) -> Result<String, PlanError> {
     use mz_sql_parser::ast::{CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName};
 
-    let parsed = parse::parse(sql)?.into_element().ast;
+    let parsed = parse::parse(sql, true)?.into_element().ast;
     let (mut resolved, _) = names::resolve(catalog, parsed)?;
 
     // Simplify names.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1353,7 +1353,7 @@ impl<'a> RunnerInner<'a> {
         in_transaction: &mut bool,
     ) -> Result<PrepareQueryOutcome<'r>, anyhow::Error> {
         // get statement
-        let statements = match mz_sql::parse::parse(sql) {
+        let statements = match mz_sql::parse::parse(sql, true) {
             Ok(statements) => statements,
             Err(e) => match output {
                 Ok(_) => {
@@ -2288,7 +2288,7 @@ fn generate_view_sql(
     // data structure cloning. However, running DDL is so slow that
     // it did not matter in terms of runtime. We can revisit this if
     // DDL cost drops dramatically in the future.
-    let stmts = parser::parse_statements(sql).unwrap_or_default();
+    let stmts = parser::parse_statements(sql, true).unwrap_or_default();
     assert!(stmts.len() == 1);
     let (query, query_as_of) = match &stmts[0].ast {
         Statement::Select(stmt) => (&stmt.query, &stmt.as_of),
@@ -2577,7 +2577,7 @@ fn derive_order_by_from_projection(
 
 /// Returns extra statements to execute after `stmt` is executed.
 fn mutate(sql: &str) -> Vec<String> {
-    let stmts = parser::parse_statements(sql).unwrap_or_default();
+    let stmts = parser::parse_statements(sql, true).unwrap_or_default();
     let mut additional = Vec::new();
     for stmt in stmts {
         match stmt.ast {

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -36,7 +36,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
     state.rewrite_pos_start = cmd.expected_start;
     state.rewrite_pos_end = cmd.expected_end;
 
-    let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
+    let stmts = mz_sql_parser::parser::parse_statements(&cmd.query, true)
         .with_context(|| format!("unable to parse SQL: {}", cmd.query))?;
     if stmts.len() != 1 {
         bail!("expected one statement, but got {}", stmts.len());
@@ -357,7 +357,7 @@ pub async fn run_fail_sql(
 ) -> Result<ControlFlow, anyhow::Error> {
     use Statement::{AlterSink, Commit, CreateConnection, Fetch, Rollback};
 
-    let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
+    let stmts = mz_sql_parser::parser::parse_statements(&cmd.query, true)
         .map_err(|e| format!("unable to parse SQL: {}: {}", cmd.query, e));
 
     // Allow for statements that could not be parsed.

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -125,3 +125,16 @@ SELECT date('2000')
 
 query error db error: ERROR: function date\(unknown, unknown\) does not exist
 SELECT date('2000', 'a')
+
+query T
+SELECT CAST(5 + 3 AS text);
+----
+8
+
+query T
+SELECT (5 + 3)::text;
+----
+8
+
+query error db error: ERROR: operator does not exist: integer \+ text
+SELECT 5 + 3::text;


### PR DESCRIPTION
**DO NOT MERGE**

This PR is just to run Nightly with extra parser roundtrip checks: after the parsing every query we go
AST -> string -> AST
and check that the two ASTs are equal.

Running slts locally showed some false positives around char-bpchar issues. We'll see whether a full CI + Nightly (especially the random query tests) turn up any more issues.

(It's on top of https://github.com/MaterializeInc/materialize/pull/31717 )

### Motivation


### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
