### PR TITLE
[persist] Flush inline parts to a single blob when possible

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -382,6 +382,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_PREFIX)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_SUFFIX)
         .add(&crate::fetch::PART_DECODE_FORMAT)
+        .add(&crate::write::COMBINE_INLINE_WRITES)
 }
 
 impl PersistConfig {

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -745,7 +745,7 @@ pub struct FetchedPart<K: Codec, V: Codec, T, D> {
 }
 
 impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, T, D> {
-    fn new(
+    pub(crate) fn new(
         metrics: Arc<Metrics>,
         part: EncodedPart<T>,
         migration: PartMigration<K, V>,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1425,6 +1425,7 @@ pub mod datadriven {
     use crate::read::{Listen, ListenEvent, READER_LEASE_DURATION};
     use crate::rpc::NoopPubSubSender;
     use crate::tests::new_test_client;
+    use crate::write::COMBINE_INLINE_WRITES;
     use crate::{GarbageCollector, PersistClient};
 
     use super::*;
@@ -1459,6 +1460,7 @@ pub mod datadriven {
                 .cfg
                 .set_config(&STRUCTURED_ORDER, *STRUCTURED_ORDER.default());
             client.cfg.set_config(&BUILDER_STRUCTURED, true);
+            client.cfg.set_config(&COMBINE_INLINE_WRITES, false);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -18,6 +18,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use mz_dyncfg::Config;
 use mz_ore::instrument;
 use mz_ore::task::RuntimeExt;
 use mz_persist::location::Blob;
@@ -38,13 +39,21 @@ use crate::batch::{
     BatchParts, ProtoBatch, BATCH_DELETE_ENABLED,
 };
 use crate::error::{InvalidUsage, UpperMismatch};
+use crate::fetch::{EncodedPart, FetchBatchFilter, FetchedPart, PartDecodeFormat};
 use crate::internal::compact::{CompactConfig, Compactor};
 use crate::internal::encoding::{check_data_version, Schemas};
 use crate::internal::machine::{CompareAndAppendRes, ExpireFn, Machine};
 use crate::internal::metrics::Metrics;
-use crate::internal::state::{HandleDebugState, HollowBatch, RunOrder};
+use crate::internal::state::{BatchPart, HandleDebugState, HollowBatch, RunOrder, RunPart};
 use crate::read::ReadHandle;
+use crate::schema::PartMigration;
 use crate::{parse_id, GarbageCollector, IsolatedRuntime, PersistConfig, ShardId};
+
+pub(crate) const COMBINE_INLINE_WRITES: Config<bool> = Config::new(
+    "persist_write_combine_inline_writes",
+    true,
+    "If set, re-encode inline writes if they don't fit into the batch metadata limits.",
+);
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
 #[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -479,34 +488,136 @@ where
         let desc = Description::new(lower, upper, since);
 
         let mut received_inline_backpressure = false;
+        // Every hollow part must belong to some batch, so we can clean it up when the batch is dropped...
+        // but if we need to merge all our inline parts to a single run in S3, it's not correct to
+        // associate that with any of our individual input batches.
+        // At first, we'll try and put all the inline parts we receive into state... but if we
+        // get backpressured, we retry with this builder set to `Some`, put all our inline data into
+        // it, and ensure it's flushed out to S3 before including it in the batch.
+        let mut inline_batch_builder: Option<(_, BatchBuilder<K, V, T, D>)> = None;
         let maintenance = loop {
             let any_batch_rewrite = batches
                 .iter()
                 .any(|x| x.batch.parts.iter().any(|x| x.ts_rewrite().is_some()));
             let (mut parts, mut num_updates, mut run_splits, mut run_metas) =
                 (vec![], 0, vec![], vec![]);
+            let mut key_storage = None;
+            let mut val_storage = None;
             for batch in batches.iter() {
                 let () = validate_truncate_batch(&batch.batch, &desc, any_batch_rewrite)?;
                 for (run_meta, run) in batch.batch.runs() {
-                    if run.is_empty() {
+                    let start_index = parts.len();
+                    for part in run {
+                        if let (
+                            RunPart::Single(BatchPart::Inline {
+                                updates,
+                                ts_rewrite,
+                                schema_id,
+                                deprecated_schema_id: _,
+                            }),
+                            Some((schema_cache, builder)),
+                        ) = (part, &mut inline_batch_builder)
+                        {
+                            let schema_migration = PartMigration::new(
+                                *schema_id,
+                                self.write_schemas.clone(),
+                                schema_cache,
+                            )
+                            .await
+                            .expect("schemas for inline user part");
+
+                            let encoded_part = EncodedPart::from_inline(
+                                &*self.metrics,
+                                self.metrics.read.compaction.clone(),
+                                desc.clone(),
+                                updates,
+                                ts_rewrite.as_ref(),
+                            );
+                            let mut fetched_part = FetchedPart::new(
+                                Arc::clone(&self.metrics),
+                                encoded_part,
+                                schema_migration,
+                                FetchBatchFilter::Compaction {
+                                    since: desc.since().clone(),
+                                },
+                                false,
+                                PartDecodeFormat::Arrow,
+                                None,
+                            );
+
+                            while let Some(((k, v), t, d)) = fetched_part.next_with_storage(
+                                &mut key_storage,
+                                &mut val_storage,
+                                None,
+                            ) {
+                                builder
+                                    .add(
+                                        &k.expect("decoded just-encoded key data"),
+                                        &v.expect("decoded just-encoded val data"),
+                                        &t,
+                                        &d,
+                                    )
+                                    .await
+                                    .expect("re-encoding just-decoded data");
+                            }
+                        } else {
+                            parts.push(part.clone())
+                        }
+                    }
+
+                    let end_index = parts.len();
+
+                    if start_index == end_index {
                         continue;
                     }
+
                     // Mark the boundary if this is not the first run in the batch.
+                    if start_index != 0 {
+                        run_splits.push(start_index);
+                    }
+                    run_metas.push(run_meta.clone());
+                }
+                num_updates += batch.batch.len;
+            }
+
+            let mut flushed_inline_batch = if let Some((_, builder)) = inline_batch_builder.take() {
+                let mut finished = builder
+                    .finish(desc.upper().clone())
+                    .await
+                    .expect("invalid usage");
+                let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id());
+                finished
+                    .flush_to_blob(
+                        &cfg,
+                        &self.metrics.inline.backpressure,
+                        &self.isolated_runtime,
+                        &self.write_schemas,
+                    )
+                    .await;
+                Some(finished)
+            } else {
+                None
+            };
+
+            if let Some(batch) = &flushed_inline_batch {
+                for (run_meta, run) in batch.batch.runs() {
+                    assert!(run.len() > 0);
                     let start_index = parts.len();
                     if start_index != 0 {
                         run_splits.push(start_index);
                     }
                     run_metas.push(run_meta.clone());
-                    parts.extend_from_slice(run);
+                    parts.extend(run.iter().cloned())
                 }
-                num_updates += batch.batch.len;
             }
 
+            let combined_batch =
+                HollowBatch::new(desc.clone(), parts, num_updates, run_metas, run_splits);
             let heartbeat_timestamp = (self.cfg.now)();
             let res = self
                 .machine
                 .compare_and_append(
-                    &HollowBatch::new(desc.clone(), parts, num_updates, run_metas, run_splits),
+                    &combined_batch,
                     &self.writer_id,
                     &self.debug_state,
                     heartbeat_timestamp,
@@ -519,10 +630,21 @@ where
                     for batch in batches.iter_mut() {
                         batch.mark_consumed();
                     }
+                    if let Some(batch) = &mut flushed_inline_batch {
+                        batch.mark_consumed();
+                    }
                     break maintenance;
                 }
-                CompareAndAppendRes::InvalidUsage(invalid_usage) => return Err(invalid_usage),
+                CompareAndAppendRes::InvalidUsage(invalid_usage) => {
+                    if let Some(batch) = flushed_inline_batch.take() {
+                        batch.delete().await;
+                    }
+                    return Err(invalid_usage);
+                }
                 CompareAndAppendRes::UpperMismatch(_seqno, current_upper) => {
+                    if let Some(batch) = flushed_inline_batch.take() {
+                        batch.delete().await;
+                    }
                     // We tried to to a compare_and_append with the wrong expected upper, that
                     // won't work. Update the cached upper to the current upper.
                     self.upper.clone_from(&current_upper);
@@ -536,6 +658,13 @@ where
                     // too much in state. Flush it out to s3 and try again.
                     assert_eq!(received_inline_backpressure, false);
                     received_inline_backpressure = true;
+                    if COMBINE_INLINE_WRITES.get(&self.cfg) {
+                        inline_batch_builder = Some((
+                            self.machine.applier.schema_cache(),
+                            self.builder(desc.lower().clone()),
+                        ));
+                        continue;
+                    }
 
                     let cfg = BatchBuilderConfig::new(&self.cfg, self.shard_id());
                     // We could have a large number of inline parts (imagine the

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -85,7 +85,7 @@ pub trait Codec: Default + Sized + PartialEq + 'static {
 
     /// A type used with [Self::decode_from] for allocation reuse. Set to `()`
     /// if unnecessary.
-    type Storage: Default;
+    type Storage: Default + Send + Sync;
     /// An alternate form of [Self::decode] which enables amortizing allocs.
     ///
     /// First, instead of returning `Self`, it takes `&mut Self` as a parameter,


### PR DESCRIPTION
The "tricky part" is that our append API accepts multiple batches, but we need to generate a new part (or set of parts) that contain a subset of the data from all of them, and has a lifecycle that many not match any of them. 

I considered moving the batch-merging to the caller when it is required, but that requires some changes to the sink logic that increased the blast radius of this change. (Probably still a good idea, but harder to timebox.)

We instead deal with this by creating a new batch with a lifeycle bound by the individual compare-and-append call, stuffing all our inline parts in there, and flushing that batch instead. 

### Motivation

Partially addresses: https://github.com/MaterializeInc/incidents-and-escalations/issues/191

Discussed here: https://materializeinc.slack.com/archives/C08ACQNGSQK/p1741192786064389?thread_ts=1741117192.727559&cid=C08ACQNGSQK

### Tips for reviewer

This ends up messier than I'd hoped, since we need to decode and re-encode the data, and our current APIs for that have quite a bit of migration cruft. I'm hoping to revisit the `FetchedPart` etc. hierarchy once we've got structured data fully rolled out, which should make this code a little less gnarly.

I've also added a dyncfg to derisk. (Default-on.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
