### PR TITLE
[sinks] Iteratively search through the progress topic

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -256,6 +256,13 @@ pub const STORAGE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
     "The interval at which the storage server performs maintenance tasks. Zero enables maintenance on every iteration.",
 );
 
+/// If set, iteratively search the progress topic for a progress record with increasing lookback.
+pub const SINK_PROGRESS_SEARCH: Config<bool> = Config::new(
+    "storage_sink_progress_search",
+    true,
+    "If set, iteratively search the progress topic for a progress record with increasing lookback.",
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -285,4 +292,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_RECLOCK_TO_LATEST)
         .add(&STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)
+        .add(&SINK_PROGRESS_SEARCH)
 }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -76,7 +76,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::rc::Rc;
 use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
@@ -116,7 +116,7 @@ use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::error::KafkaError;
 use rdkafka::message::{Header, OwnedHeaders, ToBytes};
 use rdkafka::producer::{BaseRecord, Producer, ThreadedProducer};
@@ -1019,141 +1019,167 @@ async fn determine_sink_progress(
                 )
             })?;
 
-        // Seek to the beginning of the progress topic.
-        let mut tps = TopicPartitionList::new();
-        tps.add_partition(progress_topic, partition);
-        tps.set_partition_offset(progress_topic, partition, Offset::Beginning)?;
-        progress_client_read_committed
-            .assign(&tps)
-            .with_context(|| {
-                format!(
-                    "Error seeking in progress topic {}:{}",
-                    progress_topic, partition
-                )
-            })?;
-
-        // Helper to get the progress consumer's current position.
-        let get_position = || {
-            if child_token.strong_count() == 0 {
-                bail!("operation cancelled");
-            }
-            let position = progress_client_read_committed
-                .position()?
-                .find_partition(progress_topic, partition)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "No position info found for progress topic {}",
-                        progress_topic
-                    )
-                })?
-                .offset();
-            let position = match position {
-                Offset::Offset(position) => position,
-                // An invalid offset indicates the consumer has not yet read a
-                // message. Since we assigned the consumer to the beginning of
-                // the topic, it's safe to return the low water mark here, which
-                // indicates the position before the first possible message.
-                //
-                // Note that it's important to return the low water mark and not
-                // the minimum possible offset (i.e., zero) in order to break
-                // out of the loop if the topic is empty but the low water mark
-                // is greater than zero.
-                Offset::Invalid => lo,
-                _ => bail!(
-                    "Consumer::position returned offset of wrong type: {:?}",
-                    position
-                ),
-            };
-            // Record the outstanding number of progress records that remain to be processed
-            let outstanding = u64::try_from(std::cmp::max(0, hi - position)).unwrap();
-            metrics.outstanding_progress_records.set(outstanding);
-            Ok(position)
-        };
-
-        info!("fetching latest progress record for {progress_key}, lo/hi: {lo}/{hi}");
-
-        // Read messages until the consumer is positioned at or beyond the high
-        // water mark.
-        //
-        // We use `read_committed` isolation to ensure we don't see progress
-        // records for transactions that did not commit. This means we have to
-        // wait for the LSO to progress to the high water mark `hi`, which means
-        // waiting for any open transactions for other sinks using the same
-        // progress topic to complete. We set a short transaction timeout (10s)
-        // to ensure we never need to wait more than 10s.
-        //
-        // Note that the stall time on the progress topic is not a function of
-        // transaction size. We've designed our transactions so that the
-        // progress record is always written last, after all the data has been
-        // written, and so the window of time in which the progress topic has an
-        // open transaction is quite small. The only vulnerability is if another
-        // sink using the same progress topic crashes in that small window
-        // between writing the progress record and committing the transaction,
-        // in which case we have to wait out the transaction timeout.
-        //
-        // Important invariant: we only exit this loop successfully (i.e., not
-        // returning an error) if we have positive proof of a position at or
-        // beyond the high water mark. To make this invariant easy to check, do
-        // not use `break` in the body of the loop.
-        let mut last_progress: Option<ProgressRecord> = None;
-        loop {
-            let current_position = get_position()?;
-
-            if current_position >= hi {
-                // consumer is at or beyond the high water mark and has read enough messages
-                break;
-            }
-
-            let message = match progress_client_read_committed.poll(progress_record_fetch_timeout) {
-                Some(Ok(message)) => message,
-                Some(Err(KafkaError::PartitionEOF(_))) => {
-                    // No message, but the consumer's position may have advanced
-                    // past a transaction control message that positions us at
-                    // or beyond the high water mark. Go around the loop again
-                    // to check.
-                    continue;
-                }
-                Some(Err(e)) => bail!("failed to fetch progress message {e}"),
-                None => {
-                    bail!(
-                        "timed out while waiting to reach high water mark of non-empty \
-                        topic {progress_topic}:{partition}, lo/hi: {lo}/{hi}, current position: {current_position}"
-                    );
-                }
-            };
-
-            if message.key() != Some(progress_key.to_bytes()) {
-                // This is a progress message for a different sink.
-                continue;
-            }
-
-            metrics.consumed_progress_records.inc();
-
-            let Some(payload) = message.payload() else {
-                continue
-            };
-            let progress = parse_progress_record(payload)?;
-
-            match last_progress {
-                Some(last_progress) if !PartialOrder::less_equal(&last_progress.frontier, &progress.frontier) => {
-                    bail!(
-                        "upper regressed in topic {progress_topic}:{partition} from {:?} to {:?}",
-                        &last_progress.frontier,
-                        &progress.frontier,
-                    );
-                }
-                _ => last_progress = Some(progress),
-            }
-        }
-
-        // If we get here, we are assured that we've read all messages up to
-        // the high water mark, and therefore `last_timestamp` contains the
-        // most recent timestamp for the sink under consideration.
-        Ok(last_progress)
+        progress_search(
+            &progress_client_read_committed,
+            progress_record_fetch_timeout,
+            progress_topic,
+            partition,
+            lo,
+            hi,
+            progress_key,
+            child_token.clone(),
+            Arc::clone(&metrics)
+        )
     }).await.unwrap().check_ssh_status(&ctx);
     // Express interest to the computation until after we've received its result
     drop(parent_token);
     result
