### PR TITLE
Set reduced_count in storage command history

### DIFF
--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -237,6 +237,8 @@ impl<T: timely::progress::Timestamp + TotalOrder> CommandHistory<T> {
         if allow_writes {
             self.commands.push(StorageCommand::AllowWrites);
         }
+
+        self.reduced_count = self.commands.len();
     }
 }
 


### PR DESCRIPTION
We never set the `reduced_count` to the last reduced length, causing us to
reduce the storage command history every time we'd push a command to it.
The fix is simple: set the reduced count at the end of the reduce function.

It's hard to measure the impact of this because we limit the number of storage objects to a low two-digit (base 10) number. In local tests, this problem caused environmentd's coordinator thread to spend more than half its time in reducing the storage history.

Related: MaterializeInc/incidents-and-escalations#211

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
