### PR TITLE
tests: Fix merge skew in CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,6 @@ skip = [
     { name = "bitflags", version = "1.3.2" },
 
     # TODO(parkmycar): In a followup/stacked PR, get rid of these duplicates.
-    { name = "bstr", version = "0.2.14" },
     { name = "regex-automata", version = "0.1.9" },
 
     # TODO: Required for Rust nightly upgrade

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2528,14 +2528,6 @@ class Metrics:
         assert len(values) <= 1
         return next(iter(values), None)
 
-    def get_wallclock_lag_count(self, collection_id: str) -> float | None:
-        metrics = self.with_name("mz_dataflow_wallclock_lag_seconds_count")
-        values = [
-            v for k, v in metrics.items() if f'collection_id="{collection_id}"' in k
-        ]
-        assert len(values) <= 1
-        return next(iter(values), None)
-
     def get_e2e_optimization_time(self, object_type: str) -> float:
         metrics = self.with_name("mz_optimizer_e2e_optimization_time_seconds_sum")
         values = [v for k, v in metrics.items() if f'object_type="{object_type}"' in k]


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/test/builds/100243#01956b91-6d99-4607-9c4b-adb6849d04ba

Merge skew between https://github.com/MaterializeInc/materialize/pull/31308 and https://github.com/MaterializeInc/materialize/pull/31771

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
