### PR TITLE
[sql_server] Update the `mz_sql_server_util::Client` to support tunneling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7074,6 +7074,7 @@ dependencies = [
  "mz-ore",
  "mz-proto",
  "mz-repr",
+ "mz-ssh-util",
  "ordered-float 5.0.0",
  "proptest",
  "proptest-derive",

--- a/src/sql-server-util/BUILD.bazel
+++ b/src/sql-server-util/BUILD.bazel
@@ -35,6 +35,7 @@ rust_library(
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
         "//src/repr:mz_repr",
+        "//src/ssh-util:mz_ssh_util",
     ] + all_crate_deps(normal = True),
 )
 
@@ -69,6 +70,7 @@ rust_test(
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
         "//src/repr:mz_repr",
+        "//src/ssh-util:mz_ssh_util",
     ] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -82,6 +84,7 @@ rust_doc_test(
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
         "//src/repr:mz_repr",
+        "//src/ssh-util:mz_ssh_util",
     ] + all_crate_deps(
         normal = True,
         normal_dev = True,

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 [lints]
 workspace = true
 
+[[example]]
+name = "cdc"
+
 [dependencies]
 anyhow = "1.0.66"
 async-stream = "0.3.3"
@@ -22,6 +25,7 @@ itertools = "0.12.1"
 mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
+mz-ssh-util = { path = "../ssh-util" }
 ordered-float = { version = "5.0.0", features = ["serde"] }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
@@ -30,11 +34,7 @@ serde = { version = "1.0.218", features = ["derive"] }
 smallvec = { version = "1.14.0", features = ["union"] }
 static_assertions = "1.1"
 thiserror = "2.0.11"
-tiberius = { version = "0.12", features = [
-    "chrono",
-    "sql-browser-tokio",
-    "tds73",
-], default-features = false }
+tiberius = { version = "0.12", features = [ "chrono", "sql-browser-tokio", "tds73"], default-features = false }
 timely = "0.20.0"
 tokio = { version = "1.44.1", features = ["net"] }
 tokio-stream = "0.1.17"

--- a/src/sql-server-util/src/config.rs
+++ b/src/sql-server-util/src/config.rs
@@ -1,0 +1,122 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use mz_ore::future::InTask;
+use mz_repr::CatalogItemId;
+use mz_ssh_util::tunnel::{SshTimeoutConfig, SshTunnelConfig};
+use mz_ssh_util::tunnel_manager::SshTunnelManager;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+/// Materialize specific configuration for SQL Server connections.
+///
+/// This wraps a [`tiberius::Config`] so we can configure a tunnel over SSH, AWS
+/// PrivateLink, or various other techniques, via a [`TunnelConfig`]
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// SQL Server specific configuration.
+    pub(crate) inner: tiberius::Config,
+    /// Details of how we'll connect to the upstream SQL Server instance.
+    pub(crate) tunnel: TunnelConfig,
+    /// If all of the I/O for this connection will be done in a separate task.
+    ///
+    /// Note: This is used to prevent accidentally doing I/O in timely threads.
+    pub(crate) in_task: InTask,
+}
+
+impl Config {
+    pub fn new(inner: tiberius::Config, tunnel: TunnelConfig, in_task: InTask) -> Self {
+        Config {
+            inner,
+            tunnel,
+            in_task,
+        }
+    }
+
+    /// Create a new [`Config`] from an ActiveX Data Object.
+    ///
+    /// Generally this is only used in test environments, see [`Config::new`]
+    /// for regular/production use cases.
+    pub fn from_ado_string(s: &str) -> Result<Self, anyhow::Error> {
+        let inner = tiberius::Config::from_ado_string(s).context("tiberius config")?;
+        Ok(Config {
+            inner,
+            tunnel: TunnelConfig::Direct,
+            in_task: InTask::No,
+        })
+    }
+}
+
+/// Configures an optional tunnel for use when connecting to a SQL Server database.
+///
+/// TODO(sql_server2): De-duplicate this with MySQL and Postgres sources.
+#[derive(Debug, Clone)]
+pub enum TunnelConfig {
+    /// No tunnelling.
+    Direct,
+    /// Establish a TCP connection to the database via an SSH tunnel.
+    Ssh {
+        /// Config for opening the SSH tunnel.
+        config: SshTunnelConfig,
+        /// Global manager of SSH tunnels.
+        manager: SshTunnelManager,
+        /// Timeout config for the SSH tunnel.
+        timeout: SshTimeoutConfig,
+        // TODO(sql_server1): Remove these fields by forking the `tiberius`
+        // crate and expose the `get_host` and `get_port` methods.
+        //
+        // See: <https://github.com/MaterializeInc/tiberius/blob/406ad2780d206617bd41689b1b638bddf4538f89/src/client/config.rs#L174-L191>
+        host: String,
+        port: u16,
+    },
+    /// Establish a TCP connection to the database via an AWS PrivateLink service.
+    AwsPrivatelink {
+        /// The ID of the AWS PrivateLink service.
+        connection_id: CatalogItemId,
+    },
+}
+
+/// Level of encryption to use with a SQL Server connection.
+///
+/// Mirror of [`tiberius::EncryptionLevel`] but we define our own so we can
+/// implement traits like [`Serialize`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Arbitrary, Serialize, Deserialize)]
+pub enum EncryptionLevel {
+    /// Do not use encryption at all.
+    None,
+    /// Only use encryption for the login procedure.
+    Login,
+    /// Use encryption for everything, if possible.
+    Preferred,
+    /// Require encryption, failing if not possible.
+    Required,
+}
+
+impl From<tiberius::EncryptionLevel> for EncryptionLevel {
+    fn from(value: tiberius::EncryptionLevel) -> Self {
+        match value {
+            tiberius::EncryptionLevel::NotSupported => EncryptionLevel::None,
+            tiberius::EncryptionLevel::Off => EncryptionLevel::Login,
+            tiberius::EncryptionLevel::On => EncryptionLevel::Preferred,
+            tiberius::EncryptionLevel::Required => EncryptionLevel::Required,
+        }
+    }
+}
+
+impl From<EncryptionLevel> for tiberius::EncryptionLevel {
+    fn from(value: EncryptionLevel) -> Self {
+        match value {
+            EncryptionLevel::None => tiberius::EncryptionLevel::NotSupported,
+            EncryptionLevel::Login => tiberius::EncryptionLevel::Off,
+            EncryptionLevel::Preferred => tiberius::EncryptionLevel::On,
+            EncryptionLevel::Required => tiberius::EncryptionLevel::Required,
+        }
+    }
+}

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = { version = "1.0.125", features = ["raw_value"] }
 similar = "2.7.0"
 tempfile = "3.19.0"
 termcolor = "1.4.1"
-tiberius = { version = "0.12", default-features = false }
+tiberius = { version = "0.12", features = ["sql-browser-tokio", "tds73"], default-features = false }
 time = "0.3.17"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
This PR updates the `mz_sql_server_util::Client` to have initial support for tunneling by introducing our own `mz_sql_server_util::Config` type that wraps a `tiberius::Config`. Currently the only tunneling supported is SSH, AWS PrivateLink is left as a TODO.

### Motivation

Nothing functionally changes yet, nor is the SSH tunneling testing, but it aligns our SQL Server Client with the Clients we use for Postgres and MySQL.

Progress towards: https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
