### PR TITLE
[fivetran] Use nonblocking socket for tokio

### DIFF
--- a/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
+++ b/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
@@ -61,6 +61,8 @@ async fn run(Args { port }: Args) -> Result<(), Box<dyn std::error::Error>> {
     let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
     // Disable Nagle's algorithm, maybe not needed but seems decent to start.
     socket.set_nodelay(true)?;
+    // Now required; see https://github.com/tokio-rs/tokio/issues/7172
+    socket.set_nonblocking(true)?;
     // OpenBSD disables dual-stack, if we need to support OpenBSD we'll have to explicitly create
     // two sockets.
     //


### PR DESCRIPTION
### Motivation

Testdrive started failing for me locally due to this Tokio behaviour change: https://github.com/tokio-rs/tokio/issues/7172

I'm unsure why this doesn't fail in CI... maybe a MacOS thing? Anyways setting the option makes things work as expected.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
