### PR TITLE
adapter: add some debug logging for requests to get their latency

### DIFF
--- a/src/frontegg-auth/src/client/tokens.rs
+++ b/src/frontegg-auth/src/client/tokens.rs
@@ -10,7 +10,6 @@
 use std::time::Instant;
 
 use mz_ore::instrument;
-use mz_ore::metrics::MetricsFutureExt;
 use uuid::Uuid;
 
 use crate::metrics::Metrics;


### PR DESCRIPTION
Trying to debug some high latencies with our auth provider Frontegg. This PR just adds a bit of debug logging (off by default) to report the latencies of requests with the "frontegg-trace-id" header.

### Motivation

Debug auth latencies

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
