### PR TITLE
catalog-debug: add debug line to print Persist schemas

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -692,7 +692,7 @@ async fn upgrade_check(
         // We should always have schemas registered for Shards, unless their environment happened
         // to crash after running DDL and hasn't come back up yet.
         let Some((_schema_id, persisted_relation_desc, _)) = persisted_schema else {
-            anyhow::bail!("no schema found for {gid}, did their environment crash?");
+            anyhow::bail!("no schema found for {gid}: {shard_id}, did their environment crash?");
         };
 
         let persisted_data_type =

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -679,6 +679,8 @@ async fn upgrade_check(
             .storage_metadata()
             .get_collection_shard::<Timestamp>(gid)
             .context("getting shard_id")?;
+        println!("checking Persist schema info for {gid}: {shard_id}");
+
         let diagnostics = Diagnostics {
             shard_name: gid.to_string(),
             handle_purpose: "catalog upgrade check".to_string(),


### PR DESCRIPTION
Add some more debug info for what Persist shard we're checking the schema of

### Motivation

Help debug upgrade check failures

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
