### PR TITLE
Revert "storage,0dt: include all ingestion collections in caught-up check"

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -244,7 +244,8 @@ impl Coordinator {
         let storage_frontiers = self
             .controller
             .storage
-            .active_ingestion_collections(cluster.id)
+            .active_ingestions(cluster.id)
+            .copied()
             .filter(|id| !id.is_transient() && !exclude_collections.contains(id))
             .map(|id| {
                 let (_read_frontier, write_frontier) =

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -351,16 +351,11 @@ pub trait StorageController: Debug {
     /// capabilties.
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
-    /// Returns the IDs of all collections that are associated with active
-    /// ingestions, for the given storage instance.
-    ///
-    /// Associated collections are, for example, the remap collection and
-    /// subsources. Active ingestions are those ingestions that have been
-    /// scheduled to run on the given instance.
-    fn active_ingestion_collections(
+    /// Returns the IDs of all active ingestions for the given storage instance.
+    fn active_ingestions(
         &self,
         instance_id: StorageInstanceId,
-    ) -> Box<dyn Iterator<Item = GlobalId> + '_>;
+    ) -> Box<dyn Iterator<Item = &GlobalId> + '_>;
 
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -492,32 +492,11 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
-    fn active_ingestion_collections(
+    fn active_ingestions(
         &self,
         instance_id: StorageInstanceId,
-    ) -> Box<dyn Iterator<Item = GlobalId> + '_> {
-        let active_ingestions = self.instances[&instance_id].active_ingestions();
-
-        let active_collections = active_ingestions.flat_map(|ingestion_id| {
-            let ingestion_state = self
-                .collections
-                .get(ingestion_id)
-                .expect("instance contains unknown ingestion");
-
-            let ingestion_description = match &ingestion_state.data_source {
-                DataSource::Ingestion(ingestion_description) => ingestion_description.clone(),
-                _ => panic!(
-                    "unexpected data source for ingestion: {:?}",
-                    ingestion_state.data_source
-                ),
-            };
-
-            let collection_ids: Vec<_> = ingestion_description.collection_ids().collect();
-
-            collection_ids
-        });
-
-        Box::new(active_collections)
+    ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
+        Box::new(self.instances[&instance_id].active_ingestions())
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {


### PR DESCRIPTION
This reverts commit 323190b1136ce3494c709d340a3baa03031f6926.

### Motivation

Subsources lazily report their status, so for certain loadgen subsources that produce data once and never again, we never pass the hydration checks and thus never switch over.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
