### PR TITLE
[persist] Remove some old codec write-path code

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -132,6 +132,7 @@ def get_default_system_parameters(
         ),
         "persist_batch_delete_enabled": "true",
         "persist_batch_structured_order": "true",
+        "persist_batch_builder_structured": "true",
         "persist_batch_structured_key_lower_len": "256",
         "persist_batch_max_run_len": "4",
         "persist_catalog_force_compaction_fuel": "1024",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1054,11 +1054,6 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
-        self.flags_with_values["persist_batch_columnar_format"] = [
-            "row",
-            "both_v2",
-            "structured",
-        ]
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1059,7 +1059,6 @@ class FlipFlagsAction(Action):
             "both_v2",
             "structured",
         ]
-        self.flags_with_values["persist_batch_structured_order"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_builder_structured"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1059,7 +1059,6 @@ class FlipFlagsAction(Action):
             "both_v2",
             "structured",
         ]
-        self.flags_with_values["persist_batch_builder_structured"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -326,7 +326,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
         .add(&crate::internal::compact::COMPACTION_USE_MOST_RECENT_SCHEMA)
         .add(&crate::internal::compact::COMPACTION_CHECK_PROCESS_FLAG)
-        .add(&crate::internal::compact::COMPACTION_OUTPUT_STRUCTURED_ONLY)
         .add(&crate::internal::machine::CLAIM_UNCLAIMED_COMPACTIONS)
         .add(&crate::internal::machine::CLAIM_COMPACTION_PERCENT)
         .add(&crate::internal::machine::CLAIM_COMPACTION_MIN_VERSION)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -289,8 +289,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
-        .add(&crate::batch::STRUCTURED_ORDER)
-        .add(&crate::batch::STRUCTURED_ORDER_UNTIL_SHARD)
         .add(&crate::batch::STRUCTURED_KEY_LOWER_LEN)
         .add(&crate::batch::MAX_RUN_LEN)
         .add(&crate::batch::MAX_RUNS)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -284,7 +284,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
-        .add(&crate::batch::BUILDER_STRUCTURED)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -282,7 +282,6 @@ pub(crate) const MiB: usize = 1024 * 1024;
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
-        .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -23,7 +23,6 @@ use futures_util::{StreamExt, TryFutureExt};
 use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
-use mz_persist::indexed::columnar::ColumnarRecords;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceUpdates};
 use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
@@ -48,7 +47,7 @@ use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::metrics::ShardMetrics;
 use crate::internal::state::{HollowBatch, RunMeta, RunOrder, RunPart};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
-use crate::iter::{CodecSort, Consolidator, StructuredSort};
+use crate::iter::{Consolidator, StructuredSort};
 use crate::{Metrics, PersistConfig, ShardId};
 
 /// A request for compaction.
@@ -807,151 +806,76 @@ where
             cfg.version.clone(),
         );
 
