### PR TITLE
Don't import parquet in ore without parquet feature.

### DIFF
--- a/src/ore/src/bytes.rs
+++ b/src/ore/src/bytes.rs
@@ -27,6 +27,7 @@ use std::io::Seek;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use internal::SegmentedReader;
+#[cfg(feature = "parquet")]
 use parquet::errors::ParquetError;
 use smallvec::SmallVec;
 


### PR DESCRIPTION
Don't import parquet in ore without parquet feature.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a previously unreported bug.
Parquet is optional, yet we're importing things from it.

```
error[E0433]: failed to resolve: use of undeclared crate or module `parquet`
  --> vendor/materialize/src/ore/src/bytes.rs:30:5
   |
30 | use parquet::errors::ParquetError;
   |     ^^^^^^^ use of undeclared crate or module `parquet`
```

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
