### PR TITLE
[sql_server] Update `CdcStream` to emit `CdcEvent::Progress`

### DIFF
--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -67,18 +67,6 @@ impl<'a> CdcStream<'a> {
         self
     }
 
-    /// Adds "one" to the provided [`Lsn`].
-    ///
-    /// Note: This method calls the upstream SQL Server instance to increment
-    /// the [`Lsn`] for us, but it is an entirely stateless operation, in other
-    /// words it does not modify the server state. While we understand the
-    /// structure of an [`Lsn`], the values are opaque to us so we need to call
-    /// the server to figure out what the logically next [`Lsn`] is.
-    pub async fn increment_lsn(&mut self, lsn: Lsn) -> Result<Lsn, SqlServerError> {
-        let new_lsn = crate::inspect::increment_lsn(self.client, lsn).await?;
-        Ok(new_lsn)
-    }
-
     /// Takes a snapshot of the upstream table that the specified `capture_instance` is
     /// replicating changes from.
     ///

--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -67,8 +67,14 @@ impl<'a> CdcStream<'a> {
         self
     }
 
-    /// Takes a snapshot of the upstream tables that the specified `capture_instance`s
-    /// are replicating changes from.
+    /// Bumps the provided [`Lsn`] by one.
+    pub async fn bump_lsn(&mut self, lsn: Lsn) -> Result<Lsn, SqlServerError> {
+        let new_lsn = crate::inspect::increment_lsn(self.client, lsn).await?;
+        Ok(new_lsn)
+    }
+
+    /// Takes a snapshot of the upstream table that the specified `capture_instance` is
+    /// replicating changes from.
     ///
     /// An optional `instances` parameter can be provided to only snapshot the specified instances.
     pub async fn snapshot<'b>(
@@ -199,7 +205,7 @@ impl<'a> CdcStream<'a> {
                                 let _capture_isntance = capture_instance;
                                 let _completed_lsn = lsn;
                             });
-                            let event = CdcEvent {
+                            let event = CdcEvent::Data {
                                 capture_instance: Arc::clone(instance),
                                 lsn,
                                 changes,
@@ -213,6 +219,11 @@ impl<'a> CdcStream<'a> {
                     // Increment our LSN (`get_changes` is inclusive).
                     let next_lsn = crate::inspect::increment_lsn(self.client, new_lsn).await?;
                     tracing::debug!(?curr_lsn, ?next_lsn, "incrementing LSN");
+
+                    // Notify our listener that we've emitted all changes __less than__ this LSN.
+                    //
+                    // Note: This aligns well with timely's semantics of progress tracking.
+                    yield CdcEvent::Progress { next_lsn };
 
                     // We just listed everything upto next_lsn.
                     for instance_lsn in self.capture_instances.values_mut() {
@@ -264,16 +275,24 @@ impl<'a> CdcStream<'a> {
 /// A change event from a [`CdcStream`].
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct CdcEvent {
-    /// The capture instance these changes are for.
-    pub capture_instance: Arc<str>,
-    /// The LSN that this change occurred at.
-    pub lsn: Lsn,
-    /// The change itself.
-    pub changes: Vec<Operation>,
-    /// When called marks `lsn` as complete allowing the upstream DB to clean up the record.
-    #[derivative(Debug = "ignore")]
-    pub mark_complete: Box<dyn FnOnce() + Send + Sync>,
+pub enum CdcEvent {
+    /// Changes have occurred upstream.
+    Data {
+        /// The capture instance these changes are for.
+        capture_instance: Arc<str>,
+        /// The LSN that this change occurred at.
+        lsn: Lsn,
+        /// The change itself.
+        changes: Vec<Operation>,
+        /// When called marks `lsn` as complete allowing the upstream DB to clean up the record.
+        #[derivative(Debug = "ignore")]
+        mark_complete: Box<dyn FnOnce() + Send + Sync>,
+    },
+    /// We've made progress and observed all the changes less than `next_lsn`.
+    Progress {
+        /// We've received all of the data for [`Lsn`]s __less than__ this one.
+        next_lsn: Lsn,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -67,8 +67,14 @@ impl<'a> CdcStream<'a> {
         self
     }
 
-    /// Bumps the provided [`Lsn`] by one.
-    pub async fn bump_lsn(&mut self, lsn: Lsn) -> Result<Lsn, SqlServerError> {
+    /// Adds "one" to the provided [`Lsn`].
+    ///
+    /// Note: This method calls the upstream SQL Server instance to increment
+    /// the [`Lsn`] for us, but it is an entirely stateless operation, in other
+    /// words it does not modify the server state. While we understand the
+    /// structure of an [`Lsn`], the values are opaque to us so we need to call
+    /// the server to figure out what the logically next [`Lsn`] is.
+    pub async fn increment_lsn(&mut self, lsn: Lsn) -> Result<Lsn, SqlServerError> {
         let new_lsn = crate::inspect::increment_lsn(self.client, lsn).await?;
         Ok(new_lsn)
     }


### PR DESCRIPTION
This PR changes the implementation of `mz_sql_server_util::cdc::CdcStream` to emit not only changes to upstream tables, but also "progress" events. Specifically the `CdcEvent` type is now an enum, `CdcEvent::Data` and `CdcEvent::Progress`. This matches TimelyDataflow semantics, and makes it easier to integrate into our Source pipeline.

### Motivation

Progress towards: https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
