### PR TITLE
Eliminate a quadraticness in EQProp

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -124,6 +124,8 @@ optimizer_feature_flags!({
     enable_projection_pushdown_after_relation_cse: bool,
     // See the feature flag of the same name.
     enable_less_reduce_in_eqprop: bool,
+    // See the feature flag of the same name.
+    enable_dequadratic_eqprop_map: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4651,6 +4651,7 @@ pub fn unplan_create_cluster(
                 enable_join_prioritize_arranged,
                 enable_projection_pushdown_after_relation_cse,
                 enable_less_reduce_in_eqprop: _,
+                enable_dequadratic_eqprop_map: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -435,6 +435,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_projection_pushdown_after_relation_cse: v
                     .enable_projection_pushdown_after_relation_cse,
                 enable_less_reduce_in_eqprop: Default::default(),
+                enable_dequadratic_eqprop_map: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2209,6 +2209,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_dequadratic_eqprop_map,
+        desc: "Skip the quadratic part of EquivalencePropagation's handling of Map.",
+        default: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2228,6 +2234,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_projection_pushdown_after_relation_cse: vars
                 .enable_projection_pushdown_after_relation_cse(),
             enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
+            enable_dequadratic_eqprop_map: vars.enable_dequadratic_eqprop_map(),
         }
     }
 }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -83,7 +83,9 @@ impl crate::Transform for EquivalencePropagation {
             let ck = crate::ColumnKnowledge::default();
             ck.transform(relation, ctx)?;
             if prior != *relation {
-                tracing::error!(
+                // This used to be tracing::error, but it became too common with
+                // dequadratic_eqprop_map.
+                tracing::warn!(
                     ?ctx.global_id,
                     "ColumnKnowledge performed work after EquivalencePropagation",
                 );
@@ -250,9 +252,15 @@ impl EquivalencePropagation {
                     .value::<Equivalences>()
                     .expect("Equivalences required");
 
-                if let Some(input_equivalences) = input_equivalences {
-                    // Clone the equivalences in case of variadic map, which will need to mutate them.
-                    let mut input_equivalences = input_equivalences.clone();
+                if let Some(input_equivalences_orig) = input_equivalences {
+                    // We clone `input_equivalences` only if we want to modify it, which is when
+                    // `enable_dequadratic_eqprop_map` is off. Otherwise, we work with the original
+                    // `input_equivalences`.
+                    let mut input_equivalences_cloned = None;
+                    if !ctx.features.enable_dequadratic_eqprop_map {
+                        // We mutate them for variadic Maps if the feature flag is not set.
+                        input_equivalences_cloned = Some(input_equivalences_orig.clone());
+                    }
                     // Get all output types, to reveal a prefix to each scaler expr.
                     let input_types = derived
                         .value::<RelationType>()
@@ -261,10 +269,39 @@ impl EquivalencePropagation {
                         .unwrap();
                     let input_arity = input_types.len() - scalars.len();
                     for (index, expr) in scalars.iter_mut().enumerate() {
-                        let reducer = input_equivalences.reducer();
+                        let reducer = if !ctx.features.enable_dequadratic_eqprop_map {
+                            input_equivalences_cloned
+                                .as_ref()
+                                .expect("always filled if feature flag is not set")
+                                .reducer()
+                        } else {
+                            input_equivalences_orig.reducer()
+                        };
                         let changed = reducer.reduce_expr(expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
                             expr.reduce(&input_types[..(input_arity + index)]);
+                        }
+                        if !ctx.features.enable_dequadratic_eqprop_map {
+                            // Unfortunately, we had to stop doing the following, because it
+                            // was making the `Map` handling quadratic.
+                            // TODO: Get back to this when we have e-graphs.
+                            // https://github.com/MaterializeInc/database-issues/issues/9157
+                            //
+                            // Introduce the fact relating the mapped expression and corresponding
+                            // column. This allows subsequent expressions to be optimized with this
+                            // information.
+                            input_equivalences_cloned
+                                .as_mut()
+                                .expect("always filled if feature flag is not set")
+                                .classes
+                                .push(vec![
+                                    expr.clone(),
+                                    MirScalarExpr::column(input_arity + index),
+                                ]);
+                            input_equivalences_cloned
+                                .as_mut()
+                                .expect("always filled if feature flag is not set")
+                                .minimize(Some(input_types));
                         }
                     }
                     let input_arity = *derived

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -260,6 +260,7 @@ fn apply_transform<T: mz_transform::Transform>(
     let mut features = mz_repr::optimize::OptimizerFeatures::default();
     // Apply a non-default feature flag to test the right implementation.
     features.enable_letrec_fixpoint_analysis = true;
+    features.enable_dequadratic_eqprop_map = true;
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
     let mut transform_ctx =

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -205,7 +205,7 @@ With
         Get t3
 Return
   Project (#0, #1, #3..=#6)
-    Map ((#0) IS NULL, #4, (#2) IS NULL)
+    Map ((#0) IS NULL, (#0) IS NULL, (#2) IS NULL)
       Union
         Map (null, null)
           Union

--- a/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1219.slt
@@ -325,7 +325,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #2, #6..=#9) // { arity: 6 }
-        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then #4 else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end) // { arity: 10 }
+        Map (array_index(regexp_split_to_array[",", case_insensitive=false](#1), integer_to_bigint(#2)), substr(#3, 2, 1), ((#4 = "<") OR (#4 = ">")), case when #5 then substr(#3, 1, 1) else "x" end, case when #5 then substr(#3, 2, 1) else ">" end, case when #5 then text_to_integer(array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 1)) else 0 end, case when #5 then array_index(regexp_split_to_array[":", case_insensitive=false](substr(#3, 3)), 2) else #3 end) // { arity: 10 }
           FlatMap generate_series(1, (regexp_split_to_array[",", case_insensitive=false](#1) array_length 1), 1) // { arity: 3 }
             Project (#3, #4) // { arity: 2 }
               Filter (#3) IS NOT NULL // { arity: 5 }

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -30,8 +30,8 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT record, (record).f2 FROM (SELECT ROW(a, a) AS record FROM t1);
 ----
 Explained Query:
-  Project (#2, #0{a}) // { arity: 2 }
-    Map (row(#0{a}, #0{a})) // { arity: 3 }
+  Project (#2, #3) // { arity: 2 }
+    Map (row(#0{a}, #0{a}), record_get[1](#2)) // { arity: 4 }
       ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1


### PR DESCRIPTION
This is Frank's https://github.com/MaterializeInc/materialize/pull/32093, with test rewrites and a feature flag.

I also had to change the `ColumnKnowledge performed work after EquivalencePropagation` error to a warning, because it became too common: specifically it's not happening at every startup. (This would have looked bad as an error when one starts up Materialize locally; one might think that there is something wrong. Also, a test framework is verifying that there are no error logs at startup.) (Note that in contrast to `EquivalencePropagation`, `ColumnKnowledge` is able to introduce knowledge about each Map expression as it goes without being quadratic, because it does less work when it introduces knowledge.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9144: This was causing 7-minute optimizations for some PowerBI queries.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
