### PR TITLE
cargo test: Bump timeout for all_datums_produce_valid_stats

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,7 +39,7 @@ slow-timeout = { period = "120s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 filter = "package(mz-storage-types) and test(all_datums_produce_valid_stats)"
-slow-timeout = { period = "300s", terminate-after = 2 }
+slow-timeout = { period = "450s", terminate-after = 2 }
 
 [[profile.default.overrides]]
 filter = "package(mz-storage-types) and test(all_source_data_roundtrips)"


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/100257#01956d28-094e-4394-8930-92ac62870537

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
