### PR TITLE
[tests] Add `reset-server` to `attribution_sources.slt`

### DIFF
--- a/test/sqllogictest/introspection/attribution_sources.slt
+++ b/test/sqllogictest/introspection/attribution_sources.slt
@@ -11,6 +11,8 @@
 
 mode cockroach
 
+reset-server
+
 # VIEW + INDEX
 
 statement ok
@@ -117,17 +119,17 @@ SELECT mz_unsafe.mz_sleep(8)
 query IT
 SELECT id, global_id FROM mz_internal.mz_dataflow_global_ids ORDER BY id, global_id;
 ----
-9  t59
+9  t50
 
 
 query TI
 SELECT global_id, lir_id FROM mz_internal.mz_lir_mapping ORDER BY global_id, lir_id DESC;
 ----
-t59  5
-t59  4
-t59  3
-t59  2
-t59  1
+t50  5
+t50  4
+t50  3
+t50  2
+t50  1
 
 ## attribution queries
 
@@ -140,11 +142,11 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t59  5  NULL  Join::Differential␠2␠»␠4
-t59  4  5  ␠␠Arrange␠3
-t59  3  4  ␠␠␠␠Get::Collection␠u4
-t59  2  5  ␠␠Arrange␠1
-t59  1  2  ␠␠␠␠Get::Collection␠u4
+t50  5  NULL  Join::Differential␠2␠»␠4
+t50  4  5  ␠␠Arrange␠3
+t50  3  4  ␠␠␠␠Get::Collection␠u4
+t50  2  5  ␠␠Arrange␠1
+t50  1  2  ␠␠␠␠Get::Collection␠u4
 
 # omitting pg_size_pretty(sum(size)) as size
 query TIIT
@@ -155,11 +157,11 @@ SELECT global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 2) || operator AS
 GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
-t59  5  NULL  Join::Differential␠2␠»␠4
-t59  4  5  ␠␠Arrange␠3
-t59  3  4  ␠␠␠␠Get::Collection␠u4
-t59  2  5  ␠␠Arrange␠1
-t59  1  2  ␠␠␠␠Get::Collection␠u4
+t50  5  NULL  Join::Differential␠2␠»␠4
+t50  4  5  ␠␠Arrange␠3
+t50  3  4  ␠␠␠␠Get::Collection␠u4
+t50  2  5  ␠␠Arrange␠1
+t50  1  2  ␠␠␠␠Get::Collection␠u4
 
 statement ok
 DROP TABLE u CASCADE;
@@ -236,7 +238,7 @@ FROM mz_introspection.mz_mappable_objects LEFT JOIN mz_introspection.mz_lir_mapp
 USING (global_id)
 GROUP BY name, global_id;
 ----
-materialize.public.w  t90  5
+materialize.public.w  t81  5
 materialize.public.v_idx_x  u9  5
 materialize.public.v_idx_x  u10  2
 materialize.public.v2_idx_x  u7  2


### PR DESCRIPTION
Without the `reset-server` the introspection sources queried in this file show different things based on which slt files we run before it.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
