### PR TITLE
storage: avoid rendering fat timely operator

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -362,7 +362,7 @@ where
             let mut health_cap = Some(caps.remove(0));
 
             move |frontiers| {
-                let mut statuses = vec![];
+                let mut last_status = None;
                 let mut health_output = health_output.activate();
 
                 if frontiers[0].is_empty() {
@@ -392,8 +392,9 @@ where
                             namespace: C::STATUS_NAMESPACE.clone(),
                             update: status,
                         };
-                        if statuses.last() != Some(&status) {
-                            statuses.push(status);
+                        if last_status.as_ref() != Some(&status) {
+                            last_status = Some(status.clone());
+                            health_output.session(&health_cap).give(status);
                         }
 
                         match message {
@@ -409,13 +410,6 @@ where
                     }
                     let mut output = output.activate();
                     output.session(&cap).give_container(data);
-
-                    if !statuses.is_empty() {
-                        health_output
-                            .session(&health_cap)
-                            .give_container(&mut statuses);
-                        statuses.clear();
-                    }
                 }
             }
         });

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -58,7 +58,8 @@ use timely::dataflow::operators::capture::capture::Capture;
 use timely::dataflow::operators::capture::{Event, EventPusher};
 use timely::dataflow::operators::core::Map as _;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
-use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Inspect, Leave};
+use timely::dataflow::operators::Concatenate;
+use timely::dataflow::operators::{Broadcast, CapabilitySet, Inspect, Leave};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::order::TotalOrder;
@@ -324,34 +325,8 @@ where
         source_statistics.clone(),
     );
 
-    let name = format!("SourceGenericStats({})", source_id);
-    let mut builder = OperatorBuilderRc::new(name, scope.clone());
-
-    let (mut health_output, derived_health) = builder.new_output::<CapacityContainerBuilder<_>>();
-
     let mut export_collections = BTreeMap::new();
-    let mut export_handles = vec![];
-    // Loop invariant: The operator contains `export_handles.len()` inputs and
-    // `export_handles.len() + 1` outputs.
-    for (id, export) in exports {
-        // This output is not connected to any of the existing inputs.
-        let connection = vec![Antichain::new(); export_handles.len()];
-        let (export_output, new_export) =
-            builder.new_output_connection::<CapacityContainerBuilder<_>>(connection);
 
-        // The input is not connected to any of the existing outputs.
-        let outputs_count = export_handles.len() + 1;
-        let mut connection = vec![Antichain::new(); outputs_count];
-        // Standard frontier implication for the corresponding output of this input.
-        connection.push(Antichain::from_elem(Default::default()));
-        let export_input = builder.new_input_connection(&export.inner, Pipeline, connection);
-        export_handles.push((id, export_input, export_output));
-        let new_export: StackedCollection<G, Result<SourceMessage, DataflowError>> =
-            new_export.as_collection();
-        export_collections.insert(id, new_export);
-    }
-
-    let bytes_read_counter = config.metrics.source_defs.bytes_read.clone();
     let source_metrics = config.metrics.get_source_metrics(config.id, worker_id);
 
     // Compute the overall resume upper to report for the ingestion
@@ -365,19 +340,37 @@ where
         .resume_upper
         .set(mz_persist_client::metrics::encode_ts_metric(&resume_upper));
 
-    builder.build(move |mut caps| {
-        let mut health_cap = Some(caps.remove(0));
-        move |frontiers| {
-            let mut statuses_by_idx = BTreeMap::new();
-            let mut health_output = health_output.activate();
+    let mut health_streams = vec![];
 
-            if frontiers.iter().all(|f| f.is_empty()) {
-                health_cap = None;
-                return;
-            }
-            let health_cap = health_cap.as_mut().unwrap();
+    for (id, export) in exports {
+        let name = format!("SourceGenericStats({})", id);
+        let mut builder = OperatorBuilderRc::new(name, scope.clone());
 
-            for (id, input, output) in export_handles.iter_mut() {
+        let (mut health_output, derived_health) =
+            builder.new_output::<CapacityContainerBuilder<_>>();
+        health_streams.push(derived_health);
+
+        let (mut output, new_export) = builder.new_output::<CapacityContainerBuilder<_>>();
+
+        let mut input = builder.new_input(&export.inner, Pipeline);
+        export_collections.insert(id, new_export.as_collection());
+
+        let bytes_read_counter = config.metrics.source_defs.bytes_read.clone();
+        let source_statistics = source_statistics.clone();
+
+        builder.build(move |mut caps| {
+            let mut health_cap = Some(caps.remove(0));
+
+            move |frontiers| {
+                let mut statuses = vec![];
+                let mut health_output = health_output.activate();
+
+                if frontiers[0].is_empty() {
+                    health_cap = None;
+                    return;
+                }
+                let health_cap = health_cap.as_mut().unwrap();
+
                 while let Some((cap, data)) = input.next() {
                     for (message, _, _) in data.iter() {
                         let status = match message {
@@ -394,10 +387,8 @@ where
                             ),
                         };
 
-                        let statuses: &mut Vec<_> = statuses_by_idx.entry(*id).or_default();
-
                         let status = HealthStatusMessage {
-                            id: Some(*id),
+                            id: Some(id),
                             namespace: C::STATUS_NAMESPACE.clone(),
                             update: status,
                         };
@@ -419,17 +410,16 @@ where
                     let mut output = output.activate();
                     output.session(&cap).give_container(data);
 
-                    for statuses in statuses_by_idx.values_mut() {
-                        if statuses.is_empty() {
-                            continue;
-                        }
-                        health_output.session(&health_cap).give_container(statuses);
-                        statuses.clear()
+                    if !statuses.is_empty() {
+                        health_output
+                            .session(&health_cap)
+                            .give_container(&mut statuses);
+                        statuses.clear();
                     }
                 }
             }
-        }
-    });
+        });
+    }
 
     let probe_stream = match probes {
         Some(stream) => stream,
@@ -447,7 +437,7 @@ where
     (
         export_collections,
         progress,
-        health.concat(&derived_health),
+        health.concatenate(health_streams),
         tokens,
     )
 }


### PR DESCRIPTION
We used to have a usecase for rendering a timely operator with many inputs and many outputs connected in a complicated way but after #31260 this usecase no longer exists.

This PR removes the fat operator in favor of many smaller operators with simple connectivity.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
