### PR TITLE
[bazel] fix paths for `cargo` tool

### DIFF
--- a/misc/bazel/tools/BUILD.bazel
+++ b/misc/bazel/tools/BUILD.bazel
@@ -41,10 +41,10 @@ native_binary(
     name = "cargo",
     src = select(
         {
-            "@//misc/bazel/platforms:macos_x86_64": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:cargo",
-            "@//misc/bazel/platforms:macos_arm": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:cargo",
-            "@//misc/bazel/platforms:linux_x86_64": "@rust_linux_x86_64__x86_64-apple-darwin__stable_tools//:cargo",
-            "@//misc/bazel/platforms:linux_arm": "@rust_linux_aarch64__aarch64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:macos_x86_64": "@rust_macos_x86_64__x86_64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:macos_arm": "@rust_macos_aarch64__aarch64-apple-darwin__stable_tools//:cargo",
+            "@//misc/bazel/platforms:linux_x86_64": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:cargo",
+            "@//misc/bazel/platforms:linux_arm": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:cargo",
         },
         no_match_error = "`cargo` is not supported on the current platform.",
     ),


### PR DESCRIPTION
These paths changed when upgrading to the newer `rules_rust`

### Motivation

Fix `bin/lint`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
