### PR TITLE
Improve subsource planning

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -771,6 +771,20 @@ impl Catalog {
             .err_into()
     }
 
+    /// Allocate `amount` many user IDs. See [`DurableCatalogState::allocate_user_ids`].
+    pub async fn allocate_user_ids(
+        &self,
+        amount: u64,
+        commit_ts: mz_repr::Timestamp,
+    ) -> Result<Vec<(CatalogItemId, GlobalId)>, Error> {
+        self.storage()
+            .await
+            .allocate_user_ids(amount, commit_ts)
+            .await
+            .maybe_terminate("allocating user ids")
+            .err_into()
+    }
+
     pub async fn allocate_user_id_for_test(&self) -> Result<(CatalogItemId, GlobalId), Error> {
         let commit_ts = self.storage().await.current_upper().await;
         self.allocate_user_id(commit_ts).await

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -99,7 +99,7 @@ pub(crate) async fn migrate(
 ) -> Result<MigrateResult, anyhow::Error> {
     let catalog_version = tx.get_catalog_content_version();
     let catalog_version = match catalog_version {
-        Some(v) => Version::parse(&v)?,
+        Some(v) => Version::parse(v)?,
         None => Version::new(0, 0, 0),
     };
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -386,7 +386,7 @@ impl Catalog {
 
         let last_seen_version = txn
             .get_catalog_content_version()
-            .unwrap_or_else(|| "new")
+            .unwrap_or("new")
             .to_string();
 
         // Migrate item ASTs.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -386,7 +386,8 @@ impl Catalog {
 
         let last_seen_version = txn
             .get_catalog_content_version()
-            .unwrap_or_else(|| "new".to_string());
+            .unwrap_or_else(|| "new")
+            .to_string();
 
         // Migrate item ASTs.
         let builtin_table_update = if !config.skip_migrations {
@@ -930,7 +931,7 @@ fn add_new_remove_old_builtin_introspection_source_migration(
         removed_indexes.extend(
             introspection_source_index_ids
                 .into_keys()
-                .map(|name| (cluster.id, name)),
+                .map(|name| (cluster.id, name.to_string())),
         );
     }
     txn.insert_introspection_source_indexes(new_indexes, &HashSet::new())?;
@@ -1090,7 +1091,7 @@ fn remove_invalid_config_param_role_defaults_migration(
 /// Cluster Replicas may be created ephemerally during an alter statement, these replicas
 /// are marked as pending and should be cleaned up on catalog opsn.
 fn remove_pending_cluster_replicas_migration(tx: &mut Transaction) -> Result<(), anyhow::Error> {
-    for replica in tx.get_cluster_replicas() {
+    for replica in tx.get_cluster_replicas().collect::<Vec<_>>() {
         if let mz_catalog::durable::ReplicaLocation::Managed { pending: true, .. } =
             replica.config.location
         {

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -336,6 +336,24 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         Ok(ids)
     }
 
+    /// Allocates and returns `amount` many user [`CatalogItemId`] and [`GlobalId`].
+    ///
+    /// See [`Self::commit_transaction`] for details on `commit_ts`.
+    async fn allocate_user_ids(
+        &mut self,
+        amount: u64,
+        commit_ts: Timestamp,
+    ) -> Result<Vec<(CatalogItemId, GlobalId)>, CatalogError> {
+        let ids = self
+            .allocate_id(USER_ITEM_ALLOC_KEY, amount, commit_ts)
+            .await?;
+        let ids = ids
+            .iter()
+            .map(|id| (CatalogItemId::User(*id), GlobalId::User(*id)))
+            .collect();
+        Ok(ids)
+    }
+
     /// Allocates and returns both a user [`CatalogItemId`] and [`GlobalId`].
     ///
     /// See [`Self::commit_transaction`] for details on `commit_ts`.

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -2855,8 +2855,8 @@ where
 
     /// Verifies that no items in `self` violate `self.uniqueness_violation`.
     ///
-    /// Runtime is O(n^2), where n is the number of items in `self`, if [`V::HAS_UNIQUE_NAME`]
-    /// is false. Prefer using [`Self::verify_keys`].
+    /// Runtime is O(n^2), where n is the number of items in `self`, if
+    /// [`UniqueName::HAS_UNIQUE_NAME`] is false for `V`. Prefer using [`Self::verify_keys`].
     fn verify(&self) -> Result<(), DurableCatalogError> {
         if let Some(uniqueness_violation) = self.uniqueness_violation {
             // Compare each value to each other value and ensure they are unique.
@@ -2976,8 +2976,7 @@ where
     }
 
     /// Returns the items viewable in the current transaction as references. Returns a map
-    /// of references, so this is cheaper than [`Self::items_cloned`] for keys and values with
-    /// heap-allocated data.
+    /// of references.
     fn items(&self) -> BTreeMap<&K, &V> {
         let mut items = BTreeMap::new();
         self.for_values(|k, v| {
@@ -3302,7 +3301,7 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use mz_ore::assert_none;
+    use mz_ore::{assert_none, assert_ok};
 
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::PersistClient;
@@ -3323,12 +3322,8 @@ mod tests {
 
         // Ideally, we compare for errors here, but it's hard/impossible to implement PartialEq
         // for DurableCatalogError.
-        assert!(table
-            .insert(2i64.to_le_bytes().to_vec(), "b".to_string(), 0)
-            .is_ok());
-        assert!(table
-            .insert(3i64.to_le_bytes().to_vec(), "c".to_string(), 0)
-            .is_ok());
+        assert_ok!(table.insert(2i64.to_le_bytes().to_vec(), "b".to_string(), 0));
+        assert_ok!(table.insert(3i64.to_le_bytes().to_vec(), "c".to_string(), 0));
         assert!(table
             .insert(1i64.to_le_bytes().to_vec(), "c".to_string(), 0)
             .is_err());

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -932,21 +932,24 @@ where
             changes.update(time.clone(), 1);
         }
 
-        let user_capabilities = self_collections
-            .iter_mut()
-            .filter(|(id, _c)| id.is_user())
-            .map(|(id, c)| {
-                let updates = c.read_capabilities.updates().cloned().collect_vec();
-                (*id, c.implied_capability.clone(), updates)
-            })
-            .collect_vec();
+        if tracing::span_enabled!(tracing::Level::TRACE) {
+            // Collecting `user_capabilities` is potentially slow, thus only do it when needed.
+            let user_capabilities = self_collections
+                .iter_mut()
+                .filter(|(id, _c)| id.is_user())
+                .map(|(id, c)| {
+                    let updates = c.read_capabilities.updates().cloned().collect_vec();
+                    (*id, c.implied_capability.clone(), updates)
+                })
+                .collect_vec();
 
-        trace!(
-            %from_id,
-            ?storage_dependencies,
-            ?read_capability,
-            ?user_capabilities,
-            "install_read_capabilities_inner");
+            trace!(
+                %from_id,
+                ?storage_dependencies,
+                ?read_capability,
+                ?user_capabilities,
+                "install_read_capabilities_inner");
+        }
 
         let mut storage_read_updates = storage_dependencies
             .iter()
@@ -959,21 +962,24 @@ where
             &mut storage_read_updates,
         );
 
-        let user_capabilities = self_collections
-            .iter_mut()
-            .filter(|(id, _c)| id.is_user())
-            .map(|(id, c)| {
-                let updates = c.read_capabilities.updates().cloned().collect_vec();
-                (*id, c.implied_capability.clone(), updates)
-            })
-            .collect_vec();
+        if tracing::span_enabled!(tracing::Level::TRACE) {
+            // Collecting `user_capabilities` is potentially slow, thus only do it when needed.
+            let user_capabilities = self_collections
+                .iter_mut()
+                .filter(|(id, _c)| id.is_user())
+                .map(|(id, c)| {
+                    let updates = c.read_capabilities.updates().cloned().collect_vec();
+                    (*id, c.implied_capability.clone(), updates)
+                })
+                .collect_vec();
 
-        trace!(
-            %from_id,
-            ?storage_dependencies,
-            ?read_capability,
-            ?user_capabilities,
-            "after install_read_capabilities_inner!");
+            trace!(
+                %from_id,
+                ?storage_dependencies,
+                ?read_capability,
+                ?user_capabilities,
+                "after install_read_capabilities_inner!");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Improve subsource planning by making various parts of the adapter more scalable.

This PR includes changes to:
* The *durable transaction* implementation to improve updates and validity checks. Updates are more efficient by cloning less and passing references where possible. Validity checks are more efficient by converting some that assert on name equality to a $n\cdot\log n$, where it previously was $n^2$.
* *Planning subsources* is more efficient by allocating all IDs in one operation rather than one-by-one.
* Avoiding *computing trace data* in the storage client when the level isn't high enough.

Takes planning 10k subsources from I-terminated-it-after-one-hour to around one minute.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
