### PR TITLE
docs: aws terraform supports tls

### DIFF
--- a/doc/user/content/installation/operational-guidelines.md
+++ b/doc/user/content/installation/operational-guidelines.md
@@ -23,6 +23,12 @@ It is strongly recommended to enable the Kubernetes `static` [CPU management pol
 This ensures that each worker thread of Materialize is given exclusively access to a vCPU. Our benchmarks have shown this
 to substantially improve the performance of compute-bound workloads.
 
+## TLS
+
+The sample deployment uses a self-signed ClusterIssuer for demonstration
+purposes. In production, run with certificates from an official Certificate
+Authority (CA) rather than self-signed certificates.
+
 ## Locally-attached NVMe storage
 
 For optimal performance, Materialize requires fast, locally-attached NVMe

--- a/doc/user/data/self_managed/aws_terraform_deployed_components.yml
+++ b/doc/user/data/self_managed/aws_terraform_deployed_components.yml
@@ -1,0 +1,34 @@
+columns:
+  - column: "Component"
+  - column: "Version"
+
+rows:
+  - Component: "Kubernetes (EKS) cluster"
+    Version: "All"
+  - Component: "Dedicated VPC"
+    Version: "All"
+  - Component: "S3 for blob storage"
+    Version: "All"
+  - Component: "RDS PostgreSQL cluster and database"
+    Version: "All"
+  - Component: "Materialize Operator"
+    Version: "All"
+  - Component: |
+      Materialize instances (Deployed during subsequent runs after the Operator is running)
+    Version: "All"
+  - Component: |
+      AWS Load Balancer Controller and Network Load Balancers for each
+      Materialize instance
+    Version: |
+      [v0.3.0+](/installation/appendix-terraforms/#materialize-on-aws-terraform-modules)
+  - Component: |
+      OpenEBS and NVMe instance storage to enable spill-to-disk
+    Version: |
+      [v0.3.1+](/installation/appendix-terraforms/#materialize-on-aws-terraform-modules)
+  - Component: |
+      `cert-manager` and a self-signed `ClusterIssuer`.
+      `ClusterIssuer` is
+      deployed on subsequent runs after the `cert-manager` is running.
+    Version: |
+      [v0.4.0+](/installation/appendix-terraforms/#materialize-on-aws-terraform-modules)
+

--- a/doc/user/data/self_managed/aws_terraform_versions.yml
+++ b/doc/user/data/self_managed/aws_terraform_versions.yml
@@ -4,6 +4,11 @@ columns:
 
 rows:
 - "Terraform version": |
+    [v0.3.2](https://github.com/MaterializeInc/terraform-aws-materialize/releases/)
+  "Notable changes": |
+    Adds optional TLS support using [`cert-manager`](https://cert-manager.io/docs/) and a self-signed [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/).
+
+- "Terraform version": |
     [v0.3.1](https://github.com/MaterializeInc/terraform-aws-materialize/releases/tag/v0.3.1)
   "Notable changes": |
     By default, deploys OpenEBS and NVMe instance storage to [enable spill-to-disk](https://github.com/MaterializeInc/terraform-aws-materialize?tab=readme-ov-file#enabling-disk-support).

--- a/doc/user/data/self_managed/aws_terraform_versions.yml
+++ b/doc/user/data/self_managed/aws_terraform_versions.yml
@@ -4,9 +4,11 @@ columns:
 
 rows:
 - "Terraform version": |
-    [v0.3.2](https://github.com/MaterializeInc/terraform-aws-materialize/releases/)
+    [v0.4.0](https://github.com/MaterializeInc/terraform-aws-materialize/releases/tag/v0.4.0)
   "Notable changes": |
-    Adds optional TLS support using [`cert-manager`](https://cert-manager.io/docs/) and a self-signed [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/).
+    By default, deploys
+    [`cert-manager`](https://cert-manager.io/docs/) and a self-signed
+    [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/).
 
 - "Terraform version": |
     [v0.3.1](https://github.com/MaterializeInc/terraform-aws-materialize/releases/tag/v0.3.1)

--- a/doc/user/layouts/shortcodes/self-managed/port-forwarding-handling.html
+++ b/doc/user/layouts/shortcodes/self-managed/port-forwarding-handling.html
@@ -6,7 +6,7 @@
    echo $MZ_SVC_CONSOLE
    ```
 
-2. Port forward the Materialize Console service to your local machine:[^1]
+1. Port forward the Materialize Console service to your local machine:[^1]
 
    ```shell
    (
@@ -22,8 +22,7 @@
    <br>- To bring back to foreground, use `fg %<job-number>`.
    <br>- To kill the background job, use `kill %<job-number>`.
 
-1. Open a browser and navigate to
-[http://localhost:8080](http://localhost:8080).
+1. Open a browser and navigate to [http://localhost:8080](http://localhost:8080).
 
 [^1]: The port forwarding command uses a while loop to handle a [known
 Kubernetes issue 78446](https://github.com/kubernetes/kubernetes/issues/78446),

--- a/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
@@ -9,18 +9,18 @@
    MY_ORGANIZATION=<enter-your-organization>
    ```
 
-1. Clone your forked repo and checkout the `v0.3.1` tag. For example,
+1. Clone your forked repo and checkout the `v0.3.2` tag. For example,
 
    - If cloning via SSH (replace `YOUR_ORGANIZATION` with your organization's
      name):
 
      ```bash
-     git clone --depth 1 -b v0.3.1 git@github.com:${MY_ORGANIZATION}/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.3.2 git@github.com:${MY_ORGANIZATION}/terraform-aws-materialize.git
      ```
 
    - If cloning via HTTPS (replace `YOUR_ORGANIZATION` with your
      organization's name):
 
      ```bash
-     git clone --depth 1 -b v0.3.1 https://github.com/${MY_ORGANIZATION}/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.3.2 https://github.com/${MY_ORGANIZATION}/terraform-aws-materialize.git
      ```

--- a/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/step-clone-aws-terraform-repo.html
@@ -1,4 +1,3 @@
-
 1. Fork the [Materialize's sample Terraform
    repo](https://github.com/MaterializeInc/terraform-aws-materialize).
 
@@ -9,18 +8,18 @@
    MY_ORGANIZATION=<enter-your-organization>
    ```
 
-1. Clone your forked repo and checkout the `v0.3.2` tag. For example,
+1. Clone your forked repo and checkout the `v0.4.0` tag. For example,
 
    - If cloning via SSH (replace `YOUR_ORGANIZATION` with your organization's
      name):
 
      ```bash
-     git clone --depth 1 -b v0.3.2 git@github.com:${MY_ORGANIZATION}/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.4.0 git@github.com:${MY_ORGANIZATION}/terraform-aws-materialize.git
      ```
 
    - If cloning via HTTPS (replace `YOUR_ORGANIZATION` with your
      organization's name):
 
      ```bash
-     git clone --depth 1 -b v0.3.2 https://github.com/${MY_ORGANIZATION}/terraform-aws-materialize.git
+     git clone --depth 1 -b v0.4.0 https://github.com/${MY_ORGANIZATION}/terraform-aws-materialize.git
      ```

--- a/doc/user/layouts/shortcodes/tab.html
+++ b/doc/user/layouts/shortcodes/tab.html
@@ -1,4 +1,4 @@
 <!-- Adapted from https://discourse.gohugo.io/t/code-tabs-widget/975/7 -->
 <div class="tab-pane" title="{{ .Get 0 }}">
-  {{ .Inner | .Page.RenderString }}
+  {{ .Inner | replaceRE "^\\s+" "" |  .Page.RenderString }}
 </div>


### PR DESCRIPTION
Converted to draft since won't merge until next Terraform version.
Oh, just saw the slack message about enabling TLS by default. Will update a patch.