### PR TITLE
[bazel] run `bin/fmt`

### DIFF
--- a/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
@@ -36,9 +36,9 @@ cc_library(
         ":io-bridge/include",
         ":lib-bridge/include",
         "@com_google_absl//absl/strings",
-        "@crates_io__cxx-1.0.122//:cxx_cc",
         "@com_google_protobuf//src/google/protobuf/compiler:code_generator",
         "@com_google_protobuf//src/google/protobuf/compiler:importer",
+        "@crates_io__cxx-1.0.122//:cxx_cc",
     ],
 )
 


### PR DESCRIPTION
Missed some formatting in https://github.com/MaterializeInc/materialize/pull/32098

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
