### PR TITLE
Push `MSE::If` into expressions

### DIFF
--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -297,12 +297,12 @@ where case_statement < '2023-10-02 15:55:31.918 UTC';
 ----
 Explained Query:
   Filter (#2 < 2023-10-02 15:55:31.918)
-    Map (case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end)
+    Map ((#1 - case when (#0 = 0) then 1 day else 2 days end))
       ReadStorage materialize.public.t
 
 Source materialize.public.t
-  filter=((case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end < 2023-10-02 15:55:31.918))
-  pushdown=((case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end < 2023-10-02 15:55:31.918))
+  filter=(((#1 - case when (#0 = 0) then 1 day else 2 days end) < 2023-10-02 15:55:31.918))
+  pushdown=(((#1 - case when (#0 = 0) then 1 day else 2 days end) < 2023-10-02 15:55:31.918))
 
 Target cluster: quickstart
 
@@ -317,12 +317,12 @@ select x, t from cte
 where case_statement < mz_now();
 ----
 Explained Query:
-  Filter (timestamp_to_mz_timestamp(case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end) < mz_now())
+  Filter (timestamp_to_mz_timestamp((#1 - case when (#0 = 0) then 1 day else 2 days end)) < mz_now())
     ReadStorage materialize.public.t
 
 Source materialize.public.t
-  filter=((timestamp_to_mz_timestamp(case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end) < mz_now()))
-  pushdown=((timestamp_to_mz_timestamp(case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end) < mz_now()))
+  filter=((timestamp_to_mz_timestamp((#1 - case when (#0 = 0) then 1 day else 2 days end)) < mz_now()))
+  pushdown=((timestamp_to_mz_timestamp((#1 - case when (#0 = 0) then 1 day else 2 days end)) < mz_now()))
 
 Target cluster: quickstart
 


### PR DESCRIPTION
When we have an expression `IF <cond> THEN e1 ELSE e2`, where `e1` and `e2` are the same operator except for one argument (e.g. the same unary operator, or the same binary operator and one input matches), we can push the condition into the non-matching branch. We can actually do this more generally, always pushing the condition down when the operators match, but it's less certainly a win in those cases.

One case that the conservative approach will miss is `IF <cond> THEN a = b ELSE c = d`. This could be planned as
```
(IF <cond> THEN a ELSE c) = (IF <cond> THEN b ELSE d)
```
which presents as an equivalence, for join purposes, in a way that the `IF`-wrapped expression does not.

This is equivalent to hoisting some logic out of the `If`, though it is logic evaluated in both branches, which I believe means it is safe to hoist (any erroring behavior would occur in either case).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
