### PR TITLE
Set console's pod security context fs_group to 101

### DIFF
--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -11,9 +11,9 @@ use k8s_openapi::{
     api::{
         apps::v1::{Deployment, DeploymentSpec},
         core::v1::{
-            Capabilities, Container, ContainerPort, EnvVar, HTTPGetAction, PodSpec,
-            PodTemplateSpec, Probe, SeccompProfile, SecretVolumeSource, SecurityContext, Service,
-            ServicePort, ServiceSpec, Volume, VolumeMount,
+            Capabilities, Container, ContainerPort, EnvVar, HTTPGetAction, PodSecurityContext,
+            PodSpec, PodTemplateSpec, Probe, SeccompProfile, SecretVolumeSource, SecurityContext,
+            Service, ServicePort, ServiceSpec, Volume, VolumeMount,
         },
         networking::v1::{
             IPBlock, NetworkPolicy, NetworkPolicyIngressRule, NetworkPolicyPeer, NetworkPolicyPort,
@@ -318,6 +318,10 @@ ssl_certificate_key /nginx/tls/tls.key;",
                 scheduler_name: config.scheduler_name.clone(),
                 service_account_name: Some(mz.service_account_name()),
                 volumes,
+                security_context: Some(PodSecurityContext {
+                    fs_group: Some(101),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
         },


### PR DESCRIPTION
Set console's pod security context fs_group to 101, as we use an nginx-unprivileged container that runs as uid/gid 101, and our TLS certificate mount was previously unreadable by that user.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
TLS doesn't work with the console ever since we stopped running as root.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
