### PR TITLE
doc: Adjust cluster size in Postgres source guide

### DIFF
--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -11,7 +11,7 @@ accordingly.
     ```
 
     Behind the scenes, this command adds a new `100cc` replica and removes the
-    `200cc` replica.
+    `50cc` replica.
 
 1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to
    check the status of the new replica:


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
The Postgres source guide initially suggests a `50cc` size but later on talks about a `200cc` which is not mentioned in the doc.