### PR TITLE
add listener wait for balancerd sigterm handling

### DIFF
--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -22,12 +22,18 @@ use tracing_subscriber::filter::Directive;
 // continue startup even in that case.
 //
 // All configuration names should be prefixed with "balancerd_" to avoid name collisions.
+/// Duration to wait after listeners closed via SIGTERM for outstanding connections to complete.
+pub const SIGTERM_CONNECTION_WAIT: Config<Duration> = Config::new(
+    "balancerd_sigterm_connection_wait",
+    Duration::from_secs(60 * 9),
+    "Duration to wait after listeners closed via SIGTERM for outstanding connections to complete.",
+);
 
-/// Duration to wait after SIGTERM for outstanding connections to complete.
-pub const SIGTERM_WAIT: Config<Duration> = Config::new(
-    "balancerd_sigterm_wait",
-    Duration::from_secs(60 * 10),
-    "Duration to wait after SIGTERM for outstanding connections to complete.",
+/// Duration to wait after SIGTERM to begin shutdown of servers.
+pub const SIGTERM_LISTEN_WAIT: Config<Duration> = Config::new(
+    "balancerd_sigterm_listen_wait",
+    Duration::from_secs(60),
+    "Duration to wait after SIGTERM to begin shutdown of servers.",
 );
 
 /// Whether to inject tcp proxy protocol headers to downstream http servers.
@@ -89,7 +95,8 @@ pub const SENTRY_FILTERS: Config<fn() -> String> = Config::new(
 /// Adds the full set of all balancer `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
-        .add(&SIGTERM_WAIT)
+        .add(&SIGTERM_CONNECTION_WAIT)
+        .add(&SIGTERM_LISTEN_WAIT)
         .add(&INJECT_PROXY_PROTOCOL_HEADER_HTTP)
         .add(&LOGGING_FILTER)
         .add(&OPENTELEMETRY_FILTER)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
There appears to be a delay in deleting balancerd pods (issues sigterm and closes server listening)  and the removal of the balancer from services/lb target groups. This adds a delay after receiving sigterm in the hopes that they're removed from LBs before they stop listening. 


We'd discussed just removing the connection closed entirely and more or less ignoring sigterm... this ended up being a bit simpler to add and a bit more flexible.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
**tested manually**  we weren't testing the old sig term behavior so I'm not sure adding a test is required here. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
