### PR TITLE
Draft: Saturating diff behavior

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -127,6 +127,7 @@ def get_default_system_parameters(
         "kafka_default_metadata_fetch_interval": "1s",
         "mysql_offset_known_interval": "1s",
         "force_source_table_syntax": "true" if force_source_table_syntax else "false",
+        "ore_overflowing_behavior": "saturate",
         "persist_batch_columnar_format": (
             "structured" if version > MzVersion.parse_mz("v0.135.0-dev") else "both_v2"
         ),

--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -323,6 +323,12 @@ impl ActiveSubscribe {
             SubscribeOutput::Diffs => rows.sort_by_key(|(time, _, _)| *time),
         }
 
+        if let Some((_, row, _)) = rows.iter().find(|(_, _, diff)| diff.is_overflown()) {
+            let err = format!("Overflow in row: {row:?}");
+            self.send(PeekResponseUnary::Error(err));
+            return true;
+        }
+
         let rows: Vec<Row> = rows
             .into_iter()
             .map(|(time, row, diff)| {

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -546,6 +546,11 @@ impl crate::coord::Coordinator {
                         format!("Negative multiplicity in constant result: {}", count).into(),
                     ))?
                 };
+                if count.is_overflown() {
+                    Err(EvalError::InvalidParameterValue(
+                        format!("Overflow in constant result: {}", count).into(),
+                    ))?
+                };
                 if count.is_positive() {
                     let count = usize::cast_from(
                         u64::try_from(count.into_inner())

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1375,6 +1375,12 @@ impl IndexPeek {
                     cursor.key(&storage),
                 ));
             }
+            if copies.is_overflown() {
+                return Err(format!(
+                    "Overflow detected for row: {}",
+                    cursor.key(&storage),
+                ));
+            }
             if copies.is_positive() {
                 return Err(cursor.key(&storage).to_string());
             }
@@ -1503,6 +1509,8 @@ impl IndexPeek {
                             -copies,
                             &*borrow,
                         ));
+                    } else if copies.is_overflown() {
+                        return Err(format!("Overflow detected for row: {:?}", &*borrow,));
                     } else {
                         copies.into_inner().try_into().unwrap()
                     };

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -1065,6 +1065,7 @@ mod write {
             let ok_updates = self.corrections.ok.updates_before(&desc.upper);
             let err_updates = self.corrections.err.updates_before(&desc.upper);
 
+            // TODO: extract invalid diffs.
             let oks = ok_updates.map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
             let errs = err_updates.map(|(d, t, r)| ((SourceData(Err(d)), ()), t, r.into_inner()));
             let mut updates = oks.chain(errs).peekable();

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1746,7 +1746,7 @@ pub trait OneByOneAggr {
     /// Pushes one input element into the aggregation.
     fn give(&mut self, d: &Datum);
     /// Returns the value of the aggregate computed on the given values so far.
-    fn get_current_aggregate<'a>(&self, temp_storage: &'a RowArena) -> Datum<'a>;
+    fn get_current_aggregate<'a>(&mut self, temp_storage: &'a RowArena) -> Datum<'a>;
 }
 
 /// Naive implementation of [OneByOneAggr], suitable for stuff like const folding, but too slow for
@@ -1776,7 +1776,7 @@ impl OneByOneAggr for NaiveOneByOneAggr {
         self.input.push(row);
     }
 
-    fn get_current_aggregate<'a>(&self, temp_storage: &'a RowArena) -> Datum<'a> {
+    fn get_current_aggregate<'a>(&mut self, temp_storage: &'a RowArena) -> Datum<'a> {
         temp_storage.make_datum(|packer| {
             packer.push(if !self.reverse {
                 self.agg

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -70,7 +70,7 @@ where
                                     let update = (
                                         t.into_owned(),
                                         v.clone(),
-                                        usize::cast_from(diff.unsigned_abs()),
+                                        usize::cast_from(diff.unsigned_abs().into_inner()),
                                     );
                                     if diff < Diff::ZERO {
                                         befores.push(update);

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -21,7 +21,6 @@ use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
-use mz_ore::Overflowing;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
@@ -1087,18 +1086,6 @@ impl<'a> From<bool> for Datum<'a> {
         } else {
             Datum::False
         }
-    }
-}
-
-// TODO: Reconsider whether we want this blanket impl or have precise control
-//   over the types.
-impl<'a, T> From<Overflowing<T>> for Datum<'a>
-where
-    Datum<'a>: From<T>,
-{
-    #[inline]
-    fn from(i: Overflowing<T>) -> Datum<'a> {
-        Datum::from(i.into_inner())
     }
 }
 

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -712,15 +712,20 @@ where
                                 // else is a logic bug we can't handle at the metric layer. We also
                                 // assume this addition doesn't overflow.
                                 match (is_value, diff.is_positive()) {
-                                    (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
+                                    (true, true) => {
+                                        builder.metrics.inserts += diff.unsigned_abs().into_inner()
+                                    }
                                     (true, false) => {
-                                        builder.metrics.retractions += diff.unsigned_abs()
+                                        builder.metrics.retractions +=
+                                            diff.unsigned_abs().into_inner()
                                     }
                                     (false, true) => {
-                                        builder.metrics.error_inserts += diff.unsigned_abs()
+                                        builder.metrics.error_inserts +=
+                                            diff.unsigned_abs().into_inner()
                                     }
                                     (false, false) => {
-                                        builder.metrics.error_retractions += diff.unsigned_abs()
+                                        builder.metrics.error_retractions +=
+                                            diff.unsigned_abs().into_inner()
                                     }
                                 }
                             }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -863,7 +863,7 @@ def workflow_test_github_5087(c: Composition) -> None:
                   ) AS base (data2, data4, data8, diff),
                   repeat_row(diff)
               );
-              CREATE MATERIALIZED VIEW constant_wrapped_sums AS
+              CREATE VIEW constant_wrapped_sums AS
               SELECT SUM(data2) AS sum2, SUM(data4) AS sum4, SUM(data8) AS sum8
               FROM (
                   SELECT * FROM (
@@ -950,15 +950,15 @@ def workflow_test_github_5087(c: Composition) -> None:
             1 1 18446744073709551617
 
             # This causes a panic starting with v0.140.0, but not before.
-            >[version<14000] SELECT SUM(data2) FROM data;
+            > SELECT SUM(data2) FROM data;
             1
 
             # This causes a panic starting with v0.140.0, but not before.
-            >[version<14000] SELECT SUM(data4) FROM data;
+            > SELECT SUM(data4) FROM data;
             1
 
             # This causes a panic starting with v0.140.0, but not before.
-            >[version<14000] SELECT SUM(data8) FROM data;
+            > SELECT SUM(data8) FROM data;
             18446744073709551617
             """
             )

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -147,16 +147,12 @@ SELECT f1+f2 FROM t1
 19999999999999999271792589930496.000
 19999999999999999271792589930496.000
 
-query T
+query error Overflow detected
 SELECT SUM(f1) FROM t1
-----
--282409603651671152154661355520.000
 
 # This *should* be zero, known issue https://github.com/MaterializeInc/database-issues/issues/4341
-query T
+query error Overflow detected
 SELECT MIN(f1+f2)-SUM(f1) FROM t1
-----
-20282409603651670423947251286016.000
 
 query error invalid input syntax
 SELECT ''::float::text


### PR DESCRIPTION
Enhance the Overflowing type to support a saturating mode. Once any operation overflows, all future operations will result in overflow, too.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
