### PR TITLE
controller: report compute introspection updates promptly

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1919,6 +1919,12 @@ impl Coordinator {
             init_storage_collections_start.elapsed()
         );
 
+        // The storage controller knows about the introspection collections now, so we can start
+        // sinking introspection updates in the compute controller. It makes sense to do that as
+        // soon as possible, to avoid updates piling up in the compute controller's internal
+        // buffers.
+        self.controller.start_compute_introspection_sink();
+
         let optimize_dataflows_start = Instant::now();
         info!("startup: coordinator init: bootstrap: optimize dataflow plans beginning");
         let entries: Vec<_> = self.catalog().entries().cloned().collect();

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -33,7 +33,6 @@ use std::num::NonZeroI64;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use differential_dataflow::consolidation::consolidate;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use mz_build_info::BuildInfo;
@@ -54,8 +53,8 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
-use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
+use mz_repr::{Datum, GlobalId, Row, TimestampManipulation};
+use mz_storage_client::controller::StorageController;
 use mz_storage_types::dyncfgs::ORE_OVERFLOWING_BEHAVIOR;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
@@ -75,6 +74,7 @@ use crate::controller::error::{
     ReplicaCreationError, ReplicaDropError,
 };
 use crate::controller::instance::{Instance, SharedCollectionState};
+use crate::controller::introspection::{spawn_introspection_sink, IntrospectionUpdates};
 use crate::controller::replica::ReplicaConfig;
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::metrics::ComputeControllerMetrics;
@@ -83,12 +83,12 @@ use crate::protocol::response::{PeekResponse, SubscribeBatch};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
 mod instance;
+mod introspection;
 mod replica;
 mod sequential_hydration;
 
 pub mod error;
 
-type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
 pub(crate) type StorageCollections<T> = Arc<
     dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = T> + Send + Sync,
 >;
@@ -203,9 +203,12 @@ pub struct ComputeController<T: ComputeControllerTimestamp> {
     /// Response sender that's passed to new `Instance`s.
     response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
     /// Receiver for introspection updates produced by `Instance`s.
-    introspection_rx: crossbeam_channel::Receiver<IntrospectionUpdates>,
+    ///
+    /// When [`ComputeController::start_introspection_sink`] is first called, this receiver is
+    /// passed to the introspection sink task.
+    introspection_rx: Option<mpsc::UnboundedReceiver<IntrospectionUpdates>>,
     /// Introspection updates sender that's passed to new `Instance`s.
-    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+    introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
 
     /// Ticker for scheduling periodic maintenance work.
     maintenance_ticker: tokio::time::Interval,
@@ -226,7 +229,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         wallclock_lag: WallclockLagFn<T>,
     ) -> Self {
         let (response_tx, response_rx) = mpsc::unbounded_channel();
-        let (introspection_tx, introspection_rx) = crossbeam_channel::unbounded();
+        let (introspection_tx, introspection_rx) = mpsc::unbounded_channel();
 
         let mut maintenance_ticker = time::interval(Duration::from_secs(1));
         maintenance_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -299,10 +302,23 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             dyncfg: Arc::new(mz_dyncfgs::all_dyncfgs()),
             response_rx,
             response_tx,
-            introspection_rx,
+            introspection_rx: Some(introspection_rx),
             introspection_tx,
             maintenance_ticker,
             maintenance_scheduled: false,
+        }
+    }
+
+    /// Start sinking the compute controller's introspection data into storage.
+    ///
+    /// This method should be called once the introspection collections have been registered with
+    /// the storage controller. It will panic if invoked earlier than that.
+    pub fn start_introspection_sink(
+        &mut self,
+        storage_controller: &dyn StorageController<Timestamp = T>,
+    ) {
+        if let Some(rx) = self.introspection_rx.take() {
+            spawn_introspection_sink(rx, storage_controller);
         }
     }
 
@@ -1062,55 +1078,12 @@ where
         ))
     }
 
