### PR TITLE
timely-util: fix cloning `Column::Align`

### DIFF
--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -19,7 +19,7 @@ differential-dataflow = "0.14.0"
 either = "1"
 futures-util = "0.3.31"
 lgalloc = "0.5"
-mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test", "num-traits"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test", "num-traits", "region", "differential-dataflow"] }
 num-traits = "0.2"
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
The implementation of `Column::clone` for the `Align` variant would first allocate a zero-filled region with `alloc_aligned_zeroed`, and then attempt to _append_ the bytes from the original region to its end using `Region::extend_from_slice`. The correct thing to do is to `copy_from_slice` instead, overwriting the zeroes.

Furthermore, the `Column` implementation calls `copy_from_slice` on a region returned by `alloc_aligned_zeroed` in a couple places. The returned region can be larger than the requested length, in which case `copy_from_slice` would panic because it expects both source and destination to have the same length. This is fixed here by slicing the destination to the source length.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9088

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
