### PR TITLE
Implement `SHOW REDACTED CREATE ...`

### DIFF
--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE CONNECTION <connection_name>
+SHOW [REDACTED] CREATE CONNECTION <connection_name>
 ```
 
 For available connection names, see [`SHOW CONNECTIONS`](/sql/show-connections).

--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE CONNECTION <connection_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available connection names, see [`SHOW CONNECTIONS`](/sql/show-connections).
 
 ## Examples

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE INDEX <index_name>
+SHOW [REDACTED] CREATE INDEX <index_name>
 ```
 
 For available index names, see [`SHOW INDEXES`](/sql/show-indexes).

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE INDEX <index_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available index names, see [`SHOW INDEXES`](/sql/show-indexes).
 
 ## Examples

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE MATERIALIZED VIEW <view_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available materialized view names, see [`SHOW MATERIALIZED VIEWS`](/sql/show-materialized-views).
 
 ## Examples

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE MATERIALIZED VIEW <view_name>
+SHOW [REDACTED] CREATE MATERIALIZED VIEW <view_name>
 ```
 
 For available materialized view names, see [`SHOW MATERIALIZED VIEWS`](/sql/show-materialized-views).

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE SINK <sink_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available sink names, see [`SHOW SINKS`](/sql/show-sinks).
 
 ## Examples

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE SINK <sink_name>
+SHOW [REDACTED] CREATE SINK <sink_name>
 ```
 
 For available sink names, see [`SHOW SINKS`](/sql/show-sinks).

--- a/doc/user/content/sql/show-create-source.md
+++ b/doc/user/content/sql/show-create-source.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE SOURCE <source_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available source names, see [`SHOW SOURCES`](/sql/show-sources).
 
 ## Examples

--- a/doc/user/content/sql/show-create-source.md
+++ b/doc/user/content/sql/show-create-source.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE SOURCE <source_name>
+SHOW [REDACTED] CREATE SOURCE <source_name>
 ```
 
 For available source names, see [`SHOW SOURCES`](/sql/show-sources).

--- a/doc/user/content/sql/show-create-table.md
+++ b/doc/user/content/sql/show-create-table.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE TABLE <table_name>
+SHOW [REDACTED] CREATE TABLE <table_name>
 ```
 
 For available table names, see [`SHOW TABLES`](/sql/show-tables).

--- a/doc/user/content/sql/show-create-table.md
+++ b/doc/user/content/sql/show-create-table.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE TABLE <table_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available table names, see [`SHOW TABLES`](/sql/show-tables).
 
 ## Examples

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -11,7 +11,7 @@ menu:
 ## Syntax
 
 ```sql
-SHOW CREATE VIEW <view_name>
+SHOW [REDACTED] CREATE VIEW <view_name>
 ```
 
 For available view names, see [`SHOW VIEWS`](/sql/show-views).

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -14,6 +14,8 @@ menu:
 SHOW [REDACTED] CREATE VIEW <view_name>
 ```
 
+{{< yaml-table data="show_create_redacted_option" >}}
+
 For available view names, see [`SHOW VIEWS`](/sql/show-views).
 
 ## Examples

--- a/doc/user/data/show_create_redacted_option.yml
+++ b/doc/user/data/show_create_redacted_option.yml
@@ -1,0 +1,7 @@
+columns:
+  - column: Option
+  - column: Description
+
+rows:
+  - Option: "**REDACTED**"
+    Description: "If specified, literals will be redacted."

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3561,98 +3561,134 @@ impl<T: AstInfo> AstDisplay for ShowColumnsStatement<T> {
 }
 impl_display_t!(ShowColumnsStatement);
 
-/// `SHOW CREATE VIEW <view>`
+/// `SHOW [REDACTED] CREATE VIEW <view>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateViewStatement<T: AstInfo> {
     pub view_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateViewStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE VIEW ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE VIEW ");
         f.write_node(&self.view_name);
     }
 }
 impl_display_t!(ShowCreateViewStatement);
 
