### PR TITLE
docs: add architecture section

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -342,3 +342,12 @@ select.version-dropdown {
 
 red { color: var(--code-red); }
 blue { color: #2300ce; }
+
+blockquote {
+    margin: 1em 0;
+    padding: 0.5em 1em;
+    border-left: 4px solid #ccc; /* Adds a left border */
+    color: #555; /* Changes text color */
+    font-style: italic;
+    background-color: #f9f9f9; /* Light gray background */
+}

--- a/doc/user/content/architecture/_index.md
+++ b/doc/user/content/architecture/_index.md
@@ -1,0 +1,262 @@
+---
+title: "Architecture"
+description: "Software Architecture of Materialize"
+disable_list: true
+menu:
+  main:
+    parent: get-started
+    weight: 90
+    identifier: architecture
+---
+
+Materialize is divided into three *logical* component processes:
+
+| Logical component     | Description    |
+| --------------------- | -------------- |
+| [Adapter](#adapter) | <ul><li>Translates user SQL into commands/instructions for [Storage](#storage) and [Compute](#compute)</li></ul>|
+| [Storage](#storage) | <ul><li>Maintains [partial time-varying collection (pTVC)](#ptvcs-and-frontiers)</li><li>Provides APIs for external interactions (e.g., sources and sinks)</li></ul> |
+| [Compute](#compute) | |
+
+These are supported by two *physical* component processes:
+
+| Physical component            | Description |
+| ----------------------------- | ----------- |
+| `environmentd`                | Contains all of [Adapter](#adapter) as well as part of [Compute](#compute) and [Storage](#storage) (including the controllers that maintain the durable metadata of these components)       |
+| `clusterd`                    | Contains the rest of [Compute](#compute) and [Storage](#storage)  (including the operators that actually process data)          |
+
+## Background
+
+### pTVCs and frontiers
+
+A ***collection*** is a set of rows along with their counts (counts can be
+positive or negative). Other than the fact that a count can be negative,
+collections are analogous to tables and materialized views in other database
+systems.
+
+A ***time-varying collection*** (TVC) is a collection that varies by time.
+Materialize models this by a set of sequenced versions of the collection, where
+each version represents the collection at a point in time. It is not possible to
+physically represent most TVCs in their entirety since the set of possible
+times is nearly unbounded. Instead, Materialize uses *partial time-varying
+collection* (pTVC).
+
+A ***partial time-varying collection*** (pTVC) is a TVC restricted to a
+particular interval. Every pTVC is associated with a lower bound (called ***read
+frontier***) and an upper bound (called ***write frontier***).
+
+- As readers of a pTVC declare that they are no longer interested in past times,
+  the read frontier advances; i.e., the read frontier advances when past version
+  is no longer needed.
+
+  {{< note >}}
+
+  When the read frontier advances, you cannot access versions older than the
+  read frontier. For example, if a record is inserted (R<sub>`t0`</sub>) and
+  later updated (R<sub>`t1`</sub>), and then the read frontier moves past the
+  update timestamp (`t1`), the old value of the record (R<sub>`t0`</sub>) can no
+  longer be recovered.
+
+  {{</ note >}}
+
+- As writers declare that they have finished writing data for a given timestamp,
+  the write frontier advances; i.e., the write frontier advances as new data is
+  written.
+
+pTVCs are physically represented as a stream of **diffs**. That is, instead of
+storing full version of a collection for each timestamp, Materialize associates
+each timestamp with the list of rows that were added or removed at that
+timestamp. The key insight behind [Differential Dataflow] is that this
+representation makes it possible for result sets to be **incrementally
+maintained**. Materialize's compute operators translate lists of input diffs to
+lists of output diffs rather than whole input relations to whole output
+relations. This allows Materialize to compute updated results with effort
+proportional to the sizes of the inputs **changes** and output **changes**
+rather than proportional to the sizes of the inputs and outputs themselves.
+
+### Persist
+
+*Persist* is a library that maintains TVCs/pTVCs and is distributed across all Materialize processes; that is, across:
+
+- [Storage](#storage) (which write data from the outside world into Persist);
+
+- [Compute](#compute) (which read the inputs and write the outputs of
+  computations); and
+
+- [`environmentd`](#environmentd) (which uses metadata from Persist to determine
+  the timestamps at which queries may validly be executed).
+
+These processes' Persist instances store their pTVCs in S3 and maintain
+consensus among themselves using a distributed transactional database.
+
+## Logical components
+
+### Storage
+
+The Storage component is responsible for maintaining pTVCs, as well as providing
+an API connecting them to the outside world. It is thus considered to include
+both [Persist](#persist) as well as source and sinks.
+
+[**Sources**](/concepts/sources/) handles [ingestion of data](/ingest-data/)
+from external sources into Materialize. A fundamental role of sources is to make
+data **definite**: any arbitrary decisions taken while ingesting data (for
+example, assigning timestamps derived from the system clock to new records) must
+be durably recorded in Persist so that the results of downstream computations do
+not change if re-run after process restart.
+
+[**Sinks**](/concepts/sinks/) handles emission of data to downstream systems
+like Redpanda or Kafka.
+
+Since durable relations in Materialize are represented as pTVCs maintained by
+Persist, another way to describe the Storage component  is to say that it
+translates between Persist's native representation and those understood by the
+outside world. Storage workflows run on [clusters](#clusters-and-replicas).
+
+### Adapter
+
+The Adapter is responsible for the Postgres protocol termination logic, SQL
+interpretation and catalog management, and timestamp selection. That is, the
+Adapter is responsible for taking user SQL, translating them into instructions
+that it sends to [Storage](#storage) and [Compute](#compute).
+
+#### Postgres protocol termination
+
+The Adapter component contains the relevant code that allows Materialize to
+present itself to the network as a PostgreSQL database, enabling users to
+connect from a variety of tools (such as `psql`) and libraries (such as
+`psycopg`).
+
+#### SQL interpretation and catalog management
+
+Queries to Materialize arrive as SQL text; the Adapter parses and interprets
+this SQL in order to issue instructions to [Storage](#storage) (writes) and
+[Compute](#compute) (reads).
+
+The Adapter is responsible for managing the catalog of metadata about visible
+objects (e.g., tables, views, and materialized views), performing name
+resolution, and translating relational queries into the internal representation
+(IR) understood by [Storage](#storage) and [Compute](#compute).
+
+#### Timestamp selection
+
+Every one-off query in Materialize occurs at a particular logical
+timestamp, and every long-running computation is valid beginning at a
+particular logical timestamp.
+
+As discussed in [Persist](#persist), durable relations are valid for a
+range of timestamps, and this range is not necessarily the same for every
+collection. To select a timestamp for which it will be possible to compute the
+desired result, the Adapter must track the available read and write frontiers
+for all collections. This task is further complicated by the requirements of our
+consistency model; for example, with the default [`STRICT SERIALIZABLE`
+isolation level](/get-started/isolation-level/#strict-serializable), time cannot
+go backwards: a query must never return a state that occurred earlier than a
+state already reflected by a previous query.
+
+### Compute
+
+When a user instructs Materialize to perform a computation (e.g., a one-off
+`SELECT` query, a materialized view, or an in-memory index), the
+[Adapter](#adapter) supplies Compute with a compiled description of the query,
+consisting of: an IR(internal representation) program describing the computation
+to run; a logical timestamp at which the computation should begin; and a set of
+Persist identifiers for all the durable inputs and outputs of the computation.
+
+Compute then:
+
+- Performs a series of optimization passes to the IR program, and
+
+- Compiles it into a [Differential Dataflow] program, which streams input data
+  from [Persist](#persist) and emits the required result.
+
+- Either:
+
+  - Returns the results to the Adapter in the case of a one-off `SELECT` query.
+
+  - Arranges the results in memory in the case of an
+    [index](/concepts/indexes/).
+
+  - Writes the results back to Persist in the case of a materialized view.
+
+## Physical components
+
+### `environmentd` and `clusterd`
+
+There are two classes of process in a Materialize deployment:
+
+| Process        | Description                                   |
+| -------------- | ----------------------------------------------|
+| `environmentd` | <a name="environmentd"></a> <ul><li>Handles control plane operations (e.g., instructing clusterd to perform various operations in response to user commands, maintaining the catalog of SQL-accessible objects, etc.)</li><li>Contains all of Adapter as well as part of Compute and Storage (in particular, the controllers that maintain the durable metadata of those components).</li></ul>|
+| `clusterd`  |  <a name="clusterd"></a><ul><li>Handles data plane operations (which run in [Timely Dataflow]).</li><li>`clusterd` deployments are controlled with commands like [`CREATE CLUSTER`](/sql/create-cluster/) and [`CREATE SOURCE`](/sql/create-source/).<li>Contains parts of Compute and Storage that are not in `environmentd` (in particular, the operators that actually process data).</li>|
+
+Furthermore, all Materialize processes run the Persist library, which handles
+storing and retrieving data in a durable store.
+
+### Clusters and replicas
+
+`clusterd` processes are organized into [clusters](/concepts/clusters/).
+
+A *cluster* is associated with a set of dataflow programs, which describe
+either:
+
+- [Compute](#compute) tasks (such as responding to a query, maintaining an
+  in-memory index or materialized view, etc.), or
+
+- [Storage](#storage) tasks (such as ingesting data from an external source into
+  Persist or emitting data from Persist to a Kafka sink).
+
+Each cluster is associated with zero or more
+[replicas](/concepts/clusters/#fault-tolerance), which contain the actual
+machines processing data. A cluster with one replica in Materialize is analogous
+to an "unreplicated cluster" in other systems.
+
+{{< note >}}
+
+A cluster with zero replica is not associated with any machines and does not do
+any work (e.g., does not ingest data, does not perform incremental updates for
+indexes and materialized views, etc.)
+
+{{</ note >}}
+
+Each replica may, depending on its size, consist of one or more physical
+machines across which indexes (both user-visible indexes and internal operator
+state) are distributed. Despite the distribution, the the final results are
+assembled by `environmentd` into a cohesive whole.
+
+`environmentd` includes the compute and storage controllers that ensure that
+each replica of a given cluster is always executing an identical set of dataflow
+programs. For a given query, the controller simply accepts the results of
+whichever replica returns first. Since Compute queries are deterministic, this
+does not affect correctness. For data that is written by Compute to Persist (to
+maintain a materialized view), Persist's consensus logic ensures that the data
+for a given range of timestamps is only written once.
+
+### Communication among processes
+
+#### Direct communications
+
+The following Materialize processes communicate directly:
+
+- Processes within the same replica exchange data via the Timely Dataflow
+  network protocol.
+
+- The Compute and Storage controllers in `environmentd` communicate with each
+  `clusterd` to issue commands and receive responses.
+
+#### Via Persist and S3
+
+There is no direct network communication between different clusters or between
+different replicas of the same cluster. The only way for `clusterd` processes to
+consume their inputs or emit their outputs is by reading them from S3 via
+[Persist](#persist) or writing them in S3 via
+[Persist](#persist).
+
+That is, to share data between Compute workflows on different clusters, a user
+creates a materialized view in one cluster and reads it from another; this
+causes the data to be transferred via Persist and S3. A in-memory index on a
+cluster is not visible to other clusters.
+
+[Timely Dataflow]:
+    https://github.com/TimelyDataflow/timely-dataflow#timely-dataflow
+
+[Differential Dataflow]:
+    https://github.com/timelydataflow/differential-dataflow#differential-dataflow

--- a/doc/user/content/architecture/arrangements.md
+++ b/doc/user/content/architecture/arrangements.md
@@ -3,6 +3,10 @@ title: "Arrangements"
 description: "Understand how Materialize arrangements work."
 aliases:
   - /overview/arrangements/
+  - /get-started/arrangements/
+menu:
+  main:
+    parent: architecture
 ---
 
 The mechanisms that maintain materialized views for Materialize dataflows are
@@ -122,7 +126,7 @@ For more in-depth details on joins, see [Joins in Materialize](https://materiali
 
 ### Type casting
 
-Currently, Materialize handles implicit casts inserted in join constraints in a very memory-intensive way.
+Currently, Materialize handles implicit casts inserted in join constraints in a very memory-intensive way {{% gh 4171 %}}.
 Until this issue
 is resolved, you can reduce memory usage by building an index on the view with
 the type changed for any queries that include implicit casts, for example,

--- a/doc/user/content/get-started/isolation-level.md
+++ b/doc/user/content/get-started/isolation-level.md
@@ -5,6 +5,10 @@ aliases:
     - /sql/consistency
     - /sql/isolation-level
     - /overview/isolation-level/
+menu:
+  main:
+    parent: get-started
+    weight: 60
 ---
 
 The SQL standard defines four levels of transaction isolation. In order of least strict to most strict they are:
@@ -14,24 +18,27 @@ The SQL standard defines four levels of transaction isolation. In order of least
 -   Repeatable Read
 -   Serializable
 
-In Materialize, you can request any of these isolation
-levels, but they all behave the same as the Serializable isolation level. In addition to the four levels defined in the
-SQL Standard, Materialize also defines a [Strict Serializable](#strict-serializable) isolation level.
+In Materialize, Read Uncommitted, Read Committed, Repeatable Read are aliases
+for Serializable isolation level. In addition to the four levels defined in the
+SQL Standard, Materialize also defines a [Strict
+Serializable](#strict-serializable) isolation level.
+
+## Syntax
 
 Isolation level is a configuration parameter that can be set by the user on a session-by-session basis. The default isolation level is
 [Strict Serializable](#strict-serializable).
 
-## Syntax
+```mzsql
+SET TRANSACTION_ISOLATION [TO|=] <level>;
+```
 
-{{< diagram "set-transaction-isolation.svg" >}}
-
-| Valid Isolation Levels                      |
-| ------------------------------------------- |
-| [Read Uncommitted](#serializable)           |
-| [Read Committed](#serializable)             |
-| [Repeatable Read](#serializable)            |
-| [Serializable](#serializable)               |
-| [Strict Serializable](#strict-serializable) |
+| Valid Isolation Levels                      |  Notes                  |
+| ------------------------------------------- | ----------------------- |
+| [Read Uncommitted](#serializable)           | Alias for [Serializable](#serializable) |
+| [Read Committed](#serializable)             | Alias for [Serializable](#serializable) |
+| [Repeatable Read](#serializable)            | Alias for [Serializable](#serializable) |
+| [Serializable](#serializable)               | |
+| [Strict Serializable](#strict-serializable) | Default. |
 
 ## Examples
 
@@ -52,14 +59,14 @@ The SQL standard defines the Serializable isolation level as preventing the foll
     > "SQL-transaction T1 modifies a row. SQL-transaction T2 then reads that row before T1 performs a
     > COMMIT. If T1 then performs a ROLLBACK, T2 will have read a row that was never committed and that may thus be
     > considered to have never existed."
-    > (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
+    > -- ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions
 
 -   **P2 (”Non-repeatable read”):**
 
     > "SQL-transaction T1 reads a row. SQL-transaction T2 then modifies or deletes that row and performs
     > a COMMIT. If T1 then attempts to reread the row, it may receive the modified value or discover that the row has been
     > deleted."
-    > (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
+    > -- ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions
 
 -   **P3 (”Phantom”):**
 
@@ -67,7 +74,7 @@ The SQL standard defines the Serializable isolation level as preventing the foll
     > T2 then executes SQL-statements that generate one or more rows that satisfy the \<search condition\> used by
     > SQL-transaction T1. If SQL-transaction T1 then repeats the initial read with the same \<search condition\>, it obtains a
     > different collection of rows."
-    > (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
+    > -- ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions
 
 Furthermore, Serializable also guarantees that the result of executing a group of concurrent SQL-transactions produces
 the same effect as some serial execution of those same transactions. A serial execution is one where each

--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -133,7 +133,7 @@ In this stage, the planner performs various optimizing rewrites:
 In this stage, the planner:
 
 - Decides on the exact execution details of each operator, and maps plan operators to differential dataflow operators.
-- Makes the final choices about creating or reusing [arrangements](/get-started/arrangements/#arrangements).
+- Makes the final choices about creating or reusing [arrangements](/architecture/arrangements/#arrangements).
 
 #### From physical plan to dataflow
 

--- a/doc/user/content/sql/system-catalog/mz_introspection.md
+++ b/doc/user/content/sql/system-catalog/mz_introspection.md
@@ -447,8 +447,8 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 [`uint2`]: /sql/types/uint2
 [`uint8`]: /sql/types/uint8
 [`uint8 list`]: /sql/types/list
-[arrangement]: /get-started/arrangements/#arrangements
-[dataflow]: /get-started/arrangements/#dataflows
+[arrangement]: /architecture/arrangements/#arrangements
+[dataflow]: /architecture/arrangements/#dataflows
 [`MIN`]: /sql/functions/#min
 [`MAX`]: /sql/functions/#max
 [Top K]: /transform-data/patterns/top-k

--- a/doc/user/content/transform-data/dataflow-troubleshooting.md
+++ b/doc/user/content/transform-data/dataflow-troubleshooting.md
@@ -20,7 +20,7 @@ arrives.
 
 Materialize dataflows act on collections of data. To provide fast access to the
 changes to individual records, the records can be stored in an indexed
-representation called [arrangements](/get-started/arrangements/#arrangements).
+representation called [arrangements](/architecture/arrangements/#arrangements).
 Arrangements can be manually created by users on views by creating an index on
 the view. But they are also used internally in dataflows, for instance, when
 joining relations.

--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -452,10 +452,10 @@ The column `hint` provides the estimated value to be provided to the `AGGREGATE 
 Check out the blog post [Delta Joins and Late Materialization](https://materialize.com/blog/delta-joins/) to go deeper on join optimization in Materialize.
 
 [query hints]: /sql/select/#query-hints
-[arrangements]: /get-started/arrangements/#arrangements
+[arrangements]: /architecture/arrangements/#arrangements
 [`MIN`]: /sql/functions/#min
 [`MAX`]: /sql/functions/#max
 [Top K]: /transform-data/patterns/top-k
 [`mz_introspection.mz_expected_group_size_advice`]: /sql/system-catalog/mz_introspection/#mz_expected_group_size_advice
-[dataflows]: /get-started/arrangements/#dataflows
+[dataflows]: /architecture/arrangements/#dataflows
 [`SELECT` syntax]: /sql/select/#syntax

--- a/doc/user/data/explain_plan_operators.yml
+++ b/doc/user/data/explain_plan_operators.yml
@@ -48,7 +48,7 @@ operators:
       There are three types of `Get`.
 
       1. `Get::PassArrangements`, which means the plan will use an
-         existing [arrangement](/get-started/arrangements/#arrangements).
+         existing [arrangement](/architecture/arrangements/#arrangements).
 
       2. `Get::Arrangement`, which means that the results will be
          _looked up_ in an existing arrangement.
@@ -166,7 +166,7 @@ operators:
     uses_memory: True
     memory_details: |
       The `Join` operator itself uses memory only for `type=differential` with more than 2 inputs.
-      However, `Join` operators need [arrangements](/get-started/arrangements/#arrangements) on their inputs (shown by the `ArrangeBy` operator).
+      However, `Join` operators need [arrangements](/architecture/arrangements/#arrangements) on their inputs (shown by the `ArrangeBy` operator).
       These arrangements use memory proportional to the input sizes. If an input has an [appropriate index](/transform-data/optimization/#join), then the arrangement of the index will be reused.
     expansive: True
     expansive_details: |
@@ -375,7 +375,7 @@ operators:
   - operator: ArrangeBy
     plan_types: "optimized"
     description: |
-      Indicates a point that will become an [arrangement](/get-started/arrangements/#arrangements) in the dataflow engine (each `keys` element will be a different arrangement). Note that if an appropriate index already exists on the input or the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
+      Indicates a point that will become an [arrangement](/architecture/arrangements/#arrangements) in the dataflow engine (each `keys` element will be a different arrangement). Note that if an appropriate index already exists on the input or the output of the previous operator is already arranged with a key that is also requested here, then this operator will just pass on that existing arrangement instead of creating a new one.
     uses_memory: True
     memory_details: |
       Depends. If arrangements need to be created, they use memory proportional to the input size.
@@ -385,7 +385,7 @@ operators:
   - operator: Arrange
     plan_types: "LIR"
     description: |
-      Indicates a point that will become an [arrangement](/get-started/arrangements/#arrangements) in the dataflow engine, i.e., it will consume memory to cache results.
+      Indicates a point that will become an [arrangement](/architecture/arrangements/#arrangements) in the dataflow engine, i.e., it will consume memory to cache results.
     uses_memory: True
     memory_details: |
       Uses memory proportional to the input size. Note that in the LIR / physical plan, `Arrange`/`ArrangeBy` almost always means that an arrangement will actually be created. (This is in contrast to the "optimized" plan, where an `ArrangeBy` being present in the plan often does not mean that an arrangement will actually be created.)


### PR DESCRIPTION
Add an architecture section and bubble up the arrangements page 
- Architecture landing page adapted from blog
- arrangements page except for frontmatter and reference to a github issue, left as is (see comment, https://github.com/MaterializeInc/materialize/pull/31201#discussion_r1938298247)
Bubbled up isolation level page (content also mostly left untouched)