### PR TITLE
fix string_to_array handle non string delimiter

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8207,7 +8207,9 @@ impl VariadicFunc {
                 ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable)
             }
             RegexpReplace => ScalarType::String.nullable(in_nullable),
-            StringToArray => ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable),
+            StringToArray => {
+                ScalarType::Array(Box::new(ScalarType::String)).nullable(input_types[0].nullable)
+            }
         }
     }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2151,7 +2151,12 @@ fn string_to_array<'a>(
         return string_to_array_impl(string, split_all_chars_delimiter, null_string, temp_storage);
     }
 
-    let delimiter = delimiter.unwrap_str();
+    let Datum::String(delimiter) = delimiter else {
+        return Err(EvalError::PrettyError(
+            "Invalid delimiter passed. Must be string or null.".into(),
+        ));
+    };
+
     if delimiter.is_empty() {
         let mut row = Row::default();
         let mut packer = row.packer();

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8237,7 +8237,6 @@ impl VariadicFunc {
                 | VariadicFunc::RangeCreate { .. }
                 | VariadicFunc::ArrayPosition
                 | VariadicFunc::ArrayFill { .. }
-                | VariadicFunc::StringToArray
         )
     }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2151,11 +2151,7 @@ fn string_to_array<'a>(
         return string_to_array_impl(string, split_all_chars_delimiter, null_string, temp_storage);
     }
 
-    let Datum::String(delimiter) = delimiter else {
-        return Err(EvalError::PrettyError(
-            "Invalid delimiter passed. Must be string or null.".into(),
-        ));
-    };
+    let delimiter = delimiter.unwrap_str();
 
     if delimiter.is_empty() {
         let mut row = Row::default();

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8214,6 +8214,9 @@ impl VariadicFunc {
     }
 
     /// Whether the function output is NULL if any of its inputs are NULL.
+    ///
+    /// NB: if any input is NULL the output will be returned as NULL without
+    /// calling the function.
     pub fn propagates_nulls(&self) -> bool {
         // NOTE: The following is a list of the variadic functions
         // that **DO NOT** propagate nulls.
@@ -8237,6 +8240,7 @@ impl VariadicFunc {
                 | VariadicFunc::RangeCreate { .. }
                 | VariadicFunc::ArrayPosition
                 | VariadicFunc::ArrayFill { .. }
+                | VariadicFunc::StringToArray
         )
     }
 
@@ -8281,13 +8285,13 @@ impl VariadicFunc {
             | ArrayFill { .. }
             | TimezoneTime
             | RegexpSplitToArray
-            | StringToArray
             | RegexpReplace => false,
             Coalesce
             | Greatest
             | Least
             | MakeTimestamp
             | ArrayIndex { .. }
+            | StringToArray
             | ListIndex
             | RegexpMatch => true,
         }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8207,9 +8207,7 @@ impl VariadicFunc {
                 ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable)
             }
             RegexpReplace => ScalarType::String.nullable(in_nullable),
-            StringToArray => {
-                ScalarType::Array(Box::new(ScalarType::String)).nullable(input_types[0].nullable)
-            }
+            StringToArray => ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable),
         }
     }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8207,9 +8207,7 @@ impl VariadicFunc {
                 ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable)
             }
             RegexpReplace => ScalarType::String.nullable(in_nullable),
-            StringToArray => {
-                ScalarType::Array(Box::new(ScalarType::String)).nullable(input_types[0].nullable)
-            }
+            StringToArray => ScalarType::Array(Box::new(ScalarType::String)).nullable(true),
         }
     }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3162,8 +3162,8 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
             params!(Bytes, Bytes) => Operation::binary(|_ecx, _l, _r| bail_unsupported!("string_agg on BYTEA")) => Bytes, 3545;
         },
         "string_to_array" => Scalar {
-            params!(String, Any) => VariadicFunc::StringToArray => ScalarType::Array(Box::new(ScalarType::String)), 376;
-            params!(String, Any, String) => VariadicFunc::StringToArray => ScalarType::Array(Box::new(ScalarType::String)), 394;
+            params!(String, String) => VariadicFunc::StringToArray => ScalarType::Array(Box::new(ScalarType::String)), 376;
+            params!(String, String, String) => VariadicFunc::StringToArray => ScalarType::Array(Box::new(ScalarType::String)), 394;
         },
         "sum" => Aggregate {
             params!(Int16) => AggregateFunc::SumInt16 => Int64, 2109;

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1836,6 +1836,5 @@ NULL
 # string_to_array - non string input results in error.
 query error
 select string_to_array('hello world', 0) from string_to_array_words;
-----
 
 # string_to_array - end.

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1837,6 +1837,5 @@ NULL
 query error
 select string_to_array('hello world', 0) from string_to_array_words;
 ----
-"Invalid delimiter passed. Must be string or null."
 
 # string_to_array - end.

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1833,4 +1833,10 @@ select string_to_array(null, '') from string_to_array_words;
 ----
 NULL
 
+# string_to_array - non string input results in error.
+query error
+select string_to_array('hello world', 0) from string_to_array_words;
+----
+"Invalid delimiter passed. Must be string or null."
+
 # string_to_array - end.


### PR DESCRIPTION
fixes non string handling in string_to_array. currently causing panics.

### Motivation

errors in buildkite: https://buildkite.com/materialize/nightly/builds/11690#annotation-0195f3b5-b1bd-440b-8c7e-a445219baf63-error

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
