### PR TITLE
storage: allow singleton sources on multi-replica clusters

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -245,7 +245,6 @@ impl Coordinator {
             .controller
             .storage
             .active_ingestions(cluster.id)
-            .iter()
             .copied()
             .filter(|id| !id.is_transient() && !exclude_collections.contains(id))
             .map(|id| {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -311,25 +311,9 @@ impl Coordinator {
                         .in_cluster
                         .expect("ingestion plans must specify cluster");
                     match ingestion.desc.connection {
-                        GenericSourceConnection::Postgres(_) => {
-                            if let Some(cluster) = self.catalog().try_get_cluster(cluster_id) {
-                                if cluster.replica_ids().len() > 1 {
-                                    return Err(AdapterError::Unsupported(
-                                        "Postgres sources in clusters with >1 replicas",
-                                    ));
-                                }
-                            }
-                        }
-                        GenericSourceConnection::MySql(_) => {
-                            if let Some(cluster) = self.catalog().try_get_cluster(cluster_id) {
-                                if cluster.replica_ids().len() > 1 {
-                                    return Err(AdapterError::Unsupported(
-                                        "MySQL sources in clusters with >1 replicas",
-                                    ));
-                                }
-                            }
-                        }
-                        GenericSourceConnection::Kafka(_)
+                        GenericSourceConnection::Postgres(_)
+                        | GenericSourceConnection::MySql(_)
+                        | GenericSourceConnection::Kafka(_)
                         | GenericSourceConnection::LoadGenerator(_) => {
                             if let Some(cluster) = self.catalog().try_get_cluster(cluster_id) {
                                 let enable_multi_replica_sources = ENABLE_MULTI_REPLICA_SOURCES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5319,12 +5319,14 @@ fn contains_single_replica_objects(scx: &StatementContext, cluster: &dyn Catalog
         let item = scx.catalog.get_item(id);
         let single_replica_source = match item.source_desc() {
             Ok(Some(desc)) => match desc.connection {
-                GenericSourceConnection::Kafka(_) | GenericSourceConnection::LoadGenerator(_) => {
+                GenericSourceConnection::Kafka(_)
+                | GenericSourceConnection::LoadGenerator(_)
+                | GenericSourceConnection::MySql(_)
+                | GenericSourceConnection::Postgres(_) => {
                     let enable_multi_replica_sources =
                         ENABLE_MULTI_REPLICA_SOURCES.get(scx.catalog.system_vars().dyncfgs());
                     !enable_multi_replica_sources
                 }
-                GenericSourceConnection::MySql(_) | GenericSourceConnection::Postgres(_) => true,
             },
             _ => false,
         };

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -339,7 +339,10 @@ pub trait StorageController: Debug {
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
     /// Returns the IDs of all active ingestions for the given storage instance.
-    fn active_ingestions(&self, instance_id: StorageInstanceId) -> &BTreeSet<GlobalId>;
+    fn active_ingestions(
+        &self,
+        instance_id: StorageInstanceId,
+    ) -> Box<dyn Iterator<Item = &GlobalId> + '_>;
 
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -50,7 +50,7 @@ impl<T: timely::progress::Timestamp + TotalOrder> CommandHistory<T> {
     }
 
     /// Returns an iterator over the contained storage commands.
-    pub fn iter(&self) -> impl Iterator<Item = &StorageCommand<T>> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &StorageCommand<T>> {
         self.commands.iter()
     }
 

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -163,8 +163,8 @@ where
     }
 
     /// Returns the ingestions running on this instance.
-    pub fn active_ingestions(&self) -> &BTreeSet<GlobalId> {
-        &self.active_ingestions
+    pub fn active_ingestions(&self) -> impl Iterator<Item = &GlobalId> {
+        self.active_ingestions.iter()
     }
 
     /// Returns the exports running on this instance.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -435,8 +435,11 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
-    fn active_ingestions(&self, instance_id: StorageInstanceId) -> &BTreeSet<GlobalId> {
-        self.instances[&instance_id].active_ingestions()
+    fn active_ingestions(
+        &self,
+        instance_id: StorageInstanceId,
+    ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
+        Box::new(self.instances[&instance_id].active_ingestions())
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -228,6 +228,10 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
     fn supports_read_only(&self) -> bool {
         true
     }
+
+    fn prefers_single_replica(&self) -> bool {
+        false
+    }
 }
 
 impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -167,6 +167,10 @@ impl SourceConnection for LoadGeneratorSourceConnection {
     fn supports_read_only(&self) -> bool {
         true
     }
+
+    fn prefers_single_replica(&self) -> bool {
+        false
+    }
 }
 
 impl crate::AlterCompatible for LoadGeneratorSourceConnection {}

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -141,6 +141,10 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
     fn supports_read_only(&self) -> bool {
         false
     }
+
+    fn prefers_single_replica(&self) -> bool {
+        true
+    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -130,6 +130,10 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
     fn supports_read_only(&self) -> bool {
         false
     }
+
+    fn prefers_single_replica(&self) -> bool {
+        true
+    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {


### PR DESCRIPTION
Implements https://github.com/MaterializeInc/database-issues/issues/9079

Per the design in https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20250127_multi_replica_scheduling_singleton_sources.md

There's now an issue around tracking "active replicas" in the storage controller, for the purposes of tracking `DroppedId` messages. I have a good idea how to fix it but wanted to get this out for review now.