### PR TITLE
legacy-upgrade test: Try removing version checks in check-from files

### DIFF
--- a/test/legacy-upgrade/check-from-v0.27.0-database-schema.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-database-schema.td
@@ -7,26 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
->[version<11400] SHOW DATABASES;
-materialize
-"some database"
-
->[version>=11400] SHOW DATABASES;
+> SHOW DATABASES;
 materialize ""
 "some database" ""
 
->[version<11400] SHOW SCHEMAS FROM "some database";
-public
-"some schema"
-information_schema
-mz_catalog
-mz_catalog_unstable
-mz_unsafe
-mz_internal
-mz_introspection
-pg_catalog
-
->[version>=11400] SHOW SCHEMAS FROM "some database";
+> SHOW SCHEMAS FROM "some database";
 public ""
 "some schema" ""
 information_schema ""

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
->[version<8000] SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'upgrade-kafka-sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" ENVELOPE DEBEZIUM"
-
 # Later versions of MZ do not create linked clusters
 $ skip-if
 SELECT mz_version_num() >= 8100;

--- a/test/legacy-upgrade/check-from-v0.27.0-secrets.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-secrets.td
@@ -9,12 +9,7 @@
 
 > ALTER SECRET secret2 RENAME TO secret3;
 
->[version<11400] SHOW SECRETS;
-pgpass
-secret1
-secret3
-
->[version>=11400] SHOW SECRETS;
+> SHOW SECRETS;
 pgpass ""
 secret1 ""
 secret3 ""

--- a/test/legacy-upgrade/check-from-v0.27.0-table.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-table.td
@@ -30,10 +30,7 @@
 > SELECT * FROM default_value
 123 "default value"
 
->[version<11400] SHOW COLUMNS IN not_null
-f1 false integer
-
->[version>=11400] SHOW COLUMNS IN not_null
+> SHOW COLUMNS IN not_null
 f1 false integer ""
 
 ! INSERT INTO not_null VALUES (null)

--- a/test/legacy-upgrade/check-from-v0.45.0-kafka-progress.td
+++ b/test/legacy-upgrade/check-from-v0.45.0-kafka-progress.td
@@ -15,6 +15,6 @@ $ set-regex match=\d+ replacement=<NUMBER>
 
 # Later versions of MZ have complex interactions with automatically creating
 # clusters, so skip checking this create statement.
-$ set-regex match=testdrive-upgrade-kafka-source-.*?' replacement=<TOPIC>'
->[version<8100] SHOW CREATE SOURCE kafka_source
-materialize.public.kafka_source "CREATE SOURCE \"materialize\".\"public\".\"kafka_source\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = '<TOPIC>') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"cpx\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"long\"}   ] }' ENVELOPE NONE EXPOSE PROGRESS AS \"materialize\".\"public\".\"kafka_source_progress\""
+# $ set-regex match=testdrive-upgrade-kafka-source-.*?' replacement=<TOPIC>'
+# > SHOW CREATE SOURCE kafka_source
+# materialize.public.kafka_source "CREATE SOURCE \"materialize\".\"public\".\"kafka_source\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = '<TOPIC>') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"cpx\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"long\"}   ] }' ENVELOPE NONE EXPOSE PROGRESS AS \"materialize\".\"public\".\"kafka_source_progress\""


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