-    #[mz_ore::instrument(level = "debug")]
-    fn record_introspection_updates(&mut self, storage: &mut dyn StorageController<Timestamp = T>) {
-        use IntrospectionType::*;
-
-        // We could record the contents of `introspection_rx` directly here, but to reduce the
-        // pressure on persist we spend some effort consolidating first.
-        let mut updates_by_type = BTreeMap::new();
-
-        for (type_, updates) in self.introspection_rx.try_iter() {
-            updates_by_type
-                .entry(type_)
-                .or_insert_with(Vec::new)
-                .extend(updates);
-        }
-        for updates in updates_by_type.values_mut() {
-            consolidate(updates);
-        }
-
-        for (type_, updates) in updates_by_type {
-            if updates.is_empty() {
-                continue;
-            }
-
-            match type_ {
-                Frontiers
-                | ReplicaFrontiers
-                | ComputeDependencies
-                | ComputeOperatorHydrationStatus
-                | ComputeMaterializedViewRefreshes => {
-                    let op = StorageWriteOp::Append { updates };
-                    storage.update_introspection_collection(type_, op);
-                }
-                WallclockLagHistory | WallclockLagHistogram => {
-                    storage.append_introspection_updates(type_, updates);
-                }
-                _ => panic!("unexpected introspection type: {type_:?}"),
-            }
-        }
-    }
-
     /// Processes the work queued by [`ComputeController::ready`].
     #[mz_ore::instrument(level = "debug")]
-    pub fn process(
-        &mut self,
-        storage: &mut dyn StorageController<Timestamp = T>,
-    ) -> Option<ComputeControllerResponse<T>> {
+    pub fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
         // Perform periodic maintenance work.
         if self.maintenance_scheduled {
-            self.maintain(storage);
+            self.maintain();
             self.maintenance_scheduled = false;
         }
 
@@ -1119,18 +1092,11 @@ where
     }
 
     #[mz_ore::instrument(level = "debug")]
-    fn maintain(&mut self, storage: &mut dyn StorageController<Timestamp = T>) {
+    fn maintain(&mut self) {
         // Perform instance maintenance work.
         for instance in self.instances.values_mut() {
             instance.call(Instance::maintain);
         }
-
-        // Record pending introspection updates.
-        //
-        // It's beneficial to do this as the last maintenance step because previous steps can cause
-        // dropping of state, which can can cause introspection retractions, which lower the volume
-        // of data we have to record.
-        self.record_introspection_updates(storage);
     }
 }
 

