### PR TITLE
[docs] Improve accounting of computation time

### DIFF
--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -350,20 +350,20 @@ intelligible LIR operators.
 For example, to find out how much time is spent in each operator for the `wins_by_item` index (and the underlying `winning_bids` view), run the following query:
 
 ```sql
-SELECT 
-    mo.name AS name, 
-    mo.global_id AS global_id, 
-    mlm.lir_id, 
-    mlm.parent_lir_id, 
+SELECT
+    mo.name AS name,
+    mo.global_id AS global_id,
+    mlm.lir_id,
+    mlm.parent_lir_id,
     REPEAT(' ', mlm.nesting * 2) || mlm.operator AS operator,
     ( -- Subquery to extract the duration of operators in the id range
-        SELECT SUM(elapsed_ns)/1000 * '1 microsecond'::INTERVAL 
-        FROM mz_introspection.mz_scheduling_elapsed mse 
+        SELECT SUM(elapsed_ns)/1000 * '1 microsecond'::INTERVAL
+        FROM mz_introspection.mz_scheduling_elapsed mse
         WHERE mlm.operator_id_start <= mse.id AND mse.id < mlm.operator_id_end
     ) as duration,
     ( -- Subquery to extract the invocations of operators in the id range
-        SELECT SUM(count) 
-        FROM mz_introspection.mz_compute_operator_durations_histogram mcodh 
+        SELECT SUM(count)
+        FROM mz_introspection.mz_compute_operator_durations_histogram mcodh
         WHERE mlm.operator_id_start <= mcodh.id AND mcodh.id < mlm.operator_id_end
     ) as count
     FROM mz_introspection.mz_lir_mapping mlm


### PR DESCRIPTION
Our introspection query for computation time reports an elapsed time (`duration`) that has a few flaws, deriving from the use of histograms: the numbers are off by up to 2x (due to binning), and the aggregation should scale each contribution by the `count` to tall up correctly. Instead, use independent subqueries one against `mz_scheduling_elapsed` to get precise duration information.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
