### PR TITLE
limits test: Bump max_connections for Connections scenario

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -129,7 +129,8 @@ class Connections(Generator):
         print("$ postgres-execute connection=mz_system")
         # three extra connections for mz_system, default connection, and one
         # since sqlparse 0.4.4. 3 reserved superuser connections since materialize#25666
-        print(f"ALTER SYSTEM SET max_connections = {Connections.COUNT+4};")
+        # try bumping limit a bit further since this is sometimes flaky
+        print(f"ALTER SYSTEM SET max_connections = {Connections.COUNT+10};")
 
         for i in cls.all():
             print(


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/release-qualification/builds/753#01954d6f-70b8-4b8e-be05-a8b9c0e22cfe

> 1010:1: error: db error: FATAL: creating connection would violate max_connections limit (desired: 1005, limit: 1004, current: 1004)


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
