### PR TITLE
Poll future in timely for time quantum

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -222,33 +222,43 @@ pub const COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK: Config<Duration> = Config
     "Round observed timestamps to slack.",
 );
 
+/// The time quantum for async operator builders.
+///
+/// Set to 0 to disable time quantums.
+pub const BUILDER_ASYNC_OPERATOR_TIME_QUANTUM: Config<Duration> = Config::new(
+    "builder_async_operator_time_quantum",
+    Duration::from_millis(10),
+    "Time quantum for async operator builders. Set to 0 to disable time quantums.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
-        .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&BUILDER_ASYNC_OPERATOR_TIME_QUANTUM)
+        .add(&COMPUTE_APPLY_COLUMN_DEMANDS)
+        .add(&COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK)
+        .add(&COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES)
+        .add(&COMPUTE_REPLICA_EXPIRATION_OFFSET)
+        .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)
+        .add(&CONSOLIDATING_VEC_GROWTH_DAMPENER)
+        .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
+        .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
+        .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
+        .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
+        .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
+        .add(&ENABLE_COLUMNAR_LGALLOC)
+        .add(&ENABLE_COLUMNATION_LGALLOC)
+        .add(&ENABLE_COMPUTE_LOGICAL_BACKPRESSURE)
+        .add(&ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION)
+        .add(&ENABLE_COMPUTE_REPLICA_EXPIRATION)
         .add(&ENABLE_CORRECTION_V2)
-        .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)
+        .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
+        .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&HYDRATION_CONCURRENCY)
         .add(&LGALLOC_BACKGROUND_INTERVAL)
         .add(&LGALLOC_FILE_GROWTH_DAMPENER)
         .add(&LGALLOC_LOCAL_BUFFER_BYTES)
         .add(&LGALLOC_SLOW_CLEAR_BYTES)
-        .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
-        .add(&ENABLE_COLUMNATION_LGALLOC)
-        .add(&ENABLE_COLUMNAR_LGALLOC)
-        .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)
-        .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
-        .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
-        .add(&HYDRATION_CONCURRENCY)
-        .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
-        .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
-        .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
-        .add(&ENABLE_COMPUTE_REPLICA_EXPIRATION)
-        .add(&COMPUTE_REPLICA_EXPIRATION_OFFSET)
-        .add(&COMPUTE_APPLY_COLUMN_DEMANDS)
-        .add(&CONSOLIDATING_VEC_GROWTH_DAMPENER)
-        .add(&ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION)
-        .add(&ENABLE_COMPUTE_LOGICAL_BACKPRESSURE)
-        .add(&COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES)
-        .add(&COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK)
+        .add(&LINEAR_JOIN_YIELDING)
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -307,6 +307,13 @@ impl ComputeState {
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);
+
+        // Set the default async operator time quantum. Only applied here, but will apply to both
+        // compute and storage because of shared global state.
+        mz_timely_util::builder_async::GLOBAL_ASYNC_OPERATOR_TIME_QUANTUM_MS.store(
+            BUILDER_ASYNC_OPERATOR_TIME_QUANTUM.get(config).as_millis() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 
     /// Apply the provided replica expiration `offset` by converting it to a frontier relative to


### PR DESCRIPTION
This change adds a time quantum to the async operator builder to repeatedly poll operators while they're ready, until the quantum expires. This avoids iterating through a `step` call if an future has more work to do. I picked a value that seems low enough to not cause harm while giving futures enough time to do meaningful work.

For context, the cost of entering a future just after running it is much lower than going through Timely's `step`. In local tests, this removed much of the progress tracking overhead from profiles, which is an indicator that operators are yielding too frequently.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
