### PR TITLE
[sql_server]: Add helper to easily get a stream of CDC changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,10 +7050,12 @@ name = "mz-sql-server-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "chrono",
  "dec",
  "derivative",
  "futures",
+ "hex",
  "mz-build-tools",
  "mz-ore",
  "mz-proto",
@@ -7072,6 +7074,7 @@ dependencies = [
  "tokio-util",
  "tonic-build",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "workspace-hack",
 ]

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
+async-stream = "0.3.3"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 dec = "0.4.8"
 derivative = "2.2.0"
@@ -36,6 +37,10 @@ tokio-util = { version = "0.7.4", features = ["compat"] }
 tracing = "0.1.37"
 uuid = "1.16.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
+
+[dev-dependencies]
+hex = "0.4.3"
+tracing-subscriber = "0.3.19"
 
 [build-dependencies]
 mz-build-tools = { path = "../build-tools", default-features = false }

--- a/src/sql-server-util/examples/cdc.rs
+++ b/src/sql-server-util/examples/cdc.rs
@@ -1,0 +1,68 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Example of streaming CDC changes from an instance of SQL Server.
+//!
+//! To run this example follow these steps:
+//!   1. Get the latest SQL Server Docker image: <https://hub.docker.com/r/microsoft/mssql-server>.
+//!   2. Shell into the running container to enable the SQL Agent which is
+//!      required for CDC.
+//!     ```
+//!     docker exec -t --user root <container_id> bash
+//!     $ /opt/mssql/bin/mssql-conf set sqlagent.enabled true
+//!     $ systemctl restart mssql-server.service
+//!     ```
+//!   3. Run the following SQL to setup the proper environment.
+//!     ```
+//!     -- Setup the database for CDC.
+//!     > CREATE DATABASE materialize;
+//!     > USE materialize;
+//!     > EXEC sys.sp_cdc_enable_db;
+//!
+//!     -- Enable CDC for our specific table.
+//!     > CREATE TABLE t1 (a int);
+//!     > EXEC sys.sp_cdc_enable_table
+//!       @source_schema = 'dbo',
+//!       @source_name = 't1',
+//!       @role_name = NULL,
+//!       @capture_instance = 'materialize_t1';
+//!     ```
+//!   4. Watch CDC events come streaming in as you change the table!
+
+use futures::StreamExt;
+use mz_sql_server_util::Client;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let mut config = tiberius::Config::new();
+    config.host("localhost");
+    config.port(1433);
+    config.database("materialize");
+    config.authentication(tiberius::AuthMethod::sql_server("SA", "password123?"));
+    config.trust_cert();
+
+    let (mut client, connection) = Client::connect(config).await?;
+    mz_ore::task::spawn(|| "sql-server connection", async move { connection.await });
+    tracing::info!("connection successful!");
+
+    let changes = client.cdc("materialize_t1").into_stream();
+    let mut changes = std::pin::pin!(changes);
+
+    while let Some(change) = changes.next().await {
+        let change = change?;
+        tracing::info!("event: {change:?}");
+    }
+
+    Ok(())
+}

--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -91,7 +91,7 @@ impl<'a> CdcStream<'a> {
                     )
                     .await?;
 
-                    // TODO(sql_server3): For very large changes it feels bad collecting
+                    // TODO(sql_server1): For very large changes it feels bad collecting
                     // them all in memory, it would be best if we streamed them to the
                     // caller.
 
