### PR TITLE
error_if_null: Lazily evaluate error

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6316,13 +6316,10 @@ fn error_if_null<'a>(
     temp_storage: &'a RowArena,
     exprs: &'a [MirScalarExpr],
 ) -> Result<Datum<'a>, EvalError> {
-    let datums = exprs
-        .iter()
-        .map(|e| e.eval(datums, temp_storage))
-        .collect::<Result<Vec<_>, _>>()?;
-    match datums[0] {
+    let first = exprs[0].eval(datums, temp_storage)?;
+    match first {
         Datum::Null => {
-            let err_msg = match datums[1] {
+            let err_msg = match exprs[1].eval(datums, temp_storage)? {
                 Datum::Null => {
                     return Err(EvalError::Internal(
                         "unexpected NULL in error side of error_if_null".into(),
@@ -6332,7 +6329,7 @@ fn error_if_null<'a>(
             };
             Err(EvalError::IfNullError(err_msg.into()))
         }
-        _ => Ok(datums[0]),
+        _ => Ok(first),
     }
 }
 


### PR DESCRIPTION
At the moment, `error_if_null` evaluates both its input, and in most cases discards the error input. This causes us to do a lot of unnecessary work in the common case.

Instead, only evaluate the error expression (second input) if the first one evaluates to null.

Related: MaterializeInc/database-issues#9125

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
