### PR TITLE
[persist] Optimizations for the merge tree

### DIFF
--- a/src/persist-client/src/internal/merge.rs
+++ b/src/persist-client/src/internal/merge.rs
@@ -23,21 +23,28 @@ use std::mem;
 /// - The "depth" of the merge tree - the number of merges any particular element may undergo -
 ///   is `O(log N)`.
 pub struct MergeTree<T> {
-    pub(crate) max_len: usize,
-    pub(crate) levels: Vec<Vec<T>>,
+    /// Configuration: the largest any level in the tree is allowed to grow.
+    max_level_len: usize,
+    /// The length of each level in the tree, stored in order from shallowest to deepest.
+    level_lens: Vec<usize>,
+    /// A flattened representation of the contents of the tree, stored in order from earliest /
+    /// deepest to newest / shallowest.
+    data: Vec<T>,
     merge_fn: Box<dyn Fn(Vec<T>) -> T + Sync + Send>,
 }
 
 impl<T: Debug> Debug for MergeTree<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Self {
-            max_len,
-            levels,
+            max_level_len,
+            level_lens,
+            data,
             merge_fn: _,
         } = self;
         f.debug_struct("MergeTree")
-            .field("max_len", max_len)
-            .field("levels", levels)
+            .field("max_level_len", max_level_len)
+            .field("level_lens", level_lens)
+            .field("data", data)
             .finish_non_exhaustive()
     }
 }
