### PR TITLE
Generalize `WillDistinct` to polarities

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -135,6 +135,8 @@ optimizer_feature_flags!({
     enable_simplify_quantified_comparisons: bool,
     // See the feature flag of the same name.
     enable_coalesce_case_transform: bool,
+    // See the feature flag of the same name.
+    enable_will_distinct_propagation: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4875,6 +4875,7 @@ pub fn unplan_create_cluster(
                 enable_case_literal_transform: _,
                 enable_simplify_quantified_comparisons: _,
                 enable_coalesce_case_transform: _,
+                enable_will_distinct_propagation: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -637,6 +637,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_case_literal_transform: Default::default(),
                 enable_simplify_quantified_comparisons: Default::default(),
                 enable_coalesce_case_transform: Default::default(),
+                enable_will_distinct_propagation: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2232,6 +2232,7 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    // Disposition: added 2026-05-29, default on; remove after several weeks of observation.
     {
         name: enable_will_distinct_propagation,
         desc: "Allow the WillDistinct transform to propagate a pending distinct through Map, Filter, FlatMap, Threshold, Negate, non-negative Project, and TopK with limit 1.",

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2232,6 +2232,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_will_distinct_propagation,
+        desc: "Allow the WillDistinct transform to propagate a pending distinct through Map, Filter, FlatMap, Threshold, Negate, non-negative Project, and TopK with limit 1.",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2256,6 +2262,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_case_literal_transform: vars.enable_case_literal_transform(),
             enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
             enable_coalesce_case_transform: vars.enable_coalesce_case_transform(),
+            enable_will_distinct_propagation: vars.enable_will_distinct_propagation(),
         }
     }
 }
@@ -2297,6 +2304,7 @@ mod tests {
             enable_case_literal_transform,
             enable_simplify_quantified_comparisons,
             enable_coalesce_case_transform,
+            enable_will_distinct_propagation,
         } = false_features;
 
         let mut vars = SystemVars::new();
@@ -2326,6 +2334,7 @@ mod tests {
         set_var!(enable_case_literal_transform);
         set_var!(enable_simplify_quantified_comparisons);
         set_var!(enable_coalesce_case_transform);
+        set_var!(enable_will_distinct_propagation);
 
         // Enable for item parsing, then ensure we still get the same optimizer features.
         vars.enable_for_item_parsing();

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2235,7 +2235,7 @@ feature_flags!(
     // Disposition: added 2026-05-29, default on; remove after several weeks of observation.
     {
         name: enable_will_distinct_propagation,
-        desc: "Allow the WillDistinct transform to propagate a pending distinct through Map, Filter, FlatMap, Threshold, Negate, non-negative Project, and TopK with limit 1.",
+        desc: "Allow the WillDistinct transform to propagate a pending distinct through Map, Filter, FlatMap, Threshold, Negate, non-negative Project, and TopK with limit 1 and offset 0.",
         default: true,
         enable_for_item_parsing: false,
     },

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -157,14 +157,16 @@ impl WillDistinct {
                             todo.push((input, derived.last_child(), false));
                         }
                     }
-                    MirRelationExpr::Join { inputs, .. } => {
-                        let children_rev = inputs.iter_mut().rev();
-                        todo.extend(
-                            children_rev
-                                .zip(derived.children_rev())
-                                .map(|(x, y)| (x, y, distinct_by)),
-                        );
-                    }
+                    // Although it would be nice to push distinct elision through joins, this works against
+                    // Semijoin elision that needs to see distinct-ed inputs.
+                    // MirRelationExpr::Join { inputs, .. } => {
+                    //     let children_rev = inputs.iter_mut().rev();
+                    //     todo.extend(
+                    //         children_rev
+                    //             .zip(derived.children_rev())
+                    //             .map(|(x, y)| (x, y, distinct_by)),
+                    //     );
+                    // }
                     // If all inputs to the union are non-negative, any distinct enforced above the expression can be
                     // communicated on to each input.
                     MirRelationExpr::Union { base, inputs } => {

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -39,7 +39,7 @@ impl crate::Transform for WillDistinct {
     #[mz_ore::instrument(
         target = "optimizer"
         level = "trace",
-        fields(path.segment = "distinct_by")
+        fields(path.segment = "will_distinct")
     )]
     fn actually_perform_transform(
         &self,

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -7,7 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Transform that pushes down the information that a collection will be subjected to a `Distinct` on specific columns.
+//! Transform that allows expressions to arbitarily vary the magnitude of the multiplicity of each row.
+//!
+//! This is most commonly from a `Distinct` operation, which flattens all positive multiplicities to one.
+//! When a `Distinct` will certainly be applied, its input expressions are allowed to change the magnitudes
+//! of their record multiplicities, for example removing other `Distinct` operations that are redundant.
 
 use itertools::Itertools;
 use mz_expr::MirRelationExpr;
@@ -16,7 +20,7 @@ use crate::analysis::{DerivedView, NonNegative};
 
 use crate::{TransformCtx, TransformError};
 
-/// Pushes down the information that a collection will be subjected to a `Distinct` on specific columns.
+/// Pushes down the information that a collection will be subjected to a `Distinct`.
 ///
 /// This intends to recognize idiomatic stacks of `UNION` from SQL, which look like `Distinct` over `Union`, potentially
 /// over other `Distinct` expressions. It is only able to see patterns of `DISTINCT UNION DISTINCT, ..` and other operators
@@ -35,7 +39,7 @@ impl crate::Transform for WillDistinct {
     #[mz_ore::instrument(
         target = "optimizer"
         level = "trace",
-        fields(path.segment = "will_distinct")
+        fields(path.segment = "distinct_by")
     )]
     fn actually_perform_transform(
         &self,
@@ -60,7 +64,7 @@ impl WillDistinct {
     fn apply(&self, expr: &mut MirRelationExpr, derived: DerivedView) {
         // Maintain a todo list of triples of 1. expression, 2. child analysis results, and 3. a "will distinct" bit.
         // The "will distinct" bit says that a subsequent operator will make the specific multiplicities of each record
-        // irrelevant, and the expression only needs to present the correct *multiset* of record, with any non-negative
+        // irrelevant, and the expression only needs to present the correct *multiset* of records, with any positive
         // cardinality allowed.
         let mut todo = vec![(expr, derived, false)];
         while let Some((expr, derived, distinct_by)) = todo.pop() {
@@ -111,22 +115,59 @@ impl WillDistinct {
                     );
                 }
             } else {
-                match (expr, distinct_by) {
-                    (
-                        MirRelationExpr::Reduce {
-                            input, aggregates, ..
-                        },
-                        _,
-                    ) => {
+                match expr {
+                    MirRelationExpr::Reduce {
+                        input, aggregates, ..
+                    } => {
                         if aggregates.is_empty() {
                             todo.push((input, derived.last_child(), true));
                         } else {
                             todo.push((input, derived.last_child(), false))
                         }
                     }
+                    MirRelationExpr::TopK { input, limit, .. } => {
+                        if limit.as_ref().and_then(|e| e.as_literal_int64()) == Some(1) {
+                            todo.push((input, derived.last_child(), true));
+                        } else {
+                            todo.push((input, derived.last_child(), false));
+                        }
+                    }
+                    MirRelationExpr::Map { input, .. } => {
+                        todo.push((input, derived.last_child(), distinct_by));
+                    }
+                    MirRelationExpr::Filter { input, .. } => {
+                        todo.push((input, derived.last_child(), distinct_by));
+                    }
+                    MirRelationExpr::FlatMap { input, .. } => {
+                        todo.push((input, derived.last_child(), distinct_by));
+                    }
+                    MirRelationExpr::Threshold { input, .. } => {
+                        todo.push((input, derived.last_child(), distinct_by));
+                    }
+                    MirRelationExpr::Negate { input, .. } => {
+                        todo.push((input, derived.last_child(), distinct_by));
+                    }
+                    MirRelationExpr::Project { input, .. } => {
+                        // Project needs a non-negative input to ensure output polarity does not change.
+                        // Two inputs that collapse to be one output, if their input polarities are different,
+                        // could end with either output polarity (or zero).
+                        if *derived.last_child().value::<NonNegative>().unwrap() {
+                            todo.push((input, derived.last_child(), distinct_by));
+                        } else {
+                            todo.push((input, derived.last_child(), false));
+                        }
+                    }
+                    MirRelationExpr::Join { inputs, .. } => {
+                        let children_rev = inputs.iter_mut().rev();
+                        todo.extend(
+                            children_rev
+                                .zip(derived.children_rev())
+                                .map(|(x, y)| (x, y, distinct_by)),
+                        );
+                    }
                     // If all inputs to the union are non-negative, any distinct enforced above the expression can be
                     // communicated on to each input.
-                    (MirRelationExpr::Union { base, inputs }, will_distinct) => {
+                    MirRelationExpr::Union { base, inputs } => {
                         if derived
                             .children_rev()
                             .all(|v| *v.value::<NonNegative>().unwrap())
@@ -135,7 +176,7 @@ impl WillDistinct {
                             todo.extend(
                                 children_rev
                                     .zip_eq(derived.children_rev())
-                                    .map(|(x, y)| (x, y, will_distinct)),
+                                    .map(|(x, y)| (x, y, distinct_by)),
                             );
                         } else {
                             let children_rev = inputs.iter_mut().rev().chain(Some(&mut **base));
@@ -146,7 +187,7 @@ impl WillDistinct {
                             );
                         }
                     }
-                    (x, _) => {
+                    x => {
                         todo.extend(
                             x.children_mut()
                                 .rev()

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -53,7 +53,11 @@ impl crate::Transform for WillDistinct {
         let derived = builder.visit(relation);
         let derived = derived.as_view();
 
-        self.apply(relation, derived, ctx.features.enable_will_distinct_propagation);
+        self.apply(
+            relation,
+            derived,
+            ctx.features.enable_will_distinct_propagation,
+        );
 
         mz_repr::explain::trace_plan(&*relation);
         Ok(())

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Transform that allows expressions to arbitarily vary the magnitude of the multiplicity of each row.
+//! Transform that allows expressions to arbitrarily vary the magnitude of the multiplicity of each row.
 //!
 //! This is most commonly from a `Distinct` operation, which flattens all positive multiplicities to one.
 //! When a `Distinct` will certainly be applied, its input expressions are allowed to change the magnitudes
@@ -129,8 +129,19 @@ impl WillDistinct {
                             todo.push((input, derived.last_child(), false))
                         }
                     }
-                    MirRelationExpr::TopK { input, limit, .. } => {
+                    MirRelationExpr::TopK {
+                        input,
+                        limit,
+                        offset,
+                        ..
+                    } => {
+                        // A `TopK` masks input magnitudes (behaving like a `Distinct`) only when it
+                        // returns the single first row per group: `limit == 1` and `offset == 0`.
+                        // With a non-zero offset, *which* row survives depends on the cumulative
+                        // multiplicities of the rows skipped, so a descendant that alters magnitudes
+                        // could shift the offset boundary and select a different row.
                         if generalize
+                            && *offset == 0
                             && limit.as_ref().and_then(|e| e.as_literal_int64()) == Some(1)
                         {
                             todo.push((input, derived.last_child(), true));
@@ -138,6 +149,22 @@ impl WillDistinct {
                             todo.push((input, derived.last_child(), false));
                         }
                     }
+                    // The masking `Distinct` above depends only on the *signs* of multiplicities,
+                    // not their magnitudes. The following operators are sign-preserving: given the
+                    // same input signs they produce the same output signs, because they never sum
+                    // two distinct input rows into a single output row.
+                    //   * `Map`/`Filter`/`Threshold` pass rows through (Filter/Threshold may drop
+                    //     rows, but never merge them).
+                    //   * `Negate` flips every sign uniformly, which the magnitude-masking
+                    //     `Distinct` is invariant to.
+                    //   * `FlatMap` retains the input columns, so distinct input rows stay distinct
+                    //     in the output; only same-input duplicates are scaled, by a non-negative
+                    //     count. Hence no cross-row cancellation.
+                    // Because none of these can cancel rows against each other, the permission to
+                    // alter magnitudes pushes through unconditionally. `Project` and `Union`, by
+                    // contrast, *can* sum across rows (Project by dropping distinguishing columns,
+                    // Union by combining inputs), so they require the `NonNegative` gate below to
+                    // rule out sign-changing cancellation.
                     MirRelationExpr::Map { input, .. } => {
                         todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
@@ -163,16 +190,10 @@ impl WillDistinct {
                             todo.push((input, derived.last_child(), false));
                         }
                     }
-                    // Although it would be nice to push distinct elision through joins, this works against
-                    // Semijoin elision that needs to see distinct-ed inputs.
-                    // MirRelationExpr::Join { inputs, .. } => {
-                    //     let children_rev = inputs.iter_mut().rev();
-                    //     todo.extend(
-                    //         children_rev
-                    //             .zip(derived.children_rev())
-                    //             .map(|(x, y)| (x, y, distinct_by)),
-                    //     );
-                    // }
+                    // `Join` deliberately falls through to the catch-all arm below (resetting the
+                    // bit to false). Pushing distinct elision through a join would work against
+                    // Semijoin elision, which needs to see distinct-ed inputs.
+                    //
                     // If all inputs to the union are non-negative, any distinct enforced above the expression can be
                     // communicated on to each input.
                     MirRelationExpr::Union { base, inputs } => {

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -53,7 +53,7 @@ impl crate::Transform for WillDistinct {
         let derived = builder.visit(relation);
         let derived = derived.as_view();
 
-        self.apply(relation, derived);
+        self.apply(relation, derived, ctx.features.enable_will_distinct_propagation);
 
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
@@ -61,7 +61,7 @@ impl crate::Transform for WillDistinct {
 }
 
 impl WillDistinct {
-    fn apply(&self, expr: &mut MirRelationExpr, derived: DerivedView) {
+    fn apply(&self, expr: &mut MirRelationExpr, derived: DerivedView, generalize: bool) {
         // Maintain a todo list of triples of 1. expression, 2. child analysis results, and 3. a "will distinct" bit.
         // The "will distinct" bit says that a subsequent operator will make the specific multiplicities of each record
         // irrelevant, and the expression only needs to present the correct *multiset* of records, with any positive
@@ -126,32 +126,34 @@ impl WillDistinct {
                         }
                     }
                     MirRelationExpr::TopK { input, limit, .. } => {
-                        if limit.as_ref().and_then(|e| e.as_literal_int64()) == Some(1) {
+                        if generalize
+                            && limit.as_ref().and_then(|e| e.as_literal_int64()) == Some(1)
+                        {
                             todo.push((input, derived.last_child(), true));
                         } else {
                             todo.push((input, derived.last_child(), false));
                         }
                     }
                     MirRelationExpr::Map { input, .. } => {
-                        todo.push((input, derived.last_child(), distinct_by));
+                        todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
                     MirRelationExpr::Filter { input, .. } => {
-                        todo.push((input, derived.last_child(), distinct_by));
+                        todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
                     MirRelationExpr::FlatMap { input, .. } => {
-                        todo.push((input, derived.last_child(), distinct_by));
+                        todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
                     MirRelationExpr::Threshold { input, .. } => {
-                        todo.push((input, derived.last_child(), distinct_by));
+                        todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
                     MirRelationExpr::Negate { input, .. } => {
-                        todo.push((input, derived.last_child(), distinct_by));
+                        todo.push((input, derived.last_child(), generalize && distinct_by));
                     }
                     MirRelationExpr::Project { input, .. } => {
                         // Project needs a non-negative input to ensure output polarity does not change.
                         // Two inputs that collapse to be one output, if their input polarities are different,
                         // could end with either output polarity (or zero).
-                        if *derived.last_child().value::<NonNegative>().unwrap() {
+                        if generalize && *derived.last_child().value::<NonNegative>().unwrap() {
                             todo.push((input, derived.last_child(), distinct_by));
                         } else {
                             todo.push((input, derived.last_child(), false));

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -183,7 +183,12 @@ mod tests {
         args: &HashMap<String, Vec<String>>,
         test_type: TestType,
     ) -> Result<String, Error> {
-        let features = OptimizerFeatures::default();
+        let mut features = OptimizerFeatures::default();
+        // Allow tests to opt into flag-gated transform behavior, e.g.
+        // `build apply=WillDistinct enable_will_distinct_propagation=true`.
+        if args.contains_key("enable_will_distinct_propagation") {
+            features.enable_will_distinct_propagation = true;
+        }
         let typecheck_ctx = typecheck::empty_typechecking_context();
         let mut df_meta = DataflowMetainfo::default();
         let mut transform_ctx = TransformCtx::local(
@@ -325,6 +330,7 @@ mod tests {
             )),
             "UnionNegateFusion" => Ok(Box::new(mz_transform::compound::UnionNegateFusion)),
             "UnionFusion" => Ok(Box::new(mz_transform::fusion::union::Union)),
+            "WillDistinct" => Ok(Box::new(mz_transform::will_distinct::WillDistinct)),
             _ => Err(anyhow!(
                 "no transform named {} (you might have to add it to get_transform)",
                 name

--- a/src/transform/tests/testdata/will_distinct
+++ b/src/transform/tests/testdata/will_distinct
@@ -1,0 +1,125 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Focused regression tests for the WillDistinct transform's generalized
+# propagation, gated behind `enable_will_distinct_propagation`. Each test plants
+# an inner `Distinct` (a Reduce with no aggregates) that is shadowed by an outer
+# `Distinct` through exactly one intermediate operator. When propagation reaches
+# the inner Distinct it is rewritten away into a Map+Project, so the presence or
+# absence of an inner `Reduce`/`Distinct` node in the output tells us whether the
+# arm fired.
+
+cat
+(defsource x ([int64 int64] [[0]]))
+----
+ok
+
+# ---------------------------------------------------------------------------
+# TopK, limit 1, offset 0: masks magnitudes like a Distinct, so the inner
+# Distinct is redundant and is removed when the flag is on.
+# ---------------------------------------------------------------------------
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (top_k (reduce (get x) [#0 #1] []) [] [#0] 1 0) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  TopK order_by=[#0 asc nulls_first] limit=1
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# NEGATIVE (locks in the #1 fix): TopK limit 1 OFFSET 5. Which row survives
+# depends on the cumulative multiplicities of the skipped rows, so the inner
+# Distinct must NOT be removed even with the flag on.
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (top_k (reduce (get x) [#0 #1] []) [] [#0] 1 5) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  TopK order_by=[#0 asc nulls_first] limit=1 offset=5
+    Distinct project=[#0, #1]
+      Get x
+
+# CONTROL: with the flag OFF, the generalized TopK arm is inert and the inner
+# Distinct survives even for limit 1 offset 0 (reproduces historic behavior).
+build apply=WillDistinct
+(reduce (top_k (reduce (get x) [#0 #1] []) [] [#0] 1 0) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  TopK order_by=[#0 asc nulls_first] limit=1
+    Distinct project=[#0, #1]
+      Get x
+
+# ---------------------------------------------------------------------------
+# Sign-preserving unary operators: inner Distinct removed when flag is on.
+# ---------------------------------------------------------------------------
+
+# Map
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (map (reduce (get x) [#0 #1] []) [(call_binary add_int64 #0 #1)]) [#0 #1 #2] [])
+----
+Distinct project=[#0..=#2]
+  Map ((#0 + #1))
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# Filter
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (filter (reduce (get x) [#0 #1] []) [(call_binary gt #0 #1)]) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  Filter (#0 > #1)
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# Negate
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (negate (reduce (get x) [#0 #1] [])) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  Negate
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# Threshold
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (threshold (reduce (get x) [#0 #1] [])) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  Threshold
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# ---------------------------------------------------------------------------
+# Project requires a non-negative input. Over a plain (non-negative) Distinct
+# the inner Distinct is removed; under a Negate (negative) it is preserved
+# because two rows could collapse to one with cancelling signs.
+# ---------------------------------------------------------------------------
+
+# Non-negative Project: removed.
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (project (reduce (get x) [#0 #1] []) [#0]) [#0] [])
+----
+Distinct project=[#0]
+  Project (#0)
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# Project over a Negate (negative input): preserved.
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (project (negate (reduce (get x) [#0 #1] [])) [#0]) [#0] [])
+----
+Distinct project=[#0]
+  Project (#0)
+    Negate
+      Distinct project=[#0, #1]
+        Get x

--- a/src/transform/tests/testdata/will_distinct
+++ b/src/transform/tests/testdata/will_distinct
@@ -98,6 +98,27 @@ Distinct project=[#0, #1]
       Map (#0, #1)
         Get x
 
+# FlatMap: retains input columns, so distinct input rows never merge; the
+# table-function count is non-negative, so the inner Distinct is removed.
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (flat_map (reduce (get x) [#0 #1] []) generate_series_int64 [#0 #1 1]) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  FlatMap generate_series(#0, #1, 1)
+    Project (#2, #3)
+      Map (#0, #1)
+        Get x
+
+# NEGATIVE: TopK whose limit is a non-literal expression (a column reference) is
+# not recognized as a magnitude mask, so the inner Distinct is preserved.
+build apply=WillDistinct enable_will_distinct_propagation=true
+(reduce (top_k (reduce (get x) [#0 #1] []) [] [#0] #0 0) [#0 #1] [])
+----
+Distinct project=[#0, #1]
+  TopK order_by=[#0 asc nulls_first] limit=#0
+    Distinct project=[#0, #1]
+      Get x
+
 # ---------------------------------------------------------------------------
 # Project requires a non-negative input. Over a plain (non-negative) Distinct
 # the inner Distinct is removed; under a Negate (negative) it is preserved

--- a/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1203.slt
@@ -262,37 +262,41 @@ Explained Query:
                                     Constant // { arity: 0 }
                                       - ()
     cte l2 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#2) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l3 =
-      Distinct project=[#0] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Filter (#0{symbol} = #1{right_col0_0}) // { arity: 2 }
-            FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") // { arity: 2 }
-              Get l2 // { arity: 1 }
-    cte l4 =
       ArrangeBy keys=[[#2]] // { arity: 3 }
         Get l1 // { arity: 3 }
-    cte l5 =
+    cte l3 =
+      Project (#2) // { arity: 1 }
+        Get l1 // { arity: 3 }
+    cte l4 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#2 = #3) type=differential // { arity: 4 }
           implementation
-            %1:l3[#0]UKA » %0:l4[#2]K
-          Get l4 // { arity: 3 }
+            %1[#0]UKA » %0:l2[#2]K
+          Get l2 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Get l3 // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (#0{symbol} = #1{right_col0_0}) // { arity: 2 }
+                  FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") // { arity: 2 }
+                    Get l3 // { arity: 1 }
+    cte l5 =
+      Distinct project=[#0] // { arity: 1 }
+        Get l3 // { arity: 1 }
     cte l6 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#2 = #3) type=differential // { arity: 4 }
           implementation
-            %0:l4[#2]K » %1[#0]K
-          Get l4 // { arity: 3 }
+            %0:l2[#2]K » %1[#0]K
+          Get l2 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Get l3 // { arity: 1 }
-              Get l2 // { arity: 1 }
+                Distinct project=[#0] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter (#0{symbol} = #1{right_col0_2}) // { arity: 2 }
+                      FlatMap wrap1("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") // { arity: 2 }
+                        Get l5 // { arity: 1 }
+              Get l5 // { arity: 1 }
     cte l7 =
       ArrangeBy keys=[[]] // { arity: 1 }
         Constant // { arity: 1 }
@@ -301,7 +305,7 @@ Explained Query:
           - (1)
     cte l8 =
       ArrangeBy keys=[[#0{row_idx}, #1{col_idx}]] // { arity: 3 }
-        Get l5 // { arity: 3 }
+        Get l4 // { arity: 3 }
   Return // { arity: 2 }
     With Mutually Recursive
       cte l9 =
@@ -313,12 +317,12 @@ Explained Query:
                   Map (1) // { arity: 8 }
                     Join on=(#0{row_idx} = (#3{row_idx} + #5{row_off}) AND #1{col_idx} = (#4{col_idx} + #6{col_off})) type=delta // { arity: 7 }
                       implementation
-                        %0:l5 » %1:l6[×] » %2:l7[×] » %3:l7[×]
-                        %1:l6 » %0:l5[×] » %2:l7[×] » %3:l7[×]
-                        %2:l7 » %0:l5[×] » %1:l6[×] » %3:l7[×]
-                        %3:l7 » %0:l5[×] » %1:l6[×] » %2:l7[×]
+                        %0:l4 » %1:l6[×] » %2:l7[×] » %3:l7[×]
+                        %1:l6 » %0:l4[×] » %2:l7[×] » %3:l7[×]
+                        %2:l7 » %0:l4[×] » %1:l6[×] » %3:l7[×]
+                        %3:l7 » %0:l4[×] » %1:l6[×] » %2:l7[×]
                       ArrangeBy keys=[[]] // { arity: 3 }
-                        Get l5 // { arity: 3 }
+                        Get l4 // { arity: 3 }
                       ArrangeBy keys=[[]] // { arity: 2 }
                         Project (#0, #1) // { arity: 2 }
                           Get l6 // { arity: 3 }
@@ -349,7 +353,7 @@ Explained Query:
         cte l11 =
           ArrangeBy keys=[[#0{right_col0_4}, #1{right_col1_5}]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
-              Get l5 // { arity: 3 }
+              Get l4 // { arity: 3 }
         cte l12 =
           Project (#0..=#3) // { arity: 4 }
             Join on=(#1 = #4 AND #2 = #5) type=differential // { arity: 6 }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -311,38 +311,37 @@ Explained Query:
         Distinct project=[#0..=#3] // { arity: 4 }
           Union // { arity: 4 }
             Project (#0..=#2, #1) // { arity: 4 }
-              Distinct project=[#0..=#2] // { arity: 3 }
-                Union // { arity: 3 }
-                  Project (#0, #1, #4) // { arity: 3 }
-                    Map ((#0{r} + 1)) // { arity: 5 }
-                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                        implementation
-                          %1[#0, #1]UKKA » %0:l2[#0, #1]KK
-                        Get l2 // { arity: 2 }
-                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                          Distinct project=[#0, #1] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
-                              Join on=(#1{c} = #3{right_col1_13} AND #2{right_col0_12} = (#0{r} + 1)) type=differential // { arity: 4 }
-                                implementation
-                                  %0:l1[(#0{r} + 1), #1{c}]KK » %1:l2[#0{right_col0_12}, #1{right_col1_13}]KK
-                                ArrangeBy keys=[[(#0{r} + 1), #1{c}]] // { arity: 2 }
-                                  Get l1 // { arity: 2 }
-                                Get l2 // { arity: 2 }
-                  Project (#0, #1, #4) // { arity: 3 }
-                    Map ((#0{r} - 1)) // { arity: 5 }
-                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                        implementation
-                          %1[#0, #1]UKKA » %0:l2[#0, #1]KK
-                        Get l2 // { arity: 2 }
-                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                          Distinct project=[#0, #1] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
-                              Join on=(#1{c} = #3{right_col1_16} AND #2{right_col0_15} = (#0{r} - 1)) type=differential // { arity: 4 }
-                                implementation
-                                  %0:l1[(#0{r} - 1), #1{c}]KK » %1:l2[#0{right_col0_15}, #1{right_col1_16}]KK
-                                ArrangeBy keys=[[(#0{r} - 1), #1{c}]] // { arity: 2 }
-                                  Get l1 // { arity: 2 }
-                                Get l2 // { arity: 2 }
+              Union // { arity: 3 }
+                Project (#0, #1, #4) // { arity: 3 }
+                  Map ((#0{r} + 1)) // { arity: 5 }
+                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                      implementation
+                        %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                      Get l2 // { arity: 2 }
+                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#0, #1) // { arity: 2 }
+                            Join on=(#1{c} = #3{right_col1_13} AND #2{right_col0_12} = (#0{r} + 1)) type=differential // { arity: 4 }
+                              implementation
+                                %0:l1[(#0{r} + 1), #1{c}]KK » %1:l2[#0{right_col0_12}, #1{right_col1_13}]KK
+                              ArrangeBy keys=[[(#0{r} + 1), #1{c}]] // { arity: 2 }
+                                Get l1 // { arity: 2 }
+                              Get l2 // { arity: 2 }
+                Project (#0, #1, #4) // { arity: 3 }
+                  Map ((#0{r} - 1)) // { arity: 5 }
+                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                      implementation
+                        %1[#0, #1]UKKA » %0:l2[#0, #1]KK
+                      Get l2 // { arity: 2 }
+                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#0, #1) // { arity: 2 }
+                            Join on=(#1{c} = #3{right_col1_16} AND #2{right_col0_15} = (#0{r} - 1)) type=differential // { arity: 4 }
+                              implementation
+                                %0:l1[(#0{r} - 1), #1{c}]KK » %1:l2[#0{right_col0_15}, #1{right_col1_16}]KK
+                              ArrangeBy keys=[[(#0{r} - 1), #1{c}]] // { arity: 2 }
+                                Get l1 // { arity: 2 }
+                              Get l2 // { arity: 2 }
             Project (#0, #1, #0, #4) // { arity: 4 }
               Map ((#1{c} + 1)) // { arity: 5 }
                 Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2020,9 +2020,8 @@ Explained Query:
                 Project (#0{rootpostlanguage}) // { arity: 1 }
                   Filter (#0{rootpostlanguage} = #1{right_col0_0}) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13{rootpostlanguage}) // { arity: 1 }
-                          Get l0 // { arity: 17 }
+                      Project (#13{rootpostlanguage}) // { arity: 1 }
+                        Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1{count_messageid}) // { arity: 1 }
@@ -3866,43 +3865,42 @@ Explained Query:
                       Get l1 // { arity: 5 }
         cte l4 =
           TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-            Distinct project=[#0..=#4] // { arity: 5 }
-              Union // { arity: 5 }
-                Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-                  Map ((#6{w} + bigint_to_double(#2{w})), false) // { arity: 9 }
-                    Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
-                      implementation
-                        %0:pathq19[#0{src}]KA » %1:l1[#2{dst}]K
-                      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                        ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
-                      ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
-                        Project (#0..=#3) // { arity: 4 }
-                          Filter (#2{dst}) IS NOT NULL // { arity: 5 }
-                            Get l1 // { arity: 5 }
-                Project (#0..=#3, #9) // { arity: 5 }
-                  Map ((#4{dead} OR #8)) // { arity: 10 }
-                    Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                      implementation
-                        %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                        Project (#0..=#4) // { arity: 5 }
-                          Get l7 // { arity: 6 }
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                        Union // { arity: 4 }
-                          Map (true) // { arity: 4 }
-                            Get l3 // { arity: 3 }
-                          Project (#0..=#2, #6) // { arity: 4 }
-                            Map (false) // { arity: 7 }
-                              Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                                implementation
-                                  %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
-                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                  Union // { arity: 3 }
-                                    Negate // { arity: 3 }
-                                      Get l3 // { arity: 3 }
-                                    Get l2 // { arity: 3 }
-                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Union // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                Map ((#6{w} + bigint_to_double(#2{w})), false) // { arity: 9 }
+                  Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
+                    implementation
+                      %0:pathq19[#0{src}]KA » %1:l1[#2{dst}]K
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                      ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+                    ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Filter (#2{dst}) IS NOT NULL // { arity: 5 }
+                          Get l1 // { arity: 5 }
+              Project (#0..=#3, #9) // { arity: 5 }
+                Map ((#4{dead} OR #8)) // { arity: 10 }
+                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                    implementation
+                      %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                      Project (#0..=#4) // { arity: 5 }
+                        Get l7 // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                      Union // { arity: 4 }
+                        Map (true) // { arity: 4 }
+                          Get l3 // { arity: 3 }
+                        Project (#0..=#2, #6) // { arity: 4 }
+                          Map (false) // { arity: 7 }
+                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                              implementation
+                                %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Union // { arity: 3 }
+                                  Negate // { arity: 3 }
+                                    Get l3 // { arity: 3 }
                                   Get l2 // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Get l2 // { arity: 3 }
         cte l5 =
           Reduce aggregates=[min((#0{w} + #1{w}))] // { arity: 1 }
             Project (#1, #3) // { arity: 2 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2027,9 +2027,8 @@ Explained Query:
                 Project (#0{rootpostlanguage}) // { arity: 1 }
                   Filter (#0{rootpostlanguage} = #1{right_col0_0}) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                        Project (#13{rootpostlanguage}) // { arity: 1 }
-                          Get l0 // { arity: 17 }
+                      Project (#13{rootpostlanguage}) // { arity: 1 }
+                        Get l0 // { arity: 17 }
     Return // { arity: 2 }
       Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1{count_messageid}) // { arity: 1 }
@@ -3873,43 +3872,42 @@ Explained Query:
                       Get l1 // { arity: 5 }
         cte l4 =
           TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-            Distinct project=[#0..=#4] // { arity: 5 }
-              Union // { arity: 5 }
-                Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
-                  Map ((#6{w} + bigint_to_double(#2{w})), false) // { arity: 9 }
-                    Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
-                      implementation
-                        %0:pathq19[#0{src}]KA » %1:l1[#2{dst}]K
-                      ArrangeBy keys=[[#0{src}]] // { arity: 3 }
-                        ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
-                      ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
-                        Project (#0..=#3) // { arity: 4 }
-                          Filter (#2{dst}) IS NOT NULL // { arity: 5 }
-                            Get l1 // { arity: 5 }
-                Project (#0..=#3, #9) // { arity: 5 }
-                  Map ((#4{dead} OR #8)) // { arity: 10 }
-                    Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
-                      implementation
-                        %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                        Project (#0..=#4) // { arity: 5 }
-                          Get l7 // { arity: 6 }
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                        Union // { arity: 4 }
-                          Map (true) // { arity: 4 }
-                            Get l3 // { arity: 3 }
-                          Project (#0..=#2, #6) // { arity: 4 }
-                            Map (false) // { arity: 7 }
-                              Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                                implementation
-                                  %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
-                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                                  Union // { arity: 3 }
-                                    Negate // { arity: 3 }
-                                      Get l3 // { arity: 3 }
-                                    Get l2 // { arity: 3 }
-                                ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Union // { arity: 5 }
+              Project (#3, #4, #1{dst}, #7, #8) // { arity: 5 }
+                Map ((#6{w} + bigint_to_double(#2{w})), false) // { arity: 9 }
+                  Join on=(#0{src} = #5{dst}) type=differential // { arity: 7 }
+                    implementation
+                      %0:pathq19[#0{src}]KA » %1:l1[#2{dst}]K
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
+                      ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
+                    ArrangeBy keys=[[#2{dst}]] // { arity: 4 }
+                      Project (#0..=#3) // { arity: 4 }
+                        Filter (#2{dst}) IS NOT NULL // { arity: 5 }
+                          Get l1 // { arity: 5 }
+              Project (#0..=#3, #9) // { arity: 5 }
+                Map ((#4{dead} OR #8)) // { arity: 10 }
+                  Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
+                    implementation
+                      %0:l7[#0..=#2]KKK » %1[#0..=#2]KKK
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+                      Project (#0..=#4) // { arity: 5 }
+                        Get l7 // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                      Union // { arity: 4 }
+                        Map (true) // { arity: 4 }
+                          Get l3 // { arity: 3 }
+                        Project (#0..=#2, #6) // { arity: 4 }
+                          Map (false) // { arity: 7 }
+                            Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                              implementation
+                                %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Union // { arity: 3 }
+                                  Negate // { arity: 3 }
+                                    Get l3 // { arity: 3 }
                                   Get l2 // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                Get l2 // { arity: 3 }
         cte l5 =
           Reduce aggregates=[min((#0{w} + #1{w}))] // { arity: 1 }
             Project (#1, #3) // { arity: 2 }

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -602,18 +602,17 @@ Explained Query:
                 Get l1 // { keys: "([0])" }
     cte l1 =
       TopK group_by=[#0{a}] limit=1 // { keys: "([0])" }
-        Distinct project=[#0{a}..=#4{u}] // { keys: "([0, 1, 2, 3, 4])" }
-          Union // { keys: "()" }
-            Map (null, null) // { keys: "()" }
-              Union // { keys: "()" }
-                Negate // { keys: "()" }
-                  Project (#0{a}..=#2{u}) // { keys: "()" }
-                    Get l0 // { keys: "()" }
-                ReadStorage materialize.public.foo_raw // { keys: "()" }
-            Project (#0{a}..=#2{u}, #0{a}, #3) // { keys: "()" }
-              Get l0 // { keys: "()" }
-            Project (#0{a}..=#2{u}, #0{a}, #2{u}) // { keys: "()" }
+        Union // { keys: "()" }
+          Map (null, null) // { keys: "()" }
+            Union // { keys: "()" }
+              Negate // { keys: "()" }
+                Project (#0{a}..=#2{u}) // { keys: "()" }
+                  Get l0 // { keys: "()" }
               ReadStorage materialize.public.foo_raw // { keys: "()" }
+          Project (#0{a}..=#2{u}, #0{a}, #3) // { keys: "()" }
+            Get l0 // { keys: "()" }
+          Project (#0{a}..=#2{u}, #0{a}, #2{u}) // { keys: "()" }
+            ReadStorage materialize.public.foo_raw // { keys: "()" }
   Return // { keys: "([0])" }
     Get l1 // { keys: "([0])" }
 

--- a/test/testdrive-old-kafka-src-syntax/top-1-monotonic.td
+++ b/test/testdrive-old-kafka-src-syntax/top-1-monotonic.td
@@ -294,17 +294,11 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 "Dataflow: group_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_in_top_1" "Arranged DistinctBy"
-"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
 "Dataflow: group_by_in_top_1" "Arranged MonotonicTop1 partial [val: empty]"
 "Dataflow: group_by_in_top_1" DistinctBy
-"Dataflow: group_by_in_top_1" DistinctBy
-"Dataflow: group_by_in_top_1" DistinctByErrorCheck
 "Dataflow: group_by_in_top_1" DistinctByErrorCheck
 "Dataflow: group_by_in_top_1" MonotonicTop1
-"Dataflow: group_by_limit" "Arranged DistinctBy"
 "Dataflow: group_by_limit" "Arranged MonotonicTop1 partial [val: empty]"
-"Dataflow: group_by_limit" DistinctBy
-"Dataflow: group_by_limit" DistinctByErrorCheck
 "Dataflow: group_by_limit" MonotonicTop1
 "Dataflow: group_by_order_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_order_by_in_top_1" "ArrangeBy[[Column(0)]]"

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -305,10 +305,6 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 "Dataflow: group_by_in_top_1" "Arranged DistinctBy"
 "Dataflow: group_by_in_top_1" DistinctBy
 "Dataflow: group_by_in_top_1" DistinctByErrorCheck
-"Dataflow: group_by_in_top_1" DistinctByErrorCheck
-"Dataflow: group_by_limit" "Arranged DistinctBy"
-"Dataflow: group_by_limit" DistinctBy
-"Dataflow: group_by_limit" DistinctByErrorCheck
 "Dataflow: group_by_order_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_order_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_order_by_in_top_1" "ArrangeBy[[Column(0)]]"

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -303,8 +303,6 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 "Dataflow: group_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_in_top_1" "ArrangeBy[[Column(0)]]"
 "Dataflow: group_by_in_top_1" "Arranged DistinctBy"
-"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
-"Dataflow: group_by_in_top_1" DistinctBy
 "Dataflow: group_by_in_top_1" DistinctBy
 "Dataflow: group_by_in_top_1" DistinctByErrorCheck
 "Dataflow: group_by_in_top_1" DistinctByErrorCheck


### PR DESCRIPTION
Our `WillDistinct` transform pushes down permission to do .. thing that will be masked by `Distinct`. Generalized, this is "feel free to change record multiplicity *magnitudes*, as long as you do not change the polarity (pos, neg, zero)". With that generalization, we can move the information farther along, as well as introduce some more behaviors. 

Concretely, the PR also adds `Top1` as a thing that can introduce this permission.

Edit from @ggevay: Linking the slack discussion: https://materializeinc.slack.com/archives/C08ACQNGSQK/p1742482715848509?thread_ts=1742482658.602089&cid=C08ACQNGSQK

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
