### PR TITLE
docs: AWS terraform v0.3.1 enable  disk support

### DIFF
--- a/doc/user/content/installation/install-on-aws/_index.md
+++ b/doc/user/content/installation/install-on-aws/_index.md
@@ -29,12 +29,10 @@ modules](https://github.com/MaterializeInc/terraform-aws-materialize) to:
 
 {{< /warning >}}
 
-When operating in AWS, we recommend:
+{{% self-managed/aws-recommended-instances %}}
 
-- Using the `r8g`, `r7g`, and `r6g` families when running without local disk.
-
-- Using the `r7gd` and `r6gd` families of instances (and `r8gd` once available)
-  when running with local disk (Recommended for production.  See [Operational guidelines](/installation/operational-guidelines/) for more information.)
+See [Operational guidelines](/installation/operational-guidelines/) for more
+information.
 
 ## Prerequisites
 
@@ -81,12 +79,17 @@ for evaluation purposes only. The modules deploy a sample infrastructure on AWS
 - Materialize Operator
 - Materialize instances (during subsequent runs after the Operator is running)
 
-- *Starting in v0.3.0 of Materialize on AWS Terraform*, AWS Load Balancer
+- **Starting in v0.3.0 of Materialize on AWS Terraform**, AWS Load Balancer
   Controller and AWS Network Load Balancers (NLBs) for each
   Materialize instance. If your deployment is set up using an earlier version of
   the Materialize AWS Terraform module, and you wish to upgrade to v0.3.0
   Terraform modules, see the [Upgrade
   Notes](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md#upgrade-notes).
+
+- **Starting in v0.3.1 of Materialize on AWS Terraform**, OpenEBS and NVMe
+  instance storage to [enable
+  spill-to-disk](https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#enabling-disk-support)
+  to support workloads that are larger than can fit into memory.
 
 {{< tip >}}
 
@@ -177,7 +180,7 @@ node instance type, etc.), see the
    Upon successful completion, various fields and their values are output:
 
    ```bash
-   Apply complete! Resources: 85 added, 0 changed, 0 destroyed.
+   Apply complete! Resources: 87 added, 0 changed, 0 destroyed.
 
    Outputs:
 
@@ -273,10 +276,7 @@ node instance type, etc.), see the
    for the Materialize instance configuration options.
 
    {{< tip >}}
-   If upgrading from a deployment that was set up using an earlier version of
-   the Terraform modules, see the [Upgrade
-   Notes](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md#upgrade-notes)
-   for the new version.
+   {{% self-managed/aws-terraform-upgrade-notes %}}
    {{</ tip >}}
 
 1. Run `terraform plan` with both `.tfvars` files and review the changes to be
@@ -307,7 +307,7 @@ node instance type, etc.), see the
    <a name="aws-terrafrom-output"></a>
 
    ```bash
-   Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+   Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
 
    Outputs:
 
@@ -414,7 +414,6 @@ node instance type, etc.), see the
 
       {{< /tip >}}
 
-
 ## Next steps
 
 {{% self-managed/next-steps %}}
@@ -425,10 +424,14 @@ node instance type, etc.), see the
 
   {{< tip >}}
 
-  To delete your S3 bucket, you may need to empty the S3 bucket
-  first. If the `terraform destroy` command is unable to delete the S3 bucket
-  and does not progress beyond "Still destroying...", empty the S3 bucket first
-  and rerun the `terraform destroy` command.
+  - To delete your S3 bucket, you may need to empty the S3 bucket first. If the
+    `terraform destroy` command is unable to delete the S3 bucket and does not
+    progress beyond "Still destroying...", empty the S3 bucket first and rerun
+    the `terraform destroy` command.
+
+  - Upon successful destroy, you may receive some informational messages with
+    regards to CustomResourceDefinition(CRD). You may safely ignore these
+    messages as your whole deployment has been destroyed, including the CRDs.
 
   {{</ tip >}}
 