-/// `SHOW CREATE MATERIALIZED VIEW <name>`
+/// `SHOW [REDACTED] CREATE MATERIALIZED VIEW <name>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateMaterializedViewStatement<T: AstInfo> {
     pub materialized_view_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateMaterializedViewStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE MATERIALIZED VIEW ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE MATERIALIZED VIEW ");
         f.write_node(&self.materialized_view_name);
     }
 }
 impl_display_t!(ShowCreateMaterializedViewStatement);
 
-/// `SHOW CREATE SOURCE <source>`
+/// `SHOW [REDACTED] CREATE SOURCE <source>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSourceStatement<T: AstInfo> {
     pub source_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateSourceStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE SOURCE ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE SOURCE ");
         f.write_node(&self.source_name);
     }
 }
 impl_display_t!(ShowCreateSourceStatement);
 
-/// `SHOW CREATE TABLE <table>`
+/// `SHOW [REDACTED] CREATE TABLE <table>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateTableStatement<T: AstInfo> {
     pub table_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateTableStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE TABLE ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE TABLE ");
         f.write_node(&self.table_name);
     }
 }
 impl_display_t!(ShowCreateTableStatement);
 
-/// `SHOW CREATE SINK <sink>`
+/// `SHOW [REDACTED] CREATE SINK <sink>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSinkStatement<T: AstInfo> {
     pub sink_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateSinkStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE SINK ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE SINK ");
         f.write_node(&self.sink_name);
     }
 }
 impl_display_t!(ShowCreateSinkStatement);
 
-/// `SHOW CREATE INDEX <index>`
+/// `SHOW [REDACTED] CREATE INDEX <index>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateIndexStatement<T: AstInfo> {
     pub index_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateIndexStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE INDEX ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE INDEX ");
         f.write_node(&self.index_name);
     }
 }
 impl_display_t!(ShowCreateIndexStatement);
 
+/// `SHOW [REDACTED] CREATE CONNECTION <connection>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateConnectionStatement<T: AstInfo> {
     pub connection_name: T::ItemName,
+    pub redacted: bool,
 }
 
 impl<T: AstInfo> AstDisplay for ShowCreateConnectionStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW CREATE CONNECTION ");
+        f.write_str("SHOW ");
+        if self.redacted {
+            f.write_str("REDACTED ");
+        }
+        f.write_str("CREATE CONNECTION ");
         f.write_node(&self.connection_name);
     }
 }

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -67,12 +67,15 @@ where
 }
 
 /// Describes the context in which to print an AST.
+///
+/// TODO: Currently, only the simple format can be redacted, but, ideally, whether it's redacted and
+///       whether it's stable would be orthogonal settings.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FormatMode {
     /// Simple is the normal way of printing for human consumption. Identifiers are quoted only if
-    /// necessary and sensative information is redacted.
+    /// necessary and sensitive information is not redacted.
     Simple,
