### PR TITLE
#8191: add support for BC and AD suffixes in timestamps

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1884,7 +1884,8 @@ impl CalendarEra {
 }
 
 /// Takes a 'date timezone' 'date time timezone' string and splits it into 'date
-/// {time}' and 'timezone' components with a boolean if true indicates it is BC.
+/// {time}' and 'timezone' components then checks for a 'CalenderEra' defaulting
+/// to 'AD'.
 pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
     // First we need to see if the string contains " +" or " -" because
     // timestamps can come in a format YYYY-MM-DD {+|-}<tz> (where the timezone

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -885,7 +885,7 @@ impl ParsedDateTime {
 
         if let CalendarEra::BC = era {
             pdt.year = pdt.year.map(|mut y| {
-                y.unit = y.unit * -1;
+                y.unit = -y.unit;
                 y
             });
         }

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1874,6 +1874,15 @@ pub enum CalendarEra {
     AD,
 }
 
+impl CalendarEra {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CalendarEra::BC => "BC",
+            CalendarEra::AD => "AD",
+        }
+    }
+}
+
 /// Takes a 'date timezone' 'date time timezone' string and splits it into 'date
 /// {time}' and 'timezone' components with a boolean if true indicates it is BC.
 pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
@@ -1888,8 +1897,8 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
         let (first, second) = value.split_at(cut);
 
         let (second, era) = match (
-            second.strip_suffix(stringify!(BC)),
-            second.strip_suffix(stringify!(AD)),
+            second.strip_suffix(BC.as_str()),
+            second.strip_suffix(AD.as_str()),
         ) {
             (Some(remainder), None) => (remainder, BC),
             (None, Some(remainder)) => (remainder, AD),
@@ -1912,8 +1921,8 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
             if let Some(tz) = tz {
                 let (first, second) = value.split_at(colon + tz);
                 let (second, era) = match (
-                    second.strip_suffix(stringify!(BC)),
-                    second.strip_suffix(stringify!(AD)),
+                    second.strip_suffix(BC.as_str()),
+                    second.strip_suffix(AD.as_str()),
                 ) {
                     (Some(remainder), None) => (remainder, BC),
                     (None, Some(remainder)) => (remainder, AD),
@@ -1935,8 +1944,8 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
             let (first, second) = value.split_at(cut);
 
             let (second, era) = match (
-                second.strip_suffix(stringify!(BC)),
-                second.strip_suffix(stringify!(AD)),
+                second.strip_suffix(BC.as_str()),
+                second.strip_suffix(AD.as_str()),
             ) {
                 (Some(remainder), None) => (remainder, BC),
                 (None, Some(remainder)) => (remainder, AD),

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -389,9 +389,9 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, Timezone), S
         ));
     }
 
-    let (ts_string, tz_string, was_bc) = datetime::split_timestamp_string(s);
+    let (ts_string, tz_string, era) = datetime::split_timestamp_string(s);
 
-    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string, was_bc)?;
+    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string, era)?;
     let d: NaiveDate = pdt.compute_date()?;
     let t: NaiveTime = pdt.compute_time()?;
 

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -389,9 +389,9 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, Timezone), S
         ));
     }
 
-    let (ts_string, tz_string) = datetime::split_timestamp_string(s);
+    let (ts_string, tz_string, was_bc) = datetime::split_timestamp_string(s);
 
-    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string)?;
+    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string, was_bc)?;
     let d: NaiveDate = pdt.compute_date()?;
     let t: NaiveTime = pdt.compute_time()?;
 

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -456,11 +456,31 @@ SELECT '0001-12-31 19:03:58 EST BC'::timestamp;
 0001-12-31 19:03:58 BC
 
 query T
+SELECT '0001-12-31 19:03:58 bc'::timestamp;
+----
+0001-12-31 19:03:58 BC
+
+query T
+SELECT '0001-12-31 19:03:58 BC '::timestamp;
+----
+0001-12-31 19:03:58 BC
+
+query T
 SELECT '0001-12-31 19:03:58 AD'::timestamp;
 ----
 0001-12-31 19:03:58
 
 query T
 SELECT '0001-12-31 19:03:58 EST AD'::timestamp;
+----
+0001-12-31 19:03:58
+
+query T
+SELECT '0001-12-31 19:03:58 ad'::timestamp;
+----
+0001-12-31 19:03:58
+
+query T
+SELECT '0001-12-31 19:03:58 AD '::timestamp;
 ----
 0001-12-31 19:03:58

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -444,3 +444,13 @@ NULL
 NULL
 NULL
 NULL
+
+query T
+SELECT '0001-12-31 19:03:58 BC'::timestamp;
+----
+0001-12-31 19:03:58 BC
+
+query T
+SELECT '0001-12-31 19:03:58 EST BC'::timestamp;
+----
+0001-12-31 19:03:58 BC

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -466,6 +466,11 @@ SELECT '0001-12-31 19:03:58 BC '::timestamp;
 0001-12-31 19:03:58 BC
 
 query T
+SELECT '0001-12-31 19:03:58BC '::timestamp;
+----
+0001-12-31 19:03:58 BC
+
+query T
 SELECT '0001-12-31 19:03:58 AD'::timestamp;
 ----
 0001-12-31 19:03:58
@@ -482,5 +487,10 @@ SELECT '0001-12-31 19:03:58 ad'::timestamp;
 
 query T
 SELECT '0001-12-31 19:03:58 AD '::timestamp;
+----
+0001-12-31 19:03:58
+
+query T
+SELECT '0001-12-31 19:03:58AD '::timestamp;
 ----
 0001-12-31 19:03:58

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -454,3 +454,13 @@ query T
 SELECT '0001-12-31 19:03:58 EST BC'::timestamp;
 ----
 0001-12-31 19:03:58 BC
+
+query T
+SELECT '0001-12-31 19:03:58 AD'::timestamp;
+----
+0001-12-31 19:03:58
+
+query T
+SELECT '0001-12-31 19:03:58 EST AD'::timestamp;
+----
+0001-12-31 19:03:58


### PR DESCRIPTION
adds parsing and returning BC time stamps

### Motivation

https://github.com/MaterializeInc/database-issues/issues/8191

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