@@ -319,7 +319,7 @@ impl Operation {
             })?;
 
         let lsn = Lsn::try_from(lsn).map_err(|msg| SqlServerError::InvalidData {
-            column_name: "lsn".to_string(),
+            column_name: START_LSN_COLUMN.to_string(),
             error: msg,
         })?;
         let operation = match operation {
@@ -329,7 +329,7 @@ impl Operation {
             4 => Operation::UpdateNew(data),
             other => {
                 return Err(SqlServerError::InvalidData {
-                    column_name: "operation".to_string(),
+                    column_name: OPERATION_COLUMN.to_string(),
                     error: format!("unrecognized operation {other}"),
                 });
             }

--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -1,0 +1,365 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use derivative::Derivative;
+use futures::Stream;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+use crate::{Client, SqlServerError};
+
+/// A stream of changes from a table in SQL Server that has CDC enabled.
+///
+/// SQL Server does not have an API to push or notify consumers of changes, so we periodically
+/// poll the upstream source.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-tables/change-data-capture-tables-transact-sql?view=sql-server-ver16>
+pub struct CdcStream<'a> {
+    /// Client we use for querying SQL Server.
+    client: &'a mut Client,
+    /// Upstream capture instance we'll list changes from.
+    capture_instance: Arc<str>,
+    /// How often we poll the upstream for changes.
+    poll_interval: Duration,
+    /// The log sequence number we start streaming changes from.
+    start_lsn: Option<Lsn>,
+}
+
+impl<'a> CdcStream<'a> {
+    pub(crate) fn new(client: &'a mut Client, capture_instance: Arc<str>) -> Self {
+        CdcStream {
+            client,
+            capture_instance,
+            poll_interval: Duration::from_secs(1),
+            start_lsn: None,
+        }
+    }
+
+    /// Set the [`Lsn`] that we should start streaming changes from.
+    ///
+    /// If the provided [`Lsn`] is not available, the stream will return an error
+    /// when first polled.
+    pub fn start_lsn(mut self, lsn: Lsn) -> Self {
+        self.start_lsn = Some(lsn);
+        self
+    }
+
+    /// The cadence at which we'll poll the upstream SQL Server database for changes.
+    ///
+    /// Default is 1 second.
+    pub fn poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Consume `self` returning a [`Stream`] of [`CdcEvent`]s.
+    pub fn into_stream(mut self) -> impl Stream<Item = Result<CdcEvent, SqlServerError>> + use<'a> {
+        async_stream::try_stream! {
+            // Determine the LSN to start streaming from.
+            let mut curr_lsn = self.determine_start_lsn().await?;
+
+            loop {
+                // Measure the tick before we do any operation so the time it takes
+                // to query SQL Server is included in the time that we wait.
+                let next_tick = tokio::time::Instant::now()
+                    .checked_add(self.poll_interval)
+                    .expect("tick interval overflowed!");
+
+                // Get the max LSN for the DB.
+                let new_lsn = crate::inspect::get_max_lsn(self.client).await?;
+                tracing::debug!(?new_lsn, ?curr_lsn, "got max LSN");
+
+                // If the LSN has increased then get all of our changes.
+                if new_lsn > curr_lsn {
+                    let changes = crate::inspect::get_changes(
+                        self.client,
+                        &*self.capture_instance,
+                        curr_lsn,
+                        new_lsn,
+                        RowFilterOption::AllUpdateOld,
+                    )
+                    .await?;
+
+                    // TODO(sql_server3): For very large changes it feels bad collecting
+                    // them all in memory, it would be best if we streamed them to the
+                    // caller.
+
+                    let mut events: BTreeMap<Lsn, Vec<Operation>> = BTreeMap::default();
+                    for change in changes {
+                        let (lsn, operation) = Operation::try_parse(change)?;
+                        // Group all the operations by their LSN.
+                        events.entry(lsn).or_default().push(operation);
+                    }
+
+                    for (lsn, changes) in events {
+                        // TODO(sql_server1): Handle these events and notify the upstream
+                        // that we can cleanup this LSN.
+                        let capture_instance = Arc::clone(&self.capture_instance);
+                        let mark_complete = Box::new(move || {
+                            let _capture_isntance = capture_instance;
+                            let _completed_lsn = lsn;
+                        });
+
+                        yield CdcEvent { lsn, changes, mark_complete }
+                    }
+
+                    // Increment our LSN (`get_changes` is inclusive).
+                    let next_lsn = crate::inspect::increment_lsn(self.client, new_lsn).await?;
+                    tracing::debug!(?curr_lsn, ?next_lsn, "incrementing LSN");
+                    curr_lsn = next_lsn;
+                }
+
+                tokio::time::sleep_until(next_tick).await;
+            }
+        }
+    }
+
+    /// Determine the [`Lsn`] to start streaming changes from.
+    async fn determine_start_lsn(&mut self) -> Result<Lsn, SqlServerError> {
+        match self.start_lsn {
+            Some(start_lsn) => {
+                let min_lsn =
+                    crate::inspect::get_min_lsn(self.client, &*self.capture_instance).await?;
+
+                if start_lsn < min_lsn {
+                    // The requested start_lsn is not available!
+                    Err(CdcError::LsnNotAvailable {
+                        requested: start_lsn,
+                        minimum: min_lsn,
+                    }
+                    .into())
+                } else {
+                    Ok(start_lsn)
+                }
+            }
+            // If no start_lsn is provided, then begin streaming from the most recent changes.
+            None => {
+                let max_lsn = crate::inspect::get_max_lsn(self.client).await?;
+                Ok(max_lsn)
+            }
+        }
+    }
+}
+
+/// A change event from a [`CdcStream`].
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct CdcEvent {
+    /// The LSN that this change occurred at.
+    pub lsn: Lsn,
+    /// The change itself.
+    pub changes: Vec<Operation>,
+    /// When called marks `lsn` as complete allowing the upstream DB to clean up the record.
+    #[derivative(Debug = "ignore")]
+    pub mark_complete: Box<dyn FnOnce() + Send + Sync>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CdcError {
+    #[error("the requested LSN '{requested:?}' is less then the minimum '{minimum:?}'")]
+    LsnNotAvailable { requested: Lsn, minimum: Lsn },
+    #[error("failed to get the required column '{column_name}': {error}")]
+    RequiredColumn {
+        column_name: &'static str,
+        error: String,
+    },
+}
+
+/// This type is used to represent the progress of each SQL Server instance in
+/// the ingestion dataflow.
+///
+/// A SQL Server LSN is essentially an opaque binary blob that provides a
+/// __total order__ to all transations within a database. Technically though an
+/// LSN has three components:
+///
+/// 1. A Virtual Log File (VLF) sequence number, bytes [0, 4)
+/// 2. Log block number, bytes [4, 8)
+/// 3. Log record number, bytes [8, 10)
+///
+/// To increment an LSN you need to call the [`sys.fn_cdc_increment_lsn`] T-SQL
+/// function.
+///
+/// [`sys.fn_cdc_increment_lsn`](https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-cdc-increment-lsn-transact-sql?view=sql-server-ver16)
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Arbitrary)]
+pub struct Lsn([u8; 10]);
+
+impl Lsn {
+    /// Return the underlying byte slice for this [`Lsn`].
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Returns `self` as a [`StructuredLsn`].
+    pub fn as_structured(&self) -> StructuredLsn {
+        let vlf_id: [u8; 4] = self.0[0..4].try_into().expect("known good length");
+        let block_id: [u8; 4] = self.0[4..8].try_into().expect("known good length");
+        let record_id: [u8; 2] = self.0[8..].try_into().expect("known good length");
+
+        StructuredLsn {
+            vlf_id: u32::from_be_bytes(vlf_id),
+            block_id: u32::from_be_bytes(block_id),
+            record_id: u16::from_be_bytes(record_id),
+        }
+    }
+}
+
+impl Ord for Lsn {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_structured().cmp(&other.as_structured())
+    }
+}
+
+impl PartialOrd for Lsn {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl TryFrom<&[u8]> for Lsn {
+    type Error = String;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let value: [u8; 10] = value
+            .try_into()
+            .map_err(|_| format!("incorrect length, expected 10 got {}", value.len()))?;
+        Ok(Lsn(value))
+    }
+}
+
+/// Structured format of an [`Lsn`].
+///
+/// Note: The derived impl of [`PartialOrd`] and [`Ord`] relies on the field
+/// ordering so do not change it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StructuredLsn {
+    vlf_id: u32,
+    block_id: u32,
+    record_id: u16,
+}
+
+/// When querying CDC functions like `cdc.fn_cdc_get_all_changes_<capture_instance>` this governs
+/// what content is returned.
+///
+/// Note: There exists another option `All` that exclude the _before_ value from an `UPDATE`. We
+/// don't support this for SQL Server sources yet, so it's not included in this enum.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/cdc-fn-cdc-get-all-changes-capture-instance-transact-sql?view=sql-server-ver16#row_filter_option>
+#[derive(Debug, Copy, Clone)]
+pub enum RowFilterOption {
+    /// Includes both the before and after values of a row when changed because of an `UPDATE`.
+    AllUpdateOld,
+}
+
+impl RowFilterOption {
+    /// Returns this option formatted in a way that can be used in a query.
+    pub fn to_sql_string(&self) -> &'static str {
+        match self {
+            RowFilterOption::AllUpdateOld => "all update old",
+        }
+    }
+}
+
+impl fmt::Display for RowFilterOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_sql_string())
+    }
+}
+
+/// Identifies what change was made to the SQL Server table tracked by CDC.
+#[derive(Debug)]
+pub enum Operation {
+    /// Row was `INSERT`-ed.
+    Insert(tiberius::Row),
+    /// Row was `DELETE`-ed.
+    Delete(tiberius::Row),
+    /// Original value of the row when `UPDATE`-ed.
+    UpdateOld(tiberius::Row),
+    /// New value of the row when `UPDATE`-ed.
+    UpdateNew(tiberius::Row),
+}
+
+impl Operation {
+    /// Parse the provided [`tiberius::Row`] to determine what [`Operation`] occurred.
+    ///
+    /// See <https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/cdc-fn-cdc-get-all-changes-capture-instance-transact-sql?view=sql-server-ver16#table-returned>.
+    fn try_parse(data: tiberius::Row) -> Result<(Lsn, Self), SqlServerError> {
+        static START_LSN_COLUMN: &str = "__$start_lsn";
+        static OPERATION_COLUMN: &str = "__$operation";
+
+        let lsn: &[u8] = data
+            .try_get(START_LSN_COLUMN)
+            .map_err(|e| CdcError::RequiredColumn {
+                column_name: START_LSN_COLUMN,
+                error: e.to_string(),
+            })?
+            .ok_or_else(|| CdcError::RequiredColumn {
+                column_name: START_LSN_COLUMN,
+                error: "got null value".to_string(),
+            })?;
+        let operation: i32 = data
+            .try_get(OPERATION_COLUMN)
+            .map_err(|e| CdcError::RequiredColumn {
+                column_name: OPERATION_COLUMN,
+                error: e.to_string(),
+            })?
+            .ok_or_else(|| CdcError::RequiredColumn {
+                column_name: OPERATION_COLUMN,
+                error: "got null value".to_string(),
+            })?;
+
+        let lsn = Lsn::try_from(lsn).map_err(|msg| SqlServerError::InvalidData {
+            column_name: "lsn".to_string(),
+            error: msg,
+        })?;
+        let operation = match operation {
+            1 => Operation::Delete(data),
+            2 => Operation::Insert(data),
+            3 => Operation::UpdateOld(data),
+            4 => Operation::UpdateNew(data),
+            other => {
+                return Err(SqlServerError::InvalidData {
+                    column_name: "operation".to_string(),
+                    error: format!("unrecognized operation {other}"),
+                });
+            }
+        };
+
+        Ok((lsn, operation))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Lsn;
+
+    #[mz_ore::test]
+    fn smoketest_lsn_ordering() {
+        let a = hex::decode("0000003D000019B80004").unwrap();
+        let a = Lsn::try_from(&a[..]).unwrap();
+
+        let b = hex::decode("0000003D000019F00011").unwrap();
+        let b = Lsn::try_from(&b[..]).unwrap();
+
+        let c = hex::decode("0000003D00001A500003").unwrap();
+        let c = Lsn::try_from(&c[..]).unwrap();
+
+        assert!(a < b);
+        assert!(b < c);
+        assert!(a < c);
+
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert_eq!(c, c);
+    }
+}

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -1,0 +1,101 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Useful queries to inspect the state of a SQL Server instance.
+
+use smallvec::SmallVec;
+
+use crate::cdc::{Lsn, RowFilterOption};
+use crate::{Client, SqlServerError};
+
+/// Returns the minimum log sequence number for the specified `capture_instance`.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-cdc-get-min-lsn-transact-sql?view=sql-server-ver16>
+pub async fn get_min_lsn(
+    client: &mut Client,
+    capture_instance: &str,
+) -> Result<Lsn, SqlServerError> {
+    static MIN_LSN_QUERY: &str = "SELECT sys.fn_cdc_get_min_lsn(@P1);";
+    let result = client.query(MIN_LSN_QUERY, &[&capture_instance]).await?;
+
+    mz_ore::soft_assert_eq_or_log!(result.len(), 1);
+    parse_lsn(&result[..1])
+}
+
+/// Returns the maximum log sequence number for the entire database.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-cdc-get-max-lsn-transact-sql?view=sql-server-ver16>
+pub async fn get_max_lsn(client: &mut Client) -> Result<Lsn, SqlServerError> {
+    static MAX_LSN_QUERY: &str = "SELECT sys.fn_cdc_get_max_lsn();";
+    let result = client.simple_query(MAX_LSN_QUERY).await?;
+
+    mz_ore::soft_assert_eq_or_log!(result.len(), 1);
+    parse_lsn(&result[..1])
+}
+
+/// Increments the log sequence number.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-cdc-increment-lsn-transact-sql?view=sql-server-ver16>
+pub async fn increment_lsn(client: &mut Client, lsn: Lsn) -> Result<Lsn, SqlServerError> {
+    static INCREMENT_LSN_QUERY: &str = "SELECT sys.fn_cdc_increment_lsn(@P1);";
+    let result = client
+        .query(INCREMENT_LSN_QUERY, &[&lsn.as_bytes()])
+        .await?;
+
+    mz_ore::soft_assert_eq_or_log!(result.len(), 1);
+    parse_lsn(&result[..1])
+}
+
+/// Parse an [`Lsn`] from the first column of the provided [`tiberius::Row`].
+///
+/// Returns an error if the provided slice doesn't have exactly one row.
+fn parse_lsn(result: &[tiberius::Row]) -> Result<Lsn, SqlServerError> {
+    match result {
+        [row] => {
+            let val = row
+                .try_get::<&[u8], _>(0)?
+                .ok_or_else(|| SqlServerError::InvalidData {
+                    column_name: "lsn".to_string(),
+                    error: "expected LSN at column 0, but found Null".to_string(),
+                })?;
+            let lsn = Lsn::try_from(val).map_err(|msg| SqlServerError::InvalidData {
+                column_name: "lsn".to_string(),
+                error: msg,
+            })?;
+
+            Ok(lsn)
+        }
+        other => Err(SqlServerError::InvalidData {
+            column_name: "lsn".to_string(),
+            error: format!("expected 1 column, got {other:?}"),
+        }),
+    }
+}
+
+/// Queries the specified capture instance and returns all changes from `start_lsn` to `end_lsn`.
+///
+/// TODO(sql_server1): This presents an opportunity for SQL injection. We should create a stored
+/// procedure using `QUOTENAME` to sanitize the input for the capture instance provided by the
+/// user.
+pub async fn get_changes(
+    client: &mut Client,
+    capture_instance: &str,
+    start_lsn: Lsn,
+    end_lsn: Lsn,
+    filter: RowFilterOption,
+) -> Result<SmallVec<[tiberius::Row; 1]>, SqlServerError> {
+    let query = format!(
+        "SELECT * FROM cdc.fn_cdc_get_all_changes_{capture_instance}(@P1, @P2, N'{filter}');"
+    );
+    let results = client
+        .query(&query, &[&start_lsn.as_bytes(), &end_lsn.as_bytes()])
+        .await?;
+
+    Ok(results)
+}


### PR DESCRIPTION
This PR adds a new `mz_sql_server_util::cdc` module that provides helpers to easily capture a stream of change events from a specific SQL Server "capture instance".

`mz_sql_server_util::Client` grows a new `fn cdc(capture_instance) -> CdcStream` method, where `CdcStream` can be turned into a `futures::Stream` that essentially returns `(Lsn, Vec<Changes>)` pairs. We use the well documented SQL Server CDC methods, all of the actual queries are in `mz_sql_server_util::inspect` module. SQL Server doesn't have a notification API so we poll the upstream for changes at a defined interval (default is 1 second).

Also included is an example! In `sql-server-util/examples/cdc.rs` you can see how these new types are intended to be used.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
