### PR TITLE
Update timely to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,9 +1809,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "columnar"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f6f48b6441462dc29aa45c037dd94d83b48ab712b4497291afbb90c9d1a70f"
+checksum = "ae8be54998f17fe8e92f41cc38e244342687bceb129d8066b949685f06d08d4f"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2423,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.13.7"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922c18a0f94e29defaef228ecd65589880c16f3f3462a33258f869119f039443"
+checksum = "0640656ed23155e96560e47109973632d947ab036fdd5952c38d97c264789bfc"
 dependencies = [
  "columnar",
  "columnation",
@@ -2437,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dogs3"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680def2e24f4d035de6ce128d4820f5533d9afe872d85e87b5c8ed84946c8118"
+checksum = "22b0e6f15ad6ccc4ca156c2115640787ffea632713792ba79bbebc96e994f58e"
 dependencies = [
  "differential-dataflow",
  "serde",
@@ -10703,9 +10703,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a714a3fed9aeacf63d9c5c574523c18972b788fa0414011b590af73acad30b09"
+checksum = "6ea7156d1279a6584987054087dcccb36d0b7907e2add627eb58de52d57ea9f9"
 dependencies = [
  "bincode",
  "byteorder",
@@ -10723,19 +10723,18 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e1275de95b4a2713f0850c458d3a550dc323fffda65ce3e075f62545e0484b"
+checksum = "ee3700cd9c50f14046eb86deb4f2825758966b40231ad8ffc479c510c42869a1"
 
 [[package]]
 name = "timely_communication"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cdbfc7739e6a8ed95cd591ec0e862f294c681796c6121e6b3fa1ab946473e1"
+checksum = "f6a36db4ca48c9b7169b2c886a00f371a7bb1a79b53c58b444881366f8abaa2b"
 dependencies = [
  "byteorder",
  "columnar",
- "crossbeam-channel",
  "getopts",
  "serde",
  "timely_bytes",
@@ -10745,15 +10744,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c951c468b95e2070be7f48a9d8350b6e8e5ecb23e0d13fd7f6155893bb1297d"
+checksum = "122f41e658e166b7a95a02b78265bc3f5272a4d0d28d1008f0da11b9a4cf79cd"
 
 [[package]]
 name = "timely_logging"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d46d6e2fbf5831ff8345f92723e46f778ce157cf8b74448fdcaac9efb9b9a2"
+checksum = "47c57fb79cb66b7a3dc1beb4165c111e0e1900a18a9d33a73e2148ad7299b0bf"
 dependencies = [
  "timely_container",
 ]

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.219"
-timely = "0.19.0"
+timely = "0.20.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 tracing = "0.1.37"
 

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.31"
@@ -82,7 +82,7 @@ serde_plain = "1.0.1"
 sha2 = "0.10.8"
 smallvec = { version = "1.14.0", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 ipnet = "2.11.0"
 itertools = "0.12.1"
@@ -60,7 +60,7 @@ serde_plain = "1.0.1"
 static_assertions = "1.1"
 sha2 = "0.10.8"
 thiserror = "2.0.12"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1" }
 tracing = "0.1.37"
 uuid = "1.16.0"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -13,14 +13,14 @@ workspace = true
 anyhow = "1.0.95"
 async-trait = "0.1.83"
 crossbeam-channel = "0.5.8"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 lgalloc = "0.5.0"
 mz-cluster-client = { path = "../cluster-client" }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing"] }
 mz-service = { path = "../service" }
 regex = "1.10.6"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.83"
 bytesize = "1.3.0"
 crossbeam-channel = "0.5.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 http = "1.2.0"
 mz-build-info = { path = "../build-info" }
@@ -43,7 +43,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.125"
 thiserror = "2.0.12"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 workspace = true
 
 [dependencies]
-columnar = "0.3.0"
+columnar = "0.4.1"
 columnation = "0.1.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 itertools = "0.12.1"
 mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
@@ -24,7 +24,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,11 +13,11 @@ workspace = true
 anyhow = "1.0.95"
 async-stream = "0.3.3"
 bytesize = "1.3.0"
-columnar = "0.3.0"
+columnar = "0.4.1"
 crossbeam-channel = "0.5.8"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.13.7"
-differential-dogs3 = "0.1.7"
+differential-dataflow = "0.14.0"
+differential-dogs3 = "0.1.8"
 futures = "0.3.31"
 itertools = "0.12.1"
 lgalloc = "0.5"
@@ -40,7 +40,7 @@ prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.14.0", features = ["serde", "union"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["serde", "v4"] }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -15,7 +15,7 @@ use std::fmt::{Display, Write};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use columnar::{Columnar, Index};
+use columnar::Columnar;
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::trace::{BatchReader, Cursor};
 use differential_dataflow::Collection;

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -14,7 +14,6 @@ use std::convert::TryInto;
 use std::rc::Rc;
 use std::time::Duration;
 
-use columnar::Index;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Row, Timestamp};

--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -782,7 +782,7 @@ where
         let mut input = builder.new_input_connection(
             &self.inner,
             Pipeline,
-            vec![Antichain::from_elem(step_forward_summary)],
+            [(0, Antichain::from_elem(step_forward_summary))],
         );
         builder.set_notify(false);
         builder.build(move |_caps| {

--- a/src/compute/src/sink/refresh.rs
+++ b/src/compute/src/sink/refresh.rs
@@ -15,7 +15,6 @@ use mz_repr::{Diff, Timestamp};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
 
 /// This is for REFRESH options on materialized views. It adds an operator that rounds up the
 /// timestamps of data and frontiers to the time of the next refresh. See
@@ -36,7 +35,7 @@ where
     // time, we'll round it up to the next refresh time.
     let mut builder = OperatorBuilder::new("apply_refresh".to_string(), coll.scope());
     let (mut output_buf, output_stream) = builder.new_output::<ConsolidatingContainerBuilder<_>>();
-    let mut input = builder.new_input_connection(&coll.inner, Pipeline, vec![Antichain::new()]);
+    let mut input = builder.new_input_connection(&coll.inner, Pipeline, []);
     builder.build(move |capabilities| {
         // This capability directly controls this operator's output frontier (because we have
         // disconnected the input above). We wrap it in an Option so we can drop it to advance to

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -32,7 +32,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.10.6"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.125"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = "1.44.1"
 tracing = "0.1.37"
 uuid = { version = "1.16.0" }

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.83"
 bytes = { version = "1.10.1" }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 itertools = { version = "0.12.1" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -146,7 +146,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 crc32fast = "1.4.2"
 csv = "1.3.1"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 dec = "0.4.8"
 derivative = "2.2.0"
 encoding = "0.2.0"
@@ -60,7 +60,7 @@ serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.8"
 subtle = "2.6.1"
-timely = "0.19.0"
+timely = "0.20.0"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.16.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 bytes = "1.10.1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 itertools = "0.12.1"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -33,7 +33,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.7"
 seahash = "4"
 serde_json = "1.0.125"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["serde"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.83"
 axum = "0.7.5"
 bytes = { version = "1.10.1", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 humantime = "2.2.0"
 mz-http-util = { path = "../http-util" }
@@ -40,7 +40,7 @@ num_enum = "0.7.3"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.83"
 bytes = { version = "1.10.1", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 futures-util = "0.3"
 h2 = "0.3.13"
@@ -59,7 +59,7 @@ sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.125"
-timely = "0.19.0"
+timely = "0.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.4.0"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.19.0"
+timely = "0.20.0"
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -37,7 +37,7 @@ azure_core = "0.21.0"
 base64 = "0.13.1"
 bytes = "1.10.1"
 deadpool-postgres = "0.10.3"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.31"
 itertools = "0.12.1"
@@ -60,7 +60,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 reqwest = { version = "0.12", features = ["blocking", "json", "default-tls", "charset", "http2"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,12 +31,12 @@ arrow = { version = "53.3.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.10.1"
 cfg-if = "1.0.0"
-columnar = "0.3.0"
+columnar = "0.4.1"
 columnation = "0.1.0"
 chrono = { version = "0.4.39", default-features = false, features = ["serde", "std"] }
 compact_bytes = "0.1.3"
 dec = "0.4.8"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 enum-kinds = "0.5.1"
 hex = "0.4.3"
 itertools = "0.12.1"
@@ -66,7 +66,7 @@ serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.14.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.11.1"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -35,7 +35,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.29.11"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.95"
 async-trait = "0.1.83"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 http = "1.2.0"
 itertools = { version = "0.12.1" }
@@ -48,7 +48,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 smallvec = { version = "1.14.0", features = ["serde", "union"] }
 static_assertions = "1.1"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = [
     "fs",
     "rt",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.83"
 bytes = "1.10.1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 itertools = { version = "0.12.1" }
 mz-build-info = { path = "../build-info" }
@@ -38,7 +38,7 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.125" }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.10.1"
 bytesize = "1.3.0"
 csv-async = { version = "1.3.0", features = ["tokio"] }
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 glob = "0.3.2"
 http = "1.2.0"
@@ -48,7 +48,7 @@ reqwest = { version = "0.11.13", features = ["stream"] }
 sentry = { version = "0.29.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.14.0", features = ["union"] }
-timely = "0.19.0"
+timely = "0.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-stream = "0.1.17"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.10.1"
 columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 hex = "0.4.3"
 http = "1.2.0"
 itertools = { version = "0.12.1" }
@@ -62,7 +62,7 @@ regex = "1.10.6"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "2.0.12"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -26,7 +26,7 @@ columnation = "0.1.0"
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.12" }
 dec = "0.4.8"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.31"
 indexmap = { version = "2.7.1", default-features = false, features = ["std"] }
@@ -76,7 +76,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.17" }
 sha2 = "0.10.8"
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 ahash = { version = "0.8.11", default-features = false }
 bincode = "1.3.3"
 bytemuck = "1.22.0"
-columnar = "0.3.0"
+columnar = "0.4.1"
 columnation = "0.1.0"
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 either = "1"
 futures-util = "0.3.31"
 lgalloc = "0.5"
@@ -23,7 +23,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test"] }
 num-traits = "0.2"
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["serde", "v4"] }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -503,9 +503,11 @@ impl<G: Scope> OperatorBuilder<G> {
             .push(Antichain::from_elem(G::Timestamp::minimum()));
 
         let outputs = self.builder.shape().outputs();
-        let handle = self
-            .builder
-            .new_input_connection(stream, pact, connection.describe(outputs));
+        let handle = self.builder.new_input_connection(
+            stream,
+            pact,
+            connection.describe(outputs).into_iter().enumerate(),
+        );
 
         let waker = Default::default();
         let queue = Default::default();
@@ -533,8 +535,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ) {
         let index = self.builder.shape().outputs();
 
-        let connection = vec![Antichain::new(); self.builder.shape().inputs()];
-        let (wrapper, stream) = self.builder.new_output_connection(connection);
+        let (wrapper, stream) = self.builder.new_output_connection([]);
 
         let handle = AsyncOutputHandle::new(wrapper, index);
 

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -157,13 +157,13 @@ mod container {
         type Iter<'a> = IterOwn<<C::Container as columnar::Container<C>>::Borrowed<'a>>;
 
         fn iter(&self) -> Self::Iter<'_> {
-            self.borrow().into_iter()
+            self.borrow().into_index_iter()
         }
 
         type DrainIter<'a> = IterOwn<<C::Container as columnar::Container<C>>::Borrowed<'a>>;
 
         fn drain(&mut self) -> Self::DrainIter<'_> {
-            self.borrow().into_iter()
+            self.borrow().into_index_iter()
         }
     }
 

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 enum-kinds = "0.5.1"
 itertools = "0.12.1"
 mz-compute-types = { path = "../compute-types" }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.83"
 bytes = { version = "1.10.1" }
-differential-dataflow = "0.13.7"
+differential-dataflow = "0.14.0"
 futures = "0.3.31"
 itertools = { version = "0.12.1" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.19.0"
+timely = "0.20.0"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.16.0", features = ["v4"] }


### PR DESCRIPTION
Timely's 0.20 release brings significant performance improvements for operators and scopes with a large product of inputs and outputs. This happens in our sources, where large table counts result in scopes where each table results in a scope input and output. This limitation has prevented scaling the numbers of tables brought in from sources.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
