### PR TITLE
MFP evaluation returns reference to row

### DIFF
--- a/src/compute-types/src/plan/join.rs
+++ b/src/compute-types/src/plan/join.rs
@@ -126,12 +126,12 @@ impl RustType<ProtoJoinClosure> for JoinClosure {
 impl JoinClosure {
     /// Applies per-row filtering and logic.
     #[inline(always)]
-    pub fn apply<'a>(
+    pub fn apply<'a, 'row>(
         &'a self,
         datums: &mut Vec<Datum<'a>>,
         temp_storage: &'a RowArena,
-        row: &'a mut Row,
-    ) -> Result<Option<Row>, mz_expr::EvalError> {
+        row: &'row mut Row,
+    ) -> Result<Option<&'row Row>, mz_expr::EvalError> {
         for exprs in self.ready_equivalences.iter() {
             // Each list of expressions should be equal to the same value.
             let val = exprs[0].eval(&datums[..], temp_storage)?;

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1237,6 +1237,7 @@ impl PersistPeek {
                 let mut datum_local = datum_vec.borrow_with(&row);
                 let eval_result = mfp_plan
                     .evaluate_into(&mut datum_local, &arena, &mut row_builder)
+                    .map(|row| row.cloned())
                     .map_err(|e| e.to_string())?;
                 if let Some(row) = eval_result {
                     total_size = total_size
@@ -1449,6 +1450,7 @@ impl IndexPeek {
                 if let Some(result) = peek
                     .map_filter_project
                     .evaluate_into(&mut borrow, &arena, &mut row_builder)
+                    .map(|row| row.cloned())
                     .map_err_to_string_with_causes()?
                 {
                     let mut copies = 0;

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -283,6 +283,7 @@ where
                                     // TODO(mcsherry): re-use `row` allocation.
                                     final_closure
                                         .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                        .map(|row| row.cloned())
                                         .map_err(DataflowError::from)
                                         .transpose()
                                 }
@@ -396,7 +397,9 @@ where
                 datums_local.extend(stream_row.iter());
                 datums_local.extend(lookup_row.to_datum_iter());
 
-                let row = closure.apply(&mut datums_local, &temp_storage, &mut row_builder);
+                let row = closure
+                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                    .map(|row| row.cloned());
                 let diff = diff1.clone() * diff2.clone();
                 let dout = (row, time.clone());
                 Some((dout, initial.clone(), diff))
@@ -443,6 +446,7 @@ where
 
                 let row = closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                    .map(|row| row.cloned())
                     .expect("Closure claimed to never errer");
                 let diff = diff1.clone() * diff2.clone();
                 row.map(|r| ((r, time.clone()), initial.clone(), diff))
@@ -516,6 +520,7 @@ where
                                                         &temp_storage,
                                                         &mut row_builder,
                                                     )
+                                                    .map(|row| row.cloned())
                                                     .transpose()
                                                 {
                                                     Some(Ok(row)) => ok_session.give((

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -274,6 +274,7 @@ where
                             // TODO(mcsherry): re-use `row` allocation.
                             closure
                                 .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                .map(|row| row.cloned())
                                 .map_err(DataflowError::from)
                                 .transpose()
                         }
@@ -318,6 +319,7 @@ where
                         // TODO(mcsherry): re-use `row` allocation.
                         closure
                             .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                            .map(|row| row.cloned())
                             .map_err(DataflowError::from)
                             .transpose()
                     }
@@ -509,6 +511,7 @@ where
 
                         closure
                             .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                            .map(|row| row.cloned())
                             .map_err(DataflowError::from)
                             .transpose()
                     },
@@ -541,6 +544,7 @@ where
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)
                         .expect("Closure claimed to never error")
+                        .cloned()
                 },
             );
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -136,7 +136,9 @@ where
                                     diff.clone(),
                                 ))
                             }
-                            Ok(key) => key.expect("Row expected as no predicate was used"),
+                            Ok(key) => key
+                                .expect("Row expected as no predicate was used")
+                                .clone(),
                         };
                         // Evaluate the value expressions.
                         // The prior evaluation may have left additional columns we should delete.

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1678,7 +1678,7 @@ pub mod plan {
             datums: &mut Vec<Datum<'a>>,
             arena: &'a RowArena,
             row_buf: &'row mut Row,
-        ) -> Result<Option<Row>, EvalError> {
+        ) -> Result<Option<&'row Row>, EvalError> {
             let passed_predicates = self.evaluate_inner(datums, arena)?;
             if !passed_predicates {
                 Ok(None)
@@ -1686,7 +1686,7 @@ pub mod plan {
                 row_buf
                     .packer()
                     .extend(self.mfp.projection.iter().map(|c| datums[*c]));
-                Ok(Some(row_buf.clone()))
+                Ok(Some(row_buf))
             }
         }
 

--- a/src/storage-operators/src/oneshot_source.rs
+++ b/src/storage-operators/src/oneshot_source.rs
@@ -477,7 +477,9 @@ where
                     // orders and/or fill in default values for missing columns.
                     for row in rows {
                         let mut datums = datum_vec.borrow_with(&row);
-                        let result = mfp.evaluate_into(&mut *datums, &row_arena, &mut row_buf);
+                        let result = mfp
+                            .evaluate_into(&mut *datums, &row_arena, &mut row_buf)
+                            .map(|row| row.cloned());
 
                         match result {
                             Ok(Some(row)) => row_handle.give(&capability, Ok(row)),


### PR DESCRIPTION
Instead of eagerly cloning the row in MFP evaluations, return a reference to the row containing the result. This allows columnar operators to absorb the output without cloning.

No behavior change expected, it is only code movement.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
