### PR TITLE
Ban a couple of panicky itertools APIs

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -77,9 +77,11 @@ disallowed-methods = [
     { path = "differential_dataflow::operators::reduce::join::Join::antijoin", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
     { path = "differential_dataflow::operators::reduce::join::Join::join_map", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
     { path = "differential_dataflow::operators::reduce::join::Join::semijoin", reason = "use the `differential_dataflow::operators::join::Join::join_core` function instead" },
-
     # Prevent access to Timely APIs with untested semantics.
     { path = "timely::worker::Worker::drop_dataflow", reason = "Might break logging dataflows, check with #team-compute." },
+    # Panic when formatting the same value more than once, like our tracing macros do.
+    { path = "itertools::Itertools::format", reason = "panics when passed to tracing macros; consider the methods in mz_ore::str instead" },
+    { path = "itertools::Itertools::format_with", reason = "panics when passed to tracing macros; consider the methods in mz_ore::str instead" },
 ]
 
 disallowed-macros = [


### PR DESCRIPTION
### Motivation

As seen in incident-437, the value returned by these methods can panic when formatted more than once... and tracing macro calls can end up formatting multiple times depending on configuration.

So: risk of misuse is significant and the functionality is easy to replace. Seems worth a ban.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
