### PR TITLE
make halt! use an exit code of 166

### DIFF
--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -18,7 +18,7 @@
 /// Halts the process.
 ///
 /// `halt` forwards the provided arguments to the [`tracing::warn`] macro, then
-/// terminates the process with exit code 2.
+/// terminates the process with exit code 166.
 ///
 /// Halting a process is a middle ground between a graceful shutdown and a
 /// panic. Use halts for errors that are severe enough to require shutting down
@@ -42,7 +42,7 @@
 macro_rules! halt {
     ($($arg:expr),* $(,)?) => {{
         $crate::__private::tracing::warn!("halting process: {}", format!($($arg),*));
-        $crate::process::exit_thread_safe(2);
+        $crate::process::exit_thread_safe(166);
     }}
 }
 


### PR DESCRIPTION
### Motivation

panic! already uses an exit code of 2, and it would be useful for us to be able to differentiate between these cases (because halt! is used for situations which aren't actually real errors, they should just trigger retries)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
