### PR TITLE
update other avro-resolution-no-publish-writer to use non-existent schema id

### DIFF
--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -36,18 +36,10 @@ GRANT CREATE, USAGE ON SCHEMA public TO materialize
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-resolution-no-publish-writer-${testdrive.seed}')
 
-> CREATE TABLE resolution_no_publish_writer_tbl FROM SOURCE resolution_no_publish_writer (REFERENCE "testdrive-resolution-no-publish-writer-${testdrive.seed}")
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE NONE
-
-# The value is {"f1": 123}.
+# The value is {"f1": 123}, schema_id = 0x1000000 (16777216) - that should be far beyond what the previous tests create
 # We encode it manually to avoid publishing it.
 $ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
-\\x00\x00\x00\x00\x01\xf6\x01
+\\x00\x01\x00\x00\x00\xf6\x01
 
-# TODO: Reenable when database-issues#9049 is fixed
-$ skip-if
-SELECT true
-
-! SELECT * FROM resolution_no_publish_writer_tbl;
-contains:to resolve
+SELECT status FROM mz_internal.mz_source_statuses WHERE source = 'resolution_no_publish_writer';
+stalled


### PR DESCRIPTION
This test can fail depending on the test ordering. If ordered first, it will register schema with id 1 in the schema registry, and that happens to match the schema of the test message that is expecting a failure.

This is the same issue as seen in the other test drive suite: https://github.com/MaterializeInc/materialize/pull/31398

### Motivation

fixes: https://github.com/MaterializeInc/database-issues/issues/9049

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