-    /// SimpleRedacted is like Simple, but strips out string and number literals.
+    /// SimpleRedacted is like Simple, but strips out literals, e.g. strings and numbers.
     /// This makes SQL queries be "usage data", rather than "customer data" according to our
     /// data management policy, allowing us to introspect it.
     SimpleRedacted,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7720,6 +7720,14 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_show(&mut self) -> Result<ShowStatement<Raw>, ParserError> {
+        let redacted = self.parse_keyword(REDACTED);
+        if redacted && !self.peek_keyword(CREATE) {
+            return parser_err!(
+                self,
+                self.peek_pos(),
+                "SHOW REDACTED is only supported for SHOW REDACTED CREATE ..."
+            );
+        }
         if self.parse_one_of_keywords(&[COLUMNS, FIELDS]).is_some() {
             self.parse_show_columns()
         } else if self.parse_keyword(OBJECTS) {
@@ -7860,36 +7868,50 @@ impl<'a> Parser<'a> {
         } else if self.parse_keywords(&[CREATE, VIEW]) {
             Ok(ShowStatement::ShowCreateView(ShowCreateViewStatement {
                 view_name: self.parse_raw_name()?,
+                redacted,
             }))
         } else if self.parse_keywords(&[CREATE, MATERIALIZED, VIEW]) {
             Ok(ShowStatement::ShowCreateMaterializedView(
                 ShowCreateMaterializedViewStatement {
                     materialized_view_name: self.parse_raw_name()?,
+                    redacted,
                 },
             ))
         } else if self.parse_keywords(&[CREATE, SOURCE]) {
             Ok(ShowStatement::ShowCreateSource(ShowCreateSourceStatement {
                 source_name: self.parse_raw_name()?,
+                redacted,
             }))
         } else if self.parse_keywords(&[CREATE, TABLE]) {
             Ok(ShowStatement::ShowCreateTable(ShowCreateTableStatement {
                 table_name: self.parse_raw_name()?,
+                redacted,
             }))
         } else if self.parse_keywords(&[CREATE, SINK]) {
             Ok(ShowStatement::ShowCreateSink(ShowCreateSinkStatement {
                 sink_name: self.parse_raw_name()?,
+                redacted,
             }))
         } else if self.parse_keywords(&[CREATE, INDEX]) {
             Ok(ShowStatement::ShowCreateIndex(ShowCreateIndexStatement {
                 index_name: self.parse_raw_name()?,
+                redacted,
             }))
         } else if self.parse_keywords(&[CREATE, CONNECTION]) {
             Ok(ShowStatement::ShowCreateConnection(
                 ShowCreateConnectionStatement {
                     connection_name: self.parse_raw_name()?,
+                    redacted,
                 },
             ))
         } else if self.parse_keywords(&[CREATE, CLUSTER]) {
+            if redacted {
+                return parser_err!(
+                    self,
+                    self.peek_prev_pos(),
+                    "SHOW REDACTED CREATE CLUSTER is not supported"
+                );
+            }
             Ok(ShowStatement::ShowCreateCluster(
                 ShowCreateClusterStatement {
                     cluster_name: RawClusterName::Unresolved(self.parse_identifier()?),

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -340,49 +340,49 @@ SHOW CREATE CONNECTION "FOO"
 ----
 SHOW CREATE CONNECTION "FOO"
 =>
-Show(ShowCreateConnection(ShowCreateConnectionStatement { connection_name: Name(UnresolvedItemName([Ident("FOO")])) }))
+Show(ShowCreateConnection(ShowCreateConnectionStatement { connection_name: Name(UnresolvedItemName([Ident("FOO")])), redacted: false }))
 
 parse-statement
 SHOW CREATE TABLE "FOO"
 ----
 SHOW CREATE TABLE "FOO"
 =>
-Show(ShowCreateTable(ShowCreateTableStatement { table_name: Name(UnresolvedItemName([Ident("FOO")])) }))
+Show(ShowCreateTable(ShowCreateTableStatement { table_name: Name(UnresolvedItemName([Ident("FOO")])), redacted: false }))
 
 parse-statement
 SHOW CREATE VIEW foo
 ----
 SHOW CREATE VIEW foo
 =>
-Show(ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedItemName([Ident("foo")])) }))
+Show(ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedItemName([Ident("foo")])), redacted: false }))
 
 parse-statement
 SHOW CREATE MATERIALIZED VIEW foo
 ----
 SHOW CREATE MATERIALIZED VIEW foo
 =>
-Show(ShowCreateMaterializedView(ShowCreateMaterializedViewStatement { materialized_view_name: Name(UnresolvedItemName([Ident("foo")])) }))
+Show(ShowCreateMaterializedView(ShowCreateMaterializedViewStatement { materialized_view_name: Name(UnresolvedItemName([Ident("foo")])), redacted: false }))
 
 parse-statement
 SHOW CREATE SINK foo
 ----
 SHOW CREATE SINK foo
 =>
