### PR TITLE
storage: round synthesized probe timestamps

### DIFF
--- a/test/testdrive/frontier-rounding.td
+++ b/test/testdrive/frontier-rounding.td
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests checking that frontiers of storage collections, at least when they
+# don't receive data updates, are rounded to seconds. This is important because
+# it ensures that all dataflow sources tick forward at the same time, reducing
+# the number of distinct times dataflows have to process, thus removing some
+# overhead.
+#
+# Note that we expect frontiers to be of the form XX..XX001, i.e. rounded to
+# seconds and then stepped forward. That's because things that tick forward
+# collections choose XX..XX000 as the append timestamp, and then the new write
+# frontier must be greater than that.
+#
+# The rounding is currently not working correctly for tables, compute
+# introspection sources, storage-managed collections. See database-issues#9030.
+
+$ kafka-create-topic topic=topic partitions=1
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+> CREATE SOURCE src
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic-${testdrive.seed}')
+> CREATE SOURCE ctr FROM LOAD GENERATOR COUNTER
+> CREATE SOURCE actn FROM LOAD GENERATOR AUCTION FOR ALL TABLES
+
+# sources
+> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+  FROM mz_internal.mz_frontiers
+  JOIN mz_sources ON id = object_id
+  WHERE object_id LIKE 'u%'
+true
+
+# tables
+# fails: frontiers are not rounded
+> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+  FROM mz_internal.mz_frontiers
+  JOIN mz_tables ON id = object_id
+false
+
+# compute introspection sources
+# fails: frontiers are rounded to `XX..XX000` instead of `XX..XX001`
+> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+  FROM mz_internal.mz_frontiers
+  WHERE object_id LIKE 'si%'
+false
+
+# storage-managed collections
+# fails: frontiers are not rounded
+> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+  FROM mz_internal.mz_frontiers
+  JOIN mz_sources ON id = object_id
+  WHERE object_id LIKE 's%'
+false


### PR DESCRIPTION
This PR fixes an oversight where the `probe::Ticker` that produces upstream probe timestamps rounded to seconds wasn't used for synthesized probes, so frontiers of loadgens wouldn't tick at second boundaries.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
