### PR TITLE
docs: replace explain plan syntax railroad diagram

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -766,17 +766,17 @@ p+p {
             a {
                 color: var(--body);
                 display: block;
-                padding: rem(0.8) rem(3.2);
-                font-size: rem(1.6);
+                padding: rem(0.8) rem(1.6);
+                font-size: rem(1.4);
                 text-decoration: none;
                 font-weight: 500;
 
                 @media(max-width: 850px) {
-                    padding: rem(0.8) rem(2.5);
+                    padding: rem(0.8) rem(1.6);
                 }
 
                 @media(max-width: 380px) {
-                    padding: rem(0.8) rem(1.5);
+                    padding: rem(0.8) rem(0.8);
                 }
 
                 &:hover {

--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -12,7 +12,7 @@ menu:
 
 |                             |                       |
 |-----------------------------|-----------------------|
-| <ul><li>`SELECT` statements </li><li>`CREATE VIEW` statements</li><li>`CREATE INDEX` statements</li><li>`CREATE MATERIALIZED VIEW` statements</li></ul>|<ul><li>Views</li><li>Indexes</li><li>Materialized views</li></ul> |
+| <ul><li>`SELECT` statements </li><li>`CREATE VIEW` statements</li><li>`CREATE INDEX` statements</li><li>`CREATE MATERIALIZED VIEW` statements</li></ul>|<ul><li>Existing views</li><li>Existing indexes</li><li>Existing materialized views</li></ul> |
 
 {{< warning >}}
 `EXPLAIN` is not part of Materialize's stable interface and is not subject to
@@ -26,7 +26,7 @@ change arbitrarily in future versions of Materialize.
 {{< tab "FOR SELECT">}}
 ```mzsql
 EXPLAIN [ [ RAW | DECORRELATED | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
-    [ WITH <output_modifier> [, <output_modifier> ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...])]
     [ AS TEXT | AS JSON ]
 FOR ]       -- The FOR keyword is required if the PLAN keyword is specified
     <SELECT ...>
@@ -37,7 +37,7 @@ FOR ]       -- The FOR keyword is required if the PLAN keyword is specified
 
 ```mzsql
 EXPLAIN <RAW | DECORRELATED | LOCALLY OPTIMIZED> PLAN
-    [ WITH output_modifier [, output_modifier ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...]) ]
     [ AS TEXT | AS JSON ]
 FOR
     <CREATE VIEW ...>
@@ -47,7 +47,7 @@ FOR
 {{< tab "FOR CREATE INDEX">}}
 ```mzsql
 EXPLAIN [ [ OPTIMIZED | PHYSICAL ] PLAN
-    [ WITH output_modifier [, output_modifier ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...]) ]
     [ AS TEXT | AS JSON ]
 FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
     <CREATE INDEX ...>
@@ -57,7 +57,7 @@ FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
 {{< tab "FOR CREATE MATERIALIZED VIEW">}}
 ```mzsql
 EXPLAIN [ [ RAW | DECORRELATED | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
-    [ WITH <output_modifier [, output_modifier ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...])]
     [ AS TEXT | AS JSON ]
 FOR ]          -- The FOR keyword is required if the PLAN keyword is specified
     <CREATE MATERIALIZED VIEW ...>
@@ -67,7 +67,7 @@ FOR ]          -- The FOR keyword is required if the PLAN keyword is specified
 {{< tab "FOR VIEW">}}
 ```mzsql
 EXPLAIN <RAW | LOCALLY OPTIMIZED> PLAN
-    [ WITH output_modifier [, output_modifier ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...])]
     [ AS TEXT | AS JSON ]
 FOR
   VIEW <name>
@@ -77,7 +77,7 @@ FOR
 {{< tab "FOR INDEX">}}
 ```mzsql
 EXPLAIN [ [ OPTIMIZED | PHYSICAL ] PLAN
-      [ WITH output_modifier [, output_modifier ...] ]
+      [ WITH (<output_modifier> [, <output_modifier> ...]) ]
       [ AS TEXT | AS JSON ]
 FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
   INDEX <name>
@@ -87,7 +87,7 @@ FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
 {{< tab "FOR MATERIALIZED VIEW">}}
 ```mzsql
 EXPLAIN [[ RAW | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
-    [ WITH output_modifier [, output_modifier ...] ]
+    [ WITH (<output_modifier> [, <output_modifier> ...]) ]
     [ AS TEXT | AS JSON ]
 FOR ] -- The FOR keyword is required if the PLAN keyword is specified
   MATERIALIZED VIEW <name>

--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -1,6 +1,6 @@
 ---
 title: "EXPLAIN PLAN"
-description: "`EXPLAIN PLAN` is used to inspect the plans of `SELECT` statements, indexes, and materialized views."
+description: "Reference page for `EXPLAIN PLAN`. `EXPLAIN PLAN` is used to inspect the plans of `SELECT` statements, indexes, and materialized views."
 aliases:
   - /sql/explain/
 menu:
@@ -8,7 +8,11 @@ menu:
     parent: commands
 ---
 
-`EXPLAIN PLAN` displays the plans used for `SELECT` statements, indexes, and materialized views.
+`EXPLAIN PLAN` displays the plans used for:
+
+|                             |                       |
+|-----------------------------|-----------------------|
+| <ul><li>`SELECT` statements </li><li>`CREATE VIEW` statements</li><li>`CREATE INDEX` statements</li><li>`CREATE MATERIALIZED VIEW` statements</li></ul>|<ul><li>Views</li><li>Indexes</li><li>Materialized views</li></ul> |
 
 {{< warning >}}
 `EXPLAIN` is not part of Materialize's stable interface and is not subject to
@@ -18,7 +22,79 @@ change arbitrarily in future versions of Materialize.
 
 ## Syntax
 
-{{< diagram "explain-plan.svg" >}}
+{{< tabs >}}
+{{< tab "FOR SELECT">}}
+```mzsql
+EXPLAIN [ [ RAW | DECORRELATED | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
+    [ WITH <output_modifier> [, <output_modifier> ...] ]
+    [ AS TEXT | AS JSON ]
+FOR ]       -- The FOR keyword is required if the PLAN keyword is specified
+    <SELECT ...>
+;
+```
+{{</tab>}}
+{{< tab "FOR CREATE VIEW">}}
+
+```mzsql
+EXPLAIN <RAW | DECORRELATED | LOCALLY OPTIMIZED> PLAN
+    [ WITH output_modifier [, output_modifier ...] ]
+    [ AS TEXT | AS JSON ]
+FOR
+    <CREATE VIEW ...>
+;
+```
+{{</tab>}}
+{{< tab "FOR CREATE INDEX">}}
+```mzsql
+EXPLAIN [ [ OPTIMIZED | PHYSICAL ] PLAN
+    [ WITH output_modifier [, output_modifier ...] ]
+    [ AS TEXT | AS JSON ]
+FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
+    <CREATE INDEX ...>
+;
+```
+{{</tab>}}
+{{< tab "FOR CREATE MATERIALIZED VIEW">}}
+```mzsql
+EXPLAIN [ [ RAW | DECORRELATED | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
+    [ WITH <output_modifier [, output_modifier ...] ]
+    [ AS TEXT | AS JSON ]
+FOR ]          -- The FOR keyword is required if the PLAN keyword is specified
+    <CREATE MATERIALIZED VIEW ...>
+;
+```
+{{</tab>}}
+{{< tab "FOR VIEW">}}
+```mzsql
+EXPLAIN <RAW | LOCALLY OPTIMIZED> PLAN
+    [ WITH output_modifier [, output_modifier ...] ]
+    [ AS TEXT | AS JSON ]
+FOR
+  VIEW <name>
+;
+```
+{{</tab>}}
+{{< tab "FOR INDEX">}}
+```mzsql
+EXPLAIN [ [ OPTIMIZED | PHYSICAL ] PLAN
+      [ WITH output_modifier [, output_modifier ...] ]
+      [ AS TEXT | AS JSON ]
+FOR ]  -- The FOR keyword is required if the PLAN keyword is specified
+  INDEX <name>
+;
+```
+{{</tab>}}
+{{< tab "FOR MATERIALIZED VIEW">}}
+```mzsql
+EXPLAIN [[ RAW | [LOCALLY] OPTIMIZED | PHYSICAL ] PLAN
+    [ WITH output_modifier [, output_modifier ...] ]
+    [ AS TEXT | AS JSON ]
+FOR ] -- The FOR keyword is required if the PLAN keyword is specified
+  MATERIALIZED VIEW <name>
+;
+```
+{{</tab>}}
+{{</tabs>}}
 
 Note that the `FOR` keyword is required if the `PLAN` keyword is present. In other words, the following three statements are equivalent:
 

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -33,9 +33,10 @@ You can use `SUBSCRIBE` to:
 SUBSCRIBE [TO] <object_name | (SELECT ...)>
 [ENVELOPE UPSERT (KEY (<key1>, ...)) | ENVELOPE DEBEZIUM (KEY (<key1>, ...))]
 [WITHIN TIMESTAMP ORDER BY <column1> [ASC | DESC] [NULLS LAST | NULLS FIRST], ...]
+[WITH (<option_name> [= <option_value>], ...)]
 [AS OF [AT LEAST] <timestamp_expression>]
 [UP TO <timestamp_expression>]
-[WITH (<option_name> [= <option_value>], ...)]
+
 ```
 
 where:
@@ -53,9 +54,9 @@ the input view or source.
 | **ENVELOPE UPSERT (KEY (**\<key1\>, ...**))**                | If specified, use the upsert envelope, which takes a list of `KEY` columns. The upsert envelope supports inserts, updates and deletes in the subscription output. For more information, see [Modifying the output format](#modifying-the-output-format). |
 | **ENVELOPE DEBEZIUM (KEY (**\<key1\>, ...**))**           | If specified, use a [Debezium-style diff envelope](/sql/create-sink/kafka/#debezium-envelope), which takes a list of `KEY` columns. The Debezium envelope supports inserts, updates and deletes in the subscription output along with the previous state of the key. For more information, see [Modifying the output format](#modifying-the-output-format). |
 | **WITHIN TIMESTAMP ORDER BY** \<column1\>, ... | If specified, use an `ORDER BY` clause to sort the subscription output within a timestamp. For each `ORDER BY` column, you can optionally specify: <ul><li> `ASC` or `DESC`</li><li> `NULLS FIRST` or `NULLS LAST`</li></ul> For more information, see [Modifying the output format](#modifying-the-output-format). |
+| **WITH** \<option_name\> [= \<option_value\>] | If specified, use the specified option. For more information, see [`WITH` options](#with-options). |
 | **AS OF** \<timestamp_expression\> | If specified, no rows whose timestamp is earlier than the specified timestamp will be returned. For more information, see [`AS OF`](#as-of). |
 | **UP TO** \<timestamp_expression\> | If specified, no rows whose timestamp is greater than or equal to the specified timestamp will be returned. For more information, see [`UP TO`](#up-to). |
-| **WITH** \<option_name\> [= \<option_value\>] | If specified, use the specified option. For more information, see [`WITH` options](#with-options). |
 
 
 #### `WITH` options

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -319,21 +319,6 @@ drop_user ::=
     'DROP' 'USER' ('IF EXISTS')? role_name
 execute ::=
   'EXECUTE' name   ('(' (parameter_value) ( ',' parameter_value )* ')')?
-explain_plan ::=
-  'EXPLAIN'
-  ( ( 'RAW' | 'DECORRELATED' | 'LOCALLY'? 'OPTIMIZED' | 'PHYSICAL' )? 'PLAN' )?
-  ( 'WITH (' ( output_modifier (',' output_modifier )* ) ')' )?
-  ( 'AS' ( 'TEXT' | 'JSON' ) )?
-  'FOR'?
-  (
-    select_stmt |
-    create_view |
-    create_index |
-    create_materialized_view |
-    'VIEW' name |
-    'INDEX' name |
-    'MATERIALIZED VIEW' name
-  )
 explain_filter_pushdown ::=
   'EXPLAIN FILTER PUSHDOWN'
   'FOR'


### PR DESCRIPTION
- Replaced the `EXPLAIN PLAN` railroad diagram with tabbed syntaxes per object being explained. I did have to move up a table ... and make into a list.  Otherwise, left the page alone. (think breadth first instead of depth first).
- Small fix to the SUBSCRIBE syntax. (A bit more could be done here to fix but for now, just a little bandaid).