### PR TITLE
Clone less

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -107,7 +107,7 @@ where
         scope,
         storage_state,
         resume_stream,
-        base_source_config.clone(),
+        &base_source_config,
         connection,
         start_signal,
     );
@@ -134,10 +134,10 @@ where
             export_id,
             ok_stream,
             data_config,
-            description.clone(),
+            &description,
             error_collections,
             storage_state,
-            base_source_config.clone(),
+            &base_source_config,
             starter.clone(),
         );
         needed_tokens.extend(extra_tokens);
@@ -156,10 +156,10 @@ fn render_source_stream<G, FromTime>(
     export_id: GlobalId,
     ok_source: Collection<G, SourceOutput<FromTime>, Diff>,
     data_config: SourceExportDataConfig,
-    description: IngestionDescription<CollectionMetadata>,
+    description: &IngestionDescription<CollectionMetadata>,
     mut error_collections: Vec<Collection<G, DataflowError, Diff>>,
     storage_state: &crate::storage_state::StorageState,
-    base_source_config: RawSourceCreationConfig,
+    base_source_config: &RawSourceCreationConfig,
     rehydrated_token: impl std::any::Any + 'static,
 ) -> (
     Collection<G, Row, Diff>,
@@ -358,7 +358,7 @@ where
                     {
                         crate::upsert::rehydration_finished(
                             scope.clone(),
-                            &base_source_config,
+                            base_source_config,
                             rehydrated_token,
                             refine_antichain(&resume_upper),
                             &snapshot_progress,

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -267,7 +267,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
 
     let busy_signal = Arc::clone(&config.busy_signal);
     let source_resume_uppers = config.source_resume_uppers.clone();
-    let responsible_for_unit = config.responsible_for(());
+    let is_active_worker = config.responsible_for(());
     let button = builder.build(move |caps| {
         SignaledFuture::new(busy_signal, async move {
             let [mut cap, mut progress_cap, health_cap, stats_cap] = caps.try_into().unwrap();
@@ -275,7 +275,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
             // We only need this until we reported ourselves as Running.
             let mut health_cap = Some(health_cap);
 
-            if !responsible_for_unit {
+            if !is_active_worker {
                 // Emit 0, to mark this worker as having started up correctly.
                 stats_output.give(
                     &stats_cap,

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -183,7 +183,7 @@ impl SourceRender for KafkaSourceConnection {
     fn render<G: Scope<Timestamp = KafkaTimestamp>>(
         self,
         scope: &mut G,
-        config: RawSourceCreationConfig,
+        config: &RawSourceCreationConfig,
         resume_uppers: impl futures::Stream<Item = Antichain<KafkaTimestamp>> + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
@@ -1666,8 +1666,9 @@ fn spawn_metadata_thread<C: ConsumerContext>(
     topic: String,
     tx: mpsc::UnboundedSender<(mz_repr::Timestamp, MetadataUpdate)>,
 ) {
+    // Linux thread names are limited to 15 characters. Use a truncated ID to fit the name.
     thread::Builder::new()
-        .name(format!("kafka-metadata-{}", config.id))
+        .name(format!("kfk-mtdt-{}", config.id))
         .spawn(move || {
             trace!(
                 source_id = config.id.to_string(),

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -106,7 +106,7 @@ impl SourceRender for MySqlSourceConnection {
     fn render<G: Scope<Timestamp = GtidPartition>>(
         self,
         scope: &mut G,
-        config: RawSourceCreationConfig,
+        config: &RawSourceCreationConfig,
         resume_uppers: impl futures::Stream<Item = Antichain<GtidPartition>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -126,7 +126,7 @@ impl SourceRender for PostgresSourceConnection {
     fn render<G: Scope<Timestamp = MzOffset>>(
         self,
         scope: &mut G,
-        config: RawSourceCreationConfig,
+        config: &RawSourceCreationConfig,
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -88,7 +88,7 @@ pub trait SourceRender {
     fn render<G: Scope<Timestamp = Self::Time>>(
         self,
         scope: &mut G,
-        config: RawSourceCreationConfig,
+        config: &RawSourceCreationConfig,
         resume_uppers: impl futures::Stream<Item = Antichain<Self::Time>> + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (


### PR DESCRIPTION
Addresses some performance issues observed in local testing and generally
good hygiene. Cloning `RawSourceCreatingConfig` is potentially expensive
because it sits on a lot of data and collections. Both cloning and dropping
the data costs time.

Observed via #31805.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
