### PR TITLE
dependabot: Try grouping only patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,11 @@ updates:
     time: "22:00"
   open-pull-requests-limit: 50
   labels: [A-dependencies]
-  # TODO: Reenable groups when there is a solution for many upgrades causing timeouts, see for example https://github.com/MaterializeInc/materialize/actions/runs/13487319380/job/37680155878
-  # groups:
-  #   simple:
-  #     applies-to: version-updates
-  #     update-types:
-  #       - minor
-  #       - patch
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - patch
 - package-ecosystem: cargo
   directory: /misc/wasm
   schedule:


### PR DESCRIPTION
Maybe that is fast enough to run in < 1 hour

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
