### PR TITLE
Simplify regexp replace handling

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -471,12 +471,6 @@ message ProtoBinaryFunc {
     mz_repr.adt.regex.ProtoRegex regex = 1;
     uint64 limit = 2;
   }
-  message ProtoRegexpReplaceResult {
-    oneof result {
-      ProtoRegexpReplace ok = 1;
-      ProtoEvalError err = 2;
-    }
-  }
 
   reserved 93; // timezone_time
   reserved 108; // map_get_values
@@ -671,7 +665,7 @@ message ProtoBinaryFunc {
     google.protobuf.Empty constant_time_eq_bytes = 189;
     google.protobuf.Empty timezone_offset = 190;
     google.protobuf.Empty pretty_sql = 191;
-    ProtoRegexpReplaceResult regexp_replace = 192;
+    ProtoRegexpReplace regexp_replace = 192;
     bool list_contains_list = 193;
     bool array_contains_array = 194;
     google.protobuf.Empty starts_with = 195;

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -734,11 +734,8 @@ EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
 SELECT s, regexp_replace(s, 'b(..', replacement, 'ig') FROM e;
 ----
 Explained Query:
-  Project (#0{s}, #3)
-    Map (regexp_replace[EvalError]: invalid regular expression: regex parse error:
-    b(..
-     ^
-error: unclosed group(#0{s}, #2{replacement}))
+  Map (error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group"))
+    Project (#0{s})
       ReadStorage materialize.public.e
 
 Source materialize.public.e

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -717,6 +717,11 @@ Target cluster: multiprocess
 
 EOF
 
+query T
+SELECT regexp_replace(null, 'b(..', 'X', 'ig');
+----
+NULL
+
 query error invalid regular expression: regex parse error:
 SELECT regexp_replace('foobarbaz', 'b(..', 'X', 'ig');
 
@@ -734,8 +739,8 @@ EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
 SELECT s, regexp_replace(s, 'b(..', replacement, 'ig') FROM e;
 ----
 Explained Query:
-  Map (error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group"))
-    Project (#0{s})
+  Project (#0{s}, #3)
+    Map (case when (#0{s}) IS NULL then null else error("invalid regular expression: regex parse error:\n    b(..\n     ^\nerror: unclosed group") end)
       ReadStorage materialize.public.e
 
 Source materialize.public.e


### PR DESCRIPTION
Simplify regexp replace handling by using a literal error

Instead of encapsulating a result, replace the function call by a literal error. The hope is that this is semantically equivalent to the existing implementation.

Part of MaterializeInc/database-issues#9138


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
