### PR TITLE
Improve `extract_common` to push down expressions

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -514,18 +514,119 @@ impl MapFilterProject {
                 std::mem::replace(mfps[0], MapFilterProject::new(output_arity))
             }
             _ => {
+                // More generally, we convert each mfp to ANF, at which point we can
+                // repeatedly extract atomic expressions that depend only on input
+                // columns, migrate them to an input mfp, and repeat until no such
+                // expressions exist. At this point, we can also migrate predicates
+                // and then determine and push down projections.
+
                 // Prepare a return `Self`.
-                let input_arity = mfps[0].input_arity;
-                let mut result_mfp = MapFilterProject::new(input_arity);
+                let mut result_mfp = MapFilterProject::new(mfps[0].input_arity);
 
-                // Naive strategy:
-                // First, look for identical predicates and extract them.
-                // Then, look for unused columns and project them away.
+                // We convert each mfp to ANF, using `memoize_expressions`.
+                for mfp in mfps.iter_mut() {
+                    mfp.memoize_expressions();
+                }
 
-                // First, look for identical predicates and extract them.
-                // The trouble here is CSE, as predicates may not "look"
-                // identical despite being identical.
-                // unimplemented!()
+                // We repeatedly extract common expressions, until none remain.
+                let mut done = false;
+                while !done {
+                    // We use references to determine common expressions, and must
+                    // introduce a scope here to drop the borrows before mutation.
+                    let common = {
+                        // The input arity may increase as we iterate, so recapture.
+                        let input_arity = result_mfp.projection.len();
+                        let mut prev: BTreeSet<_> = mfps[0]
+                            .expressions
+                            .iter()
+                            .filter(|e| e.support().iter().max() < Some(&input_arity))
+                            .collect();
+                        let mut next = BTreeSet::default();
+                        for mfp in mfps[1..].iter() {
+                            for expr in mfp.expressions.iter() {
+                                if prev.contains(expr) {
+                                    next.insert(expr);
+                                }
+                            }
+                            std::mem::swap(&mut prev, &mut next);
+                            next.clear();
+                        }
+                        prev.into_iter().cloned().collect::<Vec<_>>()
+                    };
+                    // Without new common expressions, we should terminate the loop.
+                    done = common.is_empty();
+
+                    // Migrate each expression in `common` to `result_mfp`.
+                    for expr in common.into_iter() {
+                        // Update each mfp by removing expr and updating column references.
+                        for mfp in mfps.iter_mut() {
+                            // With `expr` next in `result_mfp`, it is as if we are rotating it to
+                            // be the first expression in `mfp`, and then removing it from `mfp` and
+                            // increasing the input arity of `mfp`.
+                            let arity = result_mfp.projection.len();
+                            let found = mfp.expressions.iter().position(|e| e == &expr).unwrap();
+                            let index = arity + found;
+                            // Column references change due to the rotation from `index` to `arity`.
+                            let action = |c: &mut usize| {
+                                if arity <= *c && *c < index {
+                                    *c += 1;
+                                } else if *c == index {
+                                    *c = arity;
+                                }
+                            };
+                            // Rotate `expr` from `found` to first, and then snip.
+                            // Short circuit by simply removing and incrementing the input arity.
+                            mfp.input_arity += 1;
+                            mfp.expressions.remove(found);
+                            // Update column references in expressions, predicates, and projections.
+                            for e in mfp.expressions.iter_mut() {
+                                e.visit_columns(action);
+                            }
+                            for (o, e) in mfp.predicates.iter_mut() {
+                                e.visit_columns(action);
+                                // Max out the offset for the predicate; optimization will correct.
+                                *o = mfp.input_arity + mfp.expressions.len();
+                            }
+                            for c in mfp.projection.iter_mut() {
+                                action(c);
+                            }
+                        }
+                        // Install the expression and update
+                        result_mfp.expressions.push(expr);
+                        result_mfp.projection.push(result_mfp.projection.len());
+                    }
+                }
+                // As before, but easier: predicates in common to all mfps.
+                let common_preds: Vec<MirScalarExpr> = {
+                    let input_arity = result_mfp.projection.len();
+                    let mut prev: BTreeSet<_> = mfps[0]
+                        .predicates
+                        .iter()
+                        .map(|(_, e)| e)
+                        .filter(|e| e.support().iter().max() < Some(&input_arity))
+                        .collect();
+                    let mut next = BTreeSet::default();
+                    for mfp in mfps[1..].iter() {
+                        for (_, expr) in mfp.predicates.iter() {
+                            if prev.contains(expr) {
+                                next.insert(expr);
+                            }
+                        }
+                        std::mem::swap(&mut prev, &mut next);
+                        next.clear();
+                    }
+                    // Expressions in common, that we will append to `result_mfp.expressions`.
+                    prev.into_iter().cloned().collect::<Vec<_>>()
+                };
+                for mfp in mfps.iter_mut() {
+                    mfp.predicates.retain(|(_, p)| !common_preds.contains(p));
+                    mfp.optimize();
+                }
+                result_mfp.predicates.extend(
+                    common_preds
+                        .into_iter()
+                        .map(|e| (result_mfp.projection.len(), e)),
+                );
 
                 // Then, look for unused columns and project them away.
                 let mut common_demand = BTreeSet::new();
@@ -534,7 +635,7 @@ impl MapFilterProject {
                 }
                 // columns in `common_demand` must be retained, but others
                 // may be discarded.
-                let common_demand = (0..input_arity)
+                let common_demand = (0..result_mfp.projection.len())
                     .filter(|x| common_demand.contains(x))
                     .collect::<Vec<_>>();
                 let remap = common_demand
@@ -549,6 +650,7 @@ impl MapFilterProject {
                 result_mfp = result_mfp.project(common_demand);
 
                 // Return the resulting MFP.
+                result_mfp.optimize();
                 result_mfp
             }
         }


### PR DESCRIPTION
The `MapFilterProject::extract_common` method draws a common `MapFilterProject` from a list of inputs of same. It does a great job with zero or one inputs, but for more it currently only pushes down projections. This PR improves the implementation to also push down all expressions that can be pushed down, followed by predicates, and further projections (which may now be enabled with expressions pushed down).

The approach is to convert each MFP to ANF, at which point it is clear which expressions rely only on input columns, and expressions found in all input MFPs are migrated to a common prefix, whose arity is increased, and the logic repeats. In fact, it is done in batches (*all* expressions that rely only on input columns, rather than only one). The same reasoning applies to each predicate, and then projections are pushed down as normal. Expressions are also optimized, to return from ANF form.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
