### PR TITLE
Scalable schema fetching from postgres

### DIFF
--- a/src/postgres-util/src/schemas.rs
+++ b/src/postgres-util/src/schemas.rs
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Utilities to fetch schema information for Postgres sources.
+
+use std::collections::{BTreeMap, BTreeSet};
+
 use anyhow::anyhow;
 use tokio_postgres::types::Oid;
 use tokio_postgres::Client;
@@ -32,6 +36,10 @@ pub async fn get_schemas(client: &Client) -> Result<Vec<PostgresSchemaDesc>, Pos
 /// that are part of a publication, given a connection string and the
 /// publication name.
 ///
+/// The `oids` parameter controls for which tables to fetch schema information. If `None`,
+/// schema information for all tables in the publication is fetched. If `Some`, only
+/// schema information for the tables with the specified OIDs is fetched.
+///
 /// # Errors
 ///
 /// - Invalid connection string, user information, or user permissions.
@@ -39,6 +47,7 @@ pub async fn get_schemas(client: &Client) -> Result<Vec<PostgresSchemaDesc>, Pos
 pub async fn publication_info(
     client: &Client,
     publication: &str,
+    oids: Option<&[u32]>,
 ) -> Result<Vec<PostgresTableDesc>, PostgresError> {
     let server_version_num = client
         .query_one("SHOW server_version_num", &[])
@@ -57,37 +66,52 @@ pub async fn publication_info(
         .get(0)
         .ok_or_else(|| PostgresError::PublicationMissing(publication.to_string()))?;
 
-    let tables = client
-        .query(
-            "SELECT
-                c.oid, p.schemaname, p.tablename
-            FROM
-                pg_catalog.pg_class AS c
-                JOIN pg_namespace AS n ON c.relnamespace = n.oid
-                JOIN pg_publication_tables AS p ON
-                        c.relname = p.tablename AND n.nspname = p.schemaname
-            WHERE
-                p.pubname = $1",
-            &[&publication],
-        )
-        .await?;
+    let tables = if let Some(oids) = oids {
+        client
+            .query(
+                "SELECT
+                    c.oid, p.schemaname, p.tablename
+                FROM
+                    pg_catalog.pg_class AS c
+                    JOIN pg_namespace AS n ON c.relnamespace = n.oid
+                    JOIN pg_publication_tables AS p ON
+                            c.relname = p.tablename AND n.nspname = p.schemaname
+                WHERE
+                    p.pubname = $1
+                    AND c.oid = ANY($2)",
+                &[&publication, &oids],
+            )
+            .await
+    } else {
+        client
+            .query(
+                "SELECT
+                    c.oid, p.schemaname, p.tablename
+                FROM
+                    pg_catalog.pg_class AS c
+                    JOIN pg_namespace AS n ON c.relnamespace = n.oid
+                    JOIN pg_publication_tables AS p ON
+                            c.relname = p.tablename AND n.nspname = p.schemaname
+                WHERE
+                    p.pubname = $1",
+                &[&publication],
+            )
+            .await
+    }?;
 
-    let mut table_infos = vec![];
-    for row in tables {
-        let oid = row.get("oid");
+    // The Postgres replication protocol does not support GENERATED columns
+    // so we exclude them from this query. But not all Postgres-like
+    // databases have the `pg_attribute.attgenerated` column.
+    let attgenerated = if server_version_num >= 120000 {
+        "a.attgenerated = ''"
+    } else {
+        "true"
+    };
 
-        // The Postgres replication protocol does not support GENERATED columns
-        // so we exclude them from this query. But not all Postgres-like
-        // databases have the `pg_attribute.attgenerated` column.
-        let attgenerated = if server_version_num >= 120000 {
-            "a.attgenerated = ''"
-        } else {
-            "true"
-        };
-
-        let pg_columns = format!(
-            "
+    let pg_columns = format!(
+        "
         SELECT
+            a.attrelid AS table_oid,
             a.attname AS name,
             a.atttypid AS typoid,
             a.attnum AS colnum,
@@ -102,44 +126,48 @@ pub async fn publication_info(
         WHERE a.attnum > 0::pg_catalog.int2
             AND NOT a.attisdropped
             AND {attgenerated}
-            AND a.attrelid = $1
+            AND a.attrelid =ANY($1)
         ORDER BY a.attnum"
-        );
+    );
 
-        let columns = client
-            .query(&pg_columns, &[&oid])
-            .await?
-            .into_iter()
-            .map(|row| {
-                let name: String = row.get("name");
-                let type_oid = row.get("typoid");
-                let col_num = row
-                    .get::<_, i16>("colnum")
-                    .try_into()
-                    .expect("non-negative values");
-                let type_mod: i32 = row.get("typmod");
-                let not_null: bool = row.get("not_null");
-                Ok(PostgresColumnDesc {
-                    name,
-                    col_num,
-                    type_oid,
-                    type_mod,
-                    nullable: !not_null,
-                })
-            })
-            .collect::<Result<Vec<_>, PostgresError>>()?;
+    let table_oids = tables
+        .iter()
+        .map(|row| row.get("oid"))
+        .collect::<Vec<u32>>();
 
-        // PG 15 adds UNIQUE NULLS NOT DISTINCT, which would let us use `UNIQUE` constraints over
-        // nullable columns as keys; i.e. aligns a PG index's NULL handling with an arrangement's
-        // keys. For more info, see https://www.postgresql.org/about/featurematrix/detail/392/
-        let nulls_not_distinct = if server_version_num >= 150000 {
-            "pg_index.indnullsnotdistinct"
-        } else {
-            "false"
+    let mut columns: BTreeMap<u32, Vec<_>> = BTreeMap::new();
+    for row in client.query(&pg_columns, &[&table_oids]).await? {
+        let table_oid: u32 = row.get("table_oid");
+        let name: String = row.get("name");
+        let type_oid = row.get("typoid");
+        let col_num = row
+            .get::<_, i16>("colnum")
+            .try_into()
+            .expect("non-negative values");
+        let type_mod: i32 = row.get("typmod");
+        let not_null: bool = row.get("not_null");
+        let desc = PostgresColumnDesc {
+            name,
+            col_num,
+            type_oid,
+            type_mod,
+            nullable: !not_null,
         };
-        let pg_keys = format!(
-            "
+        columns.entry(table_oid).or_default().push(desc);
+    }
+
+    // PG 15 adds UNIQUE NULLS NOT DISTINCT, which would let us use `UNIQUE` constraints over
+    // nullable columns as keys; i.e. aligns a PG index's NULL handling with an arrangement's
+    // keys. For more info, see https://www.postgresql.org/about/featurematrix/detail/392/
+    let nulls_not_distinct = if server_version_num >= 150000 {
+        "pg_index.indnullsnotdistinct"
+    } else {
+        "false"
+    };
+    let pg_keys = format!(
+        "
         SELECT
+            pg_constraint.conrelid AS table_oid,
             pg_constraint.oid,
             pg_constraint.conkey,
             pg_constraint.conname,
@@ -151,43 +179,46 @@ pub async fn publication_info(
                     pg_index
                     ON pg_index.indexrelid = pg_constraint.conindid
         WHERE
-            pg_constraint.conrelid = $1
+            pg_constraint.conrelid =ANY($1)
                 AND
             pg_constraint.contype =ANY (ARRAY['p', 'u']);"
-        );
+    );
 
-        let keys = client
-            .query(&pg_keys, &[&oid])
-            .await?
+    let mut keys: BTreeMap<u32, BTreeSet<_>> = BTreeMap::new();
+    for row in client.query(&pg_keys, &[&table_oids]).await? {
+        let table_oid: u32 = row.get("table_oid");
+        let oid: u32 = row.get("oid");
+        let cols: Vec<i16> = row.get("conkey");
+        let name: String = row.get("conname");
+        let is_primary: bool = row.get("is_primary");
+        let nulls_not_distinct: bool = row.get("nulls_not_distinct");
+        let cols = cols
             .into_iter()
-            .map(|row| {
-                let oid: u32 = row.get("oid");
-                let cols: Vec<i16> = row.get("conkey");
-                let name: String = row.get("conname");
-                let is_primary: bool = row.get("is_primary");
-                let nulls_not_distinct: bool = row.get("nulls_not_distinct");
-                let cols = cols
-                    .into_iter()
-                    .map(|col| u16::try_from(col).expect("non-negative colnums"))
-                    .collect();
-                PostgresKeyDesc {
-                    oid,
-                    name,
-                    cols,
-                    is_primary,
-                    nulls_not_distinct,
-                }
-            })
+            .map(|col| u16::try_from(col).expect("non-negative colnums"))
             .collect();
-
-        table_infos.push(PostgresTableDesc {
+        let desc = PostgresKeyDesc {
             oid,
-            namespace: row.get("schemaname"),
-            name: row.get("tablename"),
-            columns,
-            keys,
-        });
+            name,
+            cols,
+            is_primary,
+            nulls_not_distinct,
+        };
+        keys.entry(table_oid).or_default().insert(desc);
     }
 
-    Ok(table_infos)
+    Ok(tables
+        .into_iter()
+        .map(|row| {
+            let oid: u32 = row.get("oid");
+            let columns = columns.remove(&oid).unwrap_or_default();
+            let keys = keys.remove(&oid).unwrap_or_default();
+            PostgresTableDesc {
+                oid,
+                namespace: row.get("schemaname"),
+                name: row.get("tablename"),
+                columns,
+                keys,
+            }
+        })
+        .collect())
 }

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -182,7 +182,7 @@ impl<'a> SourceReferenceClient<'a> {
 
                 tables
                     .into_iter()
-                    .map(|desc| ReferenceMetadata::Postgres {
+                    .map(|(_oid, desc)| ReferenceMetadata::Postgres {
                         table: desc,
                         database: database.to_string(),
                     })

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -172,7 +172,7 @@ impl<'a> SourceReferenceClient<'a> {
                 publication,
                 database,
             } => {
-                let tables = mz_postgres_util::publication_info(client, publication).await?;
+                let tables = mz_postgres_util::publication_info(client, publication, None).await?;
 
                 if tables.is_empty() {
                     Err(PgSourcePurificationError::EmptyPublication(

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -971,9 +971,12 @@ fn extract_transaction<'a>(
                         // to check the current local schema against the current remote schema to
                         // ensure e.g. we haven't received a schema update with the same terminal
                         // column name which is actually a different column.
-                        let upstream_info =
-                            mz_postgres_util::publication_info(metadata_client, publication)
-                                .await?;
+                        let upstream_info = mz_postgres_util::publication_info(
+                            metadata_client,
+                            publication,
+                            Some(&[rel_id]),
+                        )
+                        .await?;
                         let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
                         for (output_index, output) in valid_outputs {
@@ -1119,14 +1122,19 @@ fn spawn_schema_validator(
 
             let validation_start = Instant::now();
 
-            let upstream_info =
-                match mz_postgres_util::publication_info(&*client, &publication).await {
-                    Ok(info) => info.into_iter().map(|t| (t.oid, t)).collect(),
-                    Err(error) => {
-                        let _ = tx.send(SchemaValidationError::Postgres(error));
-                        continue;
-                    }
-                };
+            let upstream_info = match mz_postgres_util::publication_info(
+                &*client,
+                &publication,
+                Some(&table_info.keys().copied().collect::<Vec<_>>()),
+            )
+            .await
+            {
+                Ok(info) => info.into_iter().map(|t| (t.oid, t)).collect(),
+                Err(error) => {
+                    let _ = tx.send(SchemaValidationError::Postgres(error));
+                    continue;
+                }
+            };
 
             for (&oid, outputs) in table_info.iter() {
                 for (&output_index, output_info) in outputs {

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -395,8 +395,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 }
             };
 
-            let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
-
             let worker_tables = reader_table_info
                 .iter()
                 .map(|(_, outputs)| {

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -359,7 +359,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                         &config.config.connection_context.ssh_tunnel_manager,
                     )
                     .await?;
-                match mz_postgres_util::publication_info(&schema_client, &connection.publication)
+                match mz_postgres_util::publication_info(&schema_client, &connection.publication, Some(&reader_table_info.keys().copied().collect::<Vec<_>>()))
                     .await
                 {
                     // If the replication stream cannot be obtained in a definite way there is


### PR DESCRIPTION
Improve the scalability of `publication_info`, which fetches schema information from postgres. It not accepts a parameter for which schemas it should fetch, and is rewritten to avoid fetching data in a loop. Instead, it fetches the information for all OIDs in a single SQL query.

For pulling the schema of 1k tables, this reduces the time from about 1s to <10ms in local tests.

Related: MaterializeInc/incidents-and-escalations#211

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