--- a/src/compute-client/src/controller/introspection.rs
+++ b/src/compute-client/src/controller/introspection.rs
@@ -1,0 +1,114 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_repr::{Diff, Row};
+use mz_storage_client::client::AppendOnlyUpdate;
+use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
+use mz_storage_types::controller::StorageError;
+use timely::progress::Timestamp;
+use tokio::sync::{mpsc, oneshot};
+use tracing::info;
+
+pub type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
+
+/// Spawn a task sinking introspection updates produced by the compute controller to storage.
+pub fn spawn_introspection_sink<T: Timestamp>(
+    mut rx: mpsc::UnboundedReceiver<IntrospectionUpdates>,
+    storage_controller: &dyn StorageController<Timestamp = T>,
+) {
+    let sink = IntrospectionSink::new(storage_controller);
+
+    mz_ore::task::spawn(|| "compute-introspection-sink", async move {
+        info!("running introspection sink task");
+
+        while let Some((type_, updates)) = rx.recv().await {
+            sink.send(type_, updates);
+        }
+
+        info!("introspection sink task shutting down");
+    });
+}
+
+type Notifier<T> = oneshot::Sender<Result<(), StorageError<T>>>;
+type AppendOnlySender<T> = mpsc::UnboundedSender<(Vec<AppendOnlyUpdate>, Notifier<T>)>;
+type DifferentialSender<T> = mpsc::UnboundedSender<(StorageWriteOp, Notifier<T>)>;
+
+/// A sink for introspection updates produced by the compute controller.
+///
+/// The sender is connected to the storage controller's CollectionManager, which writes received
+/// updates to persist.
+#[derive(Debug)]
+struct IntrospectionSink<T> {
+    /// Sender for [`IntrospectionType::Frontiers`] updates.
+    frontiers_tx: DifferentialSender<T>,
+    /// Sender for [`IntrospectionType::ReplicaFrontiers`] updates.
+    replica_frontiers_tx: DifferentialSender<T>,
+    /// Sender for [`IntrospectionType::ComputeDependencies`] updates.
+    compute_dependencies_tx: DifferentialSender<T>,
+    /// Sender for [`IntrospectionType::ComputeOperatorHydrationStatus`] updates.
+    compute_operator_hydration_status_tx: DifferentialSender<T>,
+    /// Sender for [`IntrospectionType::ComputeMaterializedViewRefreshes`] updates.
+    compute_materialized_view_refreshes_tx: DifferentialSender<T>,
+    /// Sender for [`IntrospectionType::WallclockLagHistory`] updates.
+    wallclock_lag_history_tx: AppendOnlySender<T>,
+    /// Sender for [`IntrospectionType::WallclockLagHistogram`] updates.
+    wallclock_lag_histogram_tx: AppendOnlySender<T>,
+}
+
+impl<T: Timestamp> IntrospectionSink<T> {
+    /// Create a new `IntrospectionSink`.
+    pub fn new(storage_controller: &dyn StorageController<Timestamp = T>) -> Self {
+        use IntrospectionType::*;
+        Self {
+            frontiers_tx: storage_controller.differential_introspection_tx(Frontiers),
+            replica_frontiers_tx: storage_controller
+                .differential_introspection_tx(ReplicaFrontiers),
+            compute_dependencies_tx: storage_controller
+                .differential_introspection_tx(ComputeDependencies),
+            compute_operator_hydration_status_tx: storage_controller
+                .differential_introspection_tx(ComputeOperatorHydrationStatus),
+            compute_materialized_view_refreshes_tx: storage_controller
+                .differential_introspection_tx(ComputeMaterializedViewRefreshes),
+            wallclock_lag_history_tx: storage_controller
+                .append_only_introspection_tx(WallclockLagHistory),
+            wallclock_lag_histogram_tx: storage_controller
+                .append_only_introspection_tx(WallclockLagHistogram),
+        }
+    }
+
+    /// Send a batch of updates of the given introspection type.
+    pub fn send(&self, type_: IntrospectionType, updates: Vec<(Row, Diff)>) {
+        let send_append_only = |tx: &AppendOnlySender<_>, updates: Vec<_>| {
+            let updates = updates.into_iter().map(AppendOnlyUpdate::Row).collect();
+            let (notifier, _) = oneshot::channel();
+            let _ = tx.send((updates, notifier));
+        };
+        let send_differential = |tx: &DifferentialSender<_>, updates: Vec<_>| {
+            let op = StorageWriteOp::Append { updates };
+            let (notifier, _) = oneshot::channel();
+            let _ = tx.send((op, notifier));
+        };
+
+        use IntrospectionType::*;
+        match type_ {
+            Frontiers => send_differential(&self.frontiers_tx, updates),
+            ReplicaFrontiers => send_differential(&self.replica_frontiers_tx, updates),
+            ComputeDependencies => send_differential(&self.compute_dependencies_tx, updates),
+            ComputeOperatorHydrationStatus => {
+                send_differential(&self.compute_operator_hydration_status_tx, updates);
+            }
+            ComputeMaterializedViewRefreshes => {
+                send_differential(&self.compute_materialized_view_refreshes_tx, updates);
+            }
+            WallclockLagHistory => send_append_only(&self.wallclock_lag_history_tx, updates),
+            WallclockLagHistogram => send_append_only(&self.wallclock_lag_histogram_tx, updates),
+            _ => panic!("unexpected introspection type: {type_:?}"),
+        }
+    }
+}

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -207,6 +207,14 @@ impl<T: ComputeControllerTimestamp> Controller<T> {
         self.compute.set_arrangement_exert_proportionality(value);
     }
 
