### PR TITLE
[sql_server] Refactor `CdcStream` API to handle multiple "capture instances"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7069,6 +7069,7 @@ dependencies = [
  "derivative",
  "futures",
  "hex",
+ "itertools 0.12.1",
  "mz-build-tools",
  "mz-ore",
  "mz-proto",

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -18,6 +18,7 @@ dec = "0.4.8"
 derivative = "2.2.0"
 futures = "0.3.31"
 hex = "0.4.3"
+itertools = "0.12.1"
 mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -102,15 +102,14 @@ pub async fn get_changes(
     Ok(results)
 }
 
-/// Returns the `(schema_name, table_name)` for the table that is tracked by
-/// the specified `capture_instance`.
+/// Returns the `(capture_instance, schema_name, table_name)` for the tables
+/// that are tracked by the specified `capture_instance`s.
 pub async fn get_tables_for_capture_instance<'a>(
     client: &mut Client,
     capture_instances: impl IntoIterator<Item = &str>,
 ) -> Result<Vec<(Arc<str>, Arc<str>, Arc<str>)>, SqlServerError> {
     // SQL Server does not have support for array types, so we need to manually construct
     // the parameterized query.
-    // let capture_instances = capture_instances.into_iter();
     let params: SmallVec<[_; 1]> = capture_instances.into_iter().collect();
     // TODO(sql_server3): Remove this redundant collection.
     #[allow(clippy::as_conversions)]

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -9,6 +9,7 @@
 
 //! Useful queries to inspect the state of a SQL Server instance.
 
+use itertools::Itertools;
 use smallvec::SmallVec;
 use std::sync::Arc;
 
@@ -103,34 +104,59 @@ pub async fn get_changes(
 
 /// Returns the `(schema_name, table_name)` for the table that is tracked by
 /// the specified `capture_instance`.
-pub async fn get_table_for_capture_instance(
+pub async fn get_tables_for_capture_instance<'a>(
     client: &mut Client,
-    capture_instance: &str,
-) -> Result<(Arc<str>, Arc<str>), SqlServerError> {
-    static TABLE_FOR_CAPTURE_INSTANCE_QUERY: &str = "
-SELECT SCHEMA_NAME(o.schema_id) as schema_name, o.name as table_name
+    capture_instances: impl IntoIterator<Item = &str>,
+) -> Result<Vec<(Arc<str>, Arc<str>, Arc<str>)>, SqlServerError> {
+    // SQL Server does not have support for array types, so we need to manually construct
+    // the parameterized query.
+    // let capture_instances = capture_instances.into_iter();
+    let params: SmallVec<[_; 1]> = capture_instances.into_iter().collect();
+    // TODO(sql_server3): Remove this redundant collection.
+    #[allow(clippy::as_conversions)]
+    let params_dyn: SmallVec<[_; 1]> = params
+        .iter()
+        .map(|instance| instance as &dyn tiberius::ToSql)
+        .collect();
+    let param_indexes = params
+        .iter()
+        .enumerate()
+        // Params are 1-based indexed.
+        .map(|(idx, _)| format!("@P{}", idx + 1))
+        .join(", ");
+
+    let table_for_capture_instance_query = format!(
+        "
+SELECT c.capture_instance, SCHEMA_NAME(o.schema_id) as schema_name, o.name as obj_name
 FROM sys.objects o
 JOIN cdc.change_tables c
 ON o.object_id = c.source_object_id
-WHERE c.capture_instance = @P1;
-";
-    let result = client
-        .query(TABLE_FOR_CAPTURE_INSTANCE_QUERY, &[&capture_instance])
-        .await?;
+WHERE c.capture_instance IN ({param_indexes});"
+    );
 
-    match &result[..] {
-        [row] => {
+    let result = client
+        .query(&table_for_capture_instance_query, &params_dyn[..])
+        .await?;
+    let tables = result
+        .into_iter()
+        .map(|row| {
+            let capture_instance: &str = row.try_get("capture_instance")?.ok_or_else(|| {
+                SqlServerError::ProgrammingError("missing column 'capture_instance'".to_string())
+            })?;
             let schema_name: &str = row.try_get("schema_name")?.ok_or_else(|| {
                 SqlServerError::ProgrammingError("missing column 'schema_name'".to_string())
             })?;
-            let table_name: &str = row.try_get("table_name")?.ok_or_else(|| {
-                SqlServerError::ProgrammingError("missing column 'table_name'".to_string())
+            let table_name: &str = row.try_get("obj_name")?.ok_or_else(|| {
+                SqlServerError::ProgrammingError("missing column 'schema_name'".to_string())
             })?;
 
-            Ok((schema_name.into(), table_name.into()))
-        }
-        other => Err(SqlServerError::InvariantViolated(format!(
-            "expected one row found {other:?}"
-        ))),
-    }
+            Ok::<_, SqlServerError>((
+                capture_instance.into(),
+                schema_name.into(),
+                table_name.into(),
+            ))
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(tables)
 }

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -255,8 +255,16 @@ impl Client {
     /// `capture_instance`.
     ///
     /// [`CdcStream`]: crate::cdc::CdcStream
-    pub fn cdc(&mut self, capture_instance: impl Into<Arc<str>>) -> crate::cdc::CdcStream<'_> {
-        crate::cdc::CdcStream::new(self, capture_instance.into())
+    pub fn cdc<I>(&mut self, capture_instances: I) -> crate::cdc::CdcStream<'_>
+    where
+        I: IntoIterator,
+        I::Item: Into<Arc<str>>,
+    {
+        let instances = capture_instances
+            .into_iter()
+            .map(|i| (i.into(), None))
+            .collect();
+        crate::cdc::CdcStream::new(self, instances)
     }
 }
 

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -252,7 +252,7 @@ impl Client {
     }
 
     /// Return a [`CdcStream`] that can be used to track changes for the specified
-    /// `capture_instance`.
+    /// `capture_instances`.
     ///
     /// [`CdcStream`]: crate::cdc::CdcStream
     pub fn cdc<I>(&mut self, capture_instances: I) -> crate::cdc::CdcStream<'_>


### PR DESCRIPTION
This PR refactors the recently added APIs in the `mz_sql_server_util::CdcStream` type to support snapshotting and streaming changes from multiple upstream "capture instances", aka multiple upstream tables. Most of the changes here are just operating over a collection of instances as opposed to a single instance.

Note: this should be the last PR, w.r.t. interacting with SQL Server, to getting a SQL Server source working in Materialize.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Tips for reviewer

It might help to view without whitespace changes

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