-        // Duplicating a large codepath here during the migration.
-        // TODO(database-issues#7188): dedup once the migration is complete.
-        if cfg.batch.preferred_order == RunOrder::Structured {
-            // If we're not writing down the record metadata, we must always use the old compaction
-            // order. (Since that's the default when the metadata's not present.)
-            let mut consolidator = Consolidator::new(
-                format!(
-                    "{}[lower={:?},upper={:?}]",
-                    shard_id,
-                    desc.lower().elements(),
-                    desc.upper().elements()
-                ),
-                *shard_id,
-                StructuredSort::<K, V, T, D>::new(write_schemas.clone()),
-                blob,
-                Arc::clone(&metrics),
-                shard_metrics,
-                metrics.read.compaction.clone(),
-                FetchBatchFilter::Compaction {
-                    since: desc.since().clone(),
-                },
-                prefetch_budget_bytes,
-            );
+        let mut consolidator = Consolidator::new(
+            format!(
+                "{}[lower={:?},upper={:?}]",
+                shard_id,
+                desc.lower().elements(),
+                desc.upper().elements()
+            ),
+            *shard_id,
+            StructuredSort::<K, V, T, D>::new(write_schemas.clone()),
+            blob,
+            Arc::clone(&metrics),
+            shard_metrics,
+            metrics.read.compaction.clone(),
+            FetchBatchFilter::Compaction {
+                since: desc.since().clone(),
+            },
+            prefetch_budget_bytes,
+        );
 
-            for (desc, meta, parts) in runs {
-                consolidator.enqueue_run(desc, meta, parts.iter().cloned());
-            }
+        for (desc, meta, parts) in runs {
+            consolidator.enqueue_run(desc, meta, parts.iter().cloned());
+        }
 
-            let remaining_budget = consolidator.start_prefetches();
-            if remaining_budget.is_none() {
-                metrics.compaction.not_all_prefetched.inc();
-            }
+        let remaining_budget = consolidator.start_prefetches();
+        if remaining_budget.is_none() {
+            metrics.compaction.not_all_prefetched.inc();
+        }
 
-            loop {
-                let mut chunks = vec![];
-                let mut total_bytes = 0;
-                // We attempt to pull chunks out of the consolidator that match our target size,
-                // but it's possible that we may get smaller chunks... for example, if not all
-                // parts have been fetched yet. Loop until we've got enough data to justify flushing
-                // it out to blob (or we run out of data.)
-                while total_bytes < cfg.batch.blob_target_size {
-                    let fetch_start = Instant::now();
-                    let Some(chunk) = consolidator
-                        .next_chunk(
-                            cfg.compaction_yield_after_n_updates,
-                            cfg.batch.blob_target_size - total_bytes,
-                        )
-                        .await?
-                    else {
-                        break;
-                    };
-                    timings.part_fetching += fetch_start.elapsed();
-                    total_bytes += chunk.goodbytes();
-                    chunks.push(chunk);
-                    tokio::task::yield_now().await;
-                }
-
-                if chunks.is_empty() {
+        loop {
+            let mut chunks = vec![];
+            let mut total_bytes = 0;
+            // We attempt to pull chunks out of the consolidator that match our target size,
+            // but it's possible that we may get smaller chunks... for example, if not all
+            // parts have been fetched yet. Loop until we've got enough data to justify flushing
+            // it out to blob (or we run out of data.)
+            while total_bytes < cfg.batch.blob_target_size {
+                let fetch_start = Instant::now();
+                let Some(chunk) = consolidator
+                    .next_chunk(
+                        cfg.compaction_yield_after_n_updates,
+                        cfg.batch.blob_target_size - total_bytes,
+                    )
+                    .await?
+                else {
                     break;
-                }
-
-                // If we're going to write this Batch in a structured format, and our CYA
-                // dyncfg is enabled, then don't worry about making sure Codec data exists.
-                let ensure_codec = !(cfg.compaction_output_structured_only
-                    && cfg.batch.batch_columnar_format == BatchColumnarFormat::Structured);
-                // In the hopefully-common case of a single chunk, this will not copy.
-                let updates = BlobTraceUpdates::concat::<K, V>(
-                    chunks,
-                    write_schemas.key.as_ref(),
-                    write_schemas.val.as_ref(),
-                    &metrics.columnar,
-                    ensure_codec,
-                )?;
-                batch.flush_part(desc.clone(), updates).await;
-            }
-        } else {
-            let mut consolidator = Consolidator::<T, D, CodecSort<K, V, T, D>>::new(
-                format!(
-                    "{}[lower={:?},upper={:?}]",
-                    shard_id,
-                    desc.lower().elements(),
-                    desc.upper().elements()
-                ),
-                *shard_id,
-                CodecSort::new(write_schemas.clone()),
-                blob,
-                Arc::clone(&metrics),
-                shard_metrics,
-                metrics.read.compaction.clone(),
-                FetchBatchFilter::Compaction {
-                    since: desc.since().clone(),
-                },
-                prefetch_budget_bytes,
-            );
-
-            for (desc, meta, parts) in runs {
-                consolidator.enqueue_run(desc, meta, parts.iter().cloned());
+                };
+                timings.part_fetching += fetch_start.elapsed();
+                total_bytes += chunk.goodbytes();
+                chunks.push(chunk);
+                tokio::task::yield_now().await;
             }
 
-            let remaining_budget = consolidator.start_prefetches();
-            if remaining_budget.is_none() {
-                metrics.compaction.not_all_prefetched.inc();
+            if chunks.is_empty() {
+                break;
             }
 
-            loop {
-                let mut chunks = vec![];
-                let mut total_bytes = 0;
-                // We attempt to pull chunks out of the consolidator that match our target size,
-                // but it's possible that we may get smaller chunks... for example, if not all
-                // parts have been fetched yet. Loop until we've got enough data to justify flushing
-                // it out to blob (or we run out of data.)
-                while total_bytes < cfg.batch.blob_target_size {
-                    let fetch_start = Instant::now();
-                    let Some(mut chunk) = consolidator
-                        .next_chunk(
-                            cfg.compaction_yield_after_n_updates,
-                            cfg.batch.blob_target_size - total_bytes,
-                        )
-                        .await?
-                    else {
-                        break;
-                    };
-                    timings.part_fetching += fetch_start.elapsed();
-                    total_bytes += chunk.goodbytes();
-                    chunks.push(
-                        chunk
-                            .get_or_make_codec::<K, V>(
-                                write_schemas.key.as_ref(),
-                                write_schemas.val.as_ref(),
-                            )
-                            .clone(),
-                    );
-                    tokio::task::yield_now().await;
-                }
+            // If we're going to write this Batch in a structured format, and our CYA
+            // dyncfg is enabled, then don't worry about making sure Codec data exists.
+            let ensure_codec = !(cfg.compaction_output_structured_only
+                && cfg.batch.batch_columnar_format == BatchColumnarFormat::Structured);
 
-                if chunks.is_empty() {
-                    break;
-                }
-
-                // In the hopefully-common case of a single chunk, this will not copy.
-                let updates = ColumnarRecords::concat(&chunks, &metrics.columnar);
-                batch
-                    .flush_part(desc.clone(), BlobTraceUpdates::Row(updates))
-                    .await;
-            }
+            // In the hopefully-common case of a single chunk, this will not copy.
+            let updates = BlobTraceUpdates::concat::<K, V>(
+                chunks,
+                write_schemas.key.as_ref(),
+                write_schemas.val.as_ref(),
+                &metrics.columnar,
+                ensure_codec,
+            )?;
+            batch.flush_part(desc.clone(), updates).await;
         }
         let mut batch = batch.finish(desc.clone()).await?;
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1403,7 +1403,7 @@ pub mod datadriven {
 
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-        BatchParts, BLOB_TARGET_SIZE, BUILDER_STRUCTURED, STRUCTURED_ORDER,
+        BatchParts, BLOB_TARGET_SIZE, BUILDER_STRUCTURED,
     };
     use crate::cfg::COMPACTION_MEMORY_BOUND_BYTES;
     use crate::fetch::EncodedPart;
@@ -1448,9 +1448,6 @@ pub mod datadriven {
             // Our structured compaction code uses slightly different estimates
             // for array size than the old path, which can affect the results of
             // some compaction tests.
-            client
-                .cfg
-                .set_config(&STRUCTURED_ORDER, *STRUCTURED_ORDER.default());
             client.cfg.set_config(&BUILDER_STRUCTURED, true);
             client.cfg.set_config(&COMBINE_INLINE_WRITES, false);
             let state_versions = Arc::new(StateVersions::new(

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1403,7 +1403,7 @@ pub mod datadriven {
 
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-        BatchParts, BLOB_TARGET_SIZE, BUILDER_STRUCTURED,
+        BatchParts, BLOB_TARGET_SIZE,
     };
     use crate::cfg::COMPACTION_MEMORY_BOUND_BYTES;
     use crate::fetch::EncodedPart;
@@ -1448,7 +1448,6 @@ pub mod datadriven {
             // Our structured compaction code uses slightly different estimates
             // for array size than the old path, which can affect the results of
             // some compaction tests.
-            client.cfg.set_config(&BUILDER_STRUCTURED, true);
             client.cfg.set_config(&COMBINE_INLINE_WRITES, false);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
@@ -1778,11 +1777,7 @@ pub mod datadriven {
             datadriven.shard_id.clone(),
             datadriven.client.cfg.build_version.clone(),
         );
-        let mut builder = BatchBuilder::new(
-            builder,
-            Description::new(lower, upper.clone(), since),
-            Arc::clone(&datadriven.client.metrics),
-        );
+        let mut builder = BatchBuilder::new(builder, Description::new(lower, upper.clone(), since));
         for ((k, ()), t, d) in updates {
             builder.add(&k, &(), &t, &d).await.expect("invalid batch");
         }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -1136,7 +1136,6 @@ mod tests {
                     &sort.schemas.key,
                     &sort.schemas.val,
                     &metrics.columnar,
-                    false,
                 )
                 .expect("same schema")
             };

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -778,7 +778,6 @@ where
         BatchBuilder::new(
             builder,
             Description::new(lower, Antichain::new(), Antichain::from_elem(T::minimum())),
-            Arc::clone(&self.metrics),
         )
     }
 

--- a/src/persist-client/tests/machine/batch_key_lower_truncate
+++ b/src/persist-client/tests/machine/batch_key_lower_truncate
@@ -11,6 +11,7 @@
 dyncfg
 persist_inline_writes_single_max_bytes 0
 persist_inline_writes_total_max_bytes 0
+persist_batch_structured_key_lower_len 100
 ----
 ok
 
@@ -23,7 +24,6 @@ parts=1 len=1
 fetch-batch input=b0 stats=lower
 ----
 <part 0>
-<key lower=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBB 0 1
 <run 0>
 part 0

--- a/src/persist-client/tests/machine/caa_idempotent
+++ b/src/persist-client/tests/machine/caa_idempotent
@@ -51,17 +51,17 @@ parts=1 len=1
 # Okay and pretend this is a retry.
 compare-and-append input=b0w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i33333333-3333-3333-3333-333333333333 prev_indeterminate=timeout
 ----
-v2 [1]
+v3 [1]
 
 # Case 2: A compare_and_append receives an indeterminate error, but _does_
 # actually commit. On retry it is a no-op.
 compare-and-append input=b1w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i44444444-4444-4444-4444-444444444444
 ----
-v3 [2]
+v4 [2]
 
 compare-and-append input=b1w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i44444444-4444-4444-4444-444444444444 prev_indeterminate=timeout
 ----
-v3 [2]
+v4 [2]
 
 # Case 1B: A compare_and_append receives an indeterminate error, but _doesn't_
 # actually commit. Another writer advances the upper in between retries. On
@@ -72,7 +72,7 @@ v3 [2]
 
 compare-and-append input=b2w2 writer_id=w22222222-2222-2222-2222-222222222222
 ----
-v4 [3]
+v5 [3]
 
 compare-and-append input=b2w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i55555555-5555-5555-5555-555555555555 prev_indeterminate=timeout
 ----
@@ -85,15 +85,15 @@ error: Upper(Antichain { elements: [3] })
 
 compare-and-append input=b3w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i66666666-6666-6666-6666-666666666666
 ----
-v5 [4]
+v6 [4]
 
 compare-and-append input=b4w2 writer_id=w22222222-2222-2222-2222-222222222222
 ----
-v6 [5]
+v7 [5]
 
 compare-and-append input=b3w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i66666666-6666-6666-6666-666666666666 prev_indeterminate=timeout
 ----
-v6 [5]
+v7 [5]
 
 # Case 3: We expect that writers generally move "forward" in time and the
 # technique we use to make compare_and_append idempotent depends on this.

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -26,36 +26,36 @@ parts=1 len=1
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v3 [2]
+v4 [2]
 
 register-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v4 [0]
+v5 [0]
 
 register-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v5 [0]
+v6 [0]
 
 downgrade-since since=1 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v6 [1]
+v7 [1]
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=1 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v7 0 [1]
+v8 0 [1]
 
 # Now advance the since to the empty antichain, closing this shard to reads.
 downgrade-since since=() reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v8 []
+v9 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v9 0 []
+v10 0 []
 
 ####### SINCE IS EMPTY BUT UPPER IS NOT
 
@@ -73,7 +73,7 @@ parts=1 len=1
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v10 [3]
+v11 [3]
 
 compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
 ----
@@ -81,44 +81,44 @@ parts=1 len=2
 
 apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v11 true
+v12 true
 
 # We can still (no-op) downgrade since on both reader types.
 downgrade-since since=2 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v12 []
+v13 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=2 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v13 0 []
+v14 0 []
 
 # We can still register a new leased reader and do all the normal things with
 # it.
 register-leased-reader reader_id=r33333333-3333-3333-3333-333333333333
 ----
-v14 []
+v15 []
 
 downgrade-since since=() reader_id=r33333333-3333-3333-3333-333333333333
 ----
-v15 []
+v16 []
 
 expire-leased-reader reader_id=r33333333-3333-3333-3333-333333333333
 ----
-v16 ok
+v17 ok
 
 # We can still register a new critical reader and do all the normal things with
 # it.
 register-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
 ----
-v17 []
+v18 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c33333333-3333-3333-3333-333333333333
 ----
-v18 0 []
+v19 0 []
 
 expire-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
 ----
-v19 ok
+v20 ok
 
 # We can't read data
 snapshot as_of=2
@@ -129,29 +129,32 @@ error: Since(Antichain { elements: [] })
 # maintenance it needs.
 perform-maintenance
 ----
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
-v19 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
+v20 ok
 
 # Explicit finalization should fail when the shard isn't fully advanced.
 is-finalized
 ----
-v19 false
+v20 false
 
 finalize
 ----
@@ -159,7 +162,7 @@ error: finalized without fully advancing since Antichain { elements: [] } and up
 
 is-finalized
 ----
-v19 false
+v20 false
 
 # Now compare_and_append to the empty antichain, closing the shard to writes as
 # well.
@@ -172,7 +175,7 @@ parts=1 len=1
 
 compare-and-append input=b3 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v20 []
+v21 []
 
 shard-desc
 ----
@@ -182,22 +185,23 @@ since=[] upper=[]
 # perform it on demand.
 is-finalized
 ----
-v20 false
+v21 false
 
 finalize
 ----
-v24 ok
+v25 ok
 
 is-finalized
 ----
-v24 true
+v25 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
-v24 ok
 v25 ok
+v25 ok
+v26 ok
 
 perform-maintenance
 ----
@@ -209,8 +213,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v24 batches= rollups=v1
-seqno=v25 batches= rollups=v1,v24
+seqno=v25 batches= rollups=v1
+seqno=v26 batches= rollups=v1,v25
 
 blob-scan-batches
 ----
@@ -235,7 +239,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v25 ok
+v26 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -247,7 +251,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v25 ok
+v26 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -256,45 +260,45 @@ v25 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v25 []
+v26 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v25 ok
+v26 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v25 0 []
+v26 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v25 1 []
+v26 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v25 ok
+v26 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v25 []
+v26 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v25 []
+v26 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v25 ok
+v26 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v25 []
+v26 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v25 0 []
+v26 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v25 ok
+v26 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -26,27 +26,27 @@ parts=1 len=1
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v3 [2]
+v4 [2]
 
 register-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v4 [0]
+v5 [0]
 
 register-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v5 [0]
+v6 [0]
 
 downgrade-since since=1 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v6 [1]
+v7 [1]
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=1 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v7 0 [1]
+v8 0 [1]
 
 # Now advance the upper to the empty antichain, closing this shard to writes.
 #
@@ -58,7 +58,7 @@ parts=1 len=1
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v8 []
+v9 []
 
 ####### UPPER IS EMPTY BUT SINCE IS NOT
 
@@ -73,16 +73,16 @@ parts=1 len=2
 
 apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v9 true
+v10 true
 
 # We can still downgrade since on both reader types.
 downgrade-since since=2 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v10 [2]
+v11 [2]
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=2 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v11 0 [2]
+v12 0 [2]
 
 # We can still register a new writer and do all the normal things with it.
 compare-and-append input=b2 writer_id=w33333333-3333-3333-3333-333333333333
@@ -91,7 +91,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w33333333-3333-3333-3333-333333333333
 ----
-v12 ok
+v13 ok
 
 # We can still read data
 snapshot as_of=2
@@ -110,22 +110,26 @@ k1 2 -1
 # maintenance it needs.
 perform-maintenance
 ----
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
-v12 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
+v13 ok
 
 # Explicit finalization should fail when the shard isn't fully advanced.
 is-finalized
 ----
-v12 false
+v13 false
 
 finalize
 ----
@@ -133,16 +137,16 @@ error: finalized without fully advancing since Antichain { elements: [2] } and u
 
 is-finalized
 ----
-v12 false
+v13 false
 
 # Now downgrade_since to empty antichain, closing the shard to reads as well.
 downgrade-since since=() reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v13 []
+v14 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v14 0 []
+v15 0 []
 
 shard-desc
 ----
@@ -152,23 +156,23 @@ since=[] upper=[]
 # perform it on demand.
 is-finalized
 ----
-v14 false
+v15 false
 
 finalize
 ----
-v17 ok
+v18 ok
 
 is-finalized
 ----
-v17 true
+v18 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
-v17 ok
-v17 ok
 v18 ok
+v18 ok
+v19 ok
 
 perform-maintenance
 ----
@@ -180,8 +184,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v17 batches= rollups=v1
-seqno=v18 batches= rollups=v1,v17
+seqno=v18 batches= rollups=v1
+seqno=v19 batches= rollups=v1,v18
 
 blob-scan-batches
 ----
@@ -206,7 +210,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v18 ok
+v19 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -218,7 +222,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v18 ok
+v19 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -227,45 +231,45 @@ v18 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v18 []
+v19 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v18 ok
+v19 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v18 0 []
+v19 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v18 1 []
+v19 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v18 ok
+v19 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v18 []
+v19 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v18 []
+v19 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v18 ok
+v19 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v18 []
+v19 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v18 0 []
+v19 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v18 ok
+v19 ok

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -39,73 +39,73 @@ parts=1 len=2
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 # verify we have a new state that references the latest batch
-consensus-scan from_seqno=v3
+consensus-scan from_seqno=v4
 ----
 <empty>
 
 # insert a second batch into state
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v3 [2]
+v4 [2]
 
 # verify we have a new state that references both batches
-consensus-scan from_seqno=v3
+consensus-scan from_seqno=v4
 ----
-seqno=v3 batches=b0,b1 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
 
 
 # run gc up to our latest seqno, but without introducing a new rollup.
 # gc should _not_ perform any work in this case.
-gc to_seqno=v3
+gc to_seqno=v4
 ----
-v3 batch_parts=0 rollups=0 truncated= state_rollups=
+v4 batch_parts=0 rollups=0 truncated= state_rollups=
 
 # verify that consensus has not changed
-consensus-scan from_seqno=v3
+consensus-scan from_seqno=v4
 ----
-seqno=v3 batches=b0,b1 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
 
 # add a rollup
 write-rollup output=v3
 ----
-state=v3 diffs=[v2, v4)
+state=v4 diffs=[v2, v5)
 
 add-rollup input=v3
 ----
-v4
+v5
 
 # run gc up to our latest seqno. gc should truncate up to the latest rollup
 # and introduce its own seqno (to remove the older rollup from state)
-gc to_seqno=v3
+gc to_seqno=v4
 ----
-v5 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
+v6 batch_parts=0 rollups=0 truncated=v4 state_rollups=v1
 
 # verify that gc removed all seqno less than the latest
 consensus-scan from_seqno=v0
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v3
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1 rollups=v1,v4
+seqno=v6 batches=b0,b1 rollups=v4
 
 # insert another batch
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v6 [3]
+v7 [3]
 
 consensus-scan from_seqno=v0
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v3
-seqno=v6 batches=b0,b1,b2 rollups=v3
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1 rollups=v1,v4
+seqno=v6 batches=b0,b1 rollups=v4
+seqno=v7 batches=b0,b1,b2 rollups=v4
 
 # write a rollup at v6, the last seqno referencing b0 and b1
 write-rollup output=v6_last_b0_b1_reference
 ----
-state=v6 diffs=[v4, v7)
+state=v7 diffs=[v5, v8)
 
 # compact and merge b0 and b1 into b0_1
 compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
@@ -114,37 +114,37 @@ parts=1 len=3
 
 apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v7 true
+v8 true
 
 # verify that we b0_1 has replaced b0 and b1 in latest state
 consensus-scan from_seqno=v0
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1 rollups=v1,v3
-seqno=v5 batches=b0,b1 rollups=v3
-seqno=v6 batches=b0,b1,b2 rollups=v3
-seqno=v7 batches=b0_1,b2 rollups=v3
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1 rollups=v1,v4
+seqno=v6 batches=b0,b1 rollups=v4
+seqno=v7 batches=b0,b1,b2 rollups=v4
+seqno=v8 batches=b0_1,b2 rollups=v4
 
 write-rollup output=v7
 ----
-state=v7 diffs=[v4, v8)
+state=v8 diffs=[v5, v9)
 
 # now add in rollup from v6 and run gc. should clear only the b0,b1 seqnos
 add-rollup input=v6_last_b0_b1_reference
 ----
-v8
+v9
 
 # run gc to clear only the b0,b1 seqnos
-gc to_seqno=v7
+gc to_seqno=v8
 ----
-v9 batch_parts=0 rollups=1 truncated=v6 state_rollups=v3
+v10 batch_parts=0 rollups=1 truncated=v7 state_rollups=v4
 
 consensus-scan from_seqno=v0
 ----
-seqno=v6 batches=b0,b1,b2 rollups=v3
-seqno=v7 batches=b0_1,b2 rollups=v3
-seqno=v8 batches=b0_1,b2 rollups=v3,v6
-seqno=v9 batches=b0_1,b2 rollups=v6
+seqno=v7 batches=b0,b1,b2 rollups=v4
+seqno=v8 batches=b0_1,b2 rollups=v4
+seqno=v9 batches=b0_1,b2 rollups=v4,v7
+seqno=v10 batches=b0_1,b2 rollups=v7
 
 # verify that b0 and b1 still exist, because they're referenced in seqno 6
 fetch-batch input=b0
@@ -165,20 +165,20 @@ part 0
 # write a new rollup at v7 so we can GC v6, the last reference to b0 and b1, on our next call
 add-rollup input=v7
 ----
-v10
+v11
 
-gc to_seqno=v7
+gc to_seqno=v8
 ----
-v11 batch_parts=2 rollups=0 truncated=v7 state_rollups=v6
+v12 batch_parts=2 rollups=0 truncated=v8 state_rollups=v7
 
 # we should only have b0_1,b2 now
 consensus-scan from_seqno=v0
 ----
-seqno=v7 batches=b0_1,b2 rollups=v3
-seqno=v8 batches=b0_1,b2 rollups=v3,v6
-seqno=v9 batches=b0_1,b2 rollups=v6
-seqno=v10 batches=b0_1,b2 rollups=v6,v7
-seqno=v11 batches=b0_1,b2 rollups=v7
+seqno=v8 batches=b0_1,b2 rollups=v4
+seqno=v9 batches=b0_1,b2 rollups=v4,v7
+seqno=v10 batches=b0_1,b2 rollups=v7
+seqno=v11 batches=b0_1,b2 rollups=v7,v8
+seqno=v12 batches=b0_1,b2 rollups=v8
 
 # and b0 and b1 should no longer exist in the blob store, as no states still reference them
 fetch-batch input=b0

--- a/src/persist-client/tests/machine/gc_rollups
+++ b/src/persist-client/tests/machine/gc_rollups
@@ -32,125 +32,125 @@ parts=1 len=2
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v3 [2]
+v4 [2]
 
 write-rollup output=v3
 ----
-state=v3 diffs=[v2, v4)
+state=v4 diffs=[v2, v5)
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v4 [3]
+v5 [3]
 
 write-rollup output=v4
 ----
-state=v4 diffs=[v2, v5)
+state=v5 diffs=[v2, v6)
 
 # write a bunch of rollups to verify GC bounds
 add-rollup input=v3
 ----
-v5
+v6
 
 write-rollup output=v5
 ----
-state=v5 diffs=[v4, v6)
+state=v6 diffs=[v5, v7)
 
 add-rollup input=v4
 ----
-v6
+v7
 
 add-rollup input=v5
 ----
-v7
+v8
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v1 batches= rollups=v1
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v2 batches= rollups=v1
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
 
 # gc at the first seqno should be a no-op (no rollups to remove)
-gc to_seqno=v1
-----
-v7 batch_parts=0 rollups=0 truncated= state_rollups=
-
-consensus-scan from_seqno=v1
-----
-seqno=v1 batches= rollups=v1
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
-
-# there is only 1 rollup <= seqno 2, so this should also be a no-op
 gc to_seqno=v2
 ----
-v7 batch_parts=0 rollups=0 truncated= state_rollups=
+v8 batch_parts=0 rollups=0 truncated= state_rollups=
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v1 batches= rollups=v1
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v2 batches= rollups=v1
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
+
+# there is only 1 rollup <= seqno 2, so this should also be a no-op
+gc to_seqno=v3
+----
+v8 batch_parts=0 rollups=0 truncated= state_rollups=
+
+consensus-scan from_seqno=v2
+----
+seqno=v2 batches= rollups=v1
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
 
 # ok! now it gets interesting, let's gc to v3 which the latest state
 # has a rollup for. we should be able to remove v1 and states [v1, v3)
-gc to_seqno=v3
+gc to_seqno=v4
 ----
-v8 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
+v9 batch_parts=0 rollups=0 truncated=v4 state_rollups=v1
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
-seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
+seqno=v9 batches=b0,b1,b2 rollups=v4,v5,v6
 
 # if we run the same GC again, or less, they should be no-ops
 # and perform no truncations
+gc to_seqno=v4
+----
+v9 batch_parts=0 rollups=0 truncated= state_rollups=
+
 gc to_seqno=v3
 ----
-v8 batch_parts=0 rollups=0 truncated= state_rollups=
-
-gc to_seqno=v2
-----
-v8 batch_parts=0 rollups=0 truncated= state_rollups=
+v9 batch_parts=0 rollups=0 truncated= state_rollups=
 
 write-rollup output=v8
 ----
-state=v8 diffs=[v6, v9)
+state=v9 diffs=[v7, v10)
 
 # let's try GC'ing many rollups at once. here, we both ask
 # to remove >1 rollup at once, and pass in a to_seqno that is
 # not exactly covered by a rollup. we expect to see all rollups
 # <= the latest to be removed
-gc to_seqno=v8
+gc to_seqno=v9
 ----
-v9 batch_parts=0 rollups=0 truncated=v4,v5 state_rollups=v3,v4
+v10 batch_parts=0 rollups=0 truncated=v5,v6 state_rollups=v4,v5
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
-seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
-seqno=v9 batches=b0,b1,b2 rollups=v5
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
+seqno=v9 batches=b0,b1,b2 rollups=v4,v5,v6
+seqno=v10 batches=b0,b1,b2 rollups=v6
 
 # let's verify that rollups are physically deleted too.
 # it's subtle, but v8 was the first transition that
@@ -159,58 +159,58 @@ seqno=v9 batches=b0,b1,b2 rollups=v5
 
 write-rollup output=v9
 ----
-state=v9 diffs=[v6, v10)
+state=v10 diffs=[v7, v11)
 
 add-rollup input=v8
 ----
-v10
+v11
 
 add-rollup input=v9
 ----
-v11
+v12
 
 # (this is also subtle, but we GC to v8 again like before.
 # this time we can make further progress though, as previously
 # v8 was greater than the latest rollup, now v8 is less than
 # the latest rollup so everything below it can be removed)
-gc to_seqno=v8
+gc to_seqno=v9
 ----
-v12 batch_parts=0 rollups=1 truncated=v8 state_rollups=v5
+v13 batch_parts=0 rollups=1 truncated=v9 state_rollups=v6
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
-seqno=v9 batches=b0,b1,b2 rollups=v5
-seqno=v10 batches=b0,b1,b2 rollups=v5,v8
-seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
-seqno=v12 batches=b0,b1,b2 rollups=v8,v9
+seqno=v9 batches=b0,b1,b2 rollups=v4,v5,v6
+seqno=v10 batches=b0,b1,b2 rollups=v6
+seqno=v11 batches=b0,b1,b2 rollups=v6,v9
+seqno=v12 batches=b0,b1,b2 rollups=v6,v9,v10
+seqno=v13 batches=b0,b1,b2 rollups=v9,v10
 
 # truncate Consensus out-of-band to mirror overlapping GC
 # processes. we'll remove v8 from Consensus but "fail"
 # before removing v8 from state
-consensus-truncate to_seqno=v9
+consensus-truncate to_seqno=v10
 ----
 1
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v9 batches=b0,b1,b2 rollups=v5
-seqno=v10 batches=b0,b1,b2 rollups=v5,v8
-seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
-seqno=v12 batches=b0,b1,b2 rollups=v8,v9
+seqno=v10 batches=b0,b1,b2 rollups=v6
+seqno=v11 batches=b0,b1,b2 rollups=v6,v9
+seqno=v12 batches=b0,b1,b2 rollups=v6,v9,v10
+seqno=v13 batches=b0,b1,b2 rollups=v9,v10
 
 # even though the row v8 doesn't exist any more, GC
 # should still know to remove it from state. it should
 # additionally perform no actual truncate calls because
 # it started at a state greater than to_seqno
-gc to_seqno=v9
+gc to_seqno=v10
 ----
-v13 batch_parts=0 rollups=0 truncated= state_rollups=v8
+v14 batch_parts=0 rollups=0 truncated= state_rollups=v9
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v9 batches=b0,b1,b2 rollups=v5
-seqno=v10 batches=b0,b1,b2 rollups=v5,v8
-seqno=v11 batches=b0,b1,b2 rollups=v5,v8,v9
-seqno=v12 batches=b0,b1,b2 rollups=v8,v9
-seqno=v13 batches=b0,b1,b2 rollups=v9
+seqno=v10 batches=b0,b1,b2 rollups=v6
+seqno=v11 batches=b0,b1,b2 rollups=v6,v9
+seqno=v12 batches=b0,b1,b2 rollups=v6,v9,v10
+seqno=v13 batches=b0,b1,b2 rollups=v9,v10
+seqno=v14 batches=b0,b1,b2 rollups=v10

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -25,35 +25,36 @@ parts=1 len=1
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 write-rollup output=v2
 ----
-state=v2 diffs=[v2, v3)
+state=v3 diffs=[v2, v4)
 
 add-rollup input=v2
 ----
-v3
+v4
 
-consensus-scan from_seqno=v0
+consensus-scan from_seqno=v1
 ----
 seqno=v1 batches= rollups=v1
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0 rollups=v1,v2
+seqno=v2 batches= rollups=v1
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0 rollups=v1,v3
 
 # Run gc up to our latest seqno
 gc to_seqno=v3
 ----
-v4 batch_parts=0 rollups=0 truncated=v2 state_rollups=v1
+v5 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
 
 # Now some slow gc req comes in that's behind. In the regression case, this
 # panics.
 gc to_seqno=v1
 ----
-v4 batch_parts=0 rollups=0 truncated= state_rollups=
+v5 batch_parts=0 rollups=0 truncated= state_rollups=
 
 consensus-scan from_seqno=v0
 ----
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0 rollups=v1,v2
-seqno=v4 batches=b0 rollups=v2
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0 rollups=v1,v3
+seqno=v5 batches=b0 rollups=v3

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -19,7 +19,7 @@ parts=1 len=1
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [2]
+v3 [2]
 
 register-listen output=l0 as_of=0
 ----
@@ -37,7 +37,7 @@ parts=1 len=1
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v5 [3]
+v6 [3]
 
 compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0
 ----
@@ -55,12 +55,12 @@ parts=1 len=4
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v6 [4]
+v7 [4]
 
 # Now apply the merged batch.
 apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v7 true
+v8 true
 
 # Finally, verify that the listener correctly skips [1, 2) when it grabs the
 # merged batch. Without the fix, this also gets a "one 1 1" line.

--- a/src/persist-client/tests/machine/restore_blob
+++ b/src/persist-client/tests/machine/restore_blob
@@ -35,63 +35,63 @@ parts=1 len=2
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v2 [1]
+v3 [1]
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v3 [2]
+v4 [2]
 
 write-rollup output=v3
 ----
-state=v3 diffs=[v2, v4)
+state=v4 diffs=[v2, v5)
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v4 [3]
+v5 [3]
 
 write-rollup output=v4
 ----
-state=v4 diffs=[v2, v5)
+state=v5 diffs=[v2, v6)
 
 # write a bunch of rollups to verify GC bounds
 add-rollup input=v3
 ----
-v5
+v6
 
 write-rollup output=v5
 ----
-state=v5 diffs=[v4, v6)
+state=v6 diffs=[v5, v7)
 
 add-rollup input=v4
 ----
-v6
+v7
 
 add-rollup input=v5
 ----
-v7
+v8
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v1 batches= rollups=v1
-seqno=v2 batches=b0 rollups=v1
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
+seqno=v2 batches= rollups=v1
+seqno=v3 batches=b0 rollups=v1
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
 
-gc to_seqno=v3
+gc to_seqno=v4
 ----
-v8 batch_parts=0 rollups=0 truncated=v3 state_rollups=v1
+v9 batch_parts=0 rollups=0 truncated=v4 state_rollups=v1
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
-seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
+seqno=v9 batches=b0,b1,b2 rollups=v4,v5,v6
 
 # Delete our state
 clear-blob
@@ -102,14 +102,14 @@ restore-blob
 ----
 <empty>
 
-consensus-scan from_seqno=v1
+consensus-scan from_seqno=v2
 ----
-seqno=v3 batches=b0,b1 rollups=v1
-seqno=v4 batches=b0,b1,b2 rollups=v1
-seqno=v5 batches=b0,b1,b2 rollups=v1,v3
-seqno=v6 batches=b0,b1,b2 rollups=v1,v3,v4
-seqno=v7 batches=b0,b1,b2 rollups=v1,v3,v4,v5
-seqno=v8 batches=b0,b1,b2 rollups=v3,v4,v5
+seqno=v4 batches=b0,b1 rollups=v1
+seqno=v5 batches=b0,b1,b2 rollups=v1
+seqno=v6 batches=b0,b1,b2 rollups=v1,v4
+seqno=v7 batches=b0,b1,b2 rollups=v1,v4,v5
+seqno=v8 batches=b0,b1,b2 rollups=v1,v4,v5,v6
+seqno=v9 batches=b0,b1,b2 rollups=v4,v5,v6
 
 snapshot as_of=2
 ----

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -102,24 +102,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));
-                    x
-                },
-                {
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x
-                },
-                {
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
-                    x.add_dynamic("persist_batch_structured_key_lower_len", ::mz_dyncfg::ConfigVal::Usize(256));
-                    x.add_dynamic("persist_batch_structured_order", ::mz_dyncfg::ConfigVal::Bool(true));
-                    x
-                },
-                {
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_encoding_enable_dictionary", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
                 },

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -522,39 +522,18 @@ impl BlobTraceUpdates {
 
     /// Convert these updates into the specified batch format, re-encoding or discarding key-value
     /// data as necessary.
-    pub fn as_format<K: Codec, V: Codec>(
+    pub fn as_structured<K: Codec, V: Codec>(
         &self,
-        format: BatchColumnarFormat,
         key_schema: &K::Schema,
         val_schema: &V::Schema,
     ) -> Self {
-        match format {
-            BatchColumnarFormat::Row => {
-                let mut this = self.clone();
-                Self::Row(
-                    this.get_or_make_codec::<K, V>(key_schema, val_schema)
-                        .clone(),
-                )
-            }
-            BatchColumnarFormat::Both(_) => {
-                let mut this = self.clone();
-                Self::Both(
-                    this.get_or_make_codec::<K, V>(key_schema, val_schema)
-                        .clone(),
-                    this.get_or_make_structured::<K, V>(key_schema, val_schema)
-                        .clone(),
-                )
-            }
-            BatchColumnarFormat::Structured => {
-                let mut this = self.clone();
-                Self::Structured {
-                    key_values: this
-                        .get_or_make_structured::<K, V>(key_schema, val_schema)
-                        .clone(),
-                    timestamps: this.timestamps().clone(),
-                    diffs: this.diffs().clone(),
-                }
-            }
+        let mut this = self.clone();
+        Self::Structured {
+            key_values: this
+                .get_or_make_structured::<K, V>(key_schema, val_schema)
+                .clone(),
+            timestamps: this.timestamps().clone(),
+            diffs: this.diffs().clone(),
         }
     }
 }

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -15,13 +15,6 @@ ALTER SYSTEM SET persist_inline_writes_single_max_bytes = 0
 ----
 COMPLETE 0
 
-# As we iterate on the structured encoding, part sizes may vary.
-# Temporarily disable it here for now
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET persist_batch_columnar_format = 'row'
-----
-COMPLETE 0
-
 # EXPLAIN FILTER PUSHDOWN statements are blocked by a feature flag
 statement ok
 CREATE TABLE numbers (
@@ -75,12 +68,12 @@ INSERT INTO numbers VALUES (1), (2), (3);
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
 ----
-materialize.public.numbers  925  0  1  0
+materialize.public.numbers  1233  0  1  0
 
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value < 10;
 ----
-materialize.public.numbers  925  925  1  1
+materialize.public.numbers  1233  1233  1  1
 
 # Verify that pushdown of jsonb_get_string is infallible. Before this was
 # fixed, a filter expression on a jsonb field that is not present in all parts
@@ -105,7 +98,7 @@ INSERT INTO jsonb_fields VALUES (2, '{ "other-field": "value" }');
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM jsonb_fields where timestamp > 1000 AND payload->>'field' = 'not-value';
 ----
-materialize.public.jsonb_fields  1858  0  2  0
+materialize.public.jsonb_fields  2826  0  2  0
 
 # EXPLAIN FILTER PUSHDOWN should work even if there are no replicas.
 statement ok
@@ -117,7 +110,7 @@ SET CLUSTER = no_replicas;
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM jsonb_fields where timestamp > 1000 AND payload->>'field' = 'not-value';
 ----
-materialize.public.jsonb_fields  1858  0  2  0
+materialize.public.jsonb_fields  2826  0  2  0
 
 # ----------------------------------------
 # Cleanup

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -9,19 +9,6 @@
 
 mode cockroach
 
-# To make ordering deterministic for fast-path peeks, enable the
-# structured part format and set Persist to use that ordering.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET persist_batch_columnar_format = 'both_v2'
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET persist_batch_structured_order = true
-----
-COMPLETE 0
-
 # Verify that the persist fast path only kicks in when it's expected to do so.
 
 # Generate a table, with multiple batches of data and some partial overlaps


### PR DESCRIPTION
### Motivation

Followup to https://github.com/MaterializeInc/database-issues/issues/7411

- Remove a number of write-time flags that we no longer intend to use, along with the code perviously needed to support them.
- Update the remaining tests that are expressed in terms of codec data to expect structured data.
- Switch more of the internal logic over to work in terms of `Part` - the structured-only equivalent of `ColumnarRecords`.

### Tips for reviewer

This is only partially run through - in particular, I think we can probably do away with `ColumnarRecords` entirely. But it seemed like quite large enough for a first review. (Though possibly not quite as large as it looks... there are a number of mechanical and test changes that inflate the diff size.)

I think most changes are separated commit-by-commit, though there's almost certainly been some bleedover. Let me know if this is too much in one go, and I should be able to split it up a bit further.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
