### PR TITLE
storage/pg: emit an early probe during snapshotting

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -236,25 +236,25 @@ SCENARIOS = [
                     INSERT INTO t1 (f3) SELECT '{i}' || REPEAT('a', {PAD_LEN}) FROM generate_series(1, {REPEAT});
                     """
                 )
-                for i in range(0, ITERATIONS)
+                for i in range(0, ITERATIONS * 10)
             ]
         )
         + PgCdcScenario.MZ_SETUP
         + dedent(
             f"""
-            > SELECT * FROM v1; /* expect {ITERATIONS * REPEAT} */
-            {ITERATIONS * REPEAT}
+            > SELECT * FROM v1; /* expect {ITERATIONS * 10 * REPEAT} */
+            {ITERATIONS * 10 * REPEAT}
             """
         ),
         post_restart=dedent(
             f"""
             # We do not do DELETE post-restart, as it will cause OOM for clusterd
-            > SELECT * FROM v1; /* expect {ITERATIONS * REPEAT} */
-            {ITERATIONS * REPEAT}
+            > SELECT * FROM v1; /* expect {ITERATIONS * 10 * REPEAT} */
+            {ITERATIONS * 10 * REPEAT}
             """
         ),
         materialized_memory="4.5Gb",
-        clusterd_memory="3.5Gb",
+        clusterd_memory="1Gb",
     ),
     PgCdcScenario(
         name="pg-cdc-update",


### PR DESCRIPTION
This PR changes the Postgres source to emit an initial upstream probe immediately after the creation of the replication slot. The purpose of this is to produce the first timestamp binding (under RLU) as early as possible, so it can be used to reclock the snapshot updates rather than buffering them in the reclock operator.

Prior to this change, the first probe would only be emitted after the snapshot had been fully processed, which meant that that all snapshot updates needed to be buffered in the reclock operator, making the Postgres source require memory proportional to the size of the snapshot.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9061

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
