### PR TITLE
tests: Add newline handling to slt when `multiline` is not specified

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,7 +121,7 @@
 /src/sql/src/plan/lowering.rs       @MaterializeInc/cluster
 /src/sql-lexer                      @MaterializeInc/adapter
 /src/sql-parser                     @MaterializeInc/adapter
-/src/sqllogictest                   @MaterializeInc/adapter
+/src/sqllogictest                   @MaterializeInc/testing @ggevay
 /src/ssh-util                       @MaterializeInc/cluster
 /src/storage                        @MaterializeInc/cluster
 /src/storage-client                 @MaterializeInc/cluster

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -101,6 +101,7 @@ impl std::fmt::Display for Output {
 pub struct QueryOutput<'a> {
     pub types: Vec<Type>,
     pub sort: Sort,
+    pub multiline: bool,
     pub label: Option<&'a str>,
     pub column_names: Option<Vec<mz_repr::ColumnName>>,
     pub mode: Mode,

--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -300,30 +300,47 @@ impl<'a> Parser<'a> {
                     Output::Values(vec![])
                 } else {
                     let mut vals: Vec<String> = output_str.lines().map(|s| s.to_owned()).collect();
-                    if let Mode::Cockroach = self.mode {
-                        let mut rows: Vec<Vec<String>> = vec![];
-                        for line in vals {
-                            let cols = split_cols(&line, types.len());
-                            if sort != Sort::No && cols.len() != types.len() {
-                                // We can't check this condition for
-                                // Sort::No, because some tests use strings
-                                // with whitespace that look like extra
-                                // columns. (Note that these tests never
-                                // use any of the sorting options.)
-                                bail!(
-                                    "col len ({}) did not match declared col len ({})",
-                                    cols.len(),
-                                    types.len()
+                    match self.mode {
+                        Mode::Standard => {
+                            if !multiline {
+                                vals = vals.into_iter().map(|val| val.replace('⏎', "\n")).collect();
+                            }
+                        }
+                        Mode::Cockroach => {
+                            let mut rows: Vec<Vec<String>> = vec![];
+                            for line in vals {
+                                let cols = split_cols(&line, types.len());
+                                if sort != Sort::No && cols.len() != types.len() {
+                                    // We can't check this condition for
+                                    // Sort::No, because some tests use strings
+                                    // with whitespace that look like extra
+                                    // columns. (Note that these tests never
+                                    // use any of the sorting options.)
+                                    bail!(
+                                        "col len ({}) did not match declared col len ({})",
+                                        cols.len(),
+                                        types.len()
+                                    );
+                                }
+                                rows.push(
+                                    cols.into_iter()
+                                        .map(|col| {
+                                            let mut col = col.replace('␠', " ");
+                                            if !multiline {
+                                                col = col.replace('⏎', "\n");
+                                            }
+                                            col
+                                        })
+                                        .collect(),
                                 );
                             }
-                            rows.push(cols.into_iter().map(|col| col.replace('␠', " ")).collect());
-                        }
-                        if sort == Sort::Row {
-                            rows.sort();
-                        }
-                        vals = rows.into_iter().flatten().collect();
-                        if sort == Sort::Value {
-                            vals.sort();
+                            if sort == Sort::Row {
+                                rows.sort();
+                            }
+                            vals = rows.into_iter().flatten().collect();
+                            if sort == Sort::Value {
+                                vals.sort();
+                            }
                         }
                     }
                     Output::Values(vals)
@@ -335,6 +352,7 @@ impl<'a> Parser<'a> {
             output: Ok(QueryOutput {
                 types,
                 sort,
+                multiline,
                 label,
                 column_names,
                 mode: self.mode,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2231,7 +2231,7 @@ impl<'a> RewriteBuffer<'a> {
         self.append(
             &names
                 .iter()
-                .map(|name| name.as_str().replace('␠', " "))
+                .map(|name| name.as_str().replace(' ', "␠"))
                 .collect::<Vec<_>>()
                 .join(" "),
         );

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2001,6 +2001,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
         types: &Vec<Type>,
         column_names: Option<&Vec<ColumnName>>,
         actual_output: &Vec<String>,
+        multiline: bool,
     ) {
         buf.append_header(input, expected_output, column_names);
 
@@ -2013,20 +2014,46 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                         buf.append("\n");
                     }
 
-                    if row.len() <= 1 {
-                        buf.append(&row.iter().join("  "));
+                    if row.len() == 0 {
+                        // nothing to do
+                    } else if row.len() == 1 {
+                        // If there is only one column, then there is no need for space
+                        // substitution, so we only do newline substitution.
+                        if multiline {
+                            buf.append(&row[0]);
+                        } else {
+                            buf.append(&row[0].replace('\n', "⏎"))
+                        }
                     } else {
-                        buf.append(&row.iter().map(|col| col.replace(' ', "␠")).join("  "));
+                        // Substitute spaces with ␠ to avoid mistaking the spaces in the result
+                        // values with spaces that separate columns.
+                        buf.append(
+                            &row.iter()
+                                .map(|col| {
+                                    let mut col = col.replace(' ', "␠");
+                                    if !multiline {
+                                        col = col.replace('\n', "⏎");
+                                    }
+                                    col
+                                })
+                                .join("  "),
+                        );
                     }
                 }
                 // In standard mode, output each value on its own line,
                 // and ignore row boundaries.
+                // No need to substitute spaces, because every value (not row) is on a separate
+                // line. But we do need to substitute newlines.
                 Mode::Standard => {
                     for (j, col) in row.iter().enumerate() {
                         if i != 0 || j != 0 {
                             buf.append("\n");
                         }
-                        buf.append(col);
+                        buf.append(&if multiline {
+                            col.clone()
+                        } else {
+                            col.replace('\n', "⏎")
+                        });
                     }
                 }
             }
@@ -2048,6 +2075,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                             output_str: expected_output,
                             types,
                             column_names,
+                            multiline,
                             ..
                         }),
                     ..
@@ -2065,6 +2093,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                     types,
                     column_names.as_ref(),
                     actual_output,
+                    *multiline,
                 );
             }
             (
@@ -2075,6 +2104,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                             output: Output::Values(_),
                             output_str: expected_output,
                             types,
+                            multiline,
                             ..
                         }),
                     ..
@@ -2093,6 +2123,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                     types,
                     Some(actual_column_names),
                     actual_output,
+                    *multiline,
                 );
             }
             (

--- a/test/sqllogictest/slt.slt
+++ b/test/sqllogictest/slt.slt
@@ -38,3 +38,41 @@ column␠name␠with␠spaces! nospaces space␠again
 1
 2
 3
+
+mode standard
+
+query TT
+SELECT 'result' || chr(10) || 'with' || chr(10) || 'newline', 'no newline in this one, but there are spaces'
+UNION
+SELECT 'one' || chr(10) || 'more' || chr(10) || 'row (with spaces)', 'easy'
+----
+one⏎more⏎row (with spaces)
+easy
+result⏎with⏎newline
+no newline in this one, but there are spaces
+
+query T multiline
+SELECT 'result' || chr(10) || 'with' || chr(10) || 'newline';
+----
+result
+with
+newline
+EOF
+
+mode cockroach
+
+query TT
+SELECT 'result' || chr(10) || 'with' || chr(10) || 'newline', 'no newline in this one, but there are spaces'
+UNION
+SELECT 'one' || chr(10) || 'more' || chr(10) || 'row (with spaces)', 'easy'
+----
+one⏎more⏎row␠(with␠spaces)  easy
+result⏎with⏎newline  no␠newline␠in␠this␠one,␠but␠there␠are␠spaces
+
+query T multiline
+SELECT 'result' || chr(10) || 'with' || chr(10) || 'newline';
+----
+result
+with
+newline
+EOF

--- a/test/sqllogictest/slt.slt
+++ b/test/sqllogictest/slt.slt
@@ -30,3 +30,11 @@ SELECT * FROM t ORDER BY a
 3
 3
 4
+
+query III colnames
+SELECT 1 AS "column name with spaces!", 2 AS "nospaces", 3 AS "space again";
+----
+column␠name␠with␠spaces! nospaces space␠again
+1
+2
+3


### PR DESCRIPTION
The first commit changes the CODEOWNERS of `/src/sqllogictest` from `@MaterializeInc/adapter` to `@MaterializeInc/testing`. (But let me know if there was a good reason to have the Adapter team be the owner.) Edit: Also added myself, as discussed in DMs.

The second commit fixes a minor bug in space handling in slt in `colnames`.

The third commit is the main thing, which adds newline handling to slt result values, even when `multiline` is not specified. We use the replacement character trick to avoid newlines inside result values conflicting with newlines that are for field or row separation: when rewriting, we replace newlines with ⏎; when parsing, we replace ⏎ with newlines.

The motivation is that I'd like to have this feature for my next PR, which will make `SHOW CREATE ...` pretty-print its output, adding newlines. We have a gazillion tests that call `SHOW CREATE`, and it would be painful to change all of them to use `multiline`, especially that they have multi-column outputs, which, I think, is not really supported with `multiline`.

(I've added `lts-backport-v25.1`, because the `SHOW CREATE` PR will need to be backported, because `mzexplore` will rely on that, and `mzexplore` is part of the self-managed debug tool.)

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
