### PR TITLE
doc: add alternative vars syntax for different terminal environments

### DIFF
--- a/doc/user/content/manage/dbt/development-workflows.md
+++ b/doc/user/content/manage/dbt/development-workflows.md
@@ -360,6 +360,17 @@ These environments are later swapped transparently.
     deployment, which transparently handles running that subset of models
     against the deployment environment.
 
+    If you encounter an error like `String 'deploy:' is not valid YAML`, you
+    might need to use an alternative syntax depending on your terminal environment.
+    Different terminals handle quotes differently, so try:
+
+    ```bash
+    dbt run --vars "{\"deploy\": true}"
+    ```
+
+    This alternative syntax is compatible with Windows terminals, PowerShell, or
+    PyCharm Terminal.
+
 #### Validation
 
 [//]: # "TODO(morsapaes) Expand after we make dbt test more pliable to


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adding a short note to the documentation about alternative syntax for dbt variables when using different terminal environments. This should help users troubleshoot YAML parsing errors that can occur in Windows/PowerShell/PyCharm terminals when running blue/green deployments.