### PR TITLE
Enable diff overflows in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -127,6 +127,7 @@ def get_default_system_parameters(
         "kafka_default_metadata_fetch_interval": "1s",
         "mysql_offset_known_interval": "1s",
         "force_source_table_syntax": "true" if force_source_table_syntax else "false",
+        "ore_overflowing_behavior": "panic",
         "persist_batch_columnar_format": (
             "structured" if version > MzVersion.parse_mz("v0.135.0-dev") else "both_v2"
         ),

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -863,17 +863,6 @@ def workflow_test_github_5087(c: Composition) -> None:
                   ) AS base (data2, data4, data8, diff),
                   repeat_row(diff)
               );
-              CREATE MATERIALIZED VIEW constant_wrapped_sums AS
-              SELECT SUM(data2) AS sum2, SUM(data4) AS sum4, SUM(data8) AS sum8
-              FROM (
-                  SELECT * FROM (
-                      VALUES (2::uint2, 2::uint4, 2::uint8, 9223372036854775807),
-                        (1::uint2, 1::uint4, 1::uint8, 1),
-                        (1::uint2, 1::uint4, 1::uint8, 1),
-                        (1::uint2, 1::uint4, 1::uint8, 1)
-                  ) AS base (data2, data4, data8, diff),
-                  repeat_row(diff)
-              );
             """
         )
         c.testdrive(
@@ -931,23 +920,18 @@ def workflow_test_github_5087(c: Composition) -> None:
             # Test wraparound behaviors
             > INSERT INTO base VALUES (1, 1, 1, -1);
 
-            > INSERT INTO base VALUES (2, 2, 2, 9223372036854775807);
+            >[version<14000] INSERT INTO base VALUES (2, 2, 2, 9223372036854775807);
 
-            > SELECT sum(data2) FROM data;
+            >[version<14000] SELECT sum(data2) FROM data;
             18446744073709551614
 
-            > SELECT sum(data4) FROM data;
+            >[version<14000] SELECT sum(data4) FROM data;
             18446744073709551614
 
-            > SELECT sum(data8) FROM data;
+            >[version<14000] SELECT sum(data8) FROM data;
             18446744073709551614
 
             > INSERT INTO base VALUES (1, 1, 1, 1), (1, 1, 1, 1), (1, 1, 1, 1);
-
-            # Constant-folding behavior matches for now the rendered behavior
-            # wrt. wraparound; this can be revisited as part of database-issues#5172.
-            > SELECT * FROM constant_wrapped_sums;
-            1 1 18446744073709551617
 
             # This causes a panic starting with v0.140.0, but not before.
             >[version<14000] SELECT SUM(data2) FROM data;


### PR DESCRIPTION
Follow up to #32028 to enable panics on overflow in CI.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
