### PR TITLE
compute,storage: replica connection metrics

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -518,6 +518,11 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     fn refresh_state_metrics(&self) {
         let unscheduled_collections_count =
             self.collections.values().filter(|c| !c.scheduled).count();
+        let connected_replica_count = self
+            .replicas
+            .values()
+            .filter(|r| r.client.is_connected())
+            .count();
 
         self.metrics
             .replica_count
@@ -537,6 +542,9 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         self.metrics
             .copy_to_count
             .set(u64::cast_from(self.copy_tos.len()));
+        self.metrics
+            .connected_replica_count
+            .set(u64::cast_from(connected_replica_count));
     }
 
     /// Refresh the `WallclockLagHistory` introspection and the `wallclock_lag_*_seconds` metrics

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -20,17 +20,18 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::raw::UIntGaugeVec;
 use mz_ore::metrics::{
-    DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, HistogramVec, IntCounterVec,
-    MetricVecExt, MetricsRegistry,
+    CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, HistogramVec,
+    IntCounterVec, MetricVecExt, MetricsRegistry,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_repr::GlobalId;
 use mz_service::codec::StatsCollector;
-use prometheus::core::AtomicU64;
+use prometheus::core::{AtomicF64, AtomicU64};
 
 use crate::protocol::command::{ComputeCommand, ProtoComputeCommand};
 use crate::protocol::response::{PeekResponse, ProtoComputeResponse};
 
+pub(crate) type Counter = DeleteOnDropCounter<AtomicF64, Vec<String>>;
 pub(crate) type IntCounter = DeleteOnDropCounter<AtomicU64, Vec<String>>;
 pub(crate) type UIntGauge = DeleteOnDropGauge<AtomicU64, Vec<String>>;
 type Histogram = DeleteOnDropHistogram<Vec<String>>;
@@ -63,6 +64,11 @@ pub struct ComputeControllerMetrics {
     // peeks
     peeks_total: IntCounterVec,
     peek_duration_seconds: HistogramVec,
+
+    // replica connections
+    connected_replica_count: UIntGaugeVec,
+    replica_connects_total: IntCounterVec,
+    replica_connect_wait_time_seconds_total: CounterVec,
 
     /// Metrics shared with the storage controller.
     shared: ControllerMetrics,
@@ -163,6 +169,21 @@ impl ComputeControllerMetrics {
                 var_labels: ["instance_id", "result"],
                 buckets: histogram_seconds_buckets(0.000_500, 32.),
             )),
+            connected_replica_count: metrics_registry.register(metric!(
+                name: "mz_compute_controller_connected_replica_count",
+                help: "The number of replicas successfully connected to the compute controller.",
+                var_labels: ["instance_id"],
+            )),
+            replica_connects_total: metrics_registry.register(metric!(
+                name: "mz_compute_controller_replica_connects_total",
+                help: "The total number of replica (re-)connections made by the compute controller.",
+                var_labels: ["instance_id", "replica_id"],
+            )),
+            replica_connect_wait_time_seconds_total: metrics_registry.register(metric!(
+                name: "mz_compute_controller_replica_connect_wait_time_seconds_total",
+                help: "The total time the compute controller spent waiting for replica (re-)connection.",
+                var_labels: ["instance_id", "replica_id"],
+            )),
 
             shared,
         }
@@ -204,6 +225,9 @@ impl ComputeControllerMetrics {
         let response_recv_count = self
             .response_recv_count
             .get_delete_on_drop_metric(labels.clone());
+        let connected_replica_count = self
+            .connected_replica_count
+            .get_delete_on_drop_metric(labels);
 
         InstanceMetrics {
             instance_id,
@@ -220,6 +244,7 @@ impl ComputeControllerMetrics {
             peek_duration_seconds,
             response_send_count,
             response_recv_count,
+            connected_replica_count,
         }
     }
 }
@@ -250,10 +275,12 @@ pub struct InstanceMetrics {
     pub peeks_total: PeekMetrics<IntCounter>,
     /// Histogram tracking peek durations.
     pub peek_duration_seconds: PeekMetrics<Histogram>,
-    /// Gauge tracking the number of sends on the compute response queue.
+    /// Counter tracking the number of sends on the compute response queue.
     pub response_send_count: IntCounter,
-    /// Gauge tracking the number of receives on the compute response queue.
+    /// Counter tracking the number of receives on the compute response queue.
     pub response_recv_count: IntCounter,
+    /// Gauge tracking the number of connected replicas.
+    pub connected_replica_count: UIntGauge,
 }
 
 impl InstanceMetrics {
@@ -302,6 +329,15 @@ impl InstanceMetrics {
             .hydration_queue_size
             .get_delete_on_drop_metric(labels.clone());
 
+        let replica_connects_total = self
+            .metrics
+            .replica_connects_total
+            .get_delete_on_drop_metric(labels.clone());
+        let replica_connect_wait_time_seconds_total = self
+            .metrics
+            .replica_connect_wait_time_seconds_total
+            .get_delete_on_drop_metric(labels);
+
         ReplicaMetrics {
             instance_id: self.instance_id,
             replica_id,
@@ -313,6 +349,8 @@ impl InstanceMetrics {
                 response_message_bytes_total,
                 command_queue_size,
                 hydration_queue_size,
+                replica_connects_total,
+                replica_connect_wait_time_seconds_total,
             }),
         }
     }
