### PR TITLE
Run `ProjectionPushdown` after the last `RelationCSE`

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -122,6 +122,8 @@ optimizer_feature_flags!({
     enable_join_prioritize_arranged: bool,
     // Extract expressions in MFP::extract_common, making them available to sources.
     extract_common_mfp_expressions: bool,
+    // See the feature flag of the same name.
+    enable_projection_pushdown_after_relation_cse: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -29,6 +29,7 @@ Add
 Added
 Address
 Addresses
+After
 Aggregate
 Aggregation
 Aligned
@@ -112,6 +113,7 @@ Createnetworkpolicy
 Createrole
 Creation
 Cross
+Cse
 Csv
 Current
 Cursor
@@ -342,6 +344,7 @@ Prioritize
 Privatelink
 Privileges
 Progress
+Projection
 Protobuf
 Protocol
 Public
@@ -368,6 +371,7 @@ Refresh
 Regex
 Region
 Registry
+Relation
 Rename
 Reoptimize
 Repeatable

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2337,6 +2337,7 @@ pub enum ClusterFeatureName {
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
     EnableJoinPrioritizeArranged,
+    EnableProjectionPushdownAfterRelationCse,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -2352,7 +2353,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
-            | Self::EnableJoinPrioritizeArranged => false,
+            | Self::EnableJoinPrioritizeArranged
+            | Self::EnableProjectionPushdownAfterRelationCse => false,
         }
     }
 }
