### PR TITLE
Revert "Remove partition strategy migration and remaining bits (#31795)"

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -18,6 +18,7 @@ use mz_ore::now::NowFn;
 use mz_persist_types::ShardId;
 use mz_repr::{CatalogItemId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
+use mz_sql::ast::CreateSinkOptionName;
 use mz_sql::names::FullItemName;
 use mz_sql_parser::ast::{IdentError, Raw, Statement};
 use mz_storage_client::controller::StorageTxn;
@@ -113,7 +114,7 @@ pub(crate) async fn migrate(
         ast_rewrite_sources_to_tables(tx, now)?;
     }
 
-    rewrite_ast_items(tx, |_tx, _id, _stmt| {
+    rewrite_ast_items(tx, |_tx, _id, stmt| {
         // Add per-item AST migrations below.
         //
         // Each migration should be a function that takes `stmt` (the AST
@@ -122,6 +123,7 @@ pub(crate) async fn migrate(
         //
         // Migration functions may also take `tx` as input to stage
         // arbitrary changes to the catalog.
+        ast_rewrite_create_sink_partition_strategy(stmt)?;
         Ok(())
     })?;
 
@@ -851,5 +853,17 @@ fn add_to_audit_log(
     let event =
         mz_audit_log::VersionedEvent::new(id, event_type, object_type, details, None, occurred_at);
     tx.insert_audit_log_event(event);
+    Ok(())
+}
+
+// Remove PARTITION STRATEGY from CREATE SINK statements.
+fn ast_rewrite_create_sink_partition_strategy(
+    stmt: &mut Statement<Raw>,
+) -> Result<(), anyhow::Error> {
+    let Statement::CreateSink(stmt) = stmt else {
+        return Ok(());
+    };
+    stmt.with_options
+        .retain(|op| op.name != CreateSinkOptionName::PartitionStrategy);
     Ok(())
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1216,6 +1216,7 @@ impl_display_t!(CreateSubsourceStatement);
 pub enum CreateSinkOptionName {
     Snapshot,
     Version,
+    PartitionStrategy,
 }
 
 impl AstDisplay for CreateSinkOptionName {
@@ -1226,6 +1227,9 @@ impl AstDisplay for CreateSinkOptionName {
             }
             CreateSinkOptionName::Version => {
                 f.write_str("VERSION");
+            }
+            CreateSinkOptionName::PartitionStrategy => {
+                f.write_str("PARTITION STRATEGY");
             }
         }
     }
@@ -1241,6 +1245,7 @@ impl WithOptionName for CreateSinkOptionName {
         match self {
             CreateSinkOptionName::Snapshot => false,
             CreateSinkOptionName::Version => false,
+            CreateSinkOptionName::PartitionStrategy => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3237,9 +3237,13 @@ impl<'a> Parser<'a> {
 
     /// Parse the name of a CREATE SINK optional parameter
     fn parse_create_sink_option_name(&mut self) -> Result<CreateSinkOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[SNAPSHOT, VERSION])? {
+        let name = match self.expect_one_of_keywords(&[PARTITION, SNAPSHOT, VERSION])? {
             SNAPSHOT => CreateSinkOptionName::Snapshot,
             VERSION => CreateSinkOptionName::Version,
+            PARTITION => {
+                self.expect_keyword(STRATEGY)?;
+                CreateSinkOptionName::PartitionStrategy
+            }
             _ => unreachable!(),
         };
         Ok(name)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1698,21 +1698,21 @@ ALTER MATERIALIZED VIEW name SET (property = true)
 parse-statement
 ALTER SINK name SET (property = true)
 ----
-error: Expected one of SNAPSHOT or VERSION, found identifier "property"
+error: Expected one of PARTITION or SNAPSHOT or VERSION, found identifier "property"
 ALTER SINK name SET (property = true)
                      ^
 
 parse-statement
 ALTER SINK IF EXISTS name SET (SIZE LARGE)
 ----
-error: Expected one of SNAPSHOT or VERSION, found SIZE
+error: Expected one of PARTITION or SNAPSHOT or VERSION, found SIZE
 ALTER SINK IF EXISTS name SET (SIZE LARGE)
                                ^
 
 parse-statement
 ALTER SINK name RESET (SIZE)
 ----
-error: Expected one of SNAPSHOT or VERSION, found SIZE
+error: Expected one of PARTITION or SNAPSHOT or VERSION, found SIZE
 ALTER SINK name RESET (SIZE)
                        ^
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3198,7 +3198,12 @@ pub fn describe_create_sink(
     Ok(StatementDesc::new(None))
 }
 
-generate_extracted_config!(CreateSinkOption, (Snapshot, bool), (Version, u64));
+generate_extracted_config!(
+    CreateSinkOption,
+    (Snapshot, bool),
+    (PartitionStrategy, String),
+    (Version, u64)
+);
 
 pub fn plan_create_sink(
     scx: &StatementContext,
@@ -3398,6 +3403,7 @@ fn plan_sink(
     let CreateSinkOptionExtracted {
         snapshot,
         version,
+        partition_strategy: _,
         seen: _,
     } = with_options.try_into()?;
 

--- a/test/testdrive-old-kafka-src-syntax/kafka-sinks.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-sinks.td
@@ -57,7 +57,7 @@ goofus,gallant
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-contains:Expected one of SNAPSHOT or VERSION
+contains:Expected one of PARTITION or SNAPSHOT or VERSION
 
 ! CREATE SINK invalid_with_option
   IN CLUSTER ${arg.single-replica-cluster}
@@ -284,7 +284,7 @@ $ kafka-create-topic topic=snk9 partitions=4
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
   WITH (SIZE = '2')
-contains:Expected one of SNAPSHOT or VERSION, found SIZE
+contains:Expected one of PARTITION or SNAPSHOT or VERSION, found SIZE
 
 # create sink with SNAPSHOT set
 > CREATE CLUSTER sink_with_options_cluster SIZE '${arg.default-storage-size}';

--- a/test/testdrive-old-kafka-src-syntax/source-sink-clusters.td
+++ b/test/testdrive-old-kafka-src-syntax/source-sink-clusters.td
@@ -100,7 +100,7 @@ bb
   FORMAT JSON ENVELOPE DEBEZIUM
 
 ! ALTER SINK sink1 SET (SIZE = '1')
-contains:Expected one of SNAPSHOT or VERSION
+contains:Expected one of PARTITION or SNAPSHOT or VERSION
 
 > CREATE SINK sink2
   IN CLUSTER storage

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -61,7 +61,7 @@ goofus,gallant
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-contains:Expected one of SNAPSHOT or VERSION
+contains:Expected one of PARTITION or SNAPSHOT or VERSION
 
 ! CREATE SINK invalid_with_option
   IN CLUSTER ${arg.single-replica-cluster}
@@ -288,7 +288,7 @@ $ kafka-create-topic topic=snk9 partitions=4
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
   WITH (SIZE = '2')
-contains:Expected one of SNAPSHOT or VERSION, found SIZE
+contains:Expected one of PARTITION or SNAPSHOT or VERSION, found SIZE
 
 # create sink with SNAPSHOT set
 > CREATE CLUSTER sink_with_options_cluster SIZE '${arg.default-storage-size}';

--- a/test/testdrive/source-sink-clusters.td
+++ b/test/testdrive/source-sink-clusters.td
@@ -105,7 +105,7 @@ bb
   FORMAT JSON ENVELOPE DEBEZIUM
 
 ! ALTER SINK sink1 SET (SIZE = '1')
-contains:Expected one of SNAPSHOT or VERSION
+contains:Expected one of PARTITION or SNAPSHOT or VERSION
 
 > CREATE SINK sink2
   IN CLUSTER storage


### PR DESCRIPTION
This reverts commit 20069297b5cbc8a5527404612cf186ebfcd86e7d as we need to support upgrade from v0.130.4.

I ran nightly, there were a few failures, but they don't appear to be related to this change.  The scalability test failed in `SelectStarWorkload`.  

### Motivation

breaks the requirement that Materialize can be upgraded from [LTS release](https://materialize.com/docs/self-managed/v25.1/release-notes/#self-managed-versioning-and-lifecycle)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
