### PR TITLE
build: Remove unused deps in mz-license-keys

### DIFF
--- a/src/license-keys/Cargo.toml
+++ b/src/license-keys/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+development = ["tokio", "mz-aws-util"]
 
 [package.metadata.cargo-gazelle.lib]
 compile_data = ["src/license_keys/*.pub"]


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11474#0195a14d-2d4e-42e3-9e71-4c6077af92fb

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
