### PR TITLE
parallel-workload: Reenable two checks in backup&restore

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1913,7 +1913,7 @@ class CreateMySqlSourceAction(Action):
         return result
 
     def run(self, exe: Executor) -> bool:
-        # TODO: Reenable when database-issues#6881 is fixed
+        # See database-issues#6881, not expected to work
         if exe.db.scenario == Scenario.BackupRestore:
             return False
 
@@ -1982,7 +1982,7 @@ class CreatePostgresSourceAction(Action):
         return result
 
     def run(self, exe: Executor) -> bool:
-        # TODO: Reenable when database-issues#6881 is fixed
+        # See database-issues#6881, not expected to work
         if exe.db.scenario == Scenario.BackupRestore:
             return False
 


### PR DESCRIPTION
Since the associated issue has been closed

Seen in https://buildkite.com/materialize/nightly/builds/11474#0195a14d-2d4d-4344-a5e2-3ba10e2b647b

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
