### PR TITLE
Scrape mz_introspection data as CSVs per cluster replica

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6839,6 +6839,7 @@ dependencies = [
  "mz-cloud-resources",
  "mz-ore",
  "mz-tls-util",
+ "postgres-openssl",
  "serde",
  "serde_yaml",
  "tokio",

--- a/src/self-managed-debug/Cargo.toml
+++ b/src/self-managed-debug/Cargo.toml
@@ -20,6 +20,7 @@ mz-build-info = { path = "../build-info" }
 mz-cloud-resources = { path = "../cloud-resources"}
 mz-ore = { path = "../ore", features = ["cli", "test"] }
 mz-tls-util = { path = "../tls-util" }
+postgres-openssl = { version = "0.5.0" }
 serde = "1.0.219"
 serde_yaml = "0.9.25"
 tokio = "1.44.1"

--- a/src/self-managed-debug/src/main.rs
+++ b/src/self-managed-debug/src/main.rs
@@ -255,7 +255,7 @@ async fn run(context: Context) -> Result<(), anyhow::Error> {
     };
 
     if let Some(dumper) = catalog_dumper {
-        handles.extend(dumper.dump_all_relations());
+        dumper.dump_all_relations().await;
     }
 
     join_all(handles).await;

--- a/src/self-managed-debug/src/main.rs
+++ b/src/self-managed-debug/src/main.rs
@@ -88,6 +88,7 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::new("mz_self_managed_debug=info"))
         .without_time()
