### PR TITLE
testdrive: Fix error message for duplicate specification

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -165,7 +165,12 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, PosErro
 
         if let Some(original) = args.insert(pieces[0].to_owned(), pieces[1].to_owned()) {
             return Err(PosError {
-                source: anyhow!("argument '{}' specified twice", original),
+                source: anyhow!(
+                    "argument '{}' specified twice: {} & {}",
+                    pieces[0],
+                    original,
+                    pieces[1]
+                ),
                 pos: Some(pos),
             });
         };


### PR DESCRIPTION
The old message format is wrong:
```
4:42: error: argument 'graceful-reconfig' specified twice
     |
   3 |
   4 | $ kafka-ingest topic=graceful-reconfig format=bytes key-format=bytes key-terminator=: topic=format-bytes
     |                                          ^
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
