### PR TITLE
Turn jsonb stringify functions into separate functions

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -55,6 +55,8 @@ breaking:
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
+    # reason: Ignore because plans are currently not persisted.
+    - expr/src/scalar.proto
     # reason: we very carefully evolve these protobuf definitions
     - persist-client/src/internal/state.proto
     # reason: does currently not require backward-compatibility

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -38,7 +38,7 @@ build-scalar
 case when (#0 > -2) then substr(#1, 1, 4) else "hello" end
 
 build-scalar
-(call_binary (jsonb_get_string true) #2 ("field1" string))
+(call_binary (jsonb_get_string_stringify) #2 ("field1" string))
 ----
 (#2 ->> "field1")
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -9,6 +9,8 @@
 
 // See https://developers.google.com/protocol-buffers for what's going on here.
 
+// buf breaking: ignore (Ignore because plans are currently not persisted.)
+
 syntax = "proto3";
 
 package mz_expr.scalar;
@@ -574,9 +576,12 @@ message ProtoBinaryFunc {
     google.protobuf.Empty timezone_interval_timestamp_tz = 95;
     google.protobuf.Empty timezone_interval_time = 96;
     google.protobuf.Empty text_concat = 97;
-    bool jsonb_get_int64 = 98;
-    bool jsonb_get_string = 99;
-    bool jsonb_get_path = 100;
+    google.protobuf.Empty jsonb_get_int64 = 98;
+    google.protobuf.Empty jsonb_get_int64_stringify = 197;
+    google.protobuf.Empty jsonb_get_string = 99;
+    google.protobuf.Empty jsonb_get_string_stringify = 198;
+    google.protobuf.Empty jsonb_get_path = 100;
+    google.protobuf.Empty jsonb_get_path_stringify = 199;
     google.protobuf.Empty jsonb_contains_string = 101;
     google.protobuf.Empty jsonb_concat = 102;
     google.protobuf.Empty jsonb_contains_jsonb = 103;

--- a/src/expr/tests/testdata/interpret
+++ b/src/expr/tests/testdata/interpret
@@ -58,7 +58,7 @@ interpret
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
-(call_binary (jsonb_get_string false) #0 ("created_ms" string))
+(call_binary (jsonb_get_string) #0 ("created_ms" string))
 [(0 numeric) (2050 numeric) (4000 numeric) null]
 ----
 may contain: [2050]
@@ -70,7 +70,7 @@ interpret
 [
   [("{\"code\": \"00135\"}" jsonb) ("{\"code\": \"22122\"}" jsonb) ("{\"code\": \"34153\"}" jsonb)]
 ]
-(call_binary (jsonb_get_string true) #0 ("code" string))
+(call_binary (jsonb_get_string_stringify) #0 ("code" string))
 ["00000" "20000" "2" "80000" null]
 ----
 may contain: ["20000" "2"]
@@ -82,7 +82,7 @@ interpret
 [
   [("{\"created_ms\": 1000}" jsonb) ("{\"created_ms\": 2000}" jsonb) ("{\"created_ms\": 3000}" jsonb)]
 ]
-(call_binary (jsonb_get_string true) #0 ("created_ms" string))
+(call_binary (jsonb_get_string_stringify) #0 ("created_ms" string))
 ["00000" "20000" "2" "80000" null]
 ----
 may contain: ["00000" "20000" "2" "80000"]
@@ -94,7 +94,7 @@ interpret
 [
   [null null null]
 ]
-(call_binary (jsonb_get_string false) #0 ("created_ms" string))
+(call_binary (jsonb_get_string) #0 ("created_ms" string))
 ["00000" "foo" null true]
 ----
 may contain: [null]

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -50,7 +50,7 @@ false
 
 reduce
 (call_unary is_null
-    (call_binary (jsonb_get_int64 false) #1 #0))
+    (call_binary (jsonb_get_int64) #1 #0))
 [(jsonb false) (int64 false)]
 ----
 ((#1 -> #0)) IS NULL

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4765,19 +4765,19 @@ pub static OP_IMPLS: LazyLock<BTreeMap<&'static str, Func>> = LazyLock::new(|| {
 
         // JSON, MAP, RANGE, LIST, ARRAY
         "->" => Scalar {
-            params!(Jsonb, Int64) => JsonbGetInt64 { stringify: false } => Jsonb, 3212;
-            params!(Jsonb, String) => JsonbGetString { stringify: false } => Jsonb, 3211;
+            params!(Jsonb, Int64) => JsonbGetInt64 => Jsonb, 3212;
+            params!(Jsonb, String) => JsonbGetString => Jsonb, 3211;
             params!(MapAny, String) => MapGetValue => Any, oid::OP_GET_VALUE_MAP_OID;
         },
         "->>" => Scalar {
-            params!(Jsonb, Int64) => JsonbGetInt64 { stringify: true } => String, 3481;
-            params!(Jsonb, String) => JsonbGetString { stringify: true } => String, 3477;
+            params!(Jsonb, Int64) => JsonbGetInt64Stringify => String, 3481;
+            params!(Jsonb, String) => JsonbGetStringStringify => String, 3477;
         },
         "#>" => Scalar {
-            params!(Jsonb, ScalarType::Array(Box::new(ScalarType::String))) => JsonbGetPath { stringify: false } => Jsonb, 3213;
+            params!(Jsonb, ScalarType::Array(Box::new(ScalarType::String))) => JsonbGetPath => Jsonb, 3213;
         },
         "#>>" => Scalar {
-            params!(Jsonb, ScalarType::Array(Box::new(ScalarType::String))) => JsonbGetPath { stringify: true } => String, 3206;
+            params!(Jsonb, ScalarType::Array(Box::new(ScalarType::String))) => JsonbGetPathStringify => String, 3206;
         },
         "@>" => Scalar {
             params!(Jsonb, Jsonb) => JsonbContainsJsonb => Bool, 3246;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4374,7 +4374,7 @@ fn plan_subscript_jsonb(
             },
             exprs,
         },
-        BinaryFunc::JsonbGetPath { stringify: false },
+        BinaryFunc::JsonbGetPath,
     );
     Ok(expr.into())
 }

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -984,8 +984,8 @@ Arrange␠export␠iterative  2
 Arrange␠export␠iterative␠err  2
 Arrange␠recursive␠err  3
 ArrangeAccumulable␠[val:␠empty]  10
-ArrangeBy[[CallBinary␠{␠func:␠JsonbGetString␠{␠stringify:␠true␠},␠expr1:␠Column(1),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  2
-ArrangeBy[[CallBinary␠{␠func:␠JsonbGetString␠{␠stringify:␠true␠},␠expr1:␠Column(2),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  1
+ArrangeBy[[CallBinary␠{␠func:␠JsonbGetStringStringify,␠expr1:␠Column(1),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  2
+ArrangeBy[[CallBinary␠{␠func:␠JsonbGetStringStringify,␠expr1:␠Column(2),␠expr2:␠Literal(Ok(Row{[String("id")]}),␠ColumnType␠{␠scalar_type:␠String,␠nullable:␠false␠})␠}]]  1
 ArrangeBy[[CallVariadic␠{␠func:␠Coalesce,␠exprs:␠[Column(2),␠Column(3)]␠}]]  2
 ArrangeBy[[Column(0),␠CallUnary␠{␠func:␠CastInt32ToNumeric(CastInt32ToNumeric(None)),␠expr:␠Column(1)␠}]]  1
 ArrangeBy[[Column(0),␠CallUnary␠{␠func:␠CastUint64ToNumeric(CastUint64ToNumeric(None)),␠expr:␠Column(2)␠}]]  1


### PR DESCRIPTION
Some of the jsonb functions can be used in contexts where the output is either jsonb or strings. Previously, we'd encode this as part of the function call by supplying a `bool` field. This is an abstraction leak and instead it would be better to have separate functions.

This change absorbs the `stringify` parameter into different functions. No behavior change expected.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