+        .with_target(false)
         .init();
 
     let args: Args = cli::parse_args(CliConfig {

--- a/src/self-managed-debug/src/system_catalog_dumper.rs
+++ b/src/self-managed-debug/src/system_catalog_dumper.rs
@@ -241,6 +241,8 @@ pub struct Relation {
     pub category: RelationCategory,
 }
 
+/// This list is used to determine which relations to dump.
+/// The relations are grouped and delimited by their category (i.e. Basic object information)
 static RELATIONS: &[Relation] = &[
     // Basic object information
     Relation {
@@ -1024,6 +1026,11 @@ fn format_file_path(date_time: DateTime<Utc>, cluster_replica: Option<&ClusterRe
     }
 }
 
+/// Create a postgres connection string.
+/// The following defaults are used if the arguments are not provided:
+/// - host_address: "localhost"
+/// - host_port: 6877
+/// - target_port: 6877
 pub fn create_postgres_connection_string(
     host_address: Option<&str>,
     host_port: Option<i32>,

--- a/src/self-managed-debug/src/system_catalog_dumper.rs
+++ b/src/self-managed-debug/src/system_catalog_dumper.rs
@@ -19,19 +19,24 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use mz_tls_util::make_tls;
+use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
-use tokio_postgres::{Client as PgClient, Config as PgConfig};
+use tokio_postgres::{
+    Client as PgClient, Config as PgConfig, Connection, NoTls, Socket, Transaction,
+};
 use tokio_util::io::StreamReader;
 
 use k8s_openapi::api::core::v1::Service;
 use kube::{Api, Client};
+use mz_ore::collections::HashMap;
 use mz_ore::retry::{self, RetryResult};
 use mz_ore::task::{self, JoinHandle};
+use postgres_openssl::{MakeTlsConnector, TlsStream};
 use tracing::{error, info};
 
 use crate::utils::format_base_path;
@@ -609,35 +614,183 @@ const RELATIONS: &[Relation] = &[
 ];
 
 const PG_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
-// Timeout for a query. We use 6 minutes since it's a good 
-// sign that the operation won't work.
-const PG_QUERY_TIMEOUT: Duration = Duration::from_secs(60 * 6);
+/// Timeout for a query. We use 6 minutes since it's a good
+/// sign that the operation won't work.
+const PG_QUERY_TIMEOUT: Duration = Duration::from_secs(20);
 
-#[derive(Debug, Clone)]
+/// The maximum number of errors we tolerate for a cluster replica.
+/// If a cluster replica has more than this many errors, we skip it.
+const MAX_CLUSTER_REPLICA_ERROR_COUNT: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClusterReplica {
     pub cluster_name: String,
     pub replica_name: String,
 }
 
+impl Default for ClusterReplica {
+    fn default() -> Self {
+        Self {
+            cluster_name: "mz_catalog_server".to_string(),
+            replica_name: "r1".to_string(),
+        }
+    }
+}
+
+impl fmt::Display for ClusterReplica {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.cluster_name, self.replica_name)
+    }
+}
+
 pub struct SystemCatalogDumper<'n> {
     context: &'n Context,
     pg_client: Arc<Mutex<PgClient>>,
+    pg_tls: MakeTlsConnector,
     cluster_replicas: Vec<ClusterReplica>,
-    _cluster_replicas: Vec<ClusterReplica>,
     _pg_conn_handle: JoinHandle<Result<(), tokio_postgres::Error>>,
+}
+
+pub async fn create_postgres_connection(
+    connection_string: &str,
+) -> Result<
+    (
+        PgClient,
+        Connection<Socket, TlsStream<Socket>>,
+        MakeTlsConnector,
+    ),
+    anyhow::Error,
+> {
+    let mut pg_config = PgConfig::from_str(connection_string)?;
+    pg_config.connect_timeout(PG_CONNECTION_TIMEOUT);
+    let tls = make_tls(&pg_config)?;
+    let (pg_client, pg_conn) = retry::Retry::default()
+        .max_duration(PG_CONNECTION_TIMEOUT)
+        .retry_async_canceling(|_| {
+            let pg_config = pg_config.clone();
+            let tls = tls.clone();
+            async move { pg_config.connect(tls).await.map_err(|e| anyhow::anyhow!(e)) }
+        })
+        .await?;
+
+    Ok((pg_client, pg_conn, tls))
+}
+
+pub async fn copy_relation_to_csv(
+    transaction: &Transaction<'_>,
+    file_path_name: PathBuf,
+    column_names: &mut Vec<String>,
+    relation_name: &str,
+) -> Result<(), anyhow::Error> {
+    let mut file = tokio::fs::File::create(&file_path_name).await?;
+
+    file.write_all((column_names.join(",") + "\n").as_bytes())
+        .await?;
+
+    // Stream data rows to CSV
+    let copy_query = format!(
+        "COPY (SELECT * FROM {}) TO STDOUT WITH (FORMAT CSV)",
+        relation_name
+    );
+
+    let copy_stream = transaction
+        .copy_out(&copy_query)
+        .await?
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+    let copy_stream = std::pin::pin!(copy_stream);
+    let mut reader = StreamReader::new(copy_stream);
+    tokio::io::copy(&mut reader, &mut file).await?;
+
+    info!("Copied {} to {}", relation_name, file_path_name.display());
+    Ok::<(), anyhow::Error>(())
+}
+
+pub async fn query_relation(
+    transaction: &Transaction<'_>,
+    start_time: DateTime<Utc>,
+    relation: &Relation,
+    cluster_replica: Option<&ClusterReplica>,
+) -> Result<(), anyhow::Error> {
+    let relation_name = relation.name;
+    let relation_category = &relation.category;
+
+    // Some queries (i.e. mz_introspection relations) require the cluster and replica to be set.
+    if let Some(cluster_replica) = &cluster_replica {
+        transaction
+            .execute(
+                &format!("SET LOCAL CLUSTER = '{}'", cluster_replica.cluster_name),
+                &[],
+            )
+            .await?;
+        transaction
+            .execute(
+                &format!(
+                    "SET LOCAL CLUSTER_REPLICA = '{}'",
+                    cluster_replica.replica_name
+                ),
+                &[],
+            )
+            .await?;
+    }
+
+    // We query the column names to write the header row of the CSV file.
+    // TODO (SangJunBak): Use `WITH (HEADER TRUE)` once database-issues#2846 is implemented.
+    let mut column_names = transaction
+        .query(&format!("SHOW COLUMNS FROM {}", &relation_name), &[])
+        .await?
+        .into_iter()
+        .map(|row| row.get::<_, String>("name"))
+        .collect::<Vec<_>>();
+
+    match relation_category {
+        RelationCategory::Basic => {
+            let file_path = format_file_path(start_time, None);
+            let file_path_name = file_path.join(relation_name).with_extension("csv");
+            tokio::fs::create_dir_all(&file_path).await?;
+
+            copy_relation_to_csv(
+                transaction,
+                file_path_name,
+                &mut column_names,
+                relation_name,
+            )
+            .await?;
+        }
+        RelationCategory::Introspection => {
+            let file_path = format_file_path(start_time, cluster_replica);
+            tokio::fs::create_dir_all(&file_path).await?;
+
+            let file_path_name = file_path.join(relation_name).with_extension("csv");
+
+            copy_relation_to_csv(
+                transaction,
+                file_path_name,
+                &mut column_names,
+                relation_name,
+            )
+            .await?;
+        }
+        _ => {
+            let file_path = format_file_path(start_time, None);
+            let file_path_name = file_path.join(relation_name).with_extension("csv");
+            tokio::fs::create_dir_all(&file_path).await?;
+
+            copy_relation_to_csv(
+                transaction,
+                file_path_name,
+                &mut column_names,
+                relation_name,
+            )
+            .await?;
+            // TODO (debug_tool1): Dump the `FETCH ALL SUBSCRIBE` output too
+        }
+    }
+    Ok::<(), anyhow::Error>(())
 }
 
 impl<'n> SystemCatalogDumper<'n> {
     pub async fn new(context: &'n Context, connection_string: &str) -> Result<Self, anyhow::Error> {
-        let (pg_client, pg_conn) = retry::Retry::default()
-            .max_duration(PG_CONNECTION_TIMEOUT)
-            .retry_async_canceling(|_| async move {
-                let pg_config = &mut PgConfig::from_str(connection_string)?;
-                pg_config.connect_timeout(PG_CONNECTION_TIMEOUT);
-                let tls = make_tls(pg_config)?;
-                pg_config.connect(tls).await.map_err(|e| anyhow::anyhow!(e))
-            })
-            .await?;
+        let (pg_client, pg_conn, pg_tls) = create_postgres_connection(connection_string).await?;
 
         info!("Connected to PostgreSQL server at {}...", connection_string);
 
@@ -671,197 +824,170 @@ impl<'n> SystemCatalogDumper<'n> {
         Ok(Self {
             context,
             pg_client: Arc::new(Mutex::new(pg_client)),
+            pg_tls,
             cluster_replicas,
             _pg_conn_handle: handle,
         })
     }
 
-    pub fn dump_relation(
+    pub async fn dump_relation(
         &self,
         relation: &Relation,
         cluster_replica: Option<&ClusterReplica>,
-    ) -> JoinHandle<()> {
-        let start_time = self.context.start_time.clone();
-        let pg_client = Arc::clone(&self.pg_client);
-        let cluster_replica = cluster_replica.cloned();
+    ) -> Result<(), anyhow::Error> {
+        info!(
+            "Copying relation {}{}",
+            relation.name,
+            cluster_replica.map_or_else(|| "".to_string(), |replica| format!(" in {}", replica))
+        );
+
+        let start_time = self.context.start_time;
+        let pg_client = &self.pg_client;
+
         let relation_name = relation.name.to_string();
-        let relation_category = relation.category.clone();
 
-        task::spawn(|| "dump-relation", async move {
-            if let Err(err) = retry::Retry::default()
-                .max_duration(PG_QUERY_TIMEOUT)
-                .initial_backoff(Duration::from_secs(2))
-                .retry_async_canceling(|_| {
-                    let start_time = start_time.clone();
-                    let pg_client = Arc::clone(&pg_client);
-                    let relation_name = relation_name.clone();
-                    let cluster_replica = cluster_replica.clone();
-                    let relation_category = relation_category.clone();
+        let mut pg_client_lock = pg_client.lock().await;
+        // TODO (debug_tool3): Use a transaction for the entire dump instead of per query.
+        let transaction = pg_client_lock.transaction().await?;
 
+        let cancel_token = transaction.cancel_token();
 
-                    async move {
-                        match async {
-                            // TODO (debug_tool3): Use a transaction for the entire dump instead of per query.
-                            let mut pg_client_lock = pg_client.lock().await;
-                            let transaction = pg_client_lock.transaction().await?;
-                            
-                            // Some queries (i.e. mz_introspection relations) require the cluster and replica to be set.
-                            if let Some(cluster_replica) = &cluster_replica {
-                                transaction
-                                    .execute(
-                                        &format!(
-                                            "SET LOCAL CLUSTER = '{}'",
-                                            cluster_replica.cluster_name
-                                        ),
-                                        &[],
-                                    )
-                                    .await?;
-                                transaction
-                                    .execute(
-                                        &format!(
-                                            "SET LOCAL CLUSTER_REPLICA = '{}'",
-                                            cluster_replica.replica_name
-                                        ),
-                                        &[],
-                                    )
-                                    .await?;
-                            }
+        if let Err(err) = retry::Retry::default()
+            .max_duration(PG_QUERY_TIMEOUT)
+            .initial_backoff(Duration::from_secs(2))
+            .retry_async_canceling(|_| {
+                let start_time = start_time.clone();
+                let relation_name = relation.name;
+                let cluster_replica = cluster_replica.clone();
+                let transaction = &transaction;
 
-                        
-                            // We query the column names to write the header row of the CSV file.
-                            // TODO (SangJunBak): Use `WITH (HEADER TRUE)` once database-issues#2846 is implemented.
-                            let column_names = transaction
-                            .query(&format!("SHOW COLUMNS FROM {}", &relation_name), &[])
-                            .await?
-                            .into_iter()
-                            .map(|row| row.get::<_, String>("name"))
-                            .collect::<Vec<_>>();
-
-                            let copy_to_csv = |file_path_name: PathBuf, relation_category: RelationCategory| {
-                                let relation_name = relation_name.clone();
-                                let mut column_names = column_names.clone();
-
-                                if let RelationCategory::Introspection = relation_category {
-                                    column_names.splice(0..0, vec!["mz_timestamp".to_string(), "mz_diff".to_string()]);
-                                }
-
-                                async move {
-                                    let mut file = tokio::fs::File::create(&file_path_name).await?;
-
-                                    file.write_all((column_names.join(",") + "\n").as_bytes())
-                                        .await?;
-
-                                    // Stream data rows to CSV
-                                    let copy_query = format!(
-                                        "COPY (SELECT * FROM {}) TO STDOUT WITH (FORMAT CSV)",
-                                        relation_name
-                                    );
-                                    
-                                    let copy_stream = transaction.copy_out(&copy_query).await?
-                                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
-                                    let copy_stream = std::pin::pin!(copy_stream);
-                                    let mut reader = StreamReader::new(copy_stream);
-                                    tokio::io::copy(&mut reader, &mut file).await?;
-
-                                    info!(
-                                        "Copied {} to {}",
-                                        relation_name,
-                                        file_path_name.display()
-                                    );
-                                    Ok::<(), anyhow::Error>(())
-                                }
-                            };
-
-                            match relation_category {
-                                RelationCategory::Basic => {
-                                    let file_path = format_file_path(start_time, None);
-                                    let file_path_name = file_path
-                                        .join(relation_name.as_str())
-                                        .with_extension("csv");
-                                    tokio::fs::create_dir_all(&file_path).await?;
-
-                                    copy_to_csv(file_path_name, relation_category).await?;
-                                }
-                                RelationCategory::Introspection => {
-                                    let file_path =
-                                        format_file_path(start_time, cluster_replica.as_ref());
-                                    tokio::fs::create_dir_all(&file_path).await?;
-
-                                    let file_path_name = file_path
-                                        .join(relation_name.as_str())
-                                        .with_extension("csv");
-
-                                    copy_to_csv(file_path_name, relation_category).await?;
-                                }
-                                RelationCategory::Retained => {
-                                    let file_path = format_file_path(start_time, None);
-                                    let file_path_name = file_path
-                                        .join(relation_name.as_str())
-                                        .with_extension("csv");
-                                    tokio::fs::create_dir_all(&file_path).await?;
-                                    copy_to_csv(file_path_name, relation_category).await?;
-                                    // TODO (debug_tool1): Dump the `FETCH ALL SUBSCRIBE` output too
-                                }
-                            }
-                            Ok::<(), anyhow::Error>(())
-                        }
-                        .await
-                        {
-                            Ok(()) => Ok(()),
-                            Err(err) => {
-                                error!(
-                                    "{}: {}. Retrying...",
-                                    format_catalog_dump_error_message(
-                                        &relation_name,
-                                        cluster_replica.as_ref()
-                                    ),
-                                    err
-                                );
-                                Err(err)
-                            }
+                async move {
+                    match query_relation(transaction, start_time, &relation, cluster_replica).await
+                    {
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            error!(
+                                "{}: {}. Retrying...",
+                                format_catalog_dump_error_message(relation_name, cluster_replica),
+                                err
+                            );
+                            Err(err)
                         }
                     }
-                })
-                .await
+                }
+            })
+            .await
+        {
+            if let Err(_) = async {
+                let tls = self.pg_tls.clone();
+
+                cancel_token.cancel_query(tls).await?;
+                Ok::<(), anyhow::Error>(())
+            }
+            .await
             {
                 error!(
-                    "{}: {}. Consider increasing the size of your mz_catalog_server cluster \
-                    https://materialize.com/docs/self-managed/v25.1/installation/troubleshooting/#troubleshooting-console-unresponsiveness",
-                    format_catalog_dump_error_message(&relation_name, cluster_replica.as_ref()),
-                    err,
-                    
+                    "Failed to cancel query for {}{}",
+                    relation_name,
+                    cluster_replica
+                        .map_or_else(|| "".to_string(), |replica| format!(" for {}", replica))
                 );
             }
-        })
+
+            return Err(err);
+        }
+
+        Ok(())
     }
 
-    pub fn dump_all_relations(&self) -> Vec<JoinHandle<()>> {
-        RELATIONS
+    pub async fn dump_all_relations(&self) {
+        let cluster_replicas = &self.cluster_replicas;
+
+        // Create a map to count errors by cluster replica..
+        let mut cluster_replica_error_counts: HashMap<ClusterReplica, usize> = HashMap::new();
+        for replica in cluster_replicas {
+            cluster_replica_error_counts
+                .entry(replica.clone())
+                .insert_entry(0);
+        }
+
+        let non_introspection_iter = RELATIONS
             .iter()
-            .map(|relation| match relation.category {
-                RelationCategory::Introspection => self
-                    .cluster_replicas
-                    .iter()
-                    .map(|cluster_replica| self.dump_relation(relation, Some(cluster_replica)))
-                    .collect(),
-                _ => vec![self.dump_relation(relation, None)],
+            .filter(|relation| {
+                matches!(
+                    relation.category,
+                    RelationCategory::Basic | RelationCategory::Retained
+                )
             })
-            .flatten()
-            .collect()
+            .map(|relation| (relation, None::<&ClusterReplica>));
+
+        let introspection_iter = RELATIONS
+            .iter()
+            .filter(|relation| matches!(relation.category, RelationCategory::Introspection))
+            .collect::<Vec<_>>();
+
+        let introspection_iter = cluster_replicas.iter().flat_map(|replica| {
+            introspection_iter
+                .iter()
+                .map(move |relation| (*relation, Some(replica)))
+        });
+
+        // Combine and iterate over all relation/replica pairs
+        for (relation, replica) in non_introspection_iter.chain(introspection_iter) {
+            let replica_key = if let Some(replica) = replica {
+                replica
+            } else {
+                // If the replica is null, we assume it's  mz_catalog_server.
+                &ClusterReplica::default()
+            };
+
+            // If the cluster replica has more than `MAX_CLUSTER_REPLICA_ERROR_COUNT` errors,
+            // we can skip it since we can assume it's not responsive and don't want to hold up
+            // following queries.
+            if cluster_replica_error_counts.get(&replica_key).unwrap_or(&0)
+                >= &MAX_CLUSTER_REPLICA_ERROR_COUNT
+            {
+                info!(
+                    "Skipping {}{}",
+                    relation.name,
+                    replica.map_or_else(|| "".to_string(), |replica| format!(" for {}", replica))
+                );
+                continue;
+            }
+
+            if let Err(err) = self.dump_relation(relation, replica).await {
+                let docs_link = if replica.is_none()
+                    || replica.map_or(false, |r| r.cluster_name == "mz_catalog_server")
+                {
+                    "https://materialize.com/docs/self-managed/v25.1/installation/troubleshooting/#troubleshooting-console-unresponsiveness"
+                } else {
+                    "https://materialize.com/docs/sql/alter-cluster/#resizing-1"
+                };
+
+                error!(
+                    "{}: {}.\nConsider increasing the size of the cluster {}",
+                    format_catalog_dump_error_message(relation.name, replica),
+                    err,
+                    docs_link
+                );
+
+                cluster_replica_error_counts
+                    .entry(replica_key.clone())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+        }
     }
 }
 
 fn format_catalog_dump_error_message(
-    relation_name: &String,
+    relation_name: &str,
     cluster_replica: Option<&ClusterReplica>,
 ) -> String {
     format!(
         "Failed to dump relation {}{}",
         relation_name,
-        cluster_replica.map_or_else(
-            || "".to_string(),
-            |replica| format!(" for {}.{}", replica.cluster_name, replica.replica_name)
-        )
+        cluster_replica.map_or_else(|| "".to_string(), |replica| format!(" for {}", replica))
     )
 }
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #31859

## Chain of upstream PRs as of 2025-03-20

* PR #31859:
  `main` ← `jun/#8908/dump-catalog-2`

  * **PR #31951 (THIS ONE)**:
    `jun/#8908/dump-catalog-2` ← `jun/#8908/dump-catalog-3`

<!-- end git-machete generated -->

See commit messages for details

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/database-issues/issues/8908

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]



  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.