### PR TITLE
Convert more binary functions to sqlfunc

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -312,7 +312,13 @@ pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a
     }
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = i16, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int16()
         .checked_add(b.unwrap_int16())
@@ -320,7 +326,13 @@ fn add_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = i32, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int32()
         .checked_add(b.unwrap_int32())
@@ -328,7 +340,13 @@ fn add_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = i64, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int64()
         .checked_add(b.unwrap_int64())
@@ -336,7 +354,13 @@ fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = u16, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_add(b.unwrap_uint16())
@@ -344,7 +368,13 @@ fn add_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = u32, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_add(b.unwrap_uint32())
@@ -352,7 +382,13 @@ fn add_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = u64, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_add(b.unwrap_uint64())
@@ -360,7 +396,13 @@ fn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = f32, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f32",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float32();
     let b = b.unwrap_float32();
@@ -372,7 +414,13 @@ fn add_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = f64, is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f64",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float64();
     let b = b.unwrap_float64();
@@ -409,7 +457,13 @@ where
     neg_interval_inner(b).and_then(|i| add_timestamplike_interval(a, i))
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = "CheckedTimestamp<NaiveDateTime>", is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "CheckedTimestamp<NaiveDateTime>",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_date_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let date = a.unwrap_date();
     let time = b.unwrap_time();
@@ -420,7 +474,13 @@ fn add_date_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
     Ok(dt.try_into()?)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = "CheckedTimestamp<NaiveDateTime>", is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "CheckedTimestamp<NaiveDateTime>",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let date = a.unwrap_date();
     let interval = b.unwrap_interval();
@@ -433,7 +493,13 @@ fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalEr
     Ok(dt.try_into()?)
 }
 
-#[sqlfunc(is_monotone = (true, true), output_type = "CheckedTimestamp<chrono::DateTime<Utc>>", is_infix_op = true, sqlname="+", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "CheckedTimestamp<chrono::DateTime<Utc>>",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let time = a.unwrap_time();
     let interval = b.unwrap_interval();
@@ -441,7 +507,13 @@ fn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::Time(t)
 }
 
-#[sqlfunc(is_monotone = (true, false), output_type = "Numeric", is_infix_op = false, sqlname="round", propagates_nulls = true)]
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "Numeric",
+    is_infix_op = false,
+    sqlname = "round",
+    propagates_nulls = true
+)]
 fn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     let mut b = b.unwrap_int32();
@@ -490,6 +562,13 @@ fn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, Eva
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "String",
+    is_infix_op = false,
+    sqlname = "convert_from",
+    propagates_nulls = true
+)]
 fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     // Convert PostgreSQL-style encoding names[1] to WHATWG-style encoding names[2],
     // which the encoding library uses[3].
@@ -516,6 +595,13 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "String",
+    is_infix_op = false,
+    sqlname = "encode",
+    propagates_nulls = true
+)]
 fn encode<'a>(
     bytes: Datum<'a>,
     format: Datum<'a>,
@@ -536,6 +622,13 @@ fn decode<'a>(
     Ok(Datum::from(temp_storage.push_bytes(out)))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = false,
+    sqlname = "length",
+    propagates_nulls = true
+)]
 fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     // Convert PostgreSQL-style encoding names[1] to WHATWG-style encoding names[2],
     // which the encoding library uses[3].
@@ -621,6 +714,13 @@ pub fn add_timestamp_months<T: TimestampLike>(
     Ok(CheckedTimestamp::from_timestamplike(new_dt)?)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Numeric",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut cx = numeric::cx_datum();
     let mut a = a.unwrap_numeric().0;
@@ -632,6 +732,13 @@ fn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true
+)]
 fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_interval()
         .checked_add(&b.unwrap_interval())
@@ -639,78 +746,211 @@ fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int16() & b.unwrap_int16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() & b.unwrap_int32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() & b.unwrap_int64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint16() & b.unwrap_uint16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint32() & b.unwrap_uint32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "&",
+    propagates_nulls = true
+)]
 fn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint64() & b.unwrap_uint64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int16() | b.unwrap_int16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() | b.unwrap_int32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() | b.unwrap_int64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint16() | b.unwrap_uint16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint32() | b.unwrap_uint32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "|",
+    propagates_nulls = true
+)]
 fn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint64() | b.unwrap_uint64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int16() ^ b.unwrap_int16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() ^ b.unwrap_int32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() ^ b.unwrap_int64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint16() ^ b.unwrap_uint16())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint32() ^ b.unwrap_uint32())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "#",
+    propagates_nulls = true
+)]
 fn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_uint64() ^ b.unwrap_uint64())
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -722,6 +962,13 @@ fn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shl(rhs) as i16)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -730,6 +977,13 @@ fn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shl(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -738,6 +992,13 @@ fn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shl(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -749,18 +1010,39 @@ fn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shl(rhs) as u16)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 fn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let lhs = a.unwrap_uint32();
     let rhs = b.unwrap_uint32();
     Datum::from(lhs.wrapping_shl(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "<<",
+    propagates_nulls = true
+)]
 fn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let lhs = a.unwrap_uint64();
     let rhs = b.unwrap_uint32();
     Datum::from(lhs.wrapping_shl(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -772,6 +1054,13 @@ fn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shr(rhs) as i16)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -780,6 +1069,13 @@ fn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shr(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -788,6 +1084,13 @@ fn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shr(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -799,18 +1102,39 @@ fn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(lhs.wrapping_shr(rhs) as u16)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 fn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let lhs = a.unwrap_uint32();
     let rhs = b.unwrap_uint32();
     Datum::from(lhs.wrapping_shr(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = ">>",
+    propagates_nulls = true
+)]
 fn bit_shift_right_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let lhs = a.unwrap_uint64();
     let rhs = b.unwrap_uint32();
     Datum::from(lhs.wrapping_shr(rhs))
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int16()
         .checked_sub(b.unwrap_int16())
@@ -818,6 +1142,13 @@ fn sub_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int32()
         .checked_sub(b.unwrap_int32())
@@ -825,6 +1156,13 @@ fn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int64()
         .checked_sub(b.unwrap_int64())
@@ -832,6 +1170,13 @@ fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_sub(b.unwrap_uint16())
@@ -839,6 +1184,13 @@ fn sub_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_sub(b.unwrap_uint32())
@@ -846,6 +1198,13 @@ fn sub_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_sub(b.unwrap_uint64())
@@ -853,6 +1212,13 @@ fn sub_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f32",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float32();
     let b = b.unwrap_float32();
@@ -864,6 +1230,13 @@ fn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f64",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float64();
     let b = b.unwrap_float64();
@@ -875,6 +1248,13 @@ fn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Numeric",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut cx = numeric::cx_datum();
     let mut a = a.unwrap_numeric().0;
@@ -886,6 +1266,13 @@ fn sub_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = false,
+    sqlname = "age",
+    propagates_nulls = true
+)]
 fn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a_ts = a.unwrap_timestamp();
     let b_ts = b.unwrap_timestamp();
@@ -894,6 +1281,13 @@ fn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
     Ok(Datum::from(age))
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = false,
+    sqlname = "age",
+    propagates_nulls = true
+)]
 fn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a_ts = a.unwrap_timestamptz();
     let b_ts = b.unwrap_timestamptz();
@@ -902,22 +1296,57 @@ fn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalErro
     Ok(Datum::from(age))
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp())
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_timestamptz() - b.unwrap_timestamptz())
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_date() - b.unwrap_date())
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_time() - b.unwrap_time())
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     b.unwrap_interval()
         .checked_neg()
@@ -926,6 +1355,13 @@ fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "CheckedTimestamp<NaiveDateTime>",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let date = a.unwrap_date();
     let interval = b.unwrap_interval();
@@ -944,6 +1380,13 @@ fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalEr
     Ok(dt.try_into()?)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "chrono::NaiveTime",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true
+)]
 fn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let time = a.unwrap_time();
     let interval = b.unwrap_interval();
@@ -951,6 +1394,13 @@ fn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::Time(t)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int16()
         .checked_mul(b.unwrap_int16())
@@ -958,6 +1408,13 @@ fn mul_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int32()
         .checked_mul(b.unwrap_int32())
@@ -965,6 +1422,13 @@ fn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_int64()
         .checked_mul(b.unwrap_int64())
@@ -972,6 +1436,13 @@ fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint16()
         .checked_mul(b.unwrap_uint16())
@@ -979,6 +1450,13 @@ fn mul_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint32()
         .checked_mul(b.unwrap_uint32())
@@ -986,6 +1464,13 @@ fn mul_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_uint64()
         .checked_mul(b.unwrap_uint64())
@@ -993,6 +1478,13 @@ fn mul_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f32",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float32();
     let b = b.unwrap_float32();
@@ -1006,6 +1498,13 @@ fn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "f64",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float64();
     let b = b.unwrap_float64();
@@ -1019,6 +1518,13 @@ fn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Numeric",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut cx = numeric::cx_datum();
     let mut a = a.unwrap_numeric().0;
@@ -1034,6 +1540,13 @@ fn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, true)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true
+)]
 fn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     a.unwrap_interval()
         .checked_mul(b.unwrap_float64())