+    /// Start sinking the compute controller's introspection data into storage.
+    ///
+    /// This method should be called once the introspection collections have been registered with
+    /// the storage controller. It will panic if invoked earlier than that.
+    pub fn start_compute_introspection_sink(&mut self) {
+        self.compute.start_introspection_sink(&*self.storage);
+    }
+
     /// Returns the connection context installed in the controller.
     ///
     /// This is purely a helper, and can be obtained from `self.storage`.
@@ -470,7 +478,7 @@ where
     /// Process a pending response from the compute controller. If necessary,
     /// return a higher-level response to our client.
     fn process_compute_response(&mut self) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
-        let response = self.compute.process(&mut *self.storage);
+        let response = self.compute.process();
 
         let response = response.and_then(|r| match r {
             ComputeControllerResponse::PeekNotification(uuid, peek, otel_ctx) => {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -686,6 +686,32 @@ pub trait StorageController: Debug {
     /// introspection type, as readers rely on this and might panic otherwise.
     fn update_introspection_collection(&mut self, type_: IntrospectionType, op: StorageWriteOp);
 
+    /// Returns a sender for updates to the specified append-only introspection collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given introspection type is not associated with an append-only collection.
+    fn append_only_introspection_tx(
+        &self,
+        type_: IntrospectionType,
+    ) -> mpsc::UnboundedSender<(
+        Vec<AppendOnlyUpdate>,
+        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
+    )>;
+
+    /// Returns a sender for updates to the specified differential introspection collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given introspection type is not associated with a differential collection.
+    fn differential_introspection_tx(
+        &self,
+        type_: IntrospectionType,
+    ) -> mpsc::UnboundedSender<(
+        StorageWriteOp,
+        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
+    )>;
+
     async fn real_time_recent_timestamp(
         &self,
         source_ids: BTreeSet<GlobalId>,


### PR DESCRIPTION
This PR fixes a bug where certain types of introspection updates (frontiers and wallclock lag) would be reported with a 1s delay, causing confusion particularly around comparing compute with storage frontiers.

The bug was caused by the compute controller only reporting frontier advancements to the storage controller once per second. Frontier introspection is also produced once per second, but by the per-instance controllers, and the compute controller couldn't wait on the instance controllers because it had no way to know when they finished emitting frontier updates.

The fix implemented here is to have a "compute introspection sink" task that continually reads from the compute controller-internal `introspection_rx` and pushes the introspection updates to the storage controller. This task cannot hold a reference to the storage controller, so instead it gets initialized with the sending end of the channels connected to the `CollectionManager`. This way it can push updates to the persist writer tasks directly, without going through the `StorageController`.

We need to be careful about when to start the task: During controller initialization, the storage controller doesn't yet know about the introspection collections, so attempting to get channels to send updates for them won't succeed. Instead we need to wait until bootstrapping has progressed until after the storage collections have been initialized from the catalog, at which point we can start the introspection sink task.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9149

### Tips for reviewer

Thoughts about alternative approaches:

* I was hoping that we could pass the `IntrospectionSink`, i.e. all the channels connected to the `CollectionManager`, to the instance controllers directly, and get rid of the compute controller-internal `introspection_{tx,rx}` channel. Unfortunately that doesn't work because when the compute controller and the instances are initialized the storage controller doesn't yet know about introspection collections, and so we can't get the `CollectionManager` channels.
* There is a simpler fix than the one made in this PR, which is to keep the existing `record_introspection_updates` method in the compute controller and run it every time there are updates in `introspection_rx`. For that we just need to adjust the ready/process methods and don't need to introduce a new task, or change the storage controller to provide access to the `CollectionManager` channels. I'm weary of this approach because it means added noise on the coordinator's main thread, but it's something to consider.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
