### PR TITLE
Less restrictive flat_map_fallible

### DIFF
--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -235,12 +235,13 @@ where
         &self,
         name: &str,
         logic: L,
-    ) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    ) -> (
+        Collection<G, D2, R, DCB::Container>,
+        Collection<G, E, R, ECB::Container>,
+    )
     where
-        DCB: ContainerBuilder<Container = Vec<(D2, G::Timestamp, R)>>
-            + PushInto<(D2, G::Timestamp, R)>,
-        ECB: ContainerBuilder<Container = Vec<(E, G::Timestamp, R)>>
-            + PushInto<(E, G::Timestamp, R)>,
+        DCB: ContainerBuilder + PushInto<(D2, G::Timestamp, R)>,
+        ECB: ContainerBuilder + PushInto<(E, G::Timestamp, R)>,
         D2: Data,
         E: Data,
         I: IntoIterator<Item = Result<D2, E>>,
@@ -579,12 +580,13 @@ where
         &self,
         name: &str,
         mut logic: L,
-    ) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    ) -> (
+        Collection<G, D2, R, DCB::Container>,
+        Collection<G, E, R, ECB::Container>,
+    )
     where
-        DCB: ContainerBuilder<Container = Vec<(D2, G::Timestamp, R)>>
-            + PushInto<(D2, G::Timestamp, R)>,
-        ECB: ContainerBuilder<Container = Vec<(E, G::Timestamp, R)>>
-            + PushInto<(E, G::Timestamp, R)>,
+        DCB: ContainerBuilder + PushInto<(D2, G::Timestamp, R)>,
+        ECB: ContainerBuilder + PushInto<(E, G::Timestamp, R)>,
         D2: Data,
         E: Data,
         I: IntoIterator<Item = Result<D2, E>>,


### PR DESCRIPTION
The `flat_map_fallible` function currently fixes its output container type to vectors. This is a leftover from when we didn't support any other type, but there is no reason to encode this restriction here. Instead, we do what we do elsewhere: let the container builder specify the output type.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
