### PR TITLE
Remove feature flag for #30974

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -123,8 +123,6 @@ optimizer_feature_flags!({
     // See the feature flag of the same name.
     enable_projection_pushdown_after_relation_cse: bool,
     // See the feature flag of the same name.
-    enable_let_prefix_extraction: bool,
-    // See the feature flag of the same name.
     enable_less_reduce_in_eqprop: bool,
 });
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4653,7 +4653,6 @@ pub fn unplan_create_cluster(
                 enable_reduce_reduction: _,
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
-                enable_let_prefix_extraction: _,
                 enable_less_reduce_in_eqprop: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -434,7 +434,6 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_join_prioritize_arranged: v.enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
-                enable_let_prefix_extraction: Default::default(),
                 enable_less_reduce_in_eqprop: Default::default(),
             },
         })

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1785,12 +1785,6 @@ macro_rules! feature_flags {
 }
 
 feature_flags!(
-    {
-        name: enable_let_prefix_extraction,
-        desc: "Enables hoisting of loop-invariant CTE bindindgs",
-        default: true,
-        enable_for_item_parsing: false,
-    },
     // Gates for other feature flags
     {
         name: allow_real_time_recency,
@@ -2233,7 +2227,6 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
-            enable_let_prefix_extraction: vars.enable_let_prefix_extraction(),
             enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
         }
     }

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -132,32 +132,6 @@ impl NormalizeLets {
 
         // A final bottom-up traversal to normalize the shape of nested LetRec blocks
         relation.try_visit_mut_post(&mut |relation| -> Result<(), RecursionLimitError> {
-            if !features.enable_let_prefix_extraction {
-                // Disassemble `LetRec` into a `Let` stack if possible.
-                // If a `LetRec` remains, return the would-be `Let` bindings to it.
-                // This is to maintain `LetRec`-freedom for `LetRec`-free expressions.
-                let mut bindings = let_motion::harvest_non_recursive(relation);
-                if let MirRelationExpr::LetRec {
-                    ids,
-                    values,
-                    limits,
-                    body: _,
-                } = relation
-                {
-                    bindings.extend(ids.drain(..).zip(values.drain(..).zip(limits.drain(..))));
-                    support::replace_bindings_from_map(bindings, ids, values, limits);
-                } else {
-                    for (id, (value, max_iter)) in bindings.into_iter().rev() {
-                        assert_none!(max_iter);
-                        *relation = MirRelationExpr::Let {
-                            id,
-                            value: Box::new(value),
-                            body: Box::new(relation.take_dangerous()),
-                        };
-                    }
-                }
-            }
-
             // Move a non-recursive suffix of bindings from the end of the LetRec
             // to the LetRec body.
             // This is unsafe when applied to expressions which contain `ArrangeBy`,
@@ -189,20 +163,18 @@ impl NormalizeLets {
                 }
             }
 
-            if features.enable_let_prefix_extraction {
-                // Extract `Let` prefixes from `LetRec`, to reveal their non-recursive nature.
-                // This assists with hoisting e.g. arrangements out of `LetRec` blocks, a thing
-                // we don't promise to do, but it can be helpful to do. This also exposes more
-                // AST nodes to non-`LetRec` analyses, which don't always have parity with `LetRec`.
-                let bindings = let_motion::harvest_non_recursive(relation);
-                for (id, (value, max_iter)) in bindings.into_iter().rev() {
-                    assert_none!(max_iter);
-                    *relation = MirRelationExpr::Let {
-                        id,
-                        value: Box::new(value),
-                        body: Box::new(relation.take_dangerous()),
-                    };
-                }
+            // Extract `Let` prefixes from `LetRec`, to reveal their non-recursive nature.
+            // This assists with hoisting e.g. arrangements out of `LetRec` blocks, a thing
+            // we don't promise to do, but it can be helpful to do. This also exposes more
+            // AST nodes to non-`LetRec` analyses, which don't always have parity with `LetRec`.
+            let bindings = let_motion::harvest_non_recursive(relation);
+            for (id, (value, max_iter)) in bindings.into_iter().rev() {
+                assert_none!(max_iter);
+                *relation = MirRelationExpr::Let {
+                    id,
+                    value: Box::new(value),
+                    body: Box::new(relation.take_dangerous()),
+                };
             }
 
             Ok(())

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -260,7 +260,6 @@ fn apply_transform<T: mz_transform::Transform>(
     let mut features = mz_repr::optimize::OptimizerFeatures::default();
     // Apply a non-default feature flag to test the right implementation.
     features.enable_letrec_fixpoint_analysis = true;
-    features.enable_let_prefix_extraction = true;
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
     let mut transform_ctx =


### PR DESCRIPTION
Remove the defensive feature flag for #30974, which seems to have landed without incident.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
