### PR TITLE
Fix "optimizer took more than ..." log msg

### DIFF
--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -84,8 +84,12 @@ impl OptimizerMetrics {
                 object_type = object_type,
                 transform_times = serde_json::to_string(&transform_times)
                     .unwrap_or_else(|_| format!("{:?}", transform_times)),
+                threshold = format!(
+                    "{}ms",
+                    self.e2e_optimization_time_seconds_log_threshold.as_millis()
+                ),
                 duration = format!("{}ms", duration.as_millis()),
-                "optimizer took more than 500ms"
+                "slow optimization",
             );
         }
     }


### PR DESCRIPTION
The message was always saying 500ms, even when the threshold was configured to be something else.

### Motivation


### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
