### PR TITLE
Revert "data-ingest: Disable RTR"

### DIFF
--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -332,35 +332,18 @@ def execute_workload(
     for executor in executors:
         executor.mz_service = workload.mz_service
         conn.autocommit = True
-        correct_once = False
-        sleep_time = 0.1
-        # TODO: Reenable RTR when database-issues#8657 is fixed
-        while sleep_time < 60:
-            conn.autocommit = True
-            with conn.cursor() as cur:
-                try:
-                    cur.execute(
-                        f"SELECT * FROM {executor.table} ORDER BY {order_str}".encode()
-                    )
-                except:
-                    print(f"Comparing against {type(executor).__name__} failed")
-                    print(traceback.format_exc())
-                    raise
-                actual_result = cur.fetchall()
-            conn.autocommit = False
-            if actual_result == expected_result:
-                if correct_once:
-                    break
-                print(
-                    "Results match. Check for correctness again to make sure the result is stable"
+        with conn.cursor() as cur:
+            try:
+                cur.execute("SET REAL_TIME_RECENCY TO TRUE")
+                cur.execute(
+                    f"SELECT * FROM {executor.table} ORDER BY {order_str}".encode()
                 )
-                correct_once = True
-                time.sleep(sleep_time)
-                continue
-            else:
-                print(f"Unexpected ({type(executor).__name__}): {actual_result}")
-            print(f"Results don't match, sleeping for {sleep_time}s")
-            time.sleep(sleep_time)
-            sleep_time *= 2
-        else:
+                actual_result = cur.fetchall()
+                cur.execute("SET REAL_TIME_RECENCY TO FALSE")
+            except Exception as e:
+                print(f"Comparing against {type(executor).__name__} failed: {e}")
+                print(traceback.format_exc())
+                raise
+        conn.autocommit = False
+        if actual_result != expected_result:
             raise ValueError(f"Unexpected result for {type(executor).__name__}: {actual_result} != {expected_result}")  # type: ignore


### PR DESCRIPTION
This reverts commit d2a2f280e73e1f4d51ccbc9e459030677669c6fd.

So far, unable to reproduce the failure locally.  There have been many changes to PG source, I suspect one or more fixed the issue.

### Motivation

checking if https://github.com/MaterializeInc/database-issues/issues/8657 is reproducible

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