@@ -369,6 +407,11 @@ pub struct ReplicaMetricsInner {
     pub command_queue_size: UIntGauge,
     /// Gauge tracking the size of the hydration queue.
     pub hydration_queue_size: UIntGauge,
+
+    /// Counter tracking the total number of (re-)connects.
+    replica_connects_total: IntCounter,
+    /// Counter tracking the total time spent waiting for (re-)connects.
+    replica_connect_wait_time_seconds_total: Counter,
 }
 
 impl ReplicaMetrics {
@@ -391,6 +434,18 @@ impl ReplicaMetrics {
         );
 
         Some(ReplicaCollectionMetrics { wallclock_lag })
+    }
+
+    /// Observe a successful replica connection.
+    pub(crate) fn observe_connect(&self) {
+        self.inner.replica_connects_total.inc();
+    }
+
+    /// Observe time spent waiting for a replica connection.
+    pub(crate) fn observe_connect_time(&self, wait_time: Duration) {
+        self.inner
+            .replica_connect_wait_time_seconds_total
+            .inc_by(wait_time.as_secs_f64());
     }
 }
 

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -171,7 +171,7 @@ pub type UIntGauge = GenericGauge<AtomicU64>;
 pub type CounterVec = DeleteOnDropWrapper<prometheus::CounterVec>;
 /// Delete-on-drop shadow of Prometheus [prometheus::Gauge].
 pub type Gauge = DeleteOnDropWrapper<prometheus::Gauge>;
-/// Delete-on-drop shadow of Prometheus [prometheus::CounterVec].
+/// Delete-on-drop shadow of Prometheus [prometheus::GaugeVec].
 pub type GaugeVec = DeleteOnDropWrapper<prometheus::GaugeVec>;
 /// Delete-on-drop shadow of Prometheus [prometheus::HistogramVec].
 pub type HistogramVec = DeleteOnDropWrapper<prometheus::HistogramVec>;

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -10,20 +10,21 @@
 //! Metrics for the storage controller components
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use mz_cluster_client::metrics::{ControllerMetrics, WallclockLagMetrics};
 use mz_cluster_client::ReplicaId;
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::metric;
 use mz_ore::metrics::{
-    DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, IntCounterVec, MetricVecExt,
-    MetricsRegistry, UIntGaugeVec,
+    CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, IntCounterVec,
+    MetricVecExt, MetricsRegistry, UIntGaugeVec,
 };
 use mz_ore::stats::HISTOGRAM_BYTE_BUCKETS;
 use mz_repr::GlobalId;
 use mz_service::codec::StatsCollector;
 use mz_storage_types::instances::StorageInstanceId;
-use prometheus::core::AtomicU64;
+use prometheus::core::{AtomicF64, AtomicU64};
 
 use crate::client::{ProtoStorageCommand, ProtoStorageResponse};
 
@@ -36,6 +37,11 @@ pub struct StorageControllerMetrics {
     messages_received_bytes: prometheus::HistogramVec,
     regressed_offset_known: IntCounterVec,
     history_command_count: UIntGaugeVec,
+
+    // replica connections
+    connected_replica_count: UIntGaugeVec,
+    replica_connects_total: IntCounterVec,
+    replica_connect_wait_time_seconds_total: CounterVec,
 
     /// Metrics shared with the compute controller.
     shared: ControllerMetrics,
@@ -66,6 +72,21 @@ impl StorageControllerMetrics {
                 help: "The number of commands in the controller's command history.",
                 var_labels: ["instance_id", "command_type"],
             )),
+            connected_replica_count: metrics_registry.register(metric!(
+                name: "mz_storage_controller_connected_replica_count",
+                help: "The number of replicas successfully connected to the storage controller.",
+                var_labels: ["instance_id"],
+            )),
+            replica_connects_total: metrics_registry.register(metric!(
+                name: "mz_storage_controller_replica_connects_total",
+                help: "The total number of replica (re-)connections made by the storage controller.",
+                var_labels: ["instance_id", "replica_id"],
+            )),
+            replica_connect_wait_time_seconds_total: metrics_registry.register(metric!(
+                name: "mz_storage_controller_replica_connect_wait_time_seconds_total",
+                help: "The total time the storage controller spent waiting for replica (re-)connection.",
+                var_labels: ["instance_id", "replica_id"],
+            )),
 
             shared,
         }
