### PR TITLE
limits test: Add 2 scenarios for number of Pg tables

### DIFF
--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -23,6 +23,7 @@ class Clusterd(Service):
         environment_id: str | None = None,
         environment_extra: list[str] = [],
         memory: str | None = None,
+        cpu: str | None = None,
         options: list[str] = [],
         restart: str = "no",
         stop_grace_period: str = "120s",
@@ -52,8 +53,13 @@ class Clusterd(Service):
         # Depending on the Docker Compose version, this may either work or be
         # ignored with a warning. Unfortunately no portable way of setting the
         # memory limit is known.
-        if memory:
-            config["deploy"] = {"resources": {"limits": {"memory": memory}}}
+        if memory or cpu:
+            limits = {}
+            if memory:
+                limits["memory"] = memory
+            if cpu:
+                limits["cpus"] = cpu
+            config["deploy"] = {"resources": {"limits": limits}}
 
         config.update(
             {

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -64,6 +64,7 @@ class Materialized(Service):
         volumes_extra: list[str] = [],
         depends_on: list[str] = [],
         memory: str | None = None,
+        cpu: str | None = None,
         options: list[str] = [],
         persist_blob_url: str | None = None,
         default_size: int | str = Size.DEFAULT_SIZE,
@@ -272,8 +273,13 @@ class Materialized(Service):
         # Depending on the Docker Compose version, this may either work or be
         # ignored with a warning. Unfortunately no portable way of setting the
         # memory limit is known.
-        if memory:
-            config["deploy"] = {"resources": {"limits": {"memory": memory}}}
+        if memory or cpu:
+            limits = {}
+            if memory:
+                limits["memory"] = memory
+            if cpu:
+                limits["cpus"] = cpu
+            config["deploy"] = {"resources": {"limits": limits}}
 
         if sanity_restart:
             # Workaround for https://github.com/docker/compose/issues/11133

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -26,6 +26,7 @@ from materialize import buildkite
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.clusterd import Clusterd
+from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.frontegg import FronteggMock
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
@@ -1551,6 +1552,8 @@ class PostgresTables(Generator):
         print(f"ALTER SYSTEM SET max_objects_per_schema = {cls.COUNT * 10};")
         print("$ postgres-execute connection=mz_system")
         print(f"ALTER SYSTEM SET max_tables = {cls.COUNT * 10};")
+        print("$ postgres-execute connection=mz_system")
+        print(f"ALTER SYSTEM SET max_sources = {cls.COUNT * 10};")
         print("$ postgres-execute connection=postgres://postgres:postgres@postgres")
         print("ALTER USER postgres WITH replication;")
         print("DROP SCHEMA IF EXISTS public CASCADE;")
@@ -1572,16 +1575,12 @@ class PostgresTables(Generator):
         )
         print(
             """> CREATE SOURCE p
-          IN CLUSTER single_replica_cluster
+          IN CLUSTER single_worker_cluster
           FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+          FOR ALL TABLES
           """
         )
-        for i in cls.all():
-            print(
-                f"""> CREATE TABLE t{i}
-              FROM SOURCE p (REFERENCE t{i})
-              """
-            )
+        print("> SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';")
         for i in cls.all():
             cls.store_explain_and_run(f"SELECT * FROM t{i}")
             print(f"{i}")
@@ -1739,7 +1738,11 @@ MAX_NODES = 4
 SERVICES = [
     Zookeeper(),
     Kafka(),
-    Postgres(max_wal_senders=Generator.COUNT, max_replication_slots=Generator.COUNT),
+    Postgres(
+        max_wal_senders=Generator.COUNT,
+        max_replication_slots=Generator.COUNT,
+        volumes=["sourcedata_512Mb:/var/lib/postgresql/data"],
+    ),
     MySql(),
     SchemaRegistry(),
     # We create all sources, sinks and dataflows by default with SIZE '1'
@@ -1783,8 +1786,10 @@ SERVICES = [
             "secrets:/secrets",
         ],
     ),
+    Cockroach(in_memory=True),
     Materialized(
         memory="8G",
+        cpu=2,
         default_size=1,
         options=[
             # Enable TLS on the public port to verify that balancerd is connecting to the balancerd port.
@@ -1801,6 +1806,8 @@ SERVICES = [
             "secrets:/secrets",
         ],
         sanity_restart=False,
+        external_metadata_store=True,
+        metadata_store="cockroach",
     ),
     Mz(app_password=""),
 ]
@@ -1809,7 +1816,7 @@ for cluster_id in range(1, MAX_CLUSTERS + 1):
     for replica_id in range(1, MAX_REPLICAS + 1):
         for node_id in range(1, MAX_NODES + 1):
             SERVICES.append(
-                Clusterd(name=f"clusterd_{cluster_id}_{replica_id}_{node_id}")
+                Clusterd(name=f"clusterd_{cluster_id}_{replica_id}_{node_id}", cpu=2)
             )
 
 
@@ -1828,6 +1835,7 @@ service_names = [
     "clusterd_2_2_1",
     "clusterd_3_1_1",
     "clusterd_3_2_1",
+    "clusterd_4_1_1",
 ]
 
 
@@ -1867,6 +1875,17 @@ def setup(c: Composition, workers: int) -> None:
                 COMPUTECTL ADDRESSES ['clusterd_3_1_1:2101', 'clusterd_3_2_1:2101'],
                 COMPUTE ADDRESSES ['clusterd_3_1_1:2102', 'clusterd_3_2_1:2102'],
                 WORKERS {workers}
+            )
+        );
+        GRANT ALL PRIVILEGES ON CLUSTER single_replica_cluster TO materialize;
+        DROP CLUSTER IF EXISTS single_worker_cluster CASCADE;
+        CREATE CLUSTER single_worker_cluster REPLICAS (
+            replica1 (
+                STORAGECTL ADDRESSES ['clusterd_4_1_1:2100'],
+                STORAGE ADDRESSES ['clusterd_4_1_1:2103'],
+                COMPUTECTL ADDRESSES ['clusterd_4_1_1:2101'],
+                COMPUTE ADDRESSES ['clusterd_4_1_1:2102'],
+                WORKERS 1
             )
         );
         GRANT ALL PRIVILEGES ON CLUSTER single_replica_cluster TO materialize;

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1789,7 +1789,7 @@ SERVICES = [
     Cockroach(in_memory=True),
     Materialized(
         memory="8G",
-        cpu=2,
+        cpu="2",
         default_size=1,
         options=[
             # Enable TLS on the public port to verify that balancerd is connecting to the balancerd port.
@@ -1816,7 +1816,7 @@ for cluster_id in range(1, MAX_CLUSTERS + 1):
     for replica_id in range(1, MAX_REPLICAS + 1):
         for node_id in range(1, MAX_NODES + 1):
             SERVICES.append(
-                Clusterd(name=f"clusterd_{cluster_id}_{replica_id}_{node_id}", cpu=2)
+                Clusterd(name=f"clusterd_{cluster_id}_{replica_id}_{node_id}", cpu="2")
             )
 
 


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/incidents-and-escalations/issues/211

If I made no mistakes this run should tell us the limits for old and new syntax: https://buildkite.com/materialize/release-qualification/builds/757 (for a 16 core/32 GB RAM arm64 machine)

Locally I'm running it with 1000 tables:
```
$ bin/mzcompose --find limits down && bin/mzcompose --find limits run main --scenario=PostgresTables
$ bin/mzcompose --find limits --project-name limits2 down && bin/mzcompose --find limits --project-name
limits2 run main --scenario=PostgresTablesOldSyntax
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
