### PR TITLE
[sinks] Config checks for progress topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,6 +5862,7 @@ dependencies = [
  "crossbeam",
  "fancy-regex",
  "futures",
+ "itertools 0.12.1",
  "mz-avro",
  "mz-build-tools",
  "mz-ccsr",

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 crossbeam = "0.8.4"
 fancy-regex = "0.14.0"
 futures = "0.3.30"
+itertools = "0.12.1"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["cli", "network", "async"] }

--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -12,6 +12,7 @@
 use std::iter;
 use std::time::Duration;
 
+use anyhow::{anyhow, bail};
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
@@ -39,21 +40,23 @@ pub async fn ensure_topic<'a, C>(
     client: &'a AdminClient<C>,
     admin_opts: &AdminOptions,
     new_topic: &'a NewTopic<'a>,
-) -> Result<bool, CreateTopicError>
+) -> anyhow::Result<bool>
 where
     C: ClientContext,
 {
     let res = client
         .create_topics(iter::once(new_topic), admin_opts)
         .await?;
-    if res.len() != 1 {
-        return Err(CreateTopicError::TopicCountMismatch(res.len()));
-    }
-    let already_exists = match res.into_element() {
-        Ok(_) => Ok(false),
-        Err((_, RDKafkaErrorCode::TopicAlreadyExists)) => Ok(true),
-        Err((_, e)) => Err(CreateTopicError::Kafka(KafkaError::AdminOp(e))),
-    }?;
+
+    let already_exists = match res.as_slice() {
+        &[Ok(_)] => false,
+        &[Err((_, RDKafkaErrorCode::TopicAlreadyExists))] => true,
+        &[Err((_, e))] => bail!(KafkaError::AdminOp(e)),
+        other => bail!(
+            "kafka topic creation returned {} results, but exactly one result was expected",
+            other.len()
+        ),
+    };
 
     // We don't need to read in metadata / do any validation if the topic already exists.
     if already_exists {
@@ -79,49 +82,22 @@ where
                 .topics()
                 .iter()
                 .find(|t| t.name() == new_topic.name)
-                .ok_or(CreateTopicError::MissingMetadata)?;
+                .ok_or(anyhow!("unable to fetch topic metadata after creation"))?;
             // If the desired number of partitions is not "use the broker
             // default", wait for the topic to have the correct number of
             // partitions.
             if new_topic.num_partitions != -1 {
-                let num_partitions = i32::try_from(topic.partitions().len())
-                    .map_err(|_| CreateTopicError::TooManyPartitions)?;
-                if num_partitions != new_topic.num_partitions {
-                    return Err(CreateTopicError::PartitionCountMismatch {
-                        expected: new_topic.num_partitions,
-                        actual: num_partitions,
-                    });
+                let actual = i32::try_from(topic.partitions().len())?;
+                if actual != new_topic.num_partitions {
+                    bail!(
+                        "topic reports {actual} partitions, but expected {} partitions",
+                        new_topic.num_partitions
+                    );
                 }
             }
             Ok(false)
         })
         .await
-}
-
-/// An error while creating a Kafka topic.
-#[derive(Debug, thiserror::Error)]
-pub enum CreateTopicError {
-    /// An error from the underlying Kafka library.
-    #[error(transparent)]
-    Kafka(#[from] KafkaError),
-    /// Topic creation returned the wrong number of results.
-    #[error("kafka topic creation returned {0} results, but exactly one result was expected")]
-    TopicCountMismatch(usize),
-    /// The topic metadata could not be fetched after the topic was created.
-    #[error("unable to fetch topic metadata after creation")]
-    MissingMetadata,
-    /// The topic reported more than the maximum allowable number of partitions.
-    #[error("the topic reported more than {} partitions", i32::MAX)]
-    TooManyPartitions,
-    /// The topic metadata reported a number of partitions that did not match
-    /// the number of partitions in the topic creation request.
-    #[error("topic reports {actual} partitions, but expected {expected} partitions")]
-    PartitionCountMismatch {
-        /// The requested number of partitions.
-        expected: i32,
-        /// The reported number of partitions.
-        actual: i32,
-    },
 }
 
 /// Deletes a Kafka topic and waits for it to be reported absent in the broker metadata.


### PR DESCRIPTION
Attempt to fetch the config of already-existing topics, so we can confirm that the configs match what we'd expect.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9032

### Tips for reviewer

I'd prefer to have `ensure_topic` actually attempt to update the configuration of the topic when it can, because I'd expect that to make the overall system easier to reason about. However, we don't necessarily have the right permissions to do that... and this should give us a better sense of how urgent that work might be.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
