### PR TITLE
slt: Work when run from another directory

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -495,7 +495,13 @@ def _cargo_build(
     programs = [*REQUIRED_SERVICES, *extra_programs]
     for program in programs:
         command += ["--bin", program]
-    completed_proc = spawn.runv(command, env=env)
+    completed_proc = spawn.runv(
+        command,
+        env=env,
+        cwd=pathlib.Path(
+            os.path.abspath(os.path.join(os.path.realpath(sys.argv[0]), "../.."))
+        ),
+    )
 
     artifacts = [str(_cargo_artifact_path(args, program)) for program in programs]
 


### PR DESCRIPTION
Reported by Michael in https://materializeinc.slack.com/archives/CU7ELJ6E9/p1743013487929999

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
