### PR TITLE
Implement EnterTime and Negate for Column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,8 +2424,7 @@ dependencies = [
 [[package]]
 name = "differential-dataflow"
 version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922c18a0f94e29defaef228ecd65589880c16f3f3462a33258f869119f039443"
+source = "git+https://github.com/antiguru/differential-dataflow?branch=enter_time_negate#b037eee5f5c79846518dd01cda8b520f4bd641ce"
 dependencies = [
  "columnar",
  "columnation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,7 @@ incremental = true
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
+differential-dataflow = { git = "https://github.com/antiguru/differential-dataflow", branch = "enter_time_negate" }
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }


### PR DESCRIPTION
As it says on the box, implement the two traits for the Column type.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