@@ -89,9 +110,14 @@ impl StorageControllerMetrics {
     }
 
     pub fn for_instance(&self, id: StorageInstanceId) -> InstanceMetrics {
+        let connected_replica_count = self
+            .connected_replica_count
+            .get_delete_on_drop_metric(vec![id.to_string()]);
+
         InstanceMetrics {
             instance_id: id,
             metrics: self.clone(),
+            connected_replica_count,
         }
     }
 }
@@ -100,6 +126,8 @@ impl StorageControllerMetrics {
 pub struct InstanceMetrics {
     instance_id: StorageInstanceId,
     metrics: StorageControllerMetrics,
+    /// Gauge tracking the number of connected replicas.
+    pub connected_replica_count: UIntGauge,
 }
 
 impl InstanceMetrics {
@@ -114,6 +142,14 @@ impl InstanceMetrics {
                 messages_received_bytes: self
                     .metrics
                     .messages_received_bytes
+                    .get_delete_on_drop_metric(labels.clone()),
+                replica_connects_total: self
+                    .metrics
+                    .replica_connects_total
+                    .get_delete_on_drop_metric(labels.clone()),
+                replica_connect_wait_time_seconds_total: self
+                    .metrics
+                    .replica_connect_wait_time_seconds_total
                     .get_delete_on_drop_metric(labels),
             }),
         }
@@ -143,12 +179,30 @@ impl InstanceMetrics {
 struct ReplicaMetricsInner {
     messages_sent_bytes: DeleteOnDropHistogram<Vec<String>>,
     messages_received_bytes: DeleteOnDropHistogram<Vec<String>>,
+    /// Counter tracking the total number of (re-)connects.
+    replica_connects_total: DeleteOnDropCounter<AtomicU64, Vec<String>>,
+    /// Counter tracking the total time spent waiting for (re-)connects.
+    replica_connect_wait_time_seconds_total: DeleteOnDropCounter<AtomicF64, Vec<String>>,
 }
 
 /// Per-instance metrics
 #[derive(Debug, Clone)]
 pub struct ReplicaMetrics {
     inner: Arc<ReplicaMetricsInner>,
+}
+
+impl ReplicaMetrics {
+    /// Observe a successful replica connection.
+    pub fn observe_connect(&self) {
+        self.inner.replica_connects_total.inc();
+    }
+
+    /// Observe time spent waiting for a replica connection.
+    pub fn observe_connect_time(&self, wait_time: Duration) {
+        self.inner
+            .replica_connect_wait_time_seconds_total
+            .inc_by(wait_time.as_secs_f64());
+    }
 }
 
 /// Make [`ReplicaMetrics`] pluggable into the gRPC connection.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3437,6 +3437,11 @@ where
     fn maintain(&mut self) {
         self.update_frontier_introspection();
         self.refresh_wallclock_lag();
+
+        // Perform instance maintenance work.
+        for instance in self.instances.values_mut() {
+            instance.refresh_state_metrics();
+        }
     }
 }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2827,6 +2827,15 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_peeks_total("canceled")
     assert count == 0, f"got {count}"
 
+    count = metrics.get_value("mz_compute_controller_connected_replica_count")
+    assert count == 1, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_replica_connects_total")
+    assert count == 1, f"got {count}"
+    duration = metrics.get_value(
+        "mz_compute_controller_replica_connect_wait_time_seconds_total"
+    )
+    assert duration > 0, f"got {duration}"
+
     # mz_dataflow_wallclock_lag_seconds_count
     count = metrics.get_wallclock_lag_count(index_id)
     assert count, f"got {count}"

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2963,6 +2963,15 @@ def workflow_test_storage_controller_metrics(c: Composition) -> None:
     count = metrics_u2.get_storage_controller_history_command_count("allow_writes")
     assert count == 1, f"got {count}"
 
+    count = metrics_u2.get_value("mz_compute_controller_connected_replica_count")
+    assert count == 1, f"got {count}"
+    count = metrics_u2.get_value("mz_compute_controller_replica_connects_total")
+    assert count == 1, f"got {count}"
+    duration = metrics_u2.get_value(
+        "mz_compute_controller_replica_connect_wait_time_seconds_total"
+    )
+    assert duration > 0, f"got {duration}"
+
     # mz_dataflow_wallclock_lag_seconds_count
     count = metrics_ux.get_wallclock_lag_count(table1_id)
     assert count, f"got {count}"


### PR DESCRIPTION
This PR adds a set of replica collection metrics, tracking reconnects of both compute and storage replicas. The hope is to improve observability into issues caused by unstable connections between the controller and its replicas.

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/4895.

The issue is about compute only, but the observability is useful for storage replicas as well.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
