### PR TITLE
compute: handle future epochs in channel adapter

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -747,28 +747,50 @@ fn spawn_channel_adapter(
             // for previous clients.
             let mut epoch = 0;
 
+            // It's possible that we receive responses with epochs from the future: Worker 0 might
+            // have increased its epoch before us and broadcasted it to our Timely cluster. When we
+            // receive a response with a future epoch, we need to wait with forwarding it until we
+            // have increased our own epoch sufficiently (by observing new client connections). We
+            // need to stash the response in the meantime.
+            let mut stashed_response = None;
+
             while let Ok((command_rx, response_tx)) = client_rx.recv() {
                 epoch += 1;
 
-                // Serve this connection until we see any of the channels disconnect.
-                loop {
+                // Wait for a new response while forwarding received commands.
+                let serve_rx_channels = || loop {
                     crossbeam_channel::select! {
                         recv(command_rx) -> msg => match msg {
                             Ok(cmd) => command_tx.send((cmd, epoch)),
-                            Err(_) => break,
+                            Err(_) => return Err(()),
                         },
                         recv(response_rx) -> msg => {
-                            let (resp, resp_epoch) = msg.expect("worker connected");
+                            return Ok(msg.expect("worker connected"));
+                        }
+                    }
+                };
 
-                            if resp_epoch < epoch {
-                                continue; // response for a previous connection
-                            } else if resp_epoch > epoch {
-                                panic!("epoch from the future: {resp_epoch} > {epoch}");
-                            }
+                // Serve this connection until we see any of the channels disconnect.
+                loop {
+                    let (resp, resp_epoch) = match stashed_response.take() {
+                        Some(stashed) => stashed,
+                        None => match serve_rx_channels() {
+                            Ok(response) => response,
+                            Err(()) => break,
+                        },
+                    };
 
-                            if response_tx.send(resp).is_err() {
-                                break;
-                            }
+                    if resp_epoch < epoch {
+                        // Response for a previous connection; discard it.
+                        continue;
+                    } else if resp_epoch > epoch {
+                        // Response for a future connection; stash it and reconnect.
+                        stashed_response = Some((resp, resp_epoch));
+                        break;
+                    } else {
+                        // Response for the current connection; forward it.
+                        if response_tx.send(resp).is_err() {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Previously the compute command channel adapter assumed that it is impossible to receive responses with epoch values greater than the channel adapter's current epoch. This assumption is wrong because the Timely cluster-side of workers learns about new connection epochs by observing commands from worker 0, which can be ahead of other workers' epochs.

This PR removes the assumption and instead makes the channel adapter handle responses with future epochs by stashing them until sufficiently many client reconnects have been observed.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9124

### Tips for reviewer

I've tried to write a regression test using mzcompose and toxiproxy, spawning a multi-process cluster and resetting its controller connection in a loop. Didn't manage to reproduce the race that leads to the "epoch from the future" panic though.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
