### PR TITLE
format_char_str: Avoid costly decoding if possible

### DIFF
--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -141,6 +141,12 @@ fn format_char_str(
         // does.
         Some(l) => {
             let l = usize::cast_from(l.into_u32());
+            // The number of chars in a string is always less or equal to the length of the string.
+            // Hence, if the string is shorter than the length, we do not have to check for
+            // the maximum length.
+            if s.len() < l {
+                return Ok(white_space.process_str(s, Some(l)));
+            }
             match s.char_indices().nth(l) {
                 None => white_space.process_str(s, Some(l)),
                 Some((idx, _)) => {


### PR DESCRIPTION
The `format_char_str` function formats a string as a fixed-length string, potentially cutting off overhanging white space. It needs to decode the string to find the position of the `length` character, which is a slow operation.

This change introduces an optimization where if a string certainly isn't longer than the length in characters, we bail out early. The reasoning for this is simple: a string of length $n$ can have at most $n$ characters, so the length serves as an upper bound for the number of characters.

Related: MaterializeInc/database-issues#9125


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