-Show(ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedItemName([Ident("foo")])) }))
+Show(ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedItemName([Ident("foo")])), redacted: false }))
 
 parse-statement
 SHOW CREATE INDEX foo
 ----
 SHOW CREATE INDEX foo
 =>
-Show(ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedItemName([Ident("foo")])) }))
+Show(ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedItemName([Ident("foo")])), redacted: false }))
 
 parse-statement
 SHOW CREATE SOURCE foo
 ----
 SHOW CREATE SOURCE foo
 =>
-Show(ShowCreateSource(ShowCreateSourceStatement { source_name: Name(UnresolvedItemName([Ident("foo")])) }))
+Show(ShowCreateSource(ShowCreateSourceStatement { source_name: Name(UnresolvedItemName([Ident("foo")])), redacted: false }))
 
 parse-statement
 SHOW CREATE CLUSTER foo
@@ -805,3 +805,178 @@ SHOW ROLE MEMBERSHIP FOR joe
 SHOW ROLE MEMBERSHIP FOR joe
 =>
 Show(ShowObjects(ShowObjectsStatement { object_type: RoleMembership { role: Some(Ident("joe")) }, from: None, filter: None }))
+
+parse-statement
+SHOW REDACTED CREATE VIEW foo
+----
+SHOW REDACTED CREATE VIEW foo
+=>
+Show(ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE MATERIALIZED VIEW foo
+----
+SHOW REDACTED CREATE MATERIALIZED VIEW foo
+=>
+Show(ShowCreateMaterializedView(ShowCreateMaterializedViewStatement { materialized_view_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE SOURCE foo
+----
+SHOW REDACTED CREATE SOURCE foo
+=>
+Show(ShowCreateSource(ShowCreateSourceStatement { source_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE TABLE foo
+----
+SHOW REDACTED CREATE TABLE foo
+=>
+Show(ShowCreateTable(ShowCreateTableStatement { table_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE SINK foo
+----
+SHOW REDACTED CREATE SINK foo
+=>
+Show(ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE INDEX foo
+----
+SHOW REDACTED CREATE INDEX foo
+=>
+Show(ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED CREATE CONNECTION foo
+----
+SHOW REDACTED CREATE CONNECTION foo
+=>
+Show(ShowCreateConnection(ShowCreateConnectionStatement { connection_name: Name(UnresolvedItemName([Ident("foo")])), redacted: true }))
+
+parse-statement
+SHOW REDACTED COLUMNS foo
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED COLUMNS foo
+              ^
+
+parse-statement
+SHOW REDACTED OBJECTS
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED OBJECTS
+              ^
+
+parse-statement
+SHOW REDACTED VIEWS
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED VIEWS
+              ^
+
+parse-statement
+SHOW REDACTED MATERIALIZED VIEWS
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED MATERIALIZED VIEWS
+              ^
+
+parse-statement
+SHOW REDACTED CLUSTER
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED CLUSTER
+              ^
+
+parse-statement
+SHOW REDACTED PRIVILEGES
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED PRIVILEGES
+              ^
+
+parse-statement
+SHOW REDACTED DEFAULT PRIVILEGES
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED DEFAULT PRIVILEGES
+              ^
+
+parse-statement
+SHOW REDACTED ROLE MEMBERSHIP
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED ROLE MEMBERSHIP
+              ^
+
+parse-statement
+SHOW REDACTED CREATE CLUSTER
+----
+error: SHOW REDACTED CREATE CLUSTER is not supported
+SHOW REDACTED CREATE CLUSTER
+                     ^
+
+parse-statement
+SHOW REDACTED TRANSACTION ISOLATION LEVEL
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED TRANSACTION ISOLATION LEVEL
+              ^
+
+parse-statement
+SHOW REDACTED TIME ZONE
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED TIME ZONE
+              ^
+
+parse-statement
+SHOW REDACTED foo
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED foo
+              ^
+
+parse-statement
+SHOW
+----
+error: Expected identifier, found EOF
+SHOW
+    ^
+
+parse-statement
+SHOW REDACTED
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED
+             ^
+
+parse-statement
+SHOW CREATE VIEW REDACTED v
+----
+error: Expected end of statement, found identifier "v"
+SHOW CREATE VIEW REDACTED v
+                          ^
+
+parse-statement
+SHOW VIEW
+----
+SHOW view
+=>
+Show(ShowVariable(ShowVariableStatement { variable: Ident("view") }))
+
+parse-statement
+SHOW REDACTED MATERIALIZED mv1
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED MATERIALIZED mv1
+              ^
+
+parse-statement
+SHOW REDACTED MATERIALIZED
+----
+error: SHOW REDACTED is only supported for SHOW REDACTED CREATE ...
+SHOW REDACTED MATERIALIZED
+              ^

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -60,9 +60,12 @@ pub fn describe_show_create_view(
 
 pub fn plan_show_create_view(
     scx: &StatementContext,
-    ShowCreateViewStatement { view_name }: ShowCreateViewStatement<Aug>,
+    ShowCreateViewStatement {
+        view_name,
+        redacted,
+    }: ShowCreateViewStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &view_name, CatalogItemType::View)
+    plan_show_create_item(scx, &view_name, CatalogItemType::View, redacted)
 }
 
 pub fn describe_show_create_materialized_view(
@@ -81,12 +84,14 @@ pub fn plan_show_create_materialized_view(
     scx: &StatementContext,
     ShowCreateMaterializedViewStatement {
         materialized_view_name,
+        redacted,
     }: ShowCreateMaterializedViewStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
     plan_show_create_item(
         scx,
         &materialized_view_name,
         CatalogItemType::MaterializedView,
+        redacted,
     )
 }
 
@@ -106,6 +111,7 @@ fn plan_show_create_item(
     scx: &StatementContext,
     name: &ResolvedItemName,
     expect_type: CatalogItemType,
+    redacted: bool,
 ) -> Result<ShowCreatePlan, PlanError> {
     let item = scx.get_item_by_resolved_name(name)?;
     let name = name.full_name_str();
@@ -124,7 +130,8 @@ fn plan_show_create_item(
     if item.item_type() != expect_type {
         sql_bail!("{name} is not a {expect_type}");
     }
-    let create_sql = humanize_sql_for_show_create(scx.catalog, item.id(), item.create_sql())?;
+    let create_sql =
+        humanize_sql_for_show_create(scx.catalog, item.id(), item.create_sql(), redacted)?;
     Ok(ShowCreatePlan {
         id: ObjectId::Item(item.id()),
         row: Row::pack_slice(&[Datum::String(&name), Datum::String(&create_sql)]),
@@ -133,9 +140,12 @@ fn plan_show_create_item(
 
 pub fn plan_show_create_table(
     scx: &StatementContext,
-    ShowCreateTableStatement { table_name }: ShowCreateTableStatement<Aug>,
+    ShowCreateTableStatement {
+        table_name,
+        redacted,
+    }: ShowCreateTableStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &table_name, CatalogItemType::Table)
+    plan_show_create_item(scx, &table_name, CatalogItemType::Table, redacted)
 }
 
 pub fn describe_show_create_source(
@@ -152,9 +162,12 @@ pub fn describe_show_create_source(
 
 pub fn plan_show_create_source(
     scx: &StatementContext,
-    ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement<Aug>,
+    ShowCreateSourceStatement {
+        source_name,
+        redacted,
+    }: ShowCreateSourceStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &source_name, CatalogItemType::Source)
+    plan_show_create_item(scx, &source_name, CatalogItemType::Source, redacted)
 }
 
 pub fn describe_show_create_sink(
@@ -171,9 +184,12 @@ pub fn describe_show_create_sink(
 
 pub fn plan_show_create_sink(
     scx: &StatementContext,
-    ShowCreateSinkStatement { sink_name }: ShowCreateSinkStatement<Aug>,
+    ShowCreateSinkStatement {
+        sink_name,
+        redacted,
+    }: ShowCreateSinkStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &sink_name, CatalogItemType::Sink)
+    plan_show_create_item(scx, &sink_name, CatalogItemType::Sink, redacted)
 }
 
 pub fn describe_show_create_index(
@@ -190,9 +206,12 @@ pub fn describe_show_create_index(
 
 pub fn plan_show_create_index(
     scx: &StatementContext,
-    ShowCreateIndexStatement { index_name }: ShowCreateIndexStatement<Aug>,
+    ShowCreateIndexStatement {
+        index_name,
+        redacted,
+    }: ShowCreateIndexStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &index_name, CatalogItemType::Index)
+    plan_show_create_item(scx, &index_name, CatalogItemType::Index, redacted)
 }
 
 pub fn describe_show_create_connection(
@@ -236,9 +255,12 @@ pub fn describe_show_create_cluster(
 
 pub fn plan_show_create_connection(
     scx: &StatementContext,
-    ShowCreateConnectionStatement { connection_name }: ShowCreateConnectionStatement<Aug>,
+    ShowCreateConnectionStatement {
+        connection_name,
+        redacted,
+    }: ShowCreateConnectionStatement<Aug>,
 ) -> Result<ShowCreatePlan, PlanError> {
-    plan_show_create_item(scx, &connection_name, CatalogItemType::Connection)
+    plan_show_create_item(scx, &connection_name, CatalogItemType::Connection, redacted)
 }
 
 pub fn show_databases<'a>(
@@ -999,6 +1021,7 @@ fn humanize_sql_for_show_create(
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
     sql: &str,
+    redacted: bool,
 ) -> Result<String, PlanError> {
     use mz_sql_parser::ast::{CreateSourceConnection, MySqlConfigOptionName, PgConfigOptionName};
 
@@ -1159,5 +1182,9 @@ fn humanize_sql_for_show_create(
         _ => (),
     }
 
-    Ok(resolved.to_ast_string_stable())
+    if redacted {
+        Ok(resolved.to_ast_string_redacted())
+    } else {
+        Ok(resolved.to_ast_string_stable())
+    }
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1019,7 +1019,7 @@ fn humanize_sql_for_show_create(
         //
         // For instance, `DROP SOURCE` statements can leave dangling references
         // to subsources that must be filtered out here, that, due to catalog
-        // transaction limitations, can only be be cleaned up when a top-level
+        // transaction limitations, can only be cleaned up when a top-level
         // source is altered.
         Statement::CreateSource(stmt) => {
             // Collect all current subsource references.
@@ -1053,7 +1053,7 @@ fn humanize_sql_for_show_create(
                             // COLUMNS` values that refer to the table it
                             // ingests, which we'll handle below.
                             PgConfigOptionName::TextColumns => {}
-                            // Drop details, which does not rountrip.
+                            // Drop details, which does not roundtrip.
                             PgConfigOptionName::Details => return false,
                             _ => return true,
                         };
@@ -1092,7 +1092,7 @@ fn humanize_sql_for_show_create(
                             // ingests, which we'll handle below.
                             MySqlConfigOptionName::TextColumns
                             | MySqlConfigOptionName::ExcludeColumns => {}
-                            // Drop details, which does not rountrip.
+                            // Drop details, which does not roundtrip.
                             MySqlConfigOptionName::Details => return false,
                         };
 
@@ -1148,7 +1148,7 @@ fn humanize_sql_for_show_create(
                 match o.name {
                     CreateSubsourceOptionName::TextColumns => true,
                     CreateSubsourceOptionName::ExcludeColumns => true,
-                    // Drop details, which does not rountrip.
+                    // Drop details, which does not roundtrip.
                     CreateSubsourceOptionName::Details => false,
                     CreateSubsourceOptionName::ExternalReference => true,
                     CreateSubsourceOptionName::Progress => true,

--- a/test/sqllogictest/redacted.slt
+++ b/test/sqllogictest/redacted.slt
@@ -24,6 +24,12 @@ SELECT redacted_create_sql FROM mz_tables WHERE name = 't'
 CREATE TABLE materialize.public.t (i [s20 AS pg_catalog.int4])
 EOF
 
+query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE TABLE t);
+----
+CREATE TABLE materialize.public.t (i pg_catalog.int4)
+EOF
+
 statement ok
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'localhost:9092', SECURITY PROTOCOL PLAINTEXT) WITH (VALIDATE = false);
 
@@ -34,7 +40,19 @@ CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:90
 EOF
 
 query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE CONNECTION kafka_conn);
+----
+CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:9092', SECURITY PROTOCOL = plaintext)
+EOF
+
+query T multiline
 SELECT pretty_sql(redacted_create_sql) FROM mz_connections WHERE name = 'kafka_conn'
+----
+CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:9092', SECURITY PROTOCOL = plaintext);
+EOF
+
+query T multiline
+SELECT pretty_sql(create_sql) FROM (SHOW REDACTED CREATE CONNECTION kafka_conn);
 ----
 CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:9092', SECURITY PROTOCOL = plaintext);
 EOF
@@ -54,9 +72,21 @@ CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (
 EOF
 
 query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE TABLE redactable_t);
+----
+CREATE TABLE materialize.public.redactable_t (a pg_catalog.int4) WITH (RETAIN HISTORY = FOR '2s', REDACTED = '<REDACTED>')
+EOF
+
+query T multiline
 SELECT pretty_sql(redacted_create_sql) FROM mz_tables WHERE name = 'redactable_t'
 ----
 CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '2s', REDACTED = '<REDACTED>');
+EOF
+
+query T multiline
+SELECT pretty_sql(create_sql) FROM (SHOW REDACTED CREATE TABLE redactable_t)
+----
+CREATE TABLE materialize.public.redactable_t (a pg_catalog.int4) WITH (RETAIN HISTORY = FOR '2s', REDACTED = '<REDACTED>');
 EOF
 
 statement ok
@@ -66,6 +96,12 @@ query T multiline
 SELECT redacted_create_sql FROM mz_indexes WHERE name = 't_idx_i'
 ----
 CREATE INDEX t_idx_i IN CLUSTER [u1] ON [u1 AS materialize.public.t] (i)
+EOF
+
+query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE INDEX t_idx_i);
+----
+CREATE INDEX t_idx_i IN CLUSTER quickstart ON materialize.public.t (i)
 EOF
 
 statement ok
@@ -78,7 +114,19 @@ CREATE VIEW materialize.public.v AS SELECT '<REDACTED>'
 EOF
 
 query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE VIEW v);
+----
+CREATE VIEW materialize.public.v AS SELECT '<REDACTED>'
+EOF
+
+query T multiline
 SELECT pretty_sql(redacted_create_sql) FROM mz_views WHERE name = 'v'
+----
+CREATE VIEW materialize.public.v AS SELECT '<REDACTED>';
+EOF
+
+query T multiline
+SELECT pretty_sql(create_sql) FROM (SHOW REDACTED CREATE VIEW v);
 ----
 CREATE VIEW materialize.public.v AS SELECT '<REDACTED>';
 EOF
@@ -94,12 +142,27 @@ CREATE SOURCE materialize.public.s IN CLUSTER [uX] FROM LOAD GENERATOR COUNTER E
 EOF
 
 query T multiline
+SELECT regexp_replace(create_sql, 'u[0-9]+', 'uX', 'g') FROM (SHOW REDACTED CREATE SOURCE s);
+----
+CREATE SOURCE materialize.public.s IN CLUSTER quickstart FROM LOAD GENERATOR COUNTER EXPOSE PROGRESS AS materialize.public.s_progress
+EOF
+
+query T multiline
 SELECT regexp_replace(pretty_sql(redacted_create_sql), 'u[0-9]+', 'uX', 'g') FROM mz_sources WHERE name = 's'
 ----
 CREATE SOURCE materialize.public.s
 IN CLUSTER [uX]
 FROM LOAD GENERATOR COUNTER
 EXPOSE PROGRESS AS [uX AS materialize.public.s_progress];
+EOF
+
+query T multiline
+SELECT regexp_replace(pretty_sql(create_sql), 'u[0-9]+', 'uX', 'g') FROM (SHOW REDACTED CREATE SOURCE s);
+----
+CREATE SOURCE materialize.public.s
+IN CLUSTER quickstart
+FROM LOAD GENERATOR COUNTER
+EXPOSE PROGRESS AS materialize.public.s_progress;
 EOF
 
 statement ok
@@ -110,3 +173,52 @@ SELECT redacted_create_sql FROM mz_types WHERE name = 'ty'
 ----
 CREATE TYPE materialize.public.ty AS LIST (ELEMENT TYPE = [s6 AS pg_catalog.bool])
 EOF
+
+statement ok
+CREATE MATERIALIZED VIEW mv1 AS
+SELECT i+i+5 FROM t;
+
+query T multiline
+SELECT regexp_replace(redacted_create_sql, 'AS OF [0-9]+', 'AS OF xxxxxxx', 'g') FROM mz_materialized_views WHERE name = 'mv1'
+----
+CREATE MATERIALIZED VIEW materialize.public.mv1 IN CLUSTER [u1] WITH (REFRESH = ON COMMIT) AS SELECT i + i + '<REDACTED>' FROM [u1 AS materialize.public.t] AS OF xxxxxxx
+EOF
+
+query T multiline
+SELECT create_sql FROM (SHOW REDACTED CREATE MATERIALIZED VIEW mv1);
+----
+CREATE MATERIALIZED VIEW materialize.public.mv1 IN CLUSTER quickstart WITH (REFRESH = ON COMMIT) AS SELECT i + i + '<REDACTED>' FROM materialize.public.t
+EOF
+
+query T multiline
+SELECT pretty_sql(redacted_create_sql) FROM mz_materialized_views WHERE name = 'mv1'
+----
+CREATE MATERIALIZED VIEW materialize.public.mv1
+    IN CLUSTER [u1]
+    WITH (REFRESH = ON COMMIT)
+    AS SELECT i + i + '<REDACTED>' FROM [u1 AS materialize.public.t];
+EOF
+
+query T multiline
+SELECT pretty_sql(create_sql) FROM (SHOW REDACTED CREATE MATERIALIZED VIEW mv1);
+----
+CREATE MATERIALIZED VIEW materialize.public.mv1
+    IN CLUSTER quickstart
+    WITH (REFRESH = ON COMMIT)
+    AS SELECT i + i + '<REDACTED>' FROM materialize.public.t;
+EOF
+
+query error db error: ERROR: unknown catalog item 'aaaaaaa'
+SHOW REDACTED CREATE MATERIALIZED VIEW aaaaaaa;
+
+query error db error: ERROR: materialize\.public\.v is not a materialized view
+SHOW REDACTED CREATE MATERIALIZED VIEW v;
+
+query error db error: ERROR: materialize\.public\.mv1 is not a view
+SHOW REDACTED CREATE VIEW mv1;
+
+query error Expected end of statement, found TYPE
+SHOW CREATE TYPE ty;
+
+query error Expected end of statement, found TYPE
+SHOW REDACTED CREATE TYPE ty;


### PR DESCRIPTION
Add redacted counterparts to various `SHOW CREATE ...` statements. We need this for redaction in the self-managed debug tool (through `mzexplore`).

The first commit just tweaks some comments, while the second commit is the actual thing.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/database-issues/issues/9077

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
