### PR TITLE
[sql_server]: Refactor `Client` and add `CdcStream::snapshot` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7077,6 +7077,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tiberius",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic-build",
  "tracing",

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -33,6 +33,7 @@ tiberius = { version = "0.12", features = [
     "tds73",
 ], default-features = false }
 tokio = { version = "1.44.1", features = ["net"] }
+tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.4", features = ["compat"] }
 tracing = "0.1.37"
 uuid = "1.16.0"

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -108,7 +108,7 @@ pub async fn get_table_for_capture_instance(
     capture_instance: &str,
 ) -> Result<(Arc<str>, Arc<str>), SqlServerError> {
     static TABLE_FOR_CAPTURE_INSTANCE_QUERY: &str = "
-SELECT SCHEMA_NAME(o.schema_id) as schema_name, o.name as obj_name
+SELECT SCHEMA_NAME(o.schema_id) as schema_name, o.name as table_name
 FROM sys.objects o
 JOIN cdc.change_tables c
 ON o.object_id = c.source_object_id
@@ -123,8 +123,8 @@ WHERE c.capture_instance = @P1;
             let schema_name: &str = row.try_get("schema_name")?.ok_or_else(|| {
                 SqlServerError::ProgrammingError("missing column 'schema_name'".to_string())
             })?;
-            let table_name: &str = row.try_get("obj_name")?.ok_or_else(|| {
-                SqlServerError::ProgrammingError("missing column 'schema_name'".to_string())
+            let table_name: &str = row.try_get("table_name")?.ok_or_else(|| {
+                SqlServerError::ProgrammingError("missing column 'table_name'".to_string())
             })?;
 
             Ok((schema_name.into(), table_name.into()))


### PR DESCRIPTION
This PR does a few things:

1. Refactors `mz_sql_server_util::Client` to use `SqlServerError` everywhere instead of `anyhow::Error` and refactors transaction support to work better.
2. Adds a `Client::query_streaming(...)` method that returns a `Stream<Row>` instead of `SmallVec<Row>`
3. Adds a `CdcStream::snapshot` method so we can snapshot and then subscribe to a list of changes for a given table.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Tips for reviewer

Each of these changes are made in separate commits, it might be nice to review the commits independently

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
