### PR TITLE
optimizer: Make `EQProp` call `MSE::reduce` only after a change in `reduce_expr`

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -124,6 +124,8 @@ optimizer_feature_flags!({
     enable_projection_pushdown_after_relation_cse: bool,
     // See the feature flag of the same name.
     enable_let_prefix_extraction: bool,
+    // See the feature flag of the same name.
+    enable_less_reduce_in_eqprop: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4654,7 +4654,9 @@ pub fn unplan_create_cluster(
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
                 enable_let_prefix_extraction: _,
+                enable_less_reduce_in_eqprop: _,
             } = optimizer_feature_overrides;
+            // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
                 seen: Default::default(),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -435,6 +435,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
                 enable_let_prefix_extraction: Default::default(),
+                enable_less_reduce_in_eqprop: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2209,6 +2209,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_less_reduce_in_eqprop,
+        desc: "Run MSE::reduce in EquivalencePropagation only if reduce_expr changed something.",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2228,6 +2234,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
             enable_let_prefix_extraction: vars.enable_let_prefix_extraction(),
+            enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
         }
     }
 }


### PR DESCRIPTION
[We have a CPU profile](https://pprof.me/631f3c6fd71e6b13baf0e7b2c1505b7e/) where [a user](https://github.com/MaterializeInc/accounts/issues/3) running some very complex ad-hoc queries made envd quite busy with optimization. ([Slack discussion](https://materializeinc.slack.com/archives/C03R1QZ101Z/p1742565209009279?thread_ts=1742550520.344209&cid=C03R1QZ101Z).) The profile is showing that most of the time is spent in `MirScalarExpr::reduce` calls from `EquivalencePropagation`.

This PR modifies `EquivalencePropagation` to call `reduce` only if there was a recent change in the expression. Specifically, all of EQProp's calls to `reduce` are just after a `reduce_expr`, which conveniently returns a bool that indicates whether it made any changes.

There are no EXPLAIN changes across all of our slts. I've also done a run on all slts where I added a temporary assert that the `reduce`s that we are skipping wouldn't do anything. This failed only one time across all of our slts: in `joins.slt:1275`. But looking at the EXPLAINs of this query on `main` vs. the PR, the final plan does not change even for this query.

Added a feature flag, enabled by default.

The first commit is the actual functionality, the second just adds the feature flag and wires it up.

### Motivation

  * This PR speeds up the optimizer.

### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
