### PR TITLE
*: enable borrow_interior_mutable_const clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,4 +399,5 @@ disallowed_types = "warn"
 from_over_into = "warn"
 mod_module_files = "warn"
 needless_pass_by_ref_mut = "warn"
+borrow_interior_mutable_const = "warn"
 # END LINT CONFIG

--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -175,6 +175,9 @@ WARN_CLIPPY_LINTS = [
     # We consistently don't use `mod.rs` files.
     "mod_module_files",
     "needless_pass_by_ref_mut",
+    # Helps prevent bugs caused by wrong usage of `const` instead of `static`
+    # to define global mutable values.
+    "borrow_interior_mutable_const",
 ]
 
 MESSAGE_LINT_MISSING = (

--- a/misc/wasm/Cargo.toml
+++ b/misc/wasm/Cargo.toml
@@ -83,4 +83,5 @@ disallowed_types = "warn"
 from_over_into = "warn"
 mod_module_files = "warn"
 needless_pass_by_ref_mut = "warn"
+borrow_interior_mutable_const = "warn"
 # END LINT CONFIG

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1098,7 +1098,7 @@ impl Coordinator {
     ///
     /// (Note that the chosen timestamp won't be the same timestamp as the system table inserts,
     /// unfortunately.)
-    async fn resolve_mz_now_for_create_materialized_view<'a>(
+    async fn resolve_mz_now_for_create_materialized_view(
         &mut self,
         cmvs: &CreateMaterializedViewStatement<Aug>,
         resolved_ids: &ResolvedIds,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -12,8 +12,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::sync::Arc;
-use std::sync::LazyLock;
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use futures::Future;
@@ -711,16 +709,8 @@ impl Coordinator {
 /// Convenience function for calculating the current upper bound that we want to
 /// prevent the global timestamp from exceeding.
 fn upper_bound(now: &mz_repr::Timestamp) -> mz_repr::Timestamp {
-    const TIMESTAMP_INTERVAL: LazyLock<mz_repr::Timestamp> = LazyLock::new(|| {
-        Duration::from_secs(5)
-            .as_millis()
-            .try_into()
-            .expect("5 seconds can fit into `Timestamp`")
-    });
-
+    const TIMESTAMP_INTERVAL_MS: u64 = 5000;
     const TIMESTAMP_INTERVAL_UPPER_BOUND: u64 = 2;
 
-    now.saturating_add(
-        TIMESTAMP_INTERVAL.saturating_mul(Timestamp::from(TIMESTAMP_INTERVAL_UPPER_BOUND)),
-    )
+    now.saturating_add(TIMESTAMP_INTERVAL_MS * TIMESTAMP_INTERVAL_UPPER_BOUND)
 }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -715,7 +715,7 @@ impl<T: TimestampManipulation> Session<T> {
                     datums: Row::pack(params.iter().map(|(d, _t)| d)),
                     types: params.into_iter().map(|(_d, t)| t).collect(),
                 },
-                result_formats: result_formats.into_iter().map(Into::into).collect(),
+                result_formats,
                 state: PortalState::NotStarted,
                 logging,
             },

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -114,21 +114,17 @@ const DEFAULT_ALLOCATOR_ID: u64 = 1;
 
 pub const DEFAULT_USER_NETWORK_POLICY_ID: NetworkPolicyId = NetworkPolicyId::User(1);
 pub const DEFAULT_USER_NETWORK_POLICY_NAME: &str = "default";
-pub const DEFAULT_USER_NETWORK_POLICY_RULES: LazyLock<
-    Vec<(
-        &str,
-        mz_sql::plan::NetworkPolicyRuleAction,
-        mz_sql::plan::NetworkPolicyRuleDirection,
-        &str,
-    )>,
-> = LazyLock::new(|| {
-    vec![(
-        "open_ingress",
-        mz_sql::plan::NetworkPolicyRuleAction::Allow,
-        mz_sql::plan::NetworkPolicyRuleDirection::Ingress,
-        "0.0.0.0/0",
-    )]
-});
+pub const DEFAULT_USER_NETWORK_POLICY_RULES: &[(
+    &str,
+    mz_sql::plan::NetworkPolicyRuleAction,
+    mz_sql::plan::NetworkPolicyRuleDirection,
+    &str,
+)] = &[(
+    "open_ingress",
+    mz_sql::plan::NetworkPolicyRuleAction::Allow,
+    mz_sql::plan::NetworkPolicyRuleDirection::Ingress,
+    "0.0.0.0/0",
+)];
 
 static DEFAULT_USER_NETWORK_POLICY_PRIVILEGES: LazyLock<Vec<MzAclItem>> = LazyLock::new(|| {
     vec![rbac::owner_privilege(
@@ -594,7 +590,6 @@ pub(crate) async fn initialize(
         DEFAULT_USER_NETWORK_POLICY_ID,
         DEFAULT_USER_NETWORK_POLICY_NAME.to_string(),
         DEFAULT_USER_NETWORK_POLICY_RULES
-            .clone()
             .into_iter()
             .map(|(name, action, direction, ip_str)| NetworkPolicyRule {
                 name: name.to_string(),

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -155,7 +155,7 @@ async fn test_persist_debug() {
     test_debug(state_builder).await;
 }
 
-async fn test_debug<'a>(state_builder: TestCatalogStateBuilder) {
+async fn test_debug(state_builder: TestCatalogStateBuilder) {
     let state_builder = state_builder.with_default_deploy_generation();
     let mut openable_state1 = state_builder.clone().unwrap_build().await;
     // Check initial empty trace.
@@ -340,7 +340,7 @@ async fn test_persist_debug_edit_fencing() {
     test_debug_edit_fencing(state_builder).await;
 }
 
-async fn test_debug_edit_fencing<'a>(state_builder: TestCatalogStateBuilder) {
+async fn test_debug_edit_fencing(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .clone()
         .with_default_deploy_generation()
@@ -435,7 +435,7 @@ async fn test_persist_debug_delete_fencing() {
     test_debug_delete_fencing(state_builder).await;
 }
 
-async fn test_debug_delete_fencing<'a>(state_builder: TestCatalogStateBuilder) {
+async fn test_debug_delete_fencing(state_builder: TestCatalogStateBuilder) {
     let mut state = state_builder
         .clone()
         .with_default_deploy_generation()

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -239,7 +239,7 @@ impl MirScalarExprDeserializeContext {
         I: Iterator<Item = TokenTree>,
     {
         match &first_arg {
-            TokenTree::Ident(i) if i.to_string().to_ascii_lowercase() == "ok" => {
+            TokenTree::Ident(i) if i.to_string().eq_ignore_ascii_case("ok") => {
                 // literal definition is mandatory after OK token
                 let first_arg = if let Some(first_arg) = rest_of_stream.next() {
                     first_arg
@@ -251,7 +251,7 @@ impl MirScalarExprDeserializeContext {
                     _ => Err(format!("expected literal after Ident: `{}`", i)),
                 }
             }
-            TokenTree::Ident(i) if i.to_string().to_ascii_lowercase() == "err" => {
+            TokenTree::Ident(i) if i.to_string().eq_ignore_ascii_case("err") => {
                 let error = deserialize_generic(rest_of_stream, "EvalError")?;
                 let typ: Option<ScalarType> =
                     deserialize_optional_generic(rest_of_stream, "ScalarType")?;

--- a/src/frontegg-mock/src/handlers/user.rs
+++ b/src/frontegg-mock/src/handlers/user.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 // https://docs.frontegg.com/reference/userscontrollerv2_getuserprofile
-pub async fn handle_get_user_profile<'a>(
+pub async fn handle_get_user_profile(
     State(context): State<Arc<Context>>,
     TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
 ) -> Result<Json<UserProfileResponse>, StatusCode> {
@@ -41,7 +41,7 @@ pub async fn handle_get_user_profile<'a>(
 }
 
 // https://docs.frontegg.com/reference/userapitokensv1controller_createtenantapitoken
-pub async fn handle_post_user_api_token<'a>(
+pub async fn handle_post_user_api_token(
     State(context): State<Arc<Context>>,
     TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
     Json(request): Json<UserApiTokenRequest>,

--- a/src/lsp-server/tests/test.rs
+++ b/src/lsp-server/tests/test.rs
@@ -51,9 +51,9 @@ mod tests {
     }
 
     /// The file path used during the tests is where the SQL code resides.
-    const FILE_PATH: LazyLock<PathBuf> = LazyLock::new(|| temp_dir().join("foo.sql"));
+    static FILE_PATH: LazyLock<PathBuf> = LazyLock::new(|| temp_dir().join("foo.sql"));
     /// The SQL code written inside [FILE_PATH].
-    const FILE_SQL_CONTENT: LazyLock<String> =
+    static FILE_SQL_CONTENT: LazyLock<String> =
         LazyLock::new(|| "SELECT \t\t\t200, 200;".to_string());
 
     /// Tests the different capabilities of [Backend](mz_lsp::backend::Backend)

--- a/src/mz/src/config_file.rs
+++ b/src/mz/src/config_file.rs
@@ -198,7 +198,7 @@ impl ConfigFile {
     }
 
     /// Removes a profile from the configuration file.
-    pub async fn remove_profile<'a>(&self, name: &str) -> Result<(), Error> {
+    pub async fn remove_profile(&self, name: &str) -> Result<(), Error> {
         let mut editable = self.editable.clone();
         let profiles = editable["profiles"]
             .as_table_mut()

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -1135,9 +1135,9 @@ mod pubsub_state {
     use crate::rpc::{PubSubSenderInternal, PubSubState};
     use crate::ShardId;
 
-    const SHARD_ID_0: LazyLock<ShardId> =
+    static SHARD_ID_0: LazyLock<ShardId> =
         LazyLock::new(|| ShardId::from_str("s00000000-0000-0000-0000-000000000000").unwrap());
-    const SHARD_ID_1: LazyLock<ShardId> =
+    static SHARD_ID_1: LazyLock<ShardId> =
         LazyLock::new(|| ShardId::from_str("s11111111-1111-1111-1111-111111111111").unwrap());
 
     const VERSIONED_DATA_0: VersionedData = VersionedData {

--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -87,7 +87,7 @@ pub struct FlamegraphTemplate<'a> {
 }
 
 #[allow(dropping_copy_types)]
-async fn time_prof<'a>(
+async fn time_prof(
     merge_threads: bool,
     build_info: &BuildInfo,
     // the time in seconds to run the profiler for

--- a/src/secrets/src/cache.rs
+++ b/src/secrets/src/cache.rs
@@ -19,7 +19,7 @@ use mz_repr::CatalogItemId;
 use crate::{CachingPolicy, SecretsReader};
 
 /// Default "time to live" for a single cache value, represented in __seconds__.
-pub const DEFAULT_TTL_SECS: AtomicU64 = AtomicU64::new(Duration::from_secs(300).as_secs());
+pub const DEFAULT_TTL_SECS: u64 = Duration::from_secs(300).as_secs();
 
 #[derive(Debug)]
 struct CachingParameters {
@@ -53,7 +53,7 @@ impl Default for CachingParameters {
     fn default() -> Self {
         CachingParameters {
             enabled: AtomicBool::new(true),
-            ttl_secs: DEFAULT_TTL_SECS,
+            ttl_secs: AtomicU64::new(DEFAULT_TTL_SECS),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -172,7 +172,7 @@ mod connection;
 // more strict.
 const MAX_NUM_COLUMNS: usize = 256;
 
-const MANAGED_REPLICA_PATTERN: std::sync::LazyLock<regex::Regex> =
+static MANAGED_REPLICA_PATTERN: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"^r(\d)+$").unwrap());
 
 /// Given a relation desc and a column list, checks that:

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -914,9 +914,7 @@ pub static SENTRY_FILTERS: VarDefinition = VarDefinition::new_lazy(
 pub static WEBHOOKS_SECRETS_CACHING_TTL_SECS: VarDefinition = VarDefinition::new_lazy(
     "webhooks_secrets_caching_ttl_secs",
     lazy_value!(usize; || {
-        usize::cast_from(
-            mz_secrets::cache::DEFAULT_TTL_SECS.load(std::sync::atomic::Ordering::Relaxed),
-        )
+        usize::cast_from(mz_secrets::cache::DEFAULT_TTL_SECS)
     }),
     "Sets the time-to-live for values in the Webhooks secrets cache.",
     false,

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -484,7 +484,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 
 /// Produces the replication stream from the MySQL server. This will return all transactions
 /// whose GTIDs were not present in the GTID UUIDs referenced in the `resume_uppper` partitions.
-async fn raw_stream<'a>(
+async fn raw_stream(
     config: &RawSourceCreationConfig,
     mut conn: MySqlConn,
     resume_upper: &Antichain<GtidPartition>,

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -502,7 +502,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 }
 
 /// Fetch the size of the snapshot on this worker.
-async fn fetch_snapshot_size<'a, Q>(
+async fn fetch_snapshot_size<Q>(
     conn: &mut Q,
     tables: Vec<(MySqlTableName, usize)>,
     metrics: MySqlSnapshotMetrics,


### PR DESCRIPTION
This PR enables a new clip lint, [borrow_interior_mutable_const](https://rust-lang.github.io/rust-clippy/master/index.html#borrow_interior_mutable_const). This lint would have been useful in finding https://github.com/MaterializeInc/materialize/pull/31594 before it was merged, rather than only after the canary deploy.

This PR also fixes a bunch of other likely wrong usages of `const` (all only performance-impacting afaict), as well as a bunch of other clippy errors one gets on the recent Rust version.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
