### PR TITLE
Filter not-found errors in lgalloc metrics task

### DIFF
--- a/src/metrics/src/lgalloc.rs
+++ b/src/metrics/src/lgalloc.rs
@@ -130,8 +130,15 @@ macro_rules! metrics_size_class {
                                 accum.add_assign(file_stat);
                             }
                         }
+                        #[cfg(target_os = "linux")]
                         Err(err) => {
                             return Err(Error::new(ErrorKind::FileStatsFailed(err.to_string())));
+                        }
+                        #[cfg(not(target_os = "linux"))]
+                        Err(err) => {
+                            if err.kind() != std::io::ErrorKind::NotFound {
+                                return Err(Error::new(ErrorKind::FileStatsFailed(err.to_string())));
+                            }
                         }
                     }
                     for (size_class, accum) in accums {


### PR DESCRIPTION
The lgalloc metrics task tries to extract some information from `/proc/numa_maps`, which only exists on Linux. We're also using lgalloc on Mac, but don't support reading all stats. The current metrics update task notices the failure and prints a warning. With this change, it will swallow the not-found error but still propagate all other errors on Mac.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
