### PR TITLE
Rework `mz_dataflow_operator_reachability_per_worker` join condition to be more clearly an equivalence

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -5617,9 +5617,10 @@ FROM
     mz_introspection.mz_dataflow_addresses_per_worker addr1,
     mz_introspection.mz_dataflow_addresses_per_worker addr2
 WHERE
+    addr2.address =
     CASE
-        WHEN source = 0 THEN addr2.address = addr1.address
-        ELSE addr2.address = addr1.address || reachability.source
+        WHEN source = 0 THEN addr1.address
+        ELSE addr1.address || reachability.source
     END
     AND addr1.id = reachability.id
     AND addr1.worker_id = reachability.worker_id


### PR DESCRIPTION
Our built in view for `mz_dataflow_operator_reachability_per_worker` had a join condition in a `CASE` statement. By pulling the equivalence out of the case statement, and making it equate a value that is a `CASE` statement, the join planner can recognize it as an equijoin.

As a result, queries to `mz_dataflow_operator_reachability_per_worker` and derived views take substantially less time (from minutes to seconds).

Issue https://github.com/MaterializeInc/database-issues/issues/9055 describes automating this transformation.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