@@ -3900,6 +3902,7 @@ pub enum ExplainPlanOptionName {
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
     EnableJoinPrioritizeArranged,
+    EnableProjectionPushdownAfterRelationCse,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -3935,7 +3938,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis
-            | Self::EnableJoinPrioritizeArranged => false,
+            | Self::EnableJoinPrioritizeArranged
+            | Self::EnableProjectionPushdownAfterRelationCse => false,
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4402,7 +4402,12 @@ generate_extracted_config!(
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
-    (EnableJoinPrioritizeArranged, Option<bool>, Default(None))
+    (EnableJoinPrioritizeArranged, Option<bool>, Default(None)),
+    (
+        EnableProjectionPushdownAfterRelationCse,
+        Option<bool>,
+        Default(None)
+    )
 );
 
 /// Convert a [`CreateClusterStatement`] into a [`Plan`].
@@ -4540,6 +4545,7 @@ pub fn plan_create_cluster_inner(
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
+            enable_projection_pushdown_after_relation_cse,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -4549,6 +4555,7 @@ pub fn plan_create_cluster_inner(
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             enable_join_prioritize_arranged,
+            enable_projection_pushdown_after_relation_cse,
             ..Default::default()
         };
 
@@ -4646,6 +4653,7 @@ pub fn unplan_create_cluster(
                 enable_reduce_reduction: _,
                 enable_join_prioritize_arranged,
                 extract_common_mfp_expressions: _,
+                enable_projection_pushdown_after_relation_cse,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
@@ -4656,6 +4664,7 @@ pub fn unplan_create_cluster(
                 enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis,
                 enable_join_prioritize_arranged,
+                enable_projection_pushdown_after_relation_cse,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -376,7 +376,12 @@ generate_extracted_config!(
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
-    (EnableJoinPrioritizeArranged, Option<bool>, Default(None))
+    (EnableJoinPrioritizeArranged, Option<bool>, Default(None)),
+    (
+        EnableProjectionPushdownAfterRelationCse,
+        Option<bool>,
+        Default(None)
+    )
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -428,6 +433,8 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_reduce_reduction: Default::default(),
                 enable_join_prioritize_arranged: v.enable_join_prioritize_arranged,
                 extract_common_mfp_expressions: Default::default(),
+                enable_projection_pushdown_after_relation_cse: v
+                    .enable_projection_pushdown_after_relation_cse,
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2203,6 +2203,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_projection_pushdown_after_relation_cse,
+        desc: "Run ProjectionPushdown one more time after the last RelationCSE.",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2220,6 +2226,8 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             reoptimize_imported_views: false,
             enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
             extract_common_mfp_expressions: vars.extract_common_mfp_expressions(),
+            enable_projection_pushdown_after_relation_cse: vars
+                .enable_projection_pushdown_after_relation_cse(),
         }
     }
 }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -799,6 +799,14 @@ impl Optimizer {
             Box::new(CanonicalizeMfp),
             // Identifies common relation subexpressions.
             Box::new(cse::relation_cse::RelationCSE::new(false)),
+            // `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP
+            // is cut in half by `RelationCSE`, then we'd like to push projections behind the new
+            // Get as much as possible. This is because a fork in the plan involves copying the
+            // data. (But we need `ProjectionPushdown` to skip joins, because it can't deal with
+            // filled in JoinImplementations.)
+            Box::new(ProjectionPushdown::skip_joins()),
+            // Plans look nicer if we tidy MFPs again after ProjectionPushdown.
+            Box::new(CanonicalizeMfp),
             // Do a last run of constant folding. Importantly, this also runs `NormalizeLets`!
             // We need `NormalizeLets` at the end of the MIR pipeline for various reasons:
             // - The rendering expects some invariants about Let/LetRecs.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -538,9 +538,12 @@ macro_rules! transforms {
         // do nothing
     };
     ($($transforms:tt)*) => {{
-        let mut __buf = Vec::<Box<dyn Transform>>::new();
-        transforms!(@op fill __buf with $($transforms)*);
-        __buf
+        #[allow(clippy::vec_init_then_push)]
+        {
+            let mut __buf = Vec::<Box<dyn Transform>>::new();
+            transforms!(@op fill __buf with $($transforms)*);
+            __buf
+        }
     }};
 }
 
@@ -745,7 +748,7 @@ impl Optimizer {
     /// rendering.
     pub fn physical_optimizer(ctx: &mut TransformCtx) -> Self {
         // Implementation transformations
-        let transforms: Vec<Box<dyn Transform>> = vec![
+        let transforms: Vec<Box<dyn Transform>> = transforms![
             Box::new(
                 Typecheck::new(ctx.typecheck())
                     .disallow_new_globals()
@@ -804,9 +807,9 @@ impl Optimizer {
             // Get as much as possible. This is because a fork in the plan involves copying the
             // data. (But we need `ProjectionPushdown` to skip joins, because it can't deal with
             // filled in JoinImplementations.)
-            Box::new(ProjectionPushdown::skip_joins()),
+            Box::new(ProjectionPushdown::skip_joins()); if ctx.features.enable_projection_pushdown_after_relation_cse,
             // Plans look nicer if we tidy MFPs again after ProjectionPushdown.
-            Box::new(CanonicalizeMfp),
+            Box::new(CanonicalizeMfp); if ctx.features.enable_projection_pushdown_after_relation_cse,
             // Do a last run of constant folding. Importantly, this also runs `NormalizeLets`!
             // We need `NormalizeLets` at the end of the MIR pipeline for various reasons:
             // - The rendering expects some invariants about Let/LetRecs.

--- a/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1207.slt
@@ -340,12 +340,13 @@ Explained Query:
                       Get l7 // { arity: 2 }
                   Get l5 // { arity: 1 }
     cte l9 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l8 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l8 // { arity: 3 }
     cte l10 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
-          Get l9 // { arity: 3 }
+          Get l9 // { arity: 2 }
     cte l11 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -372,8 +373,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l9[#0]Kenf
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l9 // { arity: 3 }
+            Get l9 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l12 // { arity: 2 }
@@ -384,12 +384,13 @@ Explained Query:
                       Get l12 // { arity: 2 }
                   Get l10 // { arity: 1 }
     cte l14 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l13 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l13 // { arity: 3 }
     cte l15 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
-          Get l14 // { arity: 3 }
+          Get l14 // { arity: 2 }
     cte l16 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#0) // { arity: 1 }
@@ -418,8 +419,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l14[#0]Kenf
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l14 // { arity: 3 }
+            Get l14 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l18 // { arity: 2 }
@@ -472,13 +472,14 @@ Explained Query:
                       Get l23 // { arity: 2 }
                   Get l20 // { arity: 1 }
     cte l25 =
-      Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
-        Map ((#2{any} AND #3{any})) // { arity: 5 }
-          Get l24 // { arity: 4 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
+          Map ((#2{any} AND #3{any})) // { arity: 5 }
+            Get l24 // { arity: 4 }
     cte l26 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
-          Get l25 // { arity: 5 }
+          Get l25 // { arity: 2 }
     cte l27 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -502,8 +503,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l25[#0]Kenf
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l25 // { arity: 5 }
+            Get l25 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l28 // { arity: 2 }
@@ -514,12 +514,13 @@ Explained Query:
                       Get l28 // { arity: 2 }
                   Get l26 // { arity: 1 }
     cte l30 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l29 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l29 // { arity: 3 }
     cte l31 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
-          Get l30 // { arity: 3 }
+          Get l30 // { arity: 2 }
     cte l32 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -546,8 +547,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l30[#0]Kenf
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l30 // { arity: 3 }
+            Get l30 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l33 // { arity: 2 }
@@ -558,12 +558,13 @@ Explained Query:
                       Get l33 // { arity: 2 }
                   Get l31 // { arity: 1 }
     cte l35 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l34 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l34 // { arity: 3 }
     cte l36 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
-          Get l35 // { arity: 3 }
+          Get l35 // { arity: 2 }
     cte l37 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -611,8 +612,7 @@ Explained Query:
                   implementation
                     %1[#0]UK » %0:l35[#0]Kenf
                   ArrangeBy keys=[[#0]] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
-                      Get l35 // { arity: 3 }
+                    Get l35 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Union // { arity: 2 }
                       Get l38 // { arity: 2 }
@@ -738,12 +738,13 @@ Explained Query:
                       Get l48 // { arity: 2 }
                   Get l46 // { arity: 1 }
     cte l50 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l49 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l49 // { arity: 3 }
     cte l51 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l50 // { arity: 3 }
+          Get l50 // { arity: 2 }
     cte l52 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -770,8 +771,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l50[#1]Kenf
           ArrangeBy keys=[[#1]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l50 // { arity: 3 }
+            Get l50 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l53 // { arity: 2 }
@@ -782,12 +782,13 @@ Explained Query:
                       Get l53 // { arity: 2 }
                   Get l51 // { arity: 1 }
     cte l55 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l54 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l54 // { arity: 3 }
     cte l56 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l55 // { arity: 3 }
+          Get l55 // { arity: 2 }
     cte l57 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#0) // { arity: 1 }
@@ -816,8 +817,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l55[#1]Kenf
           ArrangeBy keys=[[#1]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l55 // { arity: 3 }
+            Get l55 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l59 // { arity: 2 }
@@ -870,13 +870,14 @@ Explained Query:
                       Get l64 // { arity: 2 }
                   Get l61 // { arity: 1 }
     cte l66 =
-      Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
-        Map ((#2{any} AND #3{any})) // { arity: 5 }
-          Get l65 // { arity: 4 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#4) IS NULL OR (#4 = false)) // { arity: 5 }
+          Map ((#2{any} AND #3{any})) // { arity: 5 }
+            Get l65 // { arity: 4 }
     cte l67 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l66 // { arity: 5 }
+          Get l66 // { arity: 2 }
     cte l68 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -900,8 +901,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l66[#1]Kenf
           ArrangeBy keys=[[#1]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l66 // { arity: 5 }
+            Get l66 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l69 // { arity: 2 }
@@ -912,12 +912,13 @@ Explained Query:
                       Get l69 // { arity: 2 }
                   Get l67 // { arity: 1 }
     cte l71 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l70 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l70 // { arity: 3 }
     cte l72 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l71 // { arity: 3 }
+          Get l71 // { arity: 2 }
     cte l73 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -944,8 +945,7 @@ Explained Query:
           implementation
             %1[#0]UK » %0:l71[#1]Kenf
           ArrangeBy keys=[[#1]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l71 // { arity: 3 }
+            Get l71 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Union // { arity: 2 }
               Get l74 // { arity: 2 }
@@ -956,12 +956,13 @@ Explained Query:
                       Get l74 // { arity: 2 }
                   Get l72 // { arity: 1 }
     cte l76 =
-      Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
-        Get l75 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter ((#2{any}) IS NULL OR (#2{any} = false)) // { arity: 3 }
+          Get l75 // { arity: 3 }
     cte l77 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l76 // { arity: 3 }
+          Get l76 // { arity: 2 }
     cte l78 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
@@ -1017,8 +1018,7 @@ Explained Query:
                         implementation
                           %1[#0]UK » %0:l76[#1]Kenf
                         ArrangeBy keys=[[#1]] // { arity: 2 }
-                          Project (#0, #1) // { arity: 2 }
-                            Get l76 // { arity: 3 }
+                          Get l76 // { arity: 2 }
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Union // { arity: 2 }
                             Get l79 // { arity: 2 }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1210.slt
@@ -381,28 +381,30 @@ Explained Query:
                 FlatMap generate_series(1, (regexp_split_to_array["\n", case_insensitive=false](#0{input}) array_length 1), 1) // { arity: 2 }
                   ReadStorage materialize.public.input // { arity: 1 }
     cte l1 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end) // { arity: 6 }
-        Get l0 // { arity: 3 }
+      Project (#0..=#2, #4, #5) // { arity: 5 }
+        Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 - 1) else case when (#2 = "F") then (#0 + 1) else case when (#2 = "L") then (#0 - 1) else case when (#2 = "J") then #0 else case when (#2 = "7") then #0 else null end end end end end end, case when #3 then (#1 - 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then #1 else case when (#2 = "L") then #1 else case when (#2 = "J") then (#1 - 1) else case when (#2 = "7") then (#1 - 1) else null end end end end end end) // { arity: 6 }
+          Get l0 // { arity: 3 }
     cte l2 =
-      Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end) // { arity: 6 }
-        Get l0 // { arity: 3 }
+      Project (#0..=#2, #4, #5) // { arity: 5 }
+        Map ((#2 = "-"), case when #3 then #0 else case when (#2 = "|") then (#0 + 1) else case when (#2 = "F") then #0 else case when (#2 = "L") then #0 else case when (#2 = "J") then (#0 - 1) else case when (#2 = "7") then (#0 + 1) else null end end end end end end, case when #3 then (#1 + 1) else case when (#2 = "|") then #1 else case when (#2 = "F") then (#1 + 1) else case when (#2 = "L") then (#1 + 1) else case when (#2 = "J") then #1 else case when (#2 = "7") then #1 else null end end end end end end) // { arity: 6 }
+          Get l0 // { arity: 3 }
     cte l3 =
       Project (#0..=#3) // { arity: 4 }
         Filter (#4{count} = 2) // { arity: 5 }
           Reduce group_by=[#0..=#3] aggregates=[count(*)] // { arity: 5 }
             Union // { arity: 4 }
-              Project (#0, #1, #4, #5) // { arity: 4 }
-                Filter (#2 != ".") AND (#2 != "S") // { arity: 6 }
-                  Get l1 // { arity: 6 }
-              Project (#0, #1, #4, #5) // { arity: 4 }
-                Filter (#2 != ".") AND (#2 != "S") // { arity: 6 }
-                  Get l2 // { arity: 6 }
-              Project (#4, #5, #0, #1) // { arity: 4 }
-                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
-                  Get l1 // { arity: 6 }
-              Project (#4, #5, #0, #1) // { arity: 4 }
-                Filter (#2 != ".") AND (#2 != "S") AND (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
-                  Get l2 // { arity: 6 }
+              Project (#0, #1, #3, #4) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") // { arity: 5 }
+                  Get l1 // { arity: 5 }
+              Project (#0, #1, #3, #4) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") // { arity: 5 }
+                  Get l2 // { arity: 5 }
+              Project (#3, #4, #0, #1) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") AND (#3) IS NOT NULL AND (#4) IS NOT NULL // { arity: 5 }
+                  Get l1 // { arity: 5 }
+              Project (#3, #4, #0, #1) // { arity: 4 }
+                Filter (#2 != ".") AND (#2 != "S") AND (#3) IS NOT NULL AND (#4) IS NOT NULL // { arity: 5 }
+                  Get l2 // { arity: 5 }
               Project (#0, #1, #3, #1) // { arity: 4 }
                 Filter (#2 = "S") // { arity: 4 }
                   Map ((#0 + 1)) // { arity: 4 }
@@ -572,8 +574,9 @@ Explained Query:
   Return // { arity: 2 }
     With
       cte l18 =
-        Filter (#2 = true) // { arity: 3 }
-          Get l17 // { arity: 3 }
+        Project (#0, #1) // { arity: 2 }
+          Filter (#2 = true) // { arity: 3 }
+            Get l17 // { arity: 3 }
       cte l19 =
         Reduce aggregates=[count(*)] // { arity: 1 }
           Union // { arity: 0 }
@@ -583,14 +586,13 @@ Explained Query:
                   implementation
                     %1[#0, #1]UKKA » %0:l18[#0, #1]UKKef
                   ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
-                      Get l18 // { arity: 3 }
+                    Get l18 // { arity: 2 }
                   ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                     Distinct project=[#0, #1] // { arity: 2 }
                       Project (#0, #1) // { arity: 2 }
                         Get l8 // { arity: 3 }
             Project () // { arity: 0 }
-              Get l18 // { arity: 3 }
+              Get l18 // { arity: 2 }
     Return // { arity: 2 }
       CrossJoin type=differential // { arity: 2 }
         implementation

--- a/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1214.slt
@@ -163,16 +163,16 @@ Explained Query:
           Negate // { arity: 3 }
             Get l8 // { arity: 3 }
     cte l3 =
-      Filter (#2 = "O") // { arity: 3 }
-        Get l2 // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        Filter (#2 = "O") // { arity: 3 }
+          Get l2 // { arity: 3 }
     cte l4 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = (#2 + 1) AND #1 = #3) type=differential // { arity: 4 }
           implementation
             %0:l3[#1, #0]KKef » %1:l2[#1, (#0 + 1)]KKef
           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l3 // { arity: 3 }
+            Get l3 // { arity: 2 }
           ArrangeBy keys=[[#1, (#0 + 1)]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Filter (#2 = ".") // { arity: 3 }
@@ -198,7 +198,7 @@ Explained Query:
             %1[×]U » %0:l3[×]ef
           ArrangeBy keys=[[]] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Get l3 // { arity: 3 }
+              Get l3 // { arity: 2 }
           ArrangeBy keys=[[]] // { arity: 1 }
             Union // { arity: 1 }
               Get l6 // { arity: 1 }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -177,8 +177,9 @@ Explained Query:
           Filter (#4 = "lo") AND (#1) IS NOT NULL // { arity: 5 }
             Get l27 // { arity: 5 }
     cte l5 =
-      Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2)) // { arity: 3 }
-        Get l0 // { arity: 1 }
+      Project (#1, #2) // { arity: 2 }
+        Map (array_index(regexp_split_to_array[" ", case_insensitive=false](#0), 1), substr(#1, 2)) // { arity: 3 }
+          Get l0 // { arity: 1 }
     cte l6 =
       Project (#0..=#3, #5) // { arity: 5 }
         Map ((#3 + 1)) // { arity: 6 }
@@ -187,9 +188,9 @@ Explained Query:
               %0:l4[#1]Kef » %1:l5[#0]Kef
             Get l4 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter ("%" = substr(#1, 1, 1)) // { arity: 3 }
-                  Get l5 // { arity: 3 }
+              Project (#1) // { arity: 1 }
+                Filter ("%" = substr(#0, 1, 1)) // { arity: 2 }
+                  Get l5 // { arity: 2 }
     cte l7 =
       Distinct project=[#0, #2, #3, #1] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
@@ -268,9 +269,9 @@ Explained Query:
               Project (#0..=#3) // { arity: 4 }
                 Get l13 // { arity: 5 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter ("&" = substr(#1, 1, 1)) // { arity: 3 }
-                  Get l5 // { arity: 3 }
+              Project (#1) // { arity: 1 }
+                Filter ("&" = substr(#0, 1, 1)) // { arity: 2 }
+                  Get l5 // { arity: 2 }
     cte l15 =
       Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -444,8 +444,9 @@ Explained Query:
             Project (#0, #4) // { arity: 2 }
               ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
     cte l1 =
-      Filter (null OR ((#0 <= 100) AND (#0 >= 59) AND (#11 >= 1998-03-22))) // { arity: 16 }
-        ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+      Project (#4, #11) // { arity: 2 }
+        Filter (null OR ((#0 <= 100) AND (#0 >= 59) AND (#11 >= 1998-03-22))) // { arity: 16 }
+          ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Project (#1, #0) // { arity: 2 }
@@ -457,14 +458,13 @@ Explained Query:
                   implementation
                     %1[#0]UKA » %0:l1[#1]Kif
                   ArrangeBy keys=[[#1]] // { arity: 2 }
-                    Project (#4, #11) // { arity: 2 }
-                      Get l1 // { arity: 16 }
+                    Get l1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#2) // { arity: 1 }
                         Get l0 // { arity: 5 }
-            Project (#4) // { arity: 1 }
-              Get l1 // { arity: 16 }
+            Project (#0) // { arity: 1 }
+              Get l1 // { arity: 2 }
       Project (#4, #1) // { arity: 2 }
         Filter ((#2 = #3) OR ((#0 <= 100) AND (#0 >= 59) AND (#2 >= 1998-03-22))) // { arity: 5 }
           Get l0 // { arity: 5 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -447,9 +447,10 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
     With
       cte l0 =
-        Filter (#8 < 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) // { arity: 9 }
-          Map (date_to_timestamp(#4)) // { arity: 9 }
-            ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
+        Project (#0..=#2, #4, #6) // { arity: 5 }
+          Filter (#8 < 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) // { arity: 9 }
+            Map (date_to_timestamp(#4)) // { arity: 9 }
+              ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#4) // { arity: 1 }
@@ -457,8 +458,7 @@ Explained Query:
             implementation
               %1[#0..=#3]UKKKKA » %0:l0[#0..=#3]UKKKKiif
             ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
-              Project (#0..=#2, #4, #6) // { arity: 5 }
-                Get l0 // { arity: 9 }
+              Get l0 // { arity: 5 }
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Distinct project=[#0..=#3] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
@@ -467,8 +467,8 @@ Explained Query:
                       implementation
                         %0:l0[#2, #1, #0]UKKKiif » %1:orderline[#2, #1, #0]KKKAiif
                       ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
-                        Project (#0..=#2, #4) // { arity: 4 }
-                          Get l0 // { arity: 9 }
+                        Project (#0..=#3) // { arity: 4 }
+                          Get l0 // { arity: 5 }
                       ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
                         ReadIndex on=orderline fk_orderline_order=[differential join] // { arity: 10 }
 
@@ -1614,8 +1614,9 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     With
       cte l0 =
-        Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
-          ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
+        Project (#0..=#2, #9, #16, #22) // { arity: 6 }
+          Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
+            ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
       cte l1 =
         Project (#0..=#4) // { arity: 5 }
           Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
@@ -1623,14 +1624,14 @@ Explained Query:
               implementation
                 %1[×]UA » %0:l0[×]ef
               ArrangeBy keys=[[]] // { arity: 5 }
-                Project (#0..=#2, #9, #16) // { arity: 5 }
-                  Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                    Get l0 // { arity: 23 }
+                Project (#0..=#4) // { arity: 5 }
+                  Filter ((#5 = "1") OR (#5 = "2") OR (#5 = "3") OR (#5 = "4") OR (#5 = "5") OR (#5 = "6") OR (#5 = "7")) // { arity: 6 }
+                    Get l0 // { arity: 6 }
               ArrangeBy keys=[[]] // { arity: 2 }
                 Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
-                  Project (#16) // { arity: 1 }
-                    Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                      Get l0 // { arity: 23 }
+                  Project (#4) // { arity: 1 }
+                    Filter (#4 > 0) AND ((#5 = "1") OR (#5 = "2") OR (#5 = "3") OR (#5 = "4") OR (#5 = "5") OR (#5 = "6") OR (#5 = "7")) // { arity: 6 }
+                      Get l0 // { arity: 6 }
       cte l2 =
         Project (#0..=#2) // { arity: 3 }
           Get l1 // { arity: 5 }

--- a/test/sqllogictest/explain/aggregates.slt
+++ b/test/sqllogictest/explain/aggregates.slt
@@ -235,18 +235,18 @@ EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT t1.a, array_agg(t1.c), array_a
 Explained Query:
   With
     cte l0 =
-      Filter (#2) IS NOT NULL
-        ReadStorage materialize.public.t
+      Project (#0, #2)
+        Filter (#2) IS NOT NULL
+          ReadStorage materialize.public.t
   Return
     Project (#0, #1, #1)
       Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
         Project (#0, #1)
           Join on=(#1 = #2) type=differential
             ArrangeBy keys=[[#1]]
-              Project (#0, #2)
-                Get l0
+              Get l0
             ArrangeBy keys=[[#0]]
-              Project (#2)
+              Project (#1)
                 Get l0
 
 Source materialize.public.t

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -461,18 +461,18 @@ Explained Query:
             raw=true
             arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
             types=[integer, text]
-            Get::Collection l0
-              project=(#0, #2)
+            Get::PassArrangements l0
               raw=true
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0], permutation=id, thinning=() }
             types=[text]
             Get::Collection l0
-              project=(#2)
+              project=(#1)
               raw=true
 
 Source materialize.public.t
+  project=(#0, #2)
   filter=((#2) IS NOT NULL)
 
 Target cluster: quickstart

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -549,8 +549,9 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      Filter (#1 = 1) // { arity: 2 }
-        ReadStorage materialize.public.t4362 // { arity: 2 }
+      Project (#0) // { arity: 1 }
+        Filter (#1 = 1) // { arity: 2 }
+          ReadStorage materialize.public.t4362 // { arity: 2 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -560,14 +561,13 @@ Explained Query:
           ReadStorage materialize.public.t4362 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Union // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Get l0 // { arity: 2 }
+            Get l0 // { arity: 1 }
             Map (error("more than one record produced in subquery")) // { arity: 1 }
               Project () // { arity: 0 }
                 Filter (#0 > 1) // { arity: 1 }
                   Reduce aggregates=[count(*)] // { arity: 1 }
                     Project () // { arity: 0 }
-                      Get l0 // { arity: 2 }
+                      Get l0 // { arity: 1 }
 
 Source materialize.public.t4362
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -1209,8 +1209,9 @@ Explained Query:
             ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l2 =
-        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
-          Get l0 // { arity: 3 }
+        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
+          Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
+            Get l0 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1222,14 +1223,13 @@ Explained Query:
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
-                          Get l2 // { arity: 3 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#1{messageid}) // { arity: 1 }
                             Get l1 // { arity: 4 }
-                Project (#2{creatorpersonid}) // { arity: 1 }
-                  Get l2 // { arity: 3 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
+                  Get l2 // { arity: 2 }
             Project (#2{creatorpersonid}, #3{personid}) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -1216,8 +1216,9 @@ Explained Query:
             ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l2 =
-        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
-          Get l0 // { arity: 3 }
+        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
+          Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
+            Get l0 // { arity: 3 }
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
@@ -1229,14 +1230,13 @@ Explained Query:
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1{messageid}, #2{creatorpersonid}) // { arity: 2 }
-                          Get l2 // { arity: 3 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#1{messageid}) // { arity: 1 }
                             Get l1 // { arity: 4 }
-                Project (#2{creatorpersonid}) // { arity: 1 }
-                  Get l2 // { arity: 3 }
+                Project (#1{creatorpersonid}) // { arity: 1 }
+                  Get l2 // { arity: 2 }
             Project (#2{creatorpersonid}, #3{personid}) // { arity: 2 }
               Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -496,19 +496,19 @@ Explained Query:
   Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
     With
       cte l0 =
-        Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
-          Map (timestamp_tz_to_mz_timestamp(#0))
-            ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
+        Project (#0, #3)
+          Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
+            Map (timestamp_tz_to_mz_timestamp(#0))
+              ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
     Return
       Project (#1, #0, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
             Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000))]
-              Project (#0, #3)
-                Get l0
+              Get l0
           ArrangeBy keys=[[#0]]
             Reduce group_by=[#0] aggregates=[count(*)]
-              Project (#3)
+              Project (#1)
                 Get l0
 
 Used Indexes:

--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -223,8 +223,9 @@ Explained Query:
               Filter (#2) IS NULL AND (#1 = "view")
                 ReadStorage mz_internal.mz_comments
     cte l1 =
-      Filter (#2 = "u3")
-        ReadStorage mz_catalog.mz_views
+      Project (#0, #3)
+        Filter (#2 = "u3")
+          ReadStorage mz_catalog.mz_views
   Return
     Project (#0, #2)
       Map (coalesce(#1, ""))
@@ -235,13 +236,12 @@ Explained Query:
                 Project (#1)
                   Join on=(#0 = #2) type=differential
                     ArrangeBy keys=[[#0]]
-                      Project (#0, #3)
-                        Get l1
+                      Get l1
                     ArrangeBy keys=[[#0]]
                       Distinct project=[#0]
                         Project (#0)
                           Get l0
-              Project (#3)
+              Project (#1)
                 Get l1
           Project (#2, #3)
             Filter (#1 = "u3")

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -2007,8 +2007,9 @@ materialize.public.q22_primary_idx:
 materialize.public.q22:
   With
     cte l0 =
-      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+      Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}, #8) // { arity: 4 }
+        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
     cte l1 =
       Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
         Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
@@ -2016,14 +2017,14 @@ materialize.public.q22:
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
-                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
+              Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+                Filter ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                  Get l0 // { arity: 4 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5{c_acctbal}) // { arity: 1 }
-                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
+                Project (#2{c_acctbal}) // { arity: 1 }
+                  Filter (#2{c_acctbal} > 0) AND ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                    Get l0 // { arity: 4 }
     cte l2 =
       Distinct project=[#0{c_custkey}] // { arity: 1 }
         Project (#0{c_custkey}) // { arity: 1 }

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -1809,8 +1809,9 @@ ORDER BY
 materialize.public.q22:
   With
     cte l0 =
-      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+      Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}, #8) // { arity: 4 }
+        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
     cte l1 =
       Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
         Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
@@ -1818,14 +1819,14 @@ materialize.public.q22:
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
-                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
+              Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+                Filter ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                  Get l0 // { arity: 4 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                Project (#5{c_acctbal}) // { arity: 1 }
-                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
+                Project (#2{c_acctbal}) // { arity: 1 }
+                  Filter (#2{c_acctbal} > 0) AND ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                    Get l0 // { arity: 4 }
     cte l2 =
       Distinct project=[#0{c_custkey}] // { arity: 1 }
         Project (#0{c_custkey}) // { arity: 1 }

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -1804,8 +1804,9 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     With
       cte l0 =
-        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
-          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+        Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}, #8) // { arity: 4 }
+          Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
+            ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
       cte l1 =
         Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
           Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
@@ -1813,14 +1814,14 @@ Explained Query:
               implementation
                 %1[×]UA » %0:l0[×]ef
               ArrangeBy keys=[[]] // { arity: 3 }
-                Project (#0{c_custkey}, #4{c_phone}, #5{c_acctbal}) // { arity: 3 }
-                  Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
+                Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
+                  Filter ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                    Get l0 // { arity: 4 }
               ArrangeBy keys=[[]] // { arity: 2 }
                 Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
-                  Project (#5{c_acctbal}) // { arity: 1 }
-                    Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                      Get l0 // { arity: 9 }
+                  Project (#2{c_acctbal}) // { arity: 1 }
+                    Filter (#2{c_acctbal} > 0) AND ((#3 = "13") OR (#3 = "17") OR (#3 = "18") OR (#3 = "23") OR (#3 = "29") OR (#3 = "30") OR (#3 = "31")) // { arity: 4 }
+                      Get l0 // { arity: 4 }
       cte l2 =
         Distinct project=[#0{c_custkey}] // { arity: 1 }
           Project (#0{c_custkey}) // { arity: 1 }

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -988,8 +988,9 @@ Explained Query:
               Filter (#2) IS NULL AND (#1 = "view")
                 ReadStorage mz_internal.mz_comments
     cte l1 =
-      Filter (#2 = "u3")
-        ReadStorage mz_catalog.mz_views
+      Project (#0, #3)
+        Filter (#2 = "u3")
+          ReadStorage mz_catalog.mz_views
   Return
     Project (#0, #2)
       Map (coalesce(#1, ""))
@@ -1000,13 +1001,12 @@ Explained Query:
                 Project (#1)
                   Join on=(#0 = #2) type=differential
                     ArrangeBy keys=[[#0]]
-                      Project (#0, #3)
-                        Get l1
+                      Get l1
                     ArrangeBy keys=[[#0]]
                       Distinct project=[#0]
                         Project (#0)
                           Get l0
-              Project (#3)
+              Project (#1)
                 Get l1
           Project (#2, #3)
             Filter (#1 = "u3")

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -150,7 +150,8 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.lineitem fk_lineitem_orderkey=[lookup value=(38)] // { arity: 9 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.lineitem fk_lineitem_orderkey=[lookup value=(38)] // { arity: 9 }
     cte l1 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#1) // { arity: 1 }
@@ -169,14 +170,13 @@ Explained Query:
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 9 }
+                Get l0 // { arity: 1 }
                 Map (error("more than one record produced in subquery")) // { arity: 1 }
                   Project () // { arity: 0 }
                     Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
                       Reduce aggregates=[count(*)] // { arity: 1 }
                         Project () // { arity: 0 }
-                          Get l0 // { arity: 9 }
+                          Get l0 // { arity: 1 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l1 // { arity: 1 }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -741,7 +741,8 @@ UNION ALL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.big big_idx_a=[lookup value=(5)] // { arity: 15 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.big big_idx_a=[lookup value=(5)] // { arity: 15 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=delta // { arity: 1 }
@@ -757,9 +758,8 @@ Explained Query:
             ReadIndex on=big big_idx_a=[*** full scan ***] // { arity: 14 }
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
-            Get l0 // { arity: 15 }
-      Project (#0) // { arity: 1 }
-        Get l0 // { arity: 15 }
+            Get l0 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.big_idx_a (*** full scan ***, lookup)

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -136,17 +136,17 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
         %0:l0[×]e » %1:l0[×]e
       ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Get l0 // { arity: 3 }
+        Get l0 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Get l0 // { arity: 3 }
+          Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -202,18 +202,18 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l1 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Union // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 3 }
+          Get l0 // { arity: 1 }
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
               Filter (#0 > 1) // { arity: 1 }
                 Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
-                    Get l0 // { arity: 3 }
+                    Get l0 // { arity: 1 }
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
@@ -379,19 +379,18 @@ AND a2.f2 = 3
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
         %0:l0[×]ef » %1:l0[×]ef
       ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = 2) // { arity: 3 }
-            Get l0 // { arity: 3 }
+        Filter (#1 = 2) // { arity: 2 }
+          Get l0 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = 3) // { arity: 3 }
-            Get l0 // { arity: 3 }
+        Filter (#1 = 3) // { arity: 2 }
+          Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -459,17 +458,17 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l1 =
       Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
+        Get l0 // { arity: 1 }
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
               Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
+                  Get l0 // { arity: 1 }
   Return // { arity: 2 }
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
@@ -503,17 +502,17 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l1 =
       Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
+        Get l0 // { arity: 1 }
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
               Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
+                  Get l0 // { arity: 1 }
     cte l2 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -566,14 +565,14 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, join implementations) AS VERBOSE TEXT FOR SEL
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l1 =
       Project () // { arity: 0 }
-        Get l0 // { arity: 3 }
+        Get l0 // { arity: 1 }
     cte l2 =
       Union // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
+        Get l0 // { arity: 1 }
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
@@ -618,19 +617,17 @@ SELECT f1 FROM t1 WHERE f1 = 1
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-    cte l1 =
       Project (#0) // { arity: 1 }
-        Get l0 // { arity: 3 }
-    cte l2 =
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l1 =
       Union // { arity: 1 }
-        Get l1 // { arity: 1 }
+        Get l0 // { arity: 1 }
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
               Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
-                  Get l0 // { arity: 3 }
+                  Get l0 // { arity: 1 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -641,16 +638,16 @@ Explained Query:
             ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Union // { arity: 1 }
-            Get l2 // { arity: 1 }
+            Get l1 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
-                      Get l2 // { arity: 1 }
+                      Get l1 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
@@ -755,9 +752,11 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadIndex on=t1 i1=[lookup] // { arity: 2 }
     cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -765,19 +764,17 @@ Explained Query:
           %0:l1[×]e » %1:l1[×]e
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
-            Get l1 // { arity: 3 }
+            Get l1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l1 // { arity: 3 }
+          Get l1 // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l2[×]e » %1:l2[×]e
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
-            Get l2 // { arity: 3 }
+            Get l2 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l2 // { arity: 3 }
+          Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -796,15 +793,15 @@ WHERE s1.f1 = 1 AND s2.f1 = 1
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l1 =
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
-          Get l0 // { arity: 3 }
+          Get l0 // { arity: 1 }
     cte l2 =
       ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
+        Get l0 // { arity: 1 }
   Return // { arity: 2 }
     CrossJoin type=delta // { arity: 2 }
       implementation
@@ -837,9 +834,11 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadIndex on=t1 i1=[lookup] // { arity: 2 }
     cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 2 }
     CrossJoin type=delta // { arity: 2 }
       implementation
@@ -849,16 +848,14 @@ Explained Query:
         %3:l2 » %0:l1[×]e » %1:l1[×]e » %2:l2[×]e
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
-          Get l1 // { arity: 3 }
+          Get l1 // { arity: 1 }
       ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l1 // { arity: 3 }
+        Get l1 // { arity: 1 }
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
-          Get l2 // { arity: 3 }
+          Get l2 // { arity: 1 }
       ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l2 // { arity: 3 }
+        Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -968,7 +965,8 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadIndex on=t1 i1=[differential join, lookup] // { arity: 2 }
     cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l2 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -977,14 +975,13 @@ Explained Query:
           Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Union // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l1 // { arity: 3 }
+              Get l1 // { arity: 1 }
               Map (error("more than one record produced in subquery")) // { arity: 1 }
                 Project () // { arity: 0 }
                   Filter (#0 > 1) // { arity: 1 }
                     Reduce aggregates=[count(*)] // { arity: 1 }
                       Project () // { arity: 0 }
-                        Get l1 // { arity: 3 }
+                        Get l1 // { arity: 1 }
   Return // { arity: 2 }
     Union // { arity: 2 }
       Get l2 // { arity: 2 }
@@ -1338,13 +1335,14 @@ SELECT f2 FROM t1 WHERE f1 = 1
 Explained Query:
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0, #1) // { arity: 2 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       Project (#0) // { arity: 1 }
-        Get l0 // { arity: 3 }
+        Get l0 // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Get l0 // { arity: 3 }
+        Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -1396,9 +1394,11 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadIndex on=t1 i1=[lookup] // { arity: 2 }
     cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
+      Project (#0) // { arity: 1 }
+        ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   Return // { arity: 1 }
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
@@ -1406,19 +1406,17 @@ Explained Query:
           %0:l1[×]e » %1:l1[×]e
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
-            Get l1 // { arity: 3 }
+            Get l1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l1 // { arity: 3 }
+          Get l1 // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l2[×]e » %1:l2[×]e
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
-            Get l2 // { arity: 3 }
+            Get l2 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l2 // { arity: 3 }
+          Get l2 // { arity: 1 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)

--- a/test/testdrive-old-kafka-src-syntax/source-linear-operators.td
+++ b/test/testdrive-old-kafka-src-syntax/source-linear-operators.td
@@ -45,26 +45,6 @@ $ set-regex match=u\d+ replacement=UID
 
 > CREATE VIEW v as SELECT * from data where a = 1 and d = 3;
 
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Filter (#0 = 1) AND (#3 = 3)
-    ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 3))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Filter (#0 = 1) AND (#3 = 3)
-    ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 3))
-
-Target cluster: quickstart
-
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
 1 2 2 3
@@ -74,28 +54,6 @@ Target cluster: quickstart
 # basic test: pushing demand down to sources
 
 > CREATE VIEW v as SELECT b from data where b = 1;
-
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Filter (#1 = 1)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#1 = 1))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Filter (#1 = 1)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#1 = 1))
-
-Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
@@ -111,28 +69,6 @@ Target cluster: quickstart
 
 > CREATE VIEW v as SELECT b from inner_view where a = 1
 
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Filter (#0 = 1) AND (#3 = 4)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 4))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Filter (#0 = 1) AND (#3 = 4)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 4))
-
-Target cluster: quickstart
-
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
 1
@@ -143,28 +79,6 @@ Target cluster: quickstart
 
 > CREATE VIEW v as SELECT d from inner_view where a = 1;
 
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Project (#3)
-    Filter (#0 = 1) AND (#3 = 4)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 4))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Project (#3)
-    Filter (#0 = 1) AND (#3 = 4)
-      ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1) AND (#3 = 4))
-
-Target cluster: quickstart
-
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
 4
@@ -172,40 +86,6 @@ Target cluster: quickstart
 > DROP VIEW v;
 
 > CREATE VIEW v as SELECT s1.a from data s1, data s2 where s1.a = s2.b and s2.d = 4;
-
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Project (#0)
-    Join on=(#0 = #1) type=differential
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Filter (#0) IS NOT NULL
-            ReadStorage materialize.public.data
-      ArrangeBy keys=[[#0]]
-        Project (#1)
-          Filter (#3 = 4) AND (#1) IS NOT NULL
-            ReadStorage materialize.public.data
-
-Source materialize.public.data
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Project (#0)
-    Join on=(#0 = #1) type=differential
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Filter (#0) IS NOT NULL
-            ReadStorage materialize.public.data
-      ArrangeBy keys=[[#0]]
-        Project (#1)
-          Filter (#3 = 4) AND (#1) IS NOT NULL
-            ReadStorage materialize.public.data
-
-Source materialize.public.data
-
-Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
@@ -220,42 +100,6 @@ Target cluster: quickstart
 
 > CREATE VIEW v as SELECT s2.a from data s1, data s2 where s1.a = s2.b and s2.d = 4 and s1.d = 4;
 
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Join on=(#0 = #2) type=differential
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Filter (#3 = 4) AND (#0) IS NOT NULL
-            ReadStorage materialize.public.data
-      ArrangeBy keys=[[#1]]
-        Project (#0, #1)
-          Filter (#3 = 4) AND (#1) IS NOT NULL
-            ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#3 = 4))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Project (#1)
-    Join on=(#0 = #2) type=differential
-      ArrangeBy keys=[[#0]]
-        Project (#0)
-          Filter (#3 = 4) AND (#0) IS NOT NULL
-            ReadStorage materialize.public.data
-      ArrangeBy keys=[[#1]]
-        Project (#0, #1)
-          Filter (#3 = 4) AND (#1) IS NOT NULL
-            ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#3 = 4))
-
-Target cluster: quickstart
-
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
 1
@@ -264,48 +108,6 @@ Target cluster: quickstart
 > DROP VIEW v;
 
 > CREATE VIEW v as SELECT s2.c from data s1, data s2 where s1.a = s2.a
-
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  With
-    cte l0 =
-      Project (#0, #2)
-        Filter (#0) IS NOT NULL
-          ReadStorage materialize.public.data
-  Return
-    Project (#2)
-      Join on=(#0 = #1) type=differential
-        ArrangeBy keys=[[#0]]
-          Project (#0)
-            Get l0
-        ArrangeBy keys=[[#0]]
-          Get l0
-
-Source materialize.public.data
-  filter=((#0) IS NOT NULL)
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  With
-    cte l0 =
-      Filter (#0) IS NOT NULL
-        ReadStorage materialize.public.data
-  Return
-    Project (#2)
-      Join on=(#0 = #1) type=differential
-        ArrangeBy keys=[[#0]]
-          Project (#0)
-            Get l0
-        ArrangeBy keys=[[#0]]
-          Project (#0, #2)
-            Get l0
-
-Source materialize.public.data
-  filter=((#0) IS NOT NULL)
-
-Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
@@ -319,44 +121,6 @@ Target cluster: quickstart
 > DROP VIEW v;
 
 > CREATE VIEW v as SELECT * FROM (SELECT a, sum(b) FROM data GROUP BY a UNION ALL SELECT a, (a + c)::numeric FROM data) WHERE a = 1;
-
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Union
-    Project (#1, #0)
-      Map (1)
-        Reduce aggregates=[sum(#0)] monotonic
-          Project (#1)
-            Filter (#0 = 1)
-              ReadStorage materialize.public.data
-    Project (#0, #4)
-      Filter (#0 = 1)
-        Map (bigint_to_numeric((1 + #2)))
-          ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1))
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Union
-    Project (#1, #0)
-      Map (1)
-        Reduce aggregates=[sum(#0)] monotonic
-          Project (#1)
-            Filter (#0 = 1)
-              ReadStorage materialize.public.data
-    Project (#0, #4)
-      Filter (#0 = 1)
-        Map (bigint_to_numeric((1 + #2)))
-          ReadStorage materialize.public.data
-
-Source materialize.public.data
-  filter=((#0 = 1))
-
-Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v
@@ -380,40 +144,6 @@ $ kafka-ingest format=avro topic=data2 schema=${schema}
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE VIEW v as SELECT a, c FROM data EXCEPT ALL SELECT a, c FROM data2 where d is null
-
-?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT * FROM v;
-Explained Query:
-  Threshold
-    Union
-      Project (#0, #2)
-        ReadStorage materialize.public.data
-      Negate
-        Project (#0, #2)
-          Filter (#3) IS NULL
-            ReadStorage materialize.public.data2
-
-Source materialize.public.data
-Source materialize.public.data2
-  filter=((#3) IS NULL)
-
-Target cluster: quickstart
-
-?[version<13500] EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM v;
-Explained Query:
-  Threshold
-    Union
-      Project (#0, #2)
-        ReadStorage materialize.public.data
-      Negate
-        Project (#0, #2)
-          Filter (#3) IS NULL
-            ReadStorage materialize.public.data2
-
-Source materialize.public.data
-Source materialize.public.data2
-  filter=((#3) IS NULL)
-
-Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
 > SELECT * FROM v

--- a/test/testdrive-old-kafka-src-syntax/source-linear-operators.td
+++ b/test/testdrive-old-kafka-src-syntax/source-linear-operators.td
@@ -269,8 +269,9 @@ Target cluster: quickstart
 Explained Query:
   With
     cte l0 =
-      Filter (#0) IS NOT NULL
-        ReadStorage materialize.public.data
+      Project (#0, #2)
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.data
   Return
     Project (#2)
       Join on=(#0 = #1) type=differential
@@ -278,8 +279,7 @@ Explained Query:
           Project (#0)
             Get l0
         ArrangeBy keys=[[#0]]
-          Project (#0, #2)
-            Get l0
+          Get l0
 
 Source materialize.public.data
   filter=((#0) IS NOT NULL)

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -193,8 +193,9 @@ Target cluster: quickstart
 Explained Query:
   With
     cte l0 =
-      Filter (#0) IS NOT NULL
-        ReadStorage materialize.public.data_tbl
+      Project (#0, #2)
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.data_tbl
   Return
     Project (#2)
       Join on=(#0 = #1) type=differential
@@ -202,8 +203,7 @@ Explained Query:
           Project (#0)
             Get l0
         ArrangeBy keys=[[#0]]
-          Project (#0, #2)
-            Get l0
+          Get l0
 
 Source materialize.public.data_tbl
   filter=((#0) IS NOT NULL)


### PR DESCRIPTION
_**Edit: I've added the `lts-backport-v25.1` label, but if this turns out to be too annoying to cherry-pick, then it's ok to skip this, as it's just a performance improvement.**_


This adds a call to `ProjectionPushdown` after the last call to `RelationCSE`. As explained in a code comment:
```
// `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP
// is cut in half by `RelationCSE`, then we'd like to push projections behind the new
// Get as much as possible. This is because a fork in the plan involves copying the
// data. (But we need `ProjectionPushdown` to skip joins, because it can't deal with
// filled in JoinImplementations.)
```

Slack discussion here:
https://materializeinc.slack.com/archives/C07SUTL7JMQ/p1741358397379089?thread_ts=1741341927.561309&cid=C07SUTL7JMQ

It's guarded by a feature flag as a precaution, but I've enabled it by default, as it's hard to imagine this hurting plans.

The first commit is the actual functionality, while the second commit just adds the feature flag.

### Motivation

* This PR increases performance.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
