### PR TITLE
cloud canary test: Bump throughput_tier version

### DIFF
--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -92,7 +92,7 @@ class Redpanda:
                 "resource_group_id": self.resource_group_id,
                 "network_id": self.network_id,
                 "region": "us-east-1",
-                "throughput_tier": "tier-1-aws-v2-arm",
+                "throughput_tier": "tier-1-aws-v3-arm",
                 "type": "TYPE_DEDICATED",
                 "zones": ["use1-az2"],
                 "aws_private_link": {


### PR DESCRIPTION
Old one doesn't exist anymore: https://buildkite.com/materialize/nightly/builds/11711#0196084e-eb09-405a-8c84-382b4c3028b7
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
