### PR TITLE
Maintenance interval to rate-limit expensive tasks

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -249,6 +249,13 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "Whether to use the new continual feedback upsert operator.",
 );
 
+/// The interval at which the compute server performs maintenance tasks.
+pub const STORAGE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
+    "storage_server_maintenance_interval",
+    Duration::from_millis(10),
+    "The interval at which the storage server performs maintenance tasks. Zero enables maintenance on every iteration.",
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -277,4 +284,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_SINK_SNAPSHOT_FRONTIER)
         .add(&STORAGE_RECLOCK_TO_LATEST)
         .add(&STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT)
+        .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)
 }

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -249,7 +249,7 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
     "Whether to use the new continual feedback upsert operator.",
 );
 
-/// The interval at which the compute server performs maintenance tasks.
+/// The interval at which the storage server performs maintenance tasks.
 pub const STORAGE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
     "storage_server_maintenance_interval",
     Duration::from_millis(10),

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -432,7 +432,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
             let config = &self.storage_state.storage_configuration;
             let stats_interval = config.parameters.statistics_collection_interval;
 
-            // Get the maintenance interval, default to zero if we don't have a compute state.
             let maintenance_interval = self.storage_state.server_maintenance_interval;
 
             let now = std::time::Instant::now();
@@ -823,7 +822,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // every server iteration.
                 self.storage_state.server_maintenance_interval =
                     STORAGE_SERVER_MAINTENANCE_INTERVAL
-                        .get(&self.storage_state.storage_configuration.config_set());
+                        .get(self.storage_state.storage_configuration.config_set());
             }
             InternalStorageCommand::StatisticsUpdate { sources, sinks } => self
                 .storage_state


### PR DESCRIPTION
Similarly to what compute has been doing for a while, introduce a
maintenance interval in the storage server to rate limit specific tasks.
At the moment, this only covers reporting frontiers to the controller. The
downside is that we might delay reporting frontier updates by the
maintenance interval.

At the moment, the maintenance interval is set to 10ms, the same as used by
compute. The largest expected frontier reporting regression is thus 10ms.

Related: https://github.com/MaterializeInc/incidents-and-escalations/issues/211

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
