### PR TITLE
Disable data-ingest KafkaRoundtripExecutor

### DIFF
--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -106,7 +106,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "mysql",
     )
 
-    # KafkaRoundtripExecutor disabled due to intermittent test failure (https://github.com/MaterializeInc/database-issues/issues/8657)
+    # TODO: Reenable when database-issues#8657 is fixed
     # executor_classes = [MySqlExecutor, KafkaRoundtripExecutor, KafkaExecutor]
     executor_classes = [MySqlExecutor, KafkaExecutor]
 


### PR DESCRIPTION
Disables KafkaRoundtripExecutor as it occasionally fails.

RE: https://github.com/MaterializeInc/database-issues/issues/8657#issuecomment-2719129095

### Motivation

CI flake

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
