### PR TITLE
storage: update RLU dyncfg defaults

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -108,7 +108,7 @@ pub const KAFKA_POLL_MAX_WAIT: Config<Duration> = Config::new(
 /// Interval to fetch topic partition metadata.
 pub static KAFKA_METADATA_FETCH_INTERVAL: Config<Duration> = Config::new(
     "kafka_default_metadata_fetch_interval",
-    Duration::from_secs(60),
+    Duration::from_secs(1),
     "Interval to fetch topic partition metadata.",
 );
 
@@ -141,7 +141,7 @@ pub const MYSQL_REPLICATION_HEARTBEAT_INTERVAL: Config<Duration> = Config::new(
 /// Interval to fetch `offset_known`, from `@gtid_executed`
 pub const MYSQL_OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
     "mysql_offset_known_interval",
-    Duration::from_secs(10),
+    Duration::from_secs(1),
     "Interval to fetch `offset_known`, from `@gtid_executed`",
 );
 
@@ -157,7 +157,7 @@ pub const PG_FETCH_SLOT_RESUME_LSN_INTERVAL: Config<Duration> = Config::new(
 /// Interval to fetch `offset_known`, from `pg_current_wal_lsn`
 pub const PG_OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
     "pg_offset_known_interval",
-    Duration::from_secs(10),
+    Duration::from_secs(1),
     "Interval to fetch `offset_known`, from `pg_current_wal_lsn`",
 );
 
@@ -245,7 +245,7 @@ pub const STORAGE_SINK_SNAPSHOT_FRONTIER: Config<bool> = Config::new(
 /// frontier.
 pub const STORAGE_RECLOCK_TO_LATEST: Config<bool> = Config::new(
     "storage_reclock_to_latest",
-    false,
+    true,
     "Whether to mint reclock bindings based on the latest probed offset or the latest ingested offset.",
 );
 


### PR DESCRIPTION
RLU is now switched on everywhere (CI, staging, prod), so update the config defaults to make sure its also switched on by default locally.

### Motivation

  * This PR brings the local config closer to the prod config.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
