### PR TITLE
storage/pg: produce probes during snapshotting

### DIFF
--- a/src/storage/src/source/postgres/statistics.rs
+++ b/src/storage/src/source/postgres/statistics.rs
@@ -1,0 +1,158 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Renders the statistics collection side of the [`PostgresSourceConnection`] ingestion dataflow.
+
+use std::cell::{Cell, RefCell};
+
+use mz_ore::future::InTask;
+use mz_postgres_util::tunnel::PostgresFlavor;
+use mz_storage_types::dyncfgs::PG_OFFSET_KNOWN_INTERVAL;
+use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
+use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
+use timely::dataflow::operators::Map;
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+use tokio_stream::StreamExt;
+
+use crate::source::postgres::{ReplicationError, TransientError};
+use crate::source::types::{Probe, ProgressStatisticsUpdate};
+use crate::source::{probe, RawSourceCreationConfig};
+
+pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
+    scope: G,
+    config: RawSourceCreationConfig,
+    connection: PostgresSourceConnection,
+    resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+) -> (
+    Stream<G, ProgressStatisticsUpdate>,
+    Stream<G, ReplicationError>,
+    Option<Stream<G, Probe<MzOffset>>>,
+    PressOnDropButton,
+) {
+    let op_name = format!("PostgresStatistics({})", config.id);
+    let mut builder = AsyncOperatorBuilder::new(op_name, scope);
+
+    let (stats_output, stats_stream) = builder.new_output();
+    let (probe_output, probe_stream) = builder.new_output();
+
+    // Yugabyte doesn't support LSN probing currently.
+    let probe_stream = match connection.connection.flavor {
+        PostgresFlavor::Vanilla => Some(probe_stream),
+        PostgresFlavor::Yugabyte => None,
+    };
+
+    let (button, transient_errors) = builder.build_fallible::<TransientError, _>(move |caps| {
+        Box::pin(async move {
+            let [stats_cap, probe_cap]: &mut [_; 2] = caps.try_into().unwrap();
+
+            // Only run the statistics collector on a single worker.
+            if !config.responsible_for("statistics") {
+                // Emit 0, to mark this worker as having started up correctly.
+                stats_output.give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::SteadyState {
+                        offset_known: 0,
+                        offset_committed: 0,
+                    },
+                );
+                return Ok(());
+            }
+
+            let connection_config = connection
+                .connection
+                .config(
+                    &config.config.connection_context.secrets_reader,
+                    &config.config,
+                    InTask::Yes,
+                )
+                .await?;
+
+            let pg_client = connection_config
+                .connect(
+                    "Postgres statistics",
+                    &config.config.connection_context.ssh_tunnel_manager,
+                )
+                .await?;
+
+            tokio::pin!(resume_uppers);
+
+            let prev_offset_known = Cell::new(None);
+            let prev_offset_committed = Cell::new(None);
+            let stats_output = RefCell::new(stats_output);
+
+            let mut probe_ticker = probe::Ticker::new(
+                || PG_OFFSET_KNOWN_INTERVAL.get(config.config.config_set()),
+                config.now_fn,
+            );
+            let probe_loop = async {
+                loop {
+                    let probe_ts = probe_ticker.tick().await;
+
+                    let lsn = super::fetch_max_lsn(&pg_client).await?;
+                    let offset_known = lsn.offset;
+                    let upstream_frontier = Antichain::from_elem(lsn);
+
+                    probe_output.give(
+                        &probe_cap[0],
+                        Probe {
+                            probe_ts,
+                            upstream_frontier,
+                        },
+                    );
+
+                    if let Some(offset_committed) = prev_offset_committed.get() {
+                        stats_output.borrow_mut().give(
+                            &stats_cap[0],
+                            ProgressStatisticsUpdate::SteadyState {
+                                // Similar to the kafka source, we don't subtract 1 from the
+                                // upper as we want to report the _number of bytes_ we have
+                                // processed/in upstream.
+                                offset_known,
+                                offset_committed,
+                            },
+                        );
+                    }
+
+                    prev_offset_known.set(Some(offset_known));
+                }
+            };
+
+            let commit_loop = async {
+                while let Some(upper) = resume_uppers.next().await {
+                    let offset_committed = match upper.into_option() {
+                        Some(lsn) => lsn.offset,
+                        None => continue,
+                    };
+
+                    if let Some(offset_known) = prev_offset_known.get() {
+                        stats_output.borrow_mut().give(
+                            &stats_cap[0],
+                            ProgressStatisticsUpdate::SteadyState {
+                                offset_known,
+                                offset_committed,
+                            },
+                        );
+                    }
+
+                    prev_offset_committed.set(Some(offset_committed));
+                }
+            };
+
+            futures::future::join(probe_loop, commit_loop).await.0
+        })
+    });
+
+    (
+        stats_stream,
+        transient_errors.map(ReplicationError::from),
+        probe_stream,
+        button.press_on_drop(),
+    )
+}

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -290,7 +290,7 @@ fn source_render_operator<G, C>(
     config: &RawSourceCreationConfig,
     source_connection: C,
     probed_upper_tx: watch::Sender<Option<Probe<C::Time>>>,
-    resume_uppers: impl futures::Stream<Item = Antichain<C::Time>> + 'static,
+    resume_uppers: impl futures::Stream<Item = Antichain<C::Time>> + Send + 'static,
     start_signal: impl std::future::Future<Output = ()> + 'static,
 ) -> (
     BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -89,7 +89,7 @@ pub trait SourceRender {
         self,
         scope: &mut G,
         config: &RawSourceCreationConfig,
-        resume_uppers: impl futures::Stream<Item = Antichain<Self::Time>> + 'static,
+        resume_uppers: impl futures::Stream<Item = Antichain<Self::Time>> + Send + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<GlobalId, StackedCollection<G, Result<SourceMessage, DataflowError>>>,


### PR DESCRIPTION
This PR fixes a defect in the postgres source where it would only start producing upstream probes once it was finished with snapshotting and started replication. The result of which being that with RLU enabled, the entire snaphot would have to be buffered in memory because no timestamp bindings would be produced during snapshotting, and thus no updates could transit the reclock operator.

This fix adds a separate "statistics" operator to the postgres source, like the mysql source already has. As in the mysql source, this operator is responsible for issueing upstream probes, so probing is decoupled from the replication process and can start immediately when the source is rendered.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9061

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
