### PR TITLE
bazel: always print a log line when we skip generating a `BUILD.bazel`

### DIFF
--- a/misc/bazel/cargo-gazelle/src/bin/main.rs
+++ b/misc/bazel/cargo-gazelle/src/bin/main.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::sync::Arc;
@@ -169,7 +170,11 @@ fn generage_build_bazel<'a>(
     let crate_config = CrateConfig::new(package);
     tracing::debug!(?crate_config, "found config");
     if crate_config.skip_generating() {
-        tracing::info!(path = ?package.manifest_path(), "skipping, because crate config");
+        let msg = format!(
+            "skipping generation of '{}' because `skip_generating = True` was set",
+            package.manifest_path()
+        );
+        log_info(msg);
         return Ok(None);
     }
 
@@ -239,4 +244,11 @@ fn hash_file(file: &Path) -> Result<Option<Vec<u8>>, anyhow::Error> {
     let file_hash = file_hasher.finalize();
 
     Ok(Some(file_hash.to_vec()))
+}
+
+/// Prints to stderr an info line that will _always_ get shown to the user.
+fn log_info(s: impl fmt::Display) {
+    static YELLOW_START: &str = "\x1b[94m";
+    static RESET: &str = "\x1b[0m";
+    eprintln!("{YELLOW_START}info:{RESET} {s}");
 }


### PR DESCRIPTION
In a few cases we need to manually maintain `BUILD.bazel` files because they require tricky semantics. This PR makes it such that we always print a log line when skipping the generation of these files to make it more obvious to the end user.

```
info: skipping generation of '/Users/parker.timmerman/Development/materialize/src/alloc/Cargo.toml' because `skip_generating = True` was set
```

### Motivation

Make generating `BUILD.bazel` files better

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