@@ -48,8 +55,9 @@ impl<T> MergeTree<T> {
     /// limit, the provided `merge_fn` is used to combine adjacent elements together.
     pub fn new(max_len: usize, merge_fn: impl Fn(Vec<T>) -> T + Send + Sync + 'static) -> Self {
         let new = Self {
-            max_len,
-            levels: vec![vec![]],
+            max_level_len: max_len,
+            level_lens: vec![0],
+            data: vec![],
             merge_fn: Box::new(merge_fn),
         };
         new.assert_invariants();
@@ -59,74 +67,89 @@ impl<T> MergeTree<T> {
     /// Iterate over (references to) the parts in this tree in first-to-latest order.
     #[allow(unused)]
     pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
-        self.levels.iter().rev().flat_map(|l| l.iter())
+        self.data.iter()
     }
 
     /// Iterate over (mutable references to) the parts in this tree in first-to-latest order.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> + DoubleEndedIterator {
-        self.levels.iter_mut().rev().flat_map(|l| l.iter_mut())
+        self.data.iter_mut()
+    }
+
+    fn merge_last(&mut self, level_len: usize) {
+        let offset = self.data.len() - level_len;
+        let split = self.data.split_off(offset);
+        let merged = (self.merge_fn)(split);
+        self.data.push(merged);
     }
 
     /// Push a new part onto the end of this tree, possibly triggering a merge.
-    pub fn push(&mut self, mut part: T) {
+    pub fn push(&mut self, part: T) {
         // Normally, all levels have strictly less than max_len elements.
         // However, the _deepest_ level is allowed to have exactly max_len elements,
         // since that can save us an unnecessary merge in some cases.
         // (For example, when precisely max_len elements are added.)
-        if let Some(last) = self.levels.last_mut() {
-            if last.len() == self.max_len {
-                let merged = (self.merge_fn)(mem::take(last));
-                self.levels.push(vec![merged]);
+        if let Some(last_len) = self.level_lens.last_mut() {
+            if *last_len == self.max_level_len {
+                let len = mem::take(last_len);
+                self.merge_last(len);
+                self.level_lens.push(1);
             }
         }
 
         // At this point, all levels have room. Add our new part, then continue
         // merging up the tree until either there's still room in the current level
         // or we've reached the top.
-        let max_level = self.levels.len() - 1;
-        for depth in 0..=max_level {
-            let level = &mut self.levels[depth];
-            level.push(part);
+        self.data.push(part);
 
-            if level.len() < self.max_len || depth == max_level {
+        let max_level = self.level_lens.len() - 1;
+        for depth in 0..=max_level {
+            let level_len = &mut self.level_lens[depth];
+            *level_len += 1;
+
+            if *level_len < self.max_level_len || depth == max_level {
                 break;
             }
 
-            part = (self.merge_fn)(mem::take(level));
+            let len = mem::take(level_len);
+            self.merge_last(len);
         }
     }
 
     /// Return the contents of this merge tree, flattened into at most `max_len` parts.
-    pub fn finish(self) -> Vec<T> {
-        self.levels
-            .into_iter()
-            .reduce(|mut shallower, mut deeper| {
-                if shallower.len() + deeper.len() <= self.max_len {
-                    // Optimization: if there's enough room in the next level for everything at the
-                    // current level, add it directly.
-                    deeper.append(&mut shallower);
-                } else {
-                    // Otherwise, merge this up as if it were a full level.
-                    let merged = (self.merge_fn)(shallower);
-                    deeper.push(merged);
-                }
-                deeper
-            })
-            .expect("non-empty level array")
+    pub fn finish(mut self) -> Vec<T> {
+        let mut tail_len = 0;
+        for level_len in mem::take(&mut self.level_lens) {
+            if tail_len + level_len <= self.max_level_len {
+                // Optimization: we can combine the current level with the last level without
+                // going over our limit.
+                tail_len += level_len;
+            } else {
+                // Otherwise, perform the merge and start a new tail.
+                self.merge_last(tail_len);
+                tail_len = level_len + 1
+            }
+        }
+        assert!(self.data.len() <= self.max_level_len);
+        self.data
     }
 
     pub(crate) fn assert_invariants(&self) {
-        assert!(self.max_len >= 2, "max_len must be at least 2");
+        assert!(self.max_level_len >= 2, "max_len must be at least 2");
 
-        let (deepest, shallow) = self.levels.split_last().expect("non-empty level array");
-        for (depth, level) in shallow.iter().enumerate() {
+        assert_eq!(
+            self.data.len(),
+            self.level_lens.iter().copied().sum::<usize>(),
+            "level sizes should sum to overall len"
+        );
+        let (deepest_len, shallow) = self.level_lens.split_last().expect("non-empty level array");
+        for (depth, level_len) in shallow.iter().enumerate() {
             assert!(
-                level.len() < self.max_len,
+                *level_len < self.max_level_len,
                 "strictly less than max elements at level {depth}"
             );
         }
         assert!(
-            deepest.len() <= self.max_len,
+            *deepest_len <= self.max_level_len,
             "at most max elements at deepest level"
         );
     }

--- a/src/persist-client/src/internal/merge.rs
+++ b/src/persist-client/src/internal/merge.rs
@@ -10,6 +10,7 @@
 use mz_ore::task::{JoinHandle, JoinHandleExt};
 use std::fmt::{Debug, Formatter};
 use std::mem;
+use std::ops::{Deref, DerefMut};
 
 /// A merge tree.
 ///
@@ -62,17 +63,6 @@ impl<T> MergeTree<T> {
         };
         new.assert_invariants();
         new
-    }
-
-    /// Iterate over (references to) the parts in this tree in first-to-latest order.
-    #[allow(unused)]
-    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
-        self.data.iter()
-    }
-
-    /// Iterate over (mutable references to) the parts in this tree in first-to-latest order.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> + DoubleEndedIterator {
-        self.data.iter_mut()
     }
 
     fn merge_last(&mut self, level_len: usize) {
@@ -152,6 +142,20 @@ impl<T> MergeTree<T> {
             *deepest_len <= self.max_level_len,
             "at most max elements at deepest level"
         );
+    }
+}
+
+impl<T> Deref for MergeTree<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &*self.data
+    }
+}
+
+impl<T> DerefMut for MergeTree<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.data
     }
 }
 


### PR DESCRIPTION
This switches our merge tree to store data as a `Vec<T>` instead of a `Vec<Vec<T>>`... a bit more memory-efficient, and lets us expose a slightly more flexible interface.

### Motivation

"Just for fun" - I don't think this type is currently used heavily enough that this matters very much. But, might as well... and there are some possible futures where this merge tree gets stressed more heavily and this sort of thing is important.

### Tips for reviewer

I appreciate this makes the code a little bit more fiddly, so I've added a bit to the exhaustive property test at the bottom. Let me know if there's any more checks there that would be useful!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
