### PR TITLE
Make `transform` import `ore` with the `differential-dataflow` feature

### DIFF
--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -15,7 +15,7 @@ enum-kinds = "0.5.1"
 itertools = "0.12.1"
 mz-compute-types = { path = "../compute-types" }
 mz-expr = { path = "../expr" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["differential-dataflow"] }
 mz-repr = { path = "../repr", features = ["tracing"] }
 mz-sql = { path = "../sql" }
 ordered-float = { version = "5.0.0", features = ["serde"] }


### PR DESCRIPTION
We need `Semigroup for Overflowing<$t>` when `fold_constants.rs` calls `differential_dataflow::consolidation::consolidate(rows);`

I'm not sure how this was even able to compile without this at all. Strangely, even without this, it compiles for me too when just starting up envd, but it doesn't compile if I want to run `cargo test` in `src/transform/tests/test_transforms`. Also, CI was somehow able to compile even the tests. Maybe the feature somehow gets pulled in when you compile not just this crate, but all crates.

### Motivation

  * This PR fixes the build for `mz-transform`.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
