### PR TITLE
storage: remove mz_storage_startup_prepared_statements_kept metric

### DIFF
--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -34,7 +34,6 @@ pub type UIntGauge = DeleteOnDropGauge<AtomicU64, Vec<String>>;
 pub struct StorageControllerMetrics {
     messages_sent_bytes: prometheus::HistogramVec,
     messages_received_bytes: prometheus::HistogramVec,
-    startup_prepared_statements_kept: prometheus::IntGauge,
     regressed_offset_known: IntCounterVec,
     history_command_count: UIntGaugeVec,
 
@@ -56,10 +55,6 @@ impl StorageControllerMetrics {
                 help: "size of storage messages received",
                 var_labels: ["instance_id", "replica_id"],
                 buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
-            )),
-            startup_prepared_statements_kept: metrics_registry.register(metric!(
-                name: "mz_storage_startup_prepared_statements_kept",
-                help: "number of prepared statements kept on startup",
             )),
             regressed_offset_known: metrics_registry.register(metric!(
                 name: "mz_storage_regressed_offset_known",
@@ -98,11 +93,6 @@ impl StorageControllerMetrics {
             instance_id: id,
             metrics: self.clone(),
         }
-    }
-
-    pub fn set_startup_prepared_statements_kept(&self, n: u64) {
-        let n: i64 = n.try_into().expect("realistic number");
-        self.startup_prepared_statements_kept.set(n);
     }
 }
 


### PR DESCRIPTION
This metric is unused as nobody writes it.

Looks like it was originally added to track something about the on-startup cleanup of the statement log, but we are not truncating the statement log nowadays.

### Motivation

   * This PR removes dead code code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