@@ -1041,6 +1554,13 @@ fn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
         .map(Datum::from)
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int16();
     if b == 0 {
@@ -1053,6 +1573,13 @@ fn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int32();
     if b == 0 {
@@ -1065,6 +1592,13 @@ fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int64();
     if b == 0 {
@@ -1077,6 +1611,13 @@ fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint16();
     if b == 0 {
@@ -1086,6 +1627,13 @@ fn div_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint32();
     if b == 0 {
@@ -1095,6 +1643,13 @@ fn div_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint64();
     if b == 0 {
@@ -1104,6 +1659,13 @@ fn div_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "f32",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float32();
     let b = b.unwrap_float32();
@@ -1121,6 +1683,13 @@ fn div_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "f64",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float64();
     let b = b.unwrap_float64();
@@ -1138,6 +1707,13 @@ fn div_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "Numeric",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut cx = numeric::cx_datum();
     let mut a = a.unwrap_numeric().0;
@@ -1160,6 +1736,13 @@ fn div_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(true, false)",
+    output_type = "Interval",
+    is_infix_op = true,
+    sqlname = "/",
+    propagates_nulls = true
+)]
 fn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_float64();
     if b == 0.0 {
@@ -1172,6 +1755,13 @@ fn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i16",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int16();
     if b == 0 {
@@ -1181,6 +1771,13 @@ fn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i32",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int32();
     if b == 0 {
@@ -1190,6 +1787,13 @@ fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "i64",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_int64();
     if b == 0 {
@@ -1199,6 +1803,13 @@ fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u16",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint16();
     if b == 0 {
@@ -1208,6 +1819,13 @@ fn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u32",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint32();
     if b == 0 {
@@ -1217,6 +1835,13 @@ fn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "u64",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_uint64();
     if b == 0 {
@@ -1226,6 +1851,13 @@ fn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "f32",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_float32();
     if b == 0.0 {
@@ -1235,6 +1867,13 @@ fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "f64",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let b = b.unwrap_float64();
     if b == 0.0 {
@@ -1244,6 +1883,13 @@ fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Numeric",
+    is_infix_op = true,
+    sqlname = "%",
+    propagates_nulls = true
+)]
 fn mod_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric();
     let b = b.unwrap_numeric();
@@ -3431,7 +4077,12 @@ impl BinaryFunc {
             | BinaryFunc::MapContainsAllKeys
             | BinaryFunc::MapContainsAnyKeys
             | BinaryFunc::MapContainsMap => false,
-            BinaryFunc::AddTimeInterval => false,
+            BinaryFunc::AddTimeInterval
+            | BinaryFunc::SubTimestamp
+            | BinaryFunc::SubTimestampTz
+            | BinaryFunc::SubDate
+            | BinaryFunc::SubTime
+            | BinaryFunc::SubTimeInterval => false,
             _ => true,
         }
     }
@@ -7363,6 +8014,14 @@ fn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_str().trim_end_matches(|c| trim_chars.contains(c)))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Option<i32>",
+    is_infix_op = true,
+    sqlname = "array_length",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 fn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let i = match usize::try_from(b.unwrap_int64()) {
         Ok(0) | Err(_) => return Ok(Datum::Null),

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_interval.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_interval()\n        .checked_add(&b.unwrap_interval())\n        .ok_or(EvalError::IntervalOutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AddInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        add_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for AddInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("+")
+    }
+}
+fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_interval()
+        .checked_add(&b.unwrap_interval())
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} + {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_numeric.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut cx = numeric::cx_datum();\n    let mut a = a.unwrap_numeric().0;\n    cx.add(&mut a, &b.unwrap_numeric().0);\n    if cx.status().overflow() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(a))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AddNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        add_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for AddNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("+")
+    }
+}
+fn add_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut cx = numeric::cx_datum();
+    let mut a = a.unwrap_numeric().0;
+    cx.add(&mut a, &b.unwrap_numeric().0);
+    if cx.status().overflow() {
+        Err(EvalError::FloatOverflow)
+    } else {
+        Ok(Datum::from(a))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamp.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = false,\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamp();\n    let b_ts = b.unwrap_timestamp();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AgeTimestamp;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AgeTimestamp {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        age_timestamp(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for AgeTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("age")
+    }
+}
+fn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a_ts = a.unwrap_timestamp();
+    let b_ts = b.unwrap_timestamp();
+    let age = a_ts.age(&b_ts)?;
+    Ok(Datum::from(age))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamptz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamptz.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = false,\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamptz();\n    let b_ts = b.unwrap_timestamptz();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AgeTimestamptz;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AgeTimestamptz {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        age_timestamptz(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for AgeTimestamptz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("age")
+    }
+}
+fn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a_ts = a.unwrap_timestamptz();
+    let b_ts = b.unwrap_timestamptz();
+    let age = a_ts.age(&b_ts)?;
+    Ok(Datum::from(age))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_length.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_length.snap
@@ -1,0 +1,87 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Option<i32>\",\n    is_infix_op = true,\n    sqlname = \"array_length\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let i = match usize::try_from(b.unwrap_int64()) {\n        Ok(0) | Err(_) => return Ok(Datum::Null),\n        Ok(n) => n - 1,\n    };\n    Ok(\n        match a.unwrap_array().dims().into_iter().nth(i) {\n            None => Datum::Null,\n            Some(dim) => {\n                Datum::Int32(\n                    dim\n                        .length\n                        .try_into()\n                        .map_err(|_| EvalError::Int32OutOfRange(\n                            dim.length.to_string().into(),\n                        ))?,\n                )\n            }\n        },\n    )\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayLength;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayLength {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_length(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Option<i32>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayLength {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("array_length")
+    }
+}
+fn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let i = match usize::try_from(b.unwrap_int64()) {
+        Ok(0) | Err(_) => return Ok(Datum::Null),
+        Ok(n) => n - 1,
+    };
+    Ok(
+        match a.unwrap_array().dims().into_iter().nth(i) {
+            None => Datum::Null,
+            Some(dim) => {
+                Datum::Int32(
+                    dim
+                        .length
+                        .try_into()
+                        .map_err(|_| EvalError::Int32OutOfRange(
+                            dim.length.to_string().into(),
+                        ))?,
+                )
+            }
+        },
+    )
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() & b.unwrap_int16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int16() & b.unwrap_int16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() & b.unwrap_int32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int32() & b.unwrap_int32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() & b.unwrap_int64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int64() & b.unwrap_int64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() & b.unwrap_uint16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint16() & b.unwrap_uint16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() & b.unwrap_uint32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint32() & b.unwrap_uint32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() & b.unwrap_uint64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitAndUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_and_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitAndUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&")
+    }
+}
+fn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint64() & b.unwrap_uint64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() | b.unwrap_int16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int16() | b.unwrap_int16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() | b.unwrap_int32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int32() | b.unwrap_int32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() | b.unwrap_int64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int64() | b.unwrap_int64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() | b.unwrap_uint16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint16() | b.unwrap_uint16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() | b.unwrap_uint32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint32() | b.unwrap_uint32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() | b.unwrap_uint64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitOrUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_or_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitOrUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("|")
+    }
+}
+fn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint64() | b.unwrap_uint64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: i32 = a.unwrap_int16() as i32;\n    let rhs: u32 = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs) as i16)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs: i32 = a.unwrap_int16() as i32;
+    let rhs: u32 = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shl(rhs) as i16)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_int32();
+    let rhs = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shl(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_int64();
+    let rhs = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shl(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: u32 = a.unwrap_uint16() as u32;\n    let rhs: u32 = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs) as u16)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs: u32 = a.unwrap_uint16() as u32;
+    let rhs: u32 = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shl(rhs) as u16)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint32.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+fn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_uint32();
+    let rhs = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shl(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint64.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftLeftUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_left_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftLeftUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+fn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_uint64();
+    let rhs = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shl(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int16() as i32;\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs) as i16)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_int16() as i32;
+    let rhs = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shr(rhs) as i16)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_int32();
+    let rhs = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shr(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_int64();
+    let rhs = b.unwrap_int32() as u32;
+    Datum::from(lhs.wrapping_shr(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint16() as u32;\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs) as u16)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_uint16() as u32;
+    let rhs = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shr(rhs) as u16)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint32.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+fn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_uint32();
+    let rhs = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shr(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint64.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitShiftRightUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_shift_right_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitShiftRightUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+fn bit_shift_right_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let lhs = a.unwrap_uint64();
+    let rhs = b.unwrap_uint32();
+    Datum::from(lhs.wrapping_shr(rhs))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() ^ b.unwrap_int16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int16() ^ b.unwrap_int16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() ^ b.unwrap_int32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int32() ^ b.unwrap_int32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() ^ b.unwrap_int64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_int64() ^ b.unwrap_int64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint16.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() ^ b.unwrap_uint16())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint16() ^ b.unwrap_uint16())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint32.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() ^ b.unwrap_uint32())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint32() ^ b.unwrap_uint32())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint64.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() ^ b.unwrap_uint64())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitXorUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        bit_xor_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitXorUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("#")
+    }
+}
+fn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_uint64() ^ b.unwrap_uint64())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
@@ -1,0 +1,81 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = String,\n    is_infix_op = false,\n    sqlname = \"convert_from\",\n    propagates_nulls = true\n)]\nfn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some(\"utf-8\") {\n        return Err(EvalError::InvalidEncodingName(encoding_name));\n    }\n    match str::from_utf8(a.unwrap_bytes()) {\n        Ok(from) => Ok(Datum::String(from)),\n        Err(e) => {\n            Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.to_string().into(),\n                encoding_name,\n            })\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ConvertFrom;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConvertFrom {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        convert_from(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ConvertFrom {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("convert_from")
+    }
+}
+fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let encoding_name = b.unwrap_str().to_lowercase().replace('_', "-").into_boxed_str();
+    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some("utf-8") {
+        return Err(EvalError::InvalidEncodingName(encoding_name));
+    }
+    match str::from_utf8(a.unwrap_bytes()) {
+        Ok(from) => Ok(Datum::String(from)),
+        Err(e) => {
+            Err(EvalError::InvalidByteSequence {
+                byte_sequence: e.to_string().into(),
+                encoding_name,
+            })
+        }
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_float32.snap
@@ -1,0 +1,82 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float32();\n    let b = b.unwrap_float32();\n    if b == 0.0f32 && !a.is_nan() {\n        Err(EvalError::DivisionByZero)\n    } else {\n        let quotient = a / b;\n        if quotient.is_infinite() && !a.is_infinite() {\n            Err(EvalError::FloatOverflow)\n        } else if quotient == 0.0f32 && a != 0.0f32 && !b.is_infinite() {\n            Err(EvalError::FloatUnderflow)\n        } else {\n            Ok(Datum::from(quotient))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivFloat32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivFloat32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_float32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float32();
+    let b = b.unwrap_float32();
+    if b == 0.0f32 && !a.is_nan() {
+        Err(EvalError::DivisionByZero)
+    } else {
+        let quotient = a / b;
+        if quotient.is_infinite() && !a.is_infinite() {
+            Err(EvalError::FloatOverflow)
+        } else if quotient == 0.0f32 && a != 0.0f32 && !b.is_infinite() {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            Ok(Datum::from(quotient))
+        }
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_float64.snap
@@ -1,0 +1,82 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    if b == 0.0f64 && !a.is_nan() {\n        Err(EvalError::DivisionByZero)\n    } else {\n        let quotient = a / b;\n        if quotient.is_infinite() && !a.is_infinite() {\n            Err(EvalError::FloatOverflow)\n        } else if quotient == 0.0f64 && a != 0.0f64 && !b.is_infinite() {\n            Err(EvalError::FloatUnderflow)\n        } else {\n            Ok(Datum::from(quotient))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivFloat64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivFloat64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_float64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float64();
+    let b = b.unwrap_float64();
+    if b == 0.0f64 && !a.is_nan() {
+        Err(EvalError::DivisionByZero)
+    } else {
+        let quotient = a / b;
+        if quotient.is_infinite() && !a.is_infinite() {
+            Err(EvalError::FloatOverflow)
+        } else if quotient == 0.0f64 && a != 0.0f64 && !b.is_infinite() {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            Ok(Datum::from(quotient))
+        }
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int16.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_int16()\n            .checked_div(b)\n            .map(Datum::from)\n            .ok_or(EvalError::Int16OutOfRange(format!(\"{a} / {b}\").into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int16();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        a.unwrap_int16()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int16OutOfRange(format!("{a} / {b}").into()))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int32.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_int32()\n            .checked_div(b)\n            .map(Datum::from)\n            .ok_or(EvalError::Int32OutOfRange(format!(\"{a} / {b}\").into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        a.unwrap_int32()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int32OutOfRange(format!("{a} / {b}").into()))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_int64.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_int64()\n            .checked_div(b)\n            .map(Datum::from)\n            .ok_or(EvalError::Int64OutOfRange(format!(\"{a} / {b}\").into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        a.unwrap_int64()
+            .checked_div(b)
+            .map(Datum::from)
+            .ok_or(EvalError::Int64OutOfRange(format!("{a} / {b}").into()))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_interval.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_interval()\n            .checked_div(b)\n            .ok_or(EvalError::IntervalOutOfRange(format!(\"{a} / {b}\").into()))\n            .map(Datum::from)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float64();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        a.unwrap_interval()
+            .checked_div(b)
+            .ok_or(EvalError::IntervalOutOfRange(format!("{a} / {b}").into()))
+            .map(Datum::from)
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_numeric.snap
@@ -1,0 +1,83 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut cx = numeric::cx_datum();\n    let mut a = a.unwrap_numeric().0;\n    let b = b.unwrap_numeric().0;\n    cx.div(&mut a, &b);\n    let cx_status = cx.status();\n    if b.is_zero() {\n        Err(EvalError::DivisionByZero)\n    } else if cx_status.overflow() {\n        Err(EvalError::FloatOverflow)\n    } else if cx_status.subnormal() {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut cx = numeric::cx_datum();
+    let mut a = a.unwrap_numeric().0;
+    let b = b.unwrap_numeric().0;
+    cx.div(&mut a, &b);
+    let cx_status = cx.status();
+    if b.is_zero() {
+        Err(EvalError::DivisionByZero)
+    } else if cx_status.overflow() {
+        Err(EvalError::FloatOverflow)
+    } else if cx_status.subnormal() {
+        Err(EvalError::FloatUnderflow)
+    } else {
+        numeric::munge_numeric(&mut a).unwrap();
+        Ok(Datum::from(a))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint16.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint16() / b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint16();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint16() / b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint32.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint32() / b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint32() / b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_uint64.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint64() / b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DivUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        div_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DivUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("/")
+    }
+}
+fn div_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint64() / b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encode.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encode.snap
@@ -1,0 +1,75 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = String,\n    is_infix_op = false,\n    sqlname = \"encode\",\n    propagates_nulls = true\n)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Encode;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        encode(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Encode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("encode")
+    }
+}
+fn encode<'a>(
+    bytes: Datum<'a>,
+    format: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let format = encoding::lookup_format(format.unwrap_str())?;
+    let out = format.encode(bytes.unwrap_bytes());
+    Ok(Datum::from(temp_storage.push_string(out)))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
@@ -1,0 +1,90 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = false,\n    sqlname = \"length\",\n    propagates_nulls = true\n)]\nfn encoded_bytes_char_length<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    let enc = match encoding_from_whatwg_label(&encoding_name) {\n        Some(enc) => enc,\n        None => return Err(EvalError::InvalidEncodingName(encoding_name)),\n    };\n    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {\n        Ok(s) => s,\n        Err(e) => {\n            return Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.into(),\n                encoding_name,\n            });\n        }\n    };\n    let count = decoded_string.chars().count();\n    match i32::try_from(count) {\n        Ok(l) => Ok(Datum::from(l)),\n        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct EncodedBytesCharLength;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for EncodedBytesCharLength {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        encoded_bytes_char_length(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for EncodedBytesCharLength {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("length")
+    }
+}
+fn encoded_bytes_char_length<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let encoding_name = b.unwrap_str().to_lowercase().replace('_', "-").into_boxed_str();
+    let enc = match encoding_from_whatwg_label(&encoding_name) {
+        Some(enc) => enc,
+        None => return Err(EvalError::InvalidEncodingName(encoding_name)),
+    };
+    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(EvalError::InvalidByteSequence {
+                byte_sequence: e.into(),
+                encoding_name,
+            });
+        }
+    };
+    let count = decoded_string.chars().count();
+    match i32::try_from(count) {
+        Ok(l) => Ok(Datum::from(l)),
+        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float32.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float32();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float32() % b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModFloat32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModFloat32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_float32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float32();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float32() % b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float64.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float64() % b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModFloat64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModFloat64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_float64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float64();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float64() % b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int16.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int16().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int16();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int16().checked_rem(b).unwrap_or(0)))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int32.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int32().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int32().checked_rem(b).unwrap_or(0)))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int64.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int64().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int64().checked_rem(b).unwrap_or(0)))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_numeric.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric();\n    let b = b.unwrap_numeric();\n    if b.0.is_zero() {\n        return Err(EvalError::DivisionByZero);\n    }\n    let mut cx = numeric::cx_datum();\n    cx.rem(&mut a.0, &b.0);\n    numeric::munge_numeric(&mut a.0).unwrap();\n    Ok(Datum::Numeric(a))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut a = a.unwrap_numeric();
+    let b = b.unwrap_numeric();
+    if b.0.is_zero() {
+        return Err(EvalError::DivisionByZero);
+    }
+    let mut cx = numeric::cx_datum();
+    cx.rem(&mut a.0, &b.0);
+    numeric::munge_numeric(&mut a.0).unwrap();
+    Ok(Datum::Numeric(a))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint16.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint16() % b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint16();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint16() % b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint32.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint32() % b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint32() % b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint64.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint64() % b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ModUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mod_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ModUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("%")
+    }
+}
+fn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_uint64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_uint64() % b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_float32.snap
@@ -1,0 +1,78 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float32();\n    let b = b.unwrap_float32();\n    let product = a * b;\n    if product.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else if product == 0.0f32 && a != 0.0f32 && b != 0.0f32 {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        Ok(Datum::from(product))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulFloat32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulFloat32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_float32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float32();
+    let b = b.unwrap_float32();
+    let product = a * b;
+    if product.is_infinite() && !a.is_infinite() && !b.is_infinite() {
+        Err(EvalError::FloatOverflow)
+    } else if product == 0.0f32 && a != 0.0f32 && b != 0.0f32 {
+        Err(EvalError::FloatUnderflow)
+    } else {
+        Ok(Datum::from(product))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_float64.snap
@@ -1,0 +1,78 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    let product = a * b;\n    if product.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else if product == 0.0f64 && a != 0.0f64 && b != 0.0f64 {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        Ok(Datum::from(product))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulFloat64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulFloat64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_float64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float64();
+    let b = b.unwrap_float64();
+    let product = a * b;
+    if product.is_infinite() && !a.is_infinite() && !b.is_infinite() {
+        Err(EvalError::FloatOverflow)
+    } else if product == 0.0f64 && a != 0.0f64 && b != 0.0f64 {
+        Err(EvalError::FloatUnderflow)
+    } else {
+        Ok(Datum::from(product))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int16()\n        .checked_mul(b.unwrap_int16())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int16()
+        .checked_mul(b.unwrap_int16())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int32()\n        .checked_mul(b.unwrap_int32())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int32()
+        .checked_mul(b.unwrap_int32())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_int64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int64()\n        .checked_mul(b.unwrap_int64())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int64()
+        .checked_mul(b.unwrap_int64())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_interval.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_interval()\n        .checked_mul(b.unwrap_float64())\n        .ok_or(EvalError::IntervalOutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_interval()
+        .checked_mul(b.unwrap_float64())
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} * {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_numeric.snap
@@ -1,0 +1,80 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut cx = numeric::cx_datum();\n    let mut a = a.unwrap_numeric().0;\n    cx.mul(&mut a, &b.unwrap_numeric().0);\n    let cx_status = cx.status();\n    if cx_status.overflow() {\n        Err(EvalError::FloatOverflow)\n    } else if cx_status.subnormal() {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut cx = numeric::cx_datum();
+    let mut a = a.unwrap_numeric().0;
+    cx.mul(&mut a, &b.unwrap_numeric().0);
+    let cx_status = cx.status();
+    if cx_status.overflow() {
+        Err(EvalError::FloatOverflow)
+    } else if cx_status.subnormal() {
+        Err(EvalError::FloatUnderflow)
+    } else {
+        numeric::munge_numeric(&mut a).unwrap();
+        Ok(Datum::from(a))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint16()\n        .checked_mul(b.unwrap_uint16())\n        .ok_or(EvalError::UInt16OutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint16()
+        .checked_mul(b.unwrap_uint16())
+        .ok_or(EvalError::UInt16OutOfRange(format!("{a} * {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint32()\n        .checked_mul(b.unwrap_uint32())\n        .ok_or(EvalError::UInt32OutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint32()
+        .checked_mul(b.unwrap_uint32())
+        .ok_or(EvalError::UInt32OutOfRange(format!("{a} * {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_uint64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint64()\n        .checked_mul(b.unwrap_uint64())\n        .ok_or(EvalError::UInt64OutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MulUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mul_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MulUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn mul_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint64()
+        .checked_mul(b.unwrap_uint64())
+        .ok_or(EvalError::UInt64OutOfRange(format!("{a} * {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_date.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_date.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_date() - b.unwrap_date())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubDate;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubDate {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_date(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_date() - b.unwrap_date())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_date_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_date_interval.snap
@@ -1,0 +1,80 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = \"CheckedTimestamp<NaiveDateTime>\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let date = a.unwrap_date();\n    let interval = b.unwrap_interval();\n    let dt = NaiveDate::from(date).and_hms_opt(0, 0, 0).unwrap();\n    let dt = interval\n        .months\n        .checked_neg()\n        .ok_or(EvalError::IntervalOutOfRange(interval.months.to_string().into()))\n        .and_then(|months| add_timestamp_months(&dt, months))?;\n    let dt = dt\n        .checked_sub_signed(interval.duration_as_chrono())\n        .ok_or(EvalError::TimestampOutOfRange)?;\n    Ok(dt.try_into()?)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubDateInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubDateInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_date_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <CheckedTimestamp<NaiveDateTime>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <CheckedTimestamp<NaiveDateTime> as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubDateInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let date = a.unwrap_date();
+    let interval = b.unwrap_interval();
+    let dt = NaiveDate::from(date).and_hms_opt(0, 0, 0).unwrap();
+    let dt = interval
+        .months
+        .checked_neg()
+        .ok_or(EvalError::IntervalOutOfRange(interval.months.to_string().into()))
+        .and_then(|months| add_timestamp_months(&dt, months))?;
+    let dt = dt
+        .checked_sub_signed(interval.duration_as_chrono())
+        .ok_or(EvalError::TimestampOutOfRange)?;
+    Ok(dt.try_into()?)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_float32.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float32();\n    let b = b.unwrap_float32();\n    let difference = a - b;\n    if difference.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(difference))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubFloat32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubFloat32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_float32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float32();
+    let b = b.unwrap_float32();
+    let difference = a - b;
+    if difference.is_infinite() && !a.is_infinite() && !b.is_infinite() {
+        Err(EvalError::FloatOverflow)
+    } else {
+        Ok(Datum::from(difference))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_float64.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    let difference = a - b;\n    if difference.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(difference))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubFloat64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubFloat64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_float64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float64();
+    let b = b.unwrap_float64();
+    let difference = a - b;
+    if difference.is_infinite() && !a.is_infinite() && !b.is_infinite() {
+        Err(EvalError::FloatOverflow)
+    } else {
+        Ok(Datum::from(difference))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int16()\n        .checked_sub(b.unwrap_int16())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubInt16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubInt16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_int16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int16()
+        .checked_sub(b.unwrap_int16())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int32()\n        .checked_sub(b.unwrap_int32())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubInt32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubInt32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_int32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int32()
+        .checked_sub(b.unwrap_int32())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_int64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int64()\n        .checked_sub(b.unwrap_int64())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_int64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int64()
+        .checked_sub(b.unwrap_int64())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_interval.snap
@@ -1,0 +1,73 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    b.unwrap_interval()\n        .checked_neg()\n        .and_then(|b| b.checked_add(&a.unwrap_interval()))\n        .ok_or(EvalError::IntervalOutOfRange(format!(\"{a} - {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    b.unwrap_interval()
+        .checked_neg()
+        .and_then(|b| b.checked_add(&a.unwrap_interval()))
+        .ok_or(EvalError::IntervalOutOfRange(format!("{a} - {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_numeric.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut cx = numeric::cx_datum();\n    let mut a = a.unwrap_numeric().0;\n    cx.sub(&mut a, &b.unwrap_numeric().0);\n    if cx.status().overflow() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(a))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut cx = numeric::cx_datum();
+    let mut a = a.unwrap_numeric().0;
+    cx.sub(&mut a, &b.unwrap_numeric().0);
+    if cx.status().overflow() {
+        Err(EvalError::FloatOverflow)
+    } else {
+        Ok(Datum::from(a))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_time() - b.unwrap_time())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubTime;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubTime {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_time(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_time() - b.unwrap_time())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time_interval.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = \"chrono::NaiveTime\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let time = a.unwrap_time();\n    let interval = b.unwrap_interval();\n    let (t, _) = time.overflowing_sub_signed(interval.duration_as_chrono());\n    Datum::Time(t)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubTimeInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubTimeInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_time_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <chrono::NaiveTime>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <chrono::NaiveTime as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubTimeInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let time = a.unwrap_time();
+    let interval = b.unwrap_interval();
+    let (t, _) = time.overflowing_sub_signed(interval.duration_as_chrono());
+    Datum::Time(t)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_timestamp.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubTimestamp;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubTimestamp {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_timestamp(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_timestamptz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_timestamptz.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_timestamptz() - b.unwrap_timestamptz())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubTimestamptz;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubTimestamptz {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_timestamptz(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubTimestamptz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_timestamptz() - b.unwrap_timestamptz())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint16.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint16()\n        .checked_sub(b.unwrap_uint16())\n        .ok_or(EvalError::UInt16OutOfRange(format!(\"{a} - {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubUint16;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubUint16 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_uint16(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u16>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint16()
+        .checked_sub(b.unwrap_uint16())
+        .ok_or(EvalError::UInt16OutOfRange(format!("{a} - {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint32.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint32()\n        .checked_sub(b.unwrap_uint32())\n        .ok_or(EvalError::UInt32OutOfRange(format!(\"{a} - {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubUint32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubUint32 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_uint32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint32()
+        .checked_sub(b.unwrap_uint32())
+        .ok_or(EvalError::UInt32OutOfRange(format!("{a} - {b}").into()))
+        .map(Datum::from)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_uint64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint64()\n        .checked_sub(b.unwrap_uint64())\n        .ok_or(EvalError::UInt64OutOfRange(format!(\"{a} - {b}\").into()))\n        .map(Datum::from)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SubUint64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubUint64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        sub_uint64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <u64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for SubUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn sub_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_uint64()
+        .checked_sub(b.unwrap_uint64())
+        .ok_or(EvalError::UInt64OutOfRange(format!("{a} - {b}").into()))
+        .map(Datum::from)
+}


### PR DESCRIPTION
Follow-up to #32083. Derive the SQL function glue code for more binary functions.

Remove the `introduces_nulls` modifier because it should be determined by the output type. For example, a function that introduces nulls should have an output type of `Option<T>` to indicate the value can be absent.

Look at the PR commit-by-commit. The last one adds the snap files, don't look at it too closely.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
