### PR TITLE
deploy: Add Unicode-3.0 license to about.toml too

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -13,6 +13,7 @@ accepted = [
     "MPL-2.0",
     "OpenSSL",
     "Zlib",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 private = { ignore = true }


### PR DESCRIPTION
It was already in deny.toml since https://github.com/MaterializeInc/materialize/pull/30780 but forgotten in about.toml. This causes the test and deploy pipeline to fail:
https://buildkite.com/materialize/test/builds/100138#01955e7c-99ef-46a6-a33a-28d9894fadc5
https://buildkite.com/materialize/deploy/builds/17944#01955e97-2e2a-44bd-a297-d5d445c7da4f

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