+}
+
+fn progress_search<C: ConsumerContext + 'static>(
+    progress_client_read_committed: &BaseConsumer<C>,
+    progress_record_fetch_timeout: Duration,
+    progress_topic: &str,
+    partition: i32,
+    lo: i64,
+    hi: i64,
+    progress_key: ProgressKey,
+    child_token: Weak<()>,
+    metrics: Arc<KafkaSinkMetrics>,
+) -> anyhow::Result<Option<ProgressRecord>> {
+    // Seek to the beginning of the progress topic.
+    let mut tps = TopicPartitionList::new();
+    tps.add_partition(progress_topic, partition);
+    tps.set_partition_offset(progress_topic, partition, Offset::Beginning)?;
+    progress_client_read_committed
+        .assign(&tps)
+        .with_context(|| {
+            format!(
+                "Error seeking in progress topic {}:{}",
+                progress_topic, partition
+            )
+        })?;
+
+    // Helper to get the progress consumer's current position.
+    let get_position = || {
+        if child_token.strong_count() == 0 {
+            bail!("operation cancelled");
+        }
+        let position = progress_client_read_committed
+            .position()?
+            .find_partition(progress_topic, partition)
+            .ok_or_else(|| {
+                anyhow!(
+                    "No position info found for progress topic {}",
+                    progress_topic
+                )
+            })?
+            .offset();
+        let position = match position {
+            Offset::Offset(position) => position,
+            // An invalid offset indicates the consumer has not yet read a
+            // message. Since we assigned the consumer to the beginning of
+            // the topic, it's safe to return the low water mark here, which
+            // indicates the position before the first possible message.
+            //
+            // Note that it's important to return the low water mark and not
+            // the minimum possible offset (i.e., zero) in order to break
+            // out of the loop if the topic is empty but the low water mark
+            // is greater than zero.
+            Offset::Invalid => lo,
+            _ => bail!(
+                "Consumer::position returned offset of wrong type: {:?}",
+                position
+            ),
+        };
+        // Record the outstanding number of progress records that remain to be processed
+        let outstanding = u64::try_from(std::cmp::max(0, hi - position)).unwrap();
+        metrics.outstanding_progress_records.set(outstanding);
+        Ok(position)
+    };
+
+    info!("fetching latest progress record for {progress_key}, lo/hi: {lo}/{hi}");
+
+    // Read messages until the consumer is positioned at or beyond the high
+    // water mark.
+    //
+    // We use `read_committed` isolation to ensure we don't see progress
+    // records for transactions that did not commit. This means we have to
+    // wait for the LSO to progress to the high water mark `hi`, which means
+    // waiting for any open transactions for other sinks using the same
+    // progress topic to complete. We set a short transaction timeout (10s)
+    // to ensure we never need to wait more than 10s.
+    //
+    // Note that the stall time on the progress topic is not a function of
+    // transaction size. We've designed our transactions so that the
+    // progress record is always written last, after all the data has been
+    // written, and so the window of time in which the progress topic has an
+    // open transaction is quite small. The only vulnerability is if another
+    // sink using the same progress topic crashes in that small window
+    // between writing the progress record and committing the transaction,
+    // in which case we have to wait out the transaction timeout.
+    //
+    // Important invariant: we only exit this loop successfully (i.e., not
+    // returning an error) if we have positive proof of a position at or
+    // beyond the high water mark. To make this invariant easy to check, do
+    // not use `break` in the body of the loop.
+    let mut last_progress: Option<ProgressRecord> = None;
+    loop {
+        let current_position = get_position()?;
+
+        if current_position >= hi {
+            // consumer is at or beyond the high water mark and has read enough messages
+            break;
+        }
+
+        let message = match progress_client_read_committed.poll(progress_record_fetch_timeout) {
+            Some(Ok(message)) => message,
+            Some(Err(KafkaError::PartitionEOF(_))) => {
+                // No message, but the consumer's position may have advanced
+                // past a transaction control message that positions us at
+                // or beyond the high water mark. Go around the loop again
+                // to check.
+                continue;
+            }
+            Some(Err(e)) => bail!("failed to fetch progress message {e}"),
+            None => {
+                bail!(
+                        "timed out while waiting to reach high water mark of non-empty \
+                        topic {progress_topic}:{partition}, lo/hi: {lo}/{hi}, current position: {current_position}"
+                    );
+            }
+        };
+
+        if message.key() != Some(progress_key.to_bytes()) {
+            // This is a progress message for a different sink.
+            continue;
+        }
+
+        metrics.consumed_progress_records.inc();
+
+        let Some(payload) = message.payload() else {
+            continue;
+        };
+        let progress = parse_progress_record(payload)?;
+
+        match last_progress {
+            Some(last_progress)
+                if !PartialOrder::less_equal(&last_progress.frontier, &progress.frontier) =>
+            {
+                bail!(
+                    "upper regressed in topic {progress_topic}:{partition} from {:?} to {:?}",
+                    &last_progress.frontier,
+                    &progress.frontier,
+                );
+            }
+            _ => last_progress = Some(progress),
+        }
+    }
+
+    // If we get here, we are assured that we've read all messages up to
+    // the high water mark, and therefore `last_timestamp` contains the
+    // most recent timestamp for the sink under consideration.
+    Ok(last_progress)
 }
 
 /// This is the legacy struct that used to be emitted as part of a transactional produce and

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1047,10 +1047,10 @@ fn progress_search<C: ConsumerContext + 'static>(
     child_token: Weak<()>,
     metrics: Arc<KafkaSinkMetrics>,
 ) -> anyhow::Result<Option<ProgressRecord>> {
-    // Seek to the beginning of the progress topic.
+    // Seek to the beginning of the given range in the progress topic.
     let mut tps = TopicPartitionList::new();
     tps.add_partition(progress_topic, partition);
-    tps.set_partition_offset(progress_topic, partition, Offset::Beginning)?;
+    tps.set_partition_offset(progress_topic, partition, Offset::Offset(lo))?;
     progress_client_read_committed
         .assign(&tps)
         .with_context(|| {


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9032#issuecomment-2711978494

### Tips for reviewer

This behaviour is difficult to meaningfully test. I've tried to isolate the semantic changes as much as possible... consider reviewing commit-by-commit to be convinced of this.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
