### PR TITLE
ci: Disable two failing tests in nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -256,6 +256,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--replicas=4]
+        skip: "Reenable when database-issues#9095 is fixed"
 
       - id: testdrive-size-1
         label: ":racing_car: testdrive with SIZE 1"
@@ -1218,6 +1219,7 @@ steps:
             composition: terraform
             run: azure-temporary
       branches: "main v*.* lts-v* *azure* *tf* *terraform* *helm* *self-managed*"
+      skip: "Keeps failing because of internal errors at Azure"
 
   - group: "Output consistency"
     key: output-consistency


### PR DESCRIPTION
@bobbyiliev Do we have an issue for the Azure problem? I'm afraid that we won't have e2e helm-chart + terraform coverage for Azure now.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