--- a/doc/user/content/installation/install-on-aws/upgrade-on-aws.md
+++ b/doc/user/content/installation/install-on-aws/upgrade-on-aws.md
@@ -77,10 +77,7 @@ documentation](https://helm.sh/docs/intro/install/).
 1. Optional. You may need to update your fork of the Terraform modules to
    upgrade.
 
-   To upgrade from a deployment set up using an earlier version of the Terraform
-   modules, see the [Upgrade
-   Notes](https://github.com/MaterializeInc/terraform-aws-materialize/blob/main/README.md#upgrade-notes)
-   for your version.
+   {{% self-managed/aws-terraform-upgrade-notes %}}
 
 1. Configure `kubectl` to connect to your EKS cluster, replacing:
 

--- a/doc/user/content/installation/operational-guidelines.md
+++ b/doc/user/content/installation/operational-guidelines.md
@@ -14,12 +14,7 @@ menu:
 - 1:8 ratio of vCPU to GiB memory
 - 1:16 ratio of vCPU to GiB local instance storage (if enabling spill-to-disk)
 
-When operating in AWS, we recommend:
-
-- Using the `r7gd` and `r6gd` families of instances (and `r8gd` once available)
-  when running with local disk
-
-- Using the `r8g`, `r7g`, and `r6g` families when running without local disk
+{{% self-managed/aws-recommended-instances %}}
 
 ## CPU affinity
 
@@ -29,14 +24,51 @@ to substantially improve the performance of compute-bound workloads.
 
 ## Locally-attached NVMe storage
 
-For optimal performance, Materialize requires fast, *locally-attached* NVMe
+For optimal performance, Materialize requires fast, locally-attached NVMe
 storage. Having a locally-attached storage allows Materialize to spill to disk
 when operating on datasets larger than main memory as well as allows for a more
-graceful degradation rather than OOMing. *Network-attached* storage (like EBS
+graceful degradation rather than OOMing. Network-attached storage (like EBS
 volumes) can significantly degrade performance and is not supported.
 
 *Additional documentation to come*
 
+{{< tabs >}}
+{{< tab  "AWS" >}}
+
+*Starting in v0.3.1 of Materialize on AWS Terraform*, you can [enable disk
+support] for Materialize using OpenEBS and NVMe instance storage. With this
+change, the following configuration options are available:
+
+- [`enable_disk_support`]
+- [`disk_support_config`]
+
+When enabled, the Terraform:
+
+- Installs OpenEBS via Helm;
+
+- Configures NVMe instance store volumes using a bootstrap script;
+
+- Creates appropriate storage classes for Materialize.
+
+By default, [`enable_disk_support`] is set to `true`.
+In addition, the default [`node_group_instance_types`] has changed from
+`"r8g.2xlarge"` to `"r7gd.2xlarge"`. See [Recommended instance types](#recommended-instance-types).
+
+[enable disk support]:
+    https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#disk-support-for-materialize
+
+[`enable_disk_support`]:
+    https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_enable_disk_support
+
+[`disk_support_config`]:
+    https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_disk_support_config
+
+[`node_group_instance_types`]:
+    https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_node_group_instance_types
+
+{{</ tab >}}
+
+{{</ tabs >}}
 
 ## See also
 

--- a/doc/user/content/release-notes/_index.md
+++ b/doc/user/content/release-notes/_index.md
@@ -26,7 +26,7 @@ menu:
 |-----------------------------------------|-------------|
 | **IAM** <br>Built-in authorization mechanisms. | In progress |
 | **License Compliance** <br>License key support to make it easier to comply with license terms. | In progress |
-| **Spill to disk** <br> Cloud feature that enables Materialize to support workloads that are larger than can fit into memory. | In progress |
+| **Spill to disk** <br> Provide Terraform modules to set up  locally-attached NVMe storage to support workloads that are larger than can fit into memory. | <ul><li>AWS: Available v0.3.1+</li><li>GCP: In progress</li><li>Azure: In progress</li><ul> |
 | **Ingress from outside cluster** <br> Provide Terraform modules to set up ingress from outside the Kubernetes cluster hosting self-managed Materialize. | <ul><li>AWS: Available v0.3.0+</li><li>GCP: In progress</li><li>Azure: In progress</li><ul> |
 | **AWS Connections** <br> AWS connections require backing cluster that hosts Materialize to be AWS EKS.  | |
 | **EKS/Azure Connections** | |

--- a/doc/user/layouts/shortcodes/self-managed/aws-recommended-instances.html
+++ b/doc/user/layouts/shortcodes/self-managed/aws-recommended-instances.html
@@ -1,0 +1,12 @@
+When operating in AWS, we recommend the following instances:
+
+| EC2 Instances  |
+| ---------------|
+| `r8g`, `r7g`, and `r6g` families when running without local disk. |
+| `r7gd` and `r6gd` families (and `r8gd` once available) when running with local disk.  *Recommended for production.* |
+
+Starting in v0.3.1, the Materialize on AWS Terraform uses `["r7gd.2xlarge"]` as
+the default [`node_group_instance_types`].
+
+[`node_group_instance_types`]:
+    https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_node_group_instance_types

--- a/doc/user/layouts/shortcodes/self-managed/aws-terraform-upgrade-notes.html
+++ b/doc/user/layouts/shortcodes/self-managed/aws-terraform-upgrade-notes.html
@@ -1,0 +1,16 @@
+If upgrading from a deployment that was set up using an earlier version of the
+Terraform modules, see the [Upgrade Notes] for any considerations that might
+apply when using an updated Terraform modules to your existing deployments.
+
+| Terraform version | Notable changes |
+|-------------------|-----------------|
+| v0.3.0            | By default, deploys the [AWS Load Balancer Controller] as well as [Network Load Balancers (NLBs)] for each Materialize instance. |
+| v0.3.1            | By default, deploys OpenEBS and NVMe instance storage to [enable spill-to-disk]. |
+
+[Upgrade Notes]: https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#upgrade-notes
+
+[AWS Load Balancer Controller]: https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_install_aws_load_balancer_controller
+
+[enable spill-to-disk]: https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#enabling-disk-support
+
+[Network Load Balancers (NLBs)]: https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#input_materialize_instances

--- a/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
@@ -2,18 +2,18 @@
 1. Fork the [Materialize's sample Terraform
    repo](https://github.com/MaterializeInc/terraform-aws-materialize).
 
-1. Clone your forked repo and checkout the `v0.3.0` tag. For example,
+1. Clone your forked repo and checkout the `v0.3.1` tag. For example,
 
-   - If cloning via SSH (substitute `your-organization` with your organization's
+   - If cloning via SSH (replace `YOUR_ORGANIZATION` with your organization's
      name):
 
      ```bash
-     git clone --depth 1 -b v0.3.0 git@github.com:your-organization/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.3.1 git@github.com:YOUR_ORGANIZATION/terraform-aws-materialize.git
      ```
 
-   - If cloning via HTTPS (substitute `your-organization` with your
+   - If cloning via HTTPS (replace `YOUR_ORGANIZATION` with your
      organization's name):
 
      ```bash
-     git clone --depth 1 -b v0.3.0 https://github.com/your-organization/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.3.1 https://github.com/YOUR_ORGANIZATION/terraform-aws-materialize.git
      ```


### PR DESCRIPTION
FYI - the tag doesn't have to be v0.3.1 -- just using it as a placeholder.