### PR TITLE
bazel build: Add mirror for bzip2

### DIFF
--- a/misc/bazel/c_deps/repositories.bzl
+++ b/misc/bazel/c_deps/repositories.bzl
@@ -35,6 +35,7 @@ def c_repositories():
         integrity = BZIP2_INTEGRITY,
         strip_prefix = "bzip2-{0}".format(BZIP2_VERSION),
         urls = [
+            "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-{0}.tar.gz".format(BZIP2_VERSION),
             "https://sourceware.org/pub/bzip2/bzip2-{0}.tar.gz".format(BZIP2_VERSION),
         ],
     )


### PR DESCRIPTION
(Transient) failure seen in https://buildkite.com/materialize/test/builds/100759#0195a377-8792-4054-be98-6f164fd147ad

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
