### PR TITLE
storage,0dt: fix overall hydration check and UPSERT hydration check

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -244,8 +244,7 @@ impl Coordinator {
         let storage_frontiers = self
             .controller
             .storage
-            .active_ingestions(cluster.id)
-            .copied()
+            .active_ingestion_collections(cluster.id)
             .filter(|id| !id.is_transient() && !exclude_collections.contains(id))
             .map(|id| {
                 let (_read_frontier, write_frontier) =

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -338,11 +338,16 @@ pub trait StorageController: Debug {
     /// capabilties.
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
-    /// Returns the IDs of all active ingestions for the given storage instance.
-    fn active_ingestions(
+    /// Returns the IDs of all collections that are associated with active
+    /// ingestions, for the given storage instance.
+    ///
+    /// Associated collections are, for example, the remap collection and
+    /// subsources. Active ingestions are those ingestions that have been
+    /// scheduled to run on the given instance.
+    fn active_ingestion_collections(
         &self,
         instance_id: StorageInstanceId,
-    ) -> Box<dyn Iterator<Item = &GlobalId> + '_>;
+    ) -> Box<dyn Iterator<Item = GlobalId> + '_>;
 
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -435,11 +435,32 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
-    fn active_ingestions(
+    fn active_ingestion_collections(
         &self,
         instance_id: StorageInstanceId,
-    ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
-        Box::new(self.instances[&instance_id].active_ingestions())
+    ) -> Box<dyn Iterator<Item = GlobalId> + '_> {
+        let active_ingestions = self.instances[&instance_id].active_ingestions();
+
+        let active_collections = active_ingestions.flat_map(|ingestion_id| {
+            let ingestion_state = self
+                .collections
+                .get(ingestion_id)
+                .expect("instance contains unknown ingestion");
+
+            let ingestion_description = match &ingestion_state.data_source {
+                DataSource::Ingestion(ingestion_description) => ingestion_description.clone(),
+                _ => panic!(
+                    "unexpected data source for ingestion: {:?}",
+                    ingestion_state.data_source
+                ),
+            };
+
+            let collection_ids: Vec<_> = ingestion_description.collection_ids().collect();
+
+            collection_ids
+        });
+
+        Box::new(active_collections)
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -965,6 +965,14 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
         )
         elapsed = time.time() - start_time
         print(f"promotion took {elapsed} seconds")
+
+        start_time = time.time()
+        result = c.sql_query("SELECT 1", service="mz_new")
+        elapsed = time.time() - start_time
+        print(f"bootstrapping (checked via SELECT 1) took {elapsed} seconds")
+        duration = time.time() - start_time
+        assert result[0][0] == 1, f"Wrong result: {result}"
+
         start_time = time.time()
         result = c.sql_query("SELECT * FROM kafka_source_cnt", service="mz_new")
         elapsed = time.time() - start_time

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -82,9 +82,6 @@ def workflow_default(c: Composition) -> None:
     def process(name: str) -> None:
         if name == "default":
             return
-        # TODO: Reenable when database-issues#9084 is fixed
-        if name == "kafka-source-rehydration":
-            return
         with c.test_case(name):
             c.workflow(name)
 

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -980,7 +980,7 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
         duration = time.time() - start_time
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            duration < 8
+            duration < 2
         ), f"Took {duration}s to SELECT on Kafka source after 0dt upgrade, is it hydrated?"
 
 


### PR DESCRIPTION
A couple of critical fixes around 0dt upgrades and UPSERT operators. Please see individual commits for a description.

Fixes https://github.com/MaterializeInc/database-issues/issues/9084

NOTE: This doesn't work yet, still working on the fix!