### PR TITLE
AllowCompaction must go through AsyncStorageWorker to avoid racing RunIngestion

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -512,7 +512,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     },
                 );
             }
-            AsyncStorageWorkerResponse::DataflowDropped(id) => {
+            AsyncStorageWorkerResponse::DropDataflow(id) => {
                 self.storage_state
                     .internal_cmd_tx
                     .send(InternalStorageCommand::DropDataflow(vec![id]));


### PR DESCRIPTION

Force AllowCompaction workflow to go through AsyncStorageWorker to ensure proper ordering with RunIngestion.



To test, I cherry picked my change onto @aljoscha's branch `https://github.com/aljoscha/materialize/tree/storage-debug-stray-compaction`  and ran one of the testdrive tests locally: `./mzcompose --bazel run default upsert-source-race.td`

> [!NOTE]
> The test runs `sanity_restart_mz()` on completion, which is why pids drop to 0 in these outputs

### Without the fix, thread counts rise beyond 1000:
```
martykulma@DN42Y6N0T4-martykulma testdrive % while true; do sleep 1; docker stats --no-stream testdrive-materialized-1 ; done
.
.

CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
4e9108c29777   testdrive-materialized-1   384.04%   8.441GiB / 10.69GiB   79.00%    6.56GB / 2.8GB   2.25GB / 3.74GB   1097
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
4e9108c29777   testdrive-materialized-1   353.59%   8.034GiB / 10.69GiB   75.19%    6.8GB / 2.93GB   2.25GB / 3.83GB   1077
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O        BLOCK I/O         PIDS
4e9108c29777   testdrive-materialized-1   383.30%   8.479GiB / 10.69GiB   79.35%    7.02GB / 3GB   2.26GB / 4.02GB   1106
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT    MEM %     NET I/O           BLOCK I/O         PIDS
4e9108c29777   testdrive-materialized-1   321.86%   8.81GiB / 10.69GiB   82.45%    7.25GB / 3.09GB   2.49GB / 4.21GB   1134
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT   MEM %     NET I/O   BLOCK I/O   PIDS
4e9108c29777   testdrive-materialized-1   0.00%     0B / 0B             0.00%     0B / 0B   0B / 0B     0
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O     BLOCK I/O        PIDS
4e9108c29777   testdrive-materialized-1   0.89%     302.4MiB / 10.69GiB   2.76%     526B / 0B   188MB / 16.8MB   9
```


### With the fix, this is stable at ~500 (very roughly)
```
martykulma@DN42Y6N0T4-martykulma testdrive % while true; do sleep 1; docker stats --no-stream testdrive-materialized-1 ; done
.
.
.
.
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O        PIDS
1d9135d36615   testdrive-materialized-1   594.32%   6.239GiB / 10.69GiB   58.38%    93.9GB / 666MB   266MB / 1.85GB   491
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O        PIDS
1d9135d36615   testdrive-materialized-1   568.74%   6.513GiB / 10.69GiB   60.95%    97.4GB / 687MB   266MB / 1.89GB   557
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O         BLOCK I/O        PIDS
1d9135d36615   testdrive-materialized-1   587.71%   6.277GiB / 10.69GiB   58.74%    101GB / 705MB   267MB / 1.99GB   497
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O         BLOCK I/O        PIDS
1d9135d36615   testdrive-materialized-1   271.94%   5.269GiB / 10.69GiB   49.31%    104GB / 780MB   272MB / 2.08GB   441
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT   MEM %     NET I/O   BLOCK I/O   PIDS
1d9135d36615   testdrive-materialized-1   0.00%     0B / 0B             0.00%     0B / 0B   0B / 0B     0
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT     MEM %     NET I/O     BLOCK I/O       PIDS
1d9135d36615   testdrive-materialized-1   2.03%     309.2MiB / 10.69GiB   2.83%     526B / 0B   57MB / 32.8kB   9
```
### Motivation

fixes https://github.com/MaterializeInc/database-issues/issues/9001


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
