### PR TITLE
doc: add note about Aurora PostgreSQL 16.1 logical replication bug

### DIFF
--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -21,6 +21,15 @@ to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 {{% postgres-direct/before-you-begin %}}
 
+{{< warning >}}
+There is a known issue with Aurora PostgreSQL 16.1 that can cause logical replication to fail with the following error:
+- `postgres: sql client error: db error: ERROR: could not map filenumber "base/16402/3147867235" to relation OID`
+
+This is due to a bug in Aurora's implementation of logical replication in PostgreSQL 16.1, where the system fails to correctly fetch relation metadata from the catalogs. If you encounter these errors, you should upgrade your Aurora PostgreSQL instance to a newer minor version (16.2 or later).
+
+For more information, see [this AWS discussion](https://repost.aws/questions/QU4RXUrLNQS_2oSwV34pmwww/error-could-not-map-filenumber-after-aurora-upgrade-to-16-1).
+{{</ warning >}}
+
 ## A. Configure Amazon Aurora
 
 ### 1. Enable logical replication


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adding a small note about a known issue with Aurora PostgreSQL 16.1 that affects logical replication:

> https://repost.aws/questions/QU4RXUrLNQS_2oSwV34pmwww/error-could-not-map-filenumber-after-aurora-upgrade-to-16-1

I've wrapped this in a warning tag, but I'm open to suggestions if we should use a different formatting approach or tag type for this information.