### PR TITLE
[sql_server] Implementent purification for SQL Server Source

### DIFF
--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -15,7 +15,7 @@ bytesize = "1.3.0"
 datadriven = { version = "0.8.0", optional = true }
 enum-kinds = "0.5.1"
 itertools = "0.12.1"
-mz-ore = { path = "../ore", default-features = false, features = ["stack", "test", "tracing"] }
+mz-ore = { path = "../ore", default-features = false, features = ["stack", "test"] }
 mz-sql-lexer = { path = "../sql-lexer", default-features = false }
 phf = { version = "0.11.1", features = ["uncased"] }
 serde = { version = "1.0.219", features = ["derive"] }
@@ -27,7 +27,7 @@ unicode-width = { version = "0.2.0", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-mz-ore = { path = "../ore", default-features = false, features = ["test"] }
+mz-ore = { path = "../ore", default-features = false, features = ["test", "tracing"] }
 mz-sql-parser = { path = ".", default-features = false, features = ["test"] }
 
 [build-dependencies]

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -15,7 +15,7 @@ bytesize = "1.3.0"
 datadriven = { version = "0.8.0", optional = true }
 enum-kinds = "0.5.1"
 itertools = "0.12.1"
-mz-ore = { path = "../ore", default-features = false, features = ["stack", "test"] }
+mz-ore = { path = "../ore", default-features = false, features = ["stack", "test", "tracing"] }
 mz-sql-lexer = { path = "../sql-lexer", default-features = false }
 phf = { version = "0.11.1", features = ["uncased"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1185,15 +1185,15 @@ impl_display_t!(MySqlConfigOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SqlServerConfigOptionName {
-    /// The name for the "capture job" that will get spawn in SQL Server to
-    /// populate the change table that we read from.
-    CaptureInstance,
+    /// Hex encoded string of binary serialization of
+    /// `mz_storage_types::sources::sql_server::SqlServerSourceDetails`.
+    Details,
 }
 
 impl AstDisplay for SqlServerConfigOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
-            SqlServerConfigOptionName::CaptureInstance => "CAPTURE INSTANCE",
+            SqlServerConfigOptionName::Details => "DETAILS",
         })
     }
 }
@@ -1207,7 +1207,7 @@ impl WithOptionName for SqlServerConfigOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
-            SqlServerConfigOptionName::CaptureInstance => false,
+            SqlServerConfigOptionName::Details => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3469,11 +3469,8 @@ impl<'a> Parser<'a> {
     fn parse_sql_server_connection_option(
         &mut self,
     ) -> Result<SqlServerConfigOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[CAPTURE])? {
-            CAPTURE => {
-                self.expect_keyword(INSTANCE)?;
-                SqlServerConfigOptionName::CaptureInstance
-            }
+        let name = match self.expect_one_of_keywords(&[DETAILS])? {
+            DETAILS => SqlServerConfigOptionName::Details,
             _ => unreachable!(),
         };
 

--- a/src/sql-parser/tests/testdata/source
+++ b/src/sql-parser/tests/testdata/source
@@ -29,8 +29,8 @@ CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("my
 parse-statement
 CREATE SOURCE "no_such_table"
   IN CLUSTER cdc_cluster
-  FROM SQL SERVER CONNECTION sql_server (CAPTURE INSTANCE 'no_such_mz_capture_1');
+  FROM SQL SERVER CONNECTION sql_server;
 ----
-CREATE SOURCE no_such_table IN CLUSTER cdc_cluster FROM SQL SERVER CONNECTION sql_server (CAPTURE INSTANCE = 'no_such_mz_capture_1')
+CREATE SOURCE no_such_table IN CLUSTER cdc_cluster FROM SQL SERVER CONNECTION sql_server
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("no_such_table")]), in_cluster: Some(Unresolved(Ident("cdc_cluster"))), col_names: [], connection: SqlServer { connection: Name(UnresolvedItemName([Ident("sql_server")])), options: [SqlServerConfigOption { name: CaptureInstance, value: Some(Value(String("no_such_mz_capture_1"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("no_such_table")]), in_cluster: Some(Unresolved(Ident("cdc_cluster"))), col_names: [], connection: SqlServer { connection: Name(UnresolvedItemName([Ident("sql_server")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })

--- a/src/sql-server-util/src/desc.proto
+++ b/src/sql-server-util/src/desc.proto
@@ -15,10 +15,11 @@ import "google/protobuf/empty.proto";
 import "repr/src/relation_and_scalar.proto";
 
 message ProtoSqlServerTableDesc {
+  reserved 4;
+
   string name = 1;
   string schema_name = 2;
   repeated ProtoSqlServerColumnDesc columns = 3;
-  bool is_cdc_enabled = 4;
 }
 
 message ProtoSqlServerColumnDesc {

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -114,6 +114,8 @@ pub struct SqlServerTableRaw {
     pub schema_name: Arc<str>,
     /// Name of the table.
     pub name: Arc<str>,
+    /// The capture instance replicating changes.
+    pub capture_instance: Arc<str>,
     /// Columns for the table.
     pub columns: Arc<[SqlServerColumnRaw]>,
     /// Whether or not CDC is enabled for this table.
@@ -543,6 +545,7 @@ impl RustType<proto_sql_server_column_desc::DecodeType> for SqlServerColumnDecod
 ///
 /// The goal of this type is to perform any expensive "downcasts" so in the hot
 /// path of decoding rows we do the minimal amount of work.
+#[derive(Debug)]
 pub struct SqlServerRowDecoder {
     decoders: Vec<(Arc<str>, ColumnType, SqlServerColumnDecodeType)>,
 }
@@ -701,6 +704,7 @@ mod tests {
         let sql_server_desc = SqlServerTableRaw {
             schema_name: "my_schema".into(),
             name: "my_table".into(),
+            capture_instance: "my_table_CT".into(),
             columns: sql_server_columns.into(),
             is_cdc_enabled: true,
         };

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -49,8 +49,6 @@ pub struct SqlServerTableDesc {
     pub name: Arc<str>,
     /// Columns for the table.
     pub columns: Arc<[SqlServerColumnDesc]>,
-    /// Is CDC enabled for this table, required to replicate into Materialize.
-    pub is_cdc_enabled: bool,
 }
 
 impl SqlServerTableDesc {
@@ -67,7 +65,6 @@ impl SqlServerTableDesc {
             schema_name: raw.schema_name,
             name: raw.name,
             columns,
-            is_cdc_enabled: raw.is_cdc_enabled,
         })
     }
 
@@ -85,7 +82,6 @@ impl RustType<ProtoSqlServerTableDesc> for SqlServerTableDesc {
             name: self.name.to_string(),
             schema_name: self.schema_name.to_string(),
             columns: self.columns.iter().map(|c| c.into_proto()).collect(),
-            is_cdc_enabled: self.is_cdc_enabled,
         }
     }
 
@@ -99,7 +95,6 @@ impl RustType<ProtoSqlServerTableDesc> for SqlServerTableDesc {
             schema_name: proto.schema_name.into(),
             name: proto.name.into(),
             columns,
-            is_cdc_enabled: proto.is_cdc_enabled,
         })
     }
 }
@@ -118,8 +113,6 @@ pub struct SqlServerTableRaw {
     pub capture_instance: Arc<str>,
     /// Columns for the table.
     pub columns: Arc<[SqlServerColumnRaw]>,
-    /// Whether or not CDC is enabled for this table.
-    pub is_cdc_enabled: bool,
 }
 
 /// Description of a column from a table in Microsoft SQL Server.
@@ -706,7 +699,6 @@ mod tests {
             name: "my_table".into(),
             capture_instance: "my_table_CT".into(),
             columns: sql_server_columns.into(),
-            is_cdc_enabled: true,
         };
         let sql_server_desc = SqlServerTableDesc::try_new(sql_server_desc).expect("known valid");
 

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -262,7 +262,7 @@ JOIN cdc.change_tables ch ON t.object_id = ch.source_object_id
                 Arc::clone(&table_name),
                 Arc::clone(&capture_instance),
             ))
-            .or_insert_with(|| Vec::default());
+            .or_default();
         columns.push(column);
     }
 

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -256,7 +256,7 @@ JOIN cdc.change_tables ch ON t.object_id = ch.source_object_id
             scale: get_value(&row, "col_scale")?,
         };
 
-        let columns = tables
+        let columns: &mut Vec<_> = tables
             .entry((
                 Arc::clone(&schema_name),
                 Arc::clone(&table_name),

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -739,6 +739,8 @@ pub enum SqlServerError {
     SqlServer(#[from] tiberius::error::Error),
     #[error(transparent)]
     CdcError(#[from] crate::cdc::CdcError),
+    #[error("expected column '{0}' to be present")]
+    MissingColumn(&'static str),
     #[error("'{column_type}' from column '{column_name}' is not supported: {reason}")]
     UnsupportedDataType {
         column_name: String,
@@ -749,6 +751,12 @@ pub enum SqlServerError {
     IO(#[from] tokio::io::Error),
     #[error("found invalid data in the column '{column_name}': {error}")]
     InvalidData { column_name: String, error: String },
+    #[error("invalid SQL Server system setting '{name}'. Expected '{expected}'. Got '{actual}'.")]
+    InvalidSystemSetting {
+        name: String,
+        expected: String,
+        actual: String,
+    },
     #[error("invariant was violated: {0}")]
     InvariantViolated(String),
     #[error(transparent)]

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -44,6 +44,7 @@ use crate::plan::typeconv::CastContext;
 use crate::pure::error::{
     CsrPurificationError, KafkaSinkPurificationError, KafkaSourcePurificationError,
     LoadGeneratorSourcePurificationError, MySqlSourcePurificationError, PgSourcePurificationError,
+    SqlServerSourcePurificationError,
 };
 use crate::session::vars::VarError;
 
@@ -250,6 +251,7 @@ pub enum PlanError {
     LoadGeneratorSourcePurification(LoadGeneratorSourcePurificationError),
     CsrPurification(CsrPurificationError),
     MySqlSourcePurification(MySqlSourcePurificationError),
+    SqlServerSourcePurificationError(SqlServerSourcePurificationError),
     UseTablesForSources(String),
     MissingName(CatalogItemType),
     InvalidRefreshAt,
@@ -331,6 +333,7 @@ impl PlanError {
             Self::InternalFunctionCall => Some("This function is for the internal use of the database system and cannot be called directly.".into()),
             Self::PgSourcePurification(e) => e.detail(),
             Self::MySqlSourcePurification(e) => e.detail(),
+            Self::SqlServerSourcePurificationError(e) => e.detail(),
             Self::KafkaSourcePurification(e) => e.detail(),
             Self::LoadGeneratorSourcePurification(e) => e.detail(),
             Self::CsrPurification(e) => e.detail(),
@@ -439,6 +442,8 @@ impl PlanError {
             Self::Catalog(e) => e.hint(),
             Self::VarError(e) => e.hint(),
             Self::PgSourcePurification(e) => e.hint(),
+            Self::MySqlSourcePurification(e) => e.hint(),
+            Self::SqlServerSourcePurificationError(e) => e.hint(),
             Self::KafkaSourcePurification(e) => e.hint(),
             Self::LoadGeneratorSourcePurification(e) => e.hint(),
             Self::CsrPurification(e) => e.hint(),
@@ -739,6 +744,7 @@ impl fmt::Display for PlanError {
             Self::KafkaSinkPurification(e) => write!(f, "KAFKA sink validation: {}", e),
             Self::CsrPurification(e) => write!(f, "CONFLUENT SCHEMA REGISTRY validation: {}", e),
             Self::MySqlSourcePurification(e) => write!(f, "MYSQL source validation: {}", e),
+            Self::SqlServerSourcePurificationError(e) => write!(f, "SQL SERVER source validation: {}", e),
             Self::UseTablesForSources(command) => write!(f, "{command} not supported; use CREATE TABLE .. FROM SOURCE instead"),
             Self::MangedReplicaName(name) => {
                 write!(f, "{name} is reserved for replicas of managed clusters")
@@ -937,6 +943,12 @@ impl From<LoadGeneratorSourcePurificationError> for PlanError {
 impl From<MySqlSourcePurificationError> for PlanError {
     fn from(e: MySqlSourcePurificationError) -> Self {
         PlanError::MySqlSourcePurification(e)
+    }
+}
+
+impl From<SqlServerSourcePurificationError> for PlanError {
+    fn from(e: SqlServerSourcePurificationError) -> Self {
+        PlanError::SqlServerSourcePurificationError(e)
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -532,7 +532,7 @@ generate_extracted_config!(
     (ExcludeColumns, Vec::<UnresolvedItemName>, Default(vec![]))
 );
 
-generate_extracted_config!(SqlServerConfigOption, (CaptureInstance, String));
+generate_extracted_config!(SqlServerConfigOption, (Details, String));
 
 pub fn plan_create_webhook_source(
     scx: &StatementContext,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1014,10 +1014,10 @@ async fn purify_create_source(
             let subsources = sql_server::purify_source_exports(
                 &mut client,
                 &retrieved_source_references,
-                &external_references,
+                external_references,
                 &text_columns,
                 &exclude_columns,
-                &source_name,
+                source_name,
                 &reference_policy,
             )
             .await?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -12,6 +12,7 @@
 //! See the [crate-level documentation](crate) for details.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::iter;
 use std::path::Path;
 use std::sync::Arc;
@@ -48,6 +49,7 @@ use mz_sql_parser::ast::{
     RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue, SourceEnvelope, Statement,
     TableFromSourceColumns, TableFromSourceOption, TableFromSourceOptionName, UnresolvedItemName,
 };
+use mz_sql_server_util::desc::SqlServerTableDesc;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::connections::{Connection, PostgresConnection};
@@ -80,6 +82,8 @@ use crate::names::{
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
 use crate::plan::{SourceReferences, StatementContext};
+use crate::pure::error::SqlServerSourcePurificationError;
+use crate::session::vars::ENABLE_SQL_SERVER_SOURCE;
 use crate::{kafka_util, normalize};
 
 use self::error::{
@@ -88,14 +92,26 @@ use self::error::{
 };
 
 pub(crate) mod error;
+mod references;
+
 pub mod mysql;
 pub mod postgres;
-mod references;
+pub mod sql_server;
 
 pub(crate) struct RequestedSourceExport<T> {
     external_reference: UnresolvedItemName,
     name: UnresolvedItemName,
     meta: T,
+}
+
+impl<T: fmt::Debug> fmt::Debug for RequestedSourceExport<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RequestedSourceExport")
+            .field("external_reference", &self.external_reference)
+            .field("name", &self.name)
+            .field("meta", &self.meta)
+            .finish()
+    }
 }
 
 impl<T> RequestedSourceExport<T> {
@@ -238,6 +254,10 @@ pub enum PurifiedExportDetails {
     Postgres {
         table: PostgresTableDesc,
         text_columns: Option<Vec<Ident>>,
+    },
+    SqlServer {
+        table: SqlServerTableDesc,
+        capture_instance: Arc<str>,
     },
     Kafka {},
     LoadGenerator {
@@ -575,6 +595,7 @@ where
 
 /// Defines whether purification should enforce that at least one valid source
 /// reference is provided on the provided statement.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum SourceReferencePolicy {
     /// Don't allow source references to be provided. This is used for
     /// enforcing that `CREATE SOURCE` statements don't create subsources.
@@ -913,14 +934,94 @@ async fn purify_create_source(
             })
         }
         CreateSourceConnection::SqlServer {
-            connection: _,
-            options: _,
+            connection,
+            options,
         } => {
-            // TODO(sql_server1): Support CREATE SOURCE ... FROM SQL SERVER.
-            return Err(PlanError::Unsupported {
-                feature: "CREATE SOURCE ... FROM SQL SERVER".to_string(),
-                discussion_no: None,
-            });
+            scx.require_feature_flag(&ENABLE_SQL_SERVER_SOURCE)?;
+
+            // Connect to the upstream SQL Server instance so we can validate
+            // we're compatible with CDC.
+            let connection_item = scx.get_item_by_resolved_name(connection)?;
+            let connection = match connection_item.connection()? {
+                Connection::SqlServer(connection) => {
+                    connection.clone().into_inline_connection(&catalog)
+                }
+                _ => Err(SqlServerSourcePurificationError::NotSqlServerConnection(
+                    scx.catalog.resolve_full_name(connection_item.name()),
+                ))?,
+            };
+            let crate::plan::statement::ddl::SqlServerConfigOptionExtracted { details, seen: _ } =
+                options.clone().try_into()?;
+
+            if details.is_some() {
+                Err(SqlServerSourcePurificationError::UserSpecifiedDetails)?;
+            }
+
+            let config = connection
+                .resolve_config(
+                    &storage_configuration.connection_context.secrets_reader,
+                    storage_configuration,
+                    InTask::No,
+                )
+                .await?;
+            let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
+            // TODO(sql_server1): Create a version of the client where we don't need to separately
+            // spawn this task.
+            mz_ore::task::spawn(|| "sql-server-conn", async move { conn.await });
+
+            // Ensure the upstream SQL Server instance is configured to allow CDC.
+            //
+            // Run all of the checks necessary and collect the errors to provide the best
+            // guidance as to which system settings need to be enabled.
+            let mut replication_errors = vec![];
+            for error in [
+                mz_sql_server_util::inspect::ensure_database_cdc_enabled(&mut client)
+                    .await
+                    .err(),
+                mz_sql_server_util::inspect::ensure_snapshot_isolation_enabled(&mut client)
+                    .await
+                    .err(),
+            ] {
+                match error {
+                    Some(mz_sql_server_util::SqlServerError::InvalidSystemSetting {
+                        name,
+                        expected,
+                        actual,
+                    }) => replication_errors.push((name, expected, actual)),
+                    Some(other) => Err(other)?,
+                    None => (),
+                }
+            }
+            if !replication_errors.is_empty() {
+                Err(SqlServerSourcePurificationError::ReplicationSettingsError(
+                    replication_errors,
+                ))?;
+            }
+
+            // TODO(sql_server1): Support text and exclude columns.
+            let text_columns = vec![];
+            let exclude_columns = vec![];
+
+            // We've validated that CDC is configured for the system, now let's
+            // purify the individual exports (i.e. subsources).
+            let reference_client = SourceReferenceClient::SqlServer {
+                client: &mut client,
+                database: connection.database.into(),
+            };
+            retrieved_source_references = reference_client.get_source_references().await?;
+            tracing::debug!(?retrieved_source_references, "got source references");
+
+            let subsources = sql_server::purify_source_exports(
+                &mut client,
+                &retrieved_source_references,
+                &external_references,
+                &text_columns,
+                &exclude_columns,
+                &source_name,
+                &reference_policy,
+            )
+            .await?;
+            requested_subsource_map.extend(subsources);
         }
         CreateSourceConnection::MySql {
             connection,
@@ -1515,12 +1616,30 @@ async fn purify_alter_source_refresh_references(
             };
             reference_client.get_source_references().await?
         }
-        GenericSourceConnection::SqlServer(_sql_server_source) => {
-            // TODO(sql_server1): Support refereshing source references.
-            return Err(PlanError::Unsupported {
-                feature: "SQL SERVER".to_string(),
-                discussion_no: None,
+        GenericSourceConnection::SqlServer(sql_server_source) => {
+            // Open a connetion to the upstream SQL Server instance.
+            let sql_server_connection = &sql_server_source.connection;
+            let config = sql_server_connection
+                .resolve_config(
+                    &storage_configuration.connection_context.secrets_reader,
+                    storage_configuration,
+                    InTask::No,
+                )
+                .await?;
+            let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
+            // TODO(sql_server1): Move the spawning of this task into the SQL Server client.
+            mz_ore::task::spawn(|| "sql-server-connection", async move {
+                conn.await;
             });
+
+            // Query the upstream SQL Server instance for available tables to replicate.
+            let source_references = SourceReferenceClient::SqlServer {
+                client: &mut client,
+                database: sql_server_connection.database.clone().into(),
+            }
+            .get_source_references()
+            .await?;
+            source_references
         }
         GenericSourceConnection::LoadGenerator(load_gen_connection) => {
             let reference_client = SourceReferenceClient::LoadGenerator {
@@ -1918,6 +2037,13 @@ async fn purify_create_table_from_source(
                 )))),
             })
         }
+        PurifiedExportDetails::SqlServer { .. } => {
+            // TODO(sql_server1): Support CREATE TABLE ... FROM SOURCE.
+            return Err(PlanError::Unsupported {
+                feature: "CREATE TABLE ... FROM SQL SERVER SOURCE".to_string(),
+                discussion_no: None,
+            });
+        }
         PurifiedExportDetails::LoadGenerator { .. } => {
             let (desc, output) = match purified_export.details {
                 PurifiedExportDetails::LoadGenerator { table, output } => (table, output),
@@ -2067,6 +2193,13 @@ pub fn generate_subsource_statements(
         }
         PurifiedExportDetails::MySql { .. } => {
             crate::pure::mysql::generate_create_subsource_statements(scx, source_name, subsources)?
+        }
+        PurifiedExportDetails::SqlServer { .. } => {
+            crate::pure::sql_server::generate_create_subsource_statements(
+                scx,
+                source_name,
+                subsources,
+            )?
         }
         PurifiedExportDetails::LoadGenerator { .. } => {
             let mut subsource_stmts = Vec::with_capacity(subsources.len());

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -7,12 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::DerefMut;
+use std::sync::Arc;
 
 use mz_ore::now::SYSTEM_TIME;
 use mz_repr::RelationDesc;
 use mz_sql_parser::ast::{ExternalReferences, Ident, IdentError, UnresolvedItemName};
+use mz_sql_server_util::SqlServerError;
 use mz_storage_types::sources::load_generator::{LoadGenerator, LoadGeneratorOutput};
 use mz_storage_types::sources::{ExternalReferenceResolutionError, SourceReferenceResolver};
 
@@ -35,6 +37,10 @@ pub(super) enum SourceReferenceClient<'a> {
         /// retrieved references.
         include_system_schemas: bool,
     },
+    SqlServer {
+        client: &'a mut mz_sql_server_util::Client,
+        database: Arc<str>,
+    },
     Kafka {
         topic: &'a str,
     },
@@ -44,13 +50,18 @@ pub(super) enum SourceReferenceClient<'a> {
 }
 
 /// Metadata about an available source reference retrieved from the upstream system.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) enum ReferenceMetadata {
     Postgres {
         table: mz_postgres_util::desc::PostgresTableDesc,
         database: String,
     },
     MySql(mz_mysql_util::MySqlTableSchema),
+    SqlServer {
+        table: mz_sql_server_util::desc::SqlServerTableDesc,
+        database: Arc<str>,
+        capture_instance: Arc<str>,
+    },
     Kafka(String),
     LoadGenerator {
         name: String,
@@ -65,6 +76,7 @@ impl ReferenceMetadata {
         match self {
             ReferenceMetadata::Postgres { table, .. } => Some(&table.namespace),
             ReferenceMetadata::MySql(table) => Some(&table.schema_name),
+            ReferenceMetadata::SqlServer { table, .. } => Some(table.schema_name.as_ref()),
             ReferenceMetadata::Kafka(_) => None,
             ReferenceMetadata::LoadGenerator { namespace, .. } => Some(namespace),
         }
@@ -74,6 +86,7 @@ impl ReferenceMetadata {
         match self {
             ReferenceMetadata::Postgres { table, .. } => &table.name,
             ReferenceMetadata::MySql(table) => &table.name,
+            ReferenceMetadata::SqlServer { table, .. } => table.name.as_ref(),
             ReferenceMetadata::Kafka(topic) => topic,
             ReferenceMetadata::LoadGenerator { name, .. } => name,
         }
@@ -89,6 +102,22 @@ impl ReferenceMetadata {
     pub(super) fn mysql_table(&self) -> Option<&mz_mysql_util::MySqlTableSchema> {
         match self {
             ReferenceMetadata::MySql(table) => Some(table),
+            _ => None,
+        }
+    }
+
+    pub(super) fn sql_server_table(&self) -> Option<&mz_sql_server_util::desc::SqlServerTableDesc> {
+        match self {
+            ReferenceMetadata::SqlServer { table, .. } => Some(table),
+            _ => None,
+        }
+    }
+
+    pub(super) fn sql_server_capture_instance(&self) -> Option<&Arc<str>> {
+        match self {
+            ReferenceMetadata::SqlServer {
+                capture_instance, ..
+            } => Some(capture_instance),
             _ => None,
         }
     }
@@ -123,6 +152,15 @@ impl ReferenceMetadata {
                 Ident::new(&table.schema_name)?,
                 Ident::new(&table.name)?,
             ])),
+            ReferenceMetadata::SqlServer {
+                table,
+                database,
+                capture_instance: _,
+            } => Ok(UnresolvedItemName::qualified(&[
+                Ident::new(database.as_ref())?,
+                Ident::new(table.schema_name.as_ref())?,
+                Ident::new(table.name.as_ref())?,
+            ])),
             ReferenceMetadata::Kafka(topic) => {
                 Ok(UnresolvedItemName::qualified(&[Ident::new(topic)?]))
             }
@@ -144,7 +182,7 @@ impl ReferenceMetadata {
 }
 
 /// A set of resolved source references.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) struct RetrievedSourceReferences {
     updated_at: u64,
     references: Vec<ReferenceMetadata>,
@@ -202,6 +240,38 @@ impl<'a> SourceReferenceClient<'a> {
                 let tables = mz_mysql_util::schema_info((*conn).deref_mut(), &request).await?;
 
                 tables.into_iter().map(ReferenceMetadata::MySql).collect()
+            }
+            SourceReferenceClient::SqlServer {
+                ref mut client,
+                ref database,
+            } => {
+                let tables = mz_sql_server_util::inspect::get_tables(client).await?;
+
+                // TODO(sql_server1): Figure out how to handle a single table with
+                // multiple capture instances.
+                let mut unique_tables = BTreeMap::default();
+                for table in tables {
+                    let key = (Arc::clone(&table.schema_name), Arc::clone(&table.name));
+                    if unique_tables.contains_key(&key) {
+                        tracing::warn!(?table, "filtering out other instance of table");
+                    } else {
+                        unique_tables.insert(key, table);
+                    }
+                }
+
+                unique_tables
+                    .into_values()
+                    .map(|raw| {
+                        let capture_instance = Arc::clone(&raw.capture_instance);
+                        let database = Arc::clone(database);
+                        let table = mz_sql_server_util::desc::SqlServerTableDesc::try_new(raw)?;
+                        Ok::<_, SqlServerError>(ReferenceMetadata::SqlServer {
+                            table,
+                            database,
+                            capture_instance,
+                        })
+                    })
+                    .collect::<Result<_, _>>()?
             }
             SourceReferenceClient::Kafka { topic } => {
                 vec![ReferenceMetadata::Kafka(topic.to_string())]
@@ -280,6 +350,15 @@ impl RetrievedSourceReferences {
                             .columns
                             .into_iter()
                             .map(|column| column.name())
+                            .collect(),
+                    },
+                    ReferenceMetadata::SqlServer { table, .. } => SourceReference {
+                        name: table.name.to_string(),
+                        namespace: Some(table.schema_name.to_string()),
+                        columns: table
+                            .columns
+                            .into_iter()
+                            .map(|c| c.name.to_string())
                             .collect(),
                     },
                     ReferenceMetadata::Kafka(topic) => SourceReference {

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -1,0 +1,193 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use mz_proto::RustType;
+use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::{
+    ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement,
+    ExternalReferences, Ident, UnresolvedItemName, Value, WithOptionValue,
+};
+use mz_storage_types::sources::SourceExportStatementDetails;
+use prost::Message;
+
+use crate::names::{Aug, ResolvedItemName};
+use crate::plan::{PlanError, StatementContext};
+use crate::pure::{
+    PurifiedExportDetails, PurifiedSourceExport, RetrievedSourceReferences, SourceReferencePolicy,
+    SqlServerSourcePurificationError,
+};
+
+/// Purify the requested [`ExternalReferences`] from the provided
+/// [`RetrievedSourceReferences`].
+pub(super) async fn purify_source_exports(
+    _client: &mut mz_sql_server_util::Client,
+    retrieved_references: &RetrievedSourceReferences,
+    requested_references: &Option<ExternalReferences>,
+    _text_columns: &[UnresolvedItemName],
+    _exclude_columns: &[UnresolvedItemName],
+    unresolved_source_name: &UnresolvedItemName,
+    reference_policy: &SourceReferencePolicy,
+) -> Result<BTreeMap<UnresolvedItemName, PurifiedSourceExport>, PlanError> {
+    let requested_exports = match requested_references.as_ref() {
+        Some(requested) => {
+            if *reference_policy == SourceReferencePolicy::NotAllowed {
+                return Err(PlanError::UseTablesForSources(requested.to_string()));
+            } else {
+                let exports = retrieved_references
+                    .requested_source_exports(Some(requested), unresolved_source_name)?;
+                exports
+            }
+        }
+        None => {
+            if *reference_policy == SourceReferencePolicy::Required {
+                return Err(SqlServerSourcePurificationError::RequiresExternalReferences.into());
+            }
+
+            // TODO(sql_server1): Check text columns and exclude columns here.
+            // If source references are empty it doesn't make sense to have
+            // those specified.
+
+            return Ok(BTreeMap::default());
+        }
+    };
+
+    if requested_exports.is_empty() {
+        sql_bail!(
+            "SQL Server source must ingest at least one table, but {} matched none",
+            requested_references
+                .as_ref()
+                .expect("checked above")
+                .to_ast_string_simple()
+        )
+    }
+
+    // TODO(sql_server1): Handle text and exclude columns.
+    // TODO(sql_server1): Validate permissions on upstream tables.
+
+    let exports = requested_exports
+        .into_iter()
+        .map(|requested| {
+            let table = requested
+                .meta
+                .sql_server_table()
+                .expect("sql server source")
+                .clone();
+            let capture_instance = requested
+                .meta
+                .sql_server_capture_instance()
+                .expect("sql server source")
+                .clone();
+            let export = PurifiedSourceExport {
+                external_reference: requested.external_reference,
+                details: PurifiedExportDetails::SqlServer {
+                    table,
+                    capture_instance,
+                },
+            };
+
+            (requested.name, export)
+        })
+        .collect();
+
+    Ok(exports)
+}
+
+pub fn generate_create_subsource_statements(
+    scx: &StatementContext,
+    source_name: ResolvedItemName,
+    requested_subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
+) -> Result<Vec<CreateSubsourceStatement<Aug>>, PlanError> {
+    let mut subsources = Vec::with_capacity(requested_subsources.len());
+
+    for (subsource_name, purified_export) in requested_subsources {
+        let SqlServerExportStatementValues {
+            columns,
+            details,
+            external_reference,
+        } = generate_source_export_statement_values(scx, purified_export)?;
+
+        let with_options = vec![
+            CreateSubsourceOption {
+                name: CreateSubsourceOptionName::ExternalReference,
+                value: Some(WithOptionValue::UnresolvedItemName(external_reference)),
+            },
+            CreateSubsourceOption {
+                name: CreateSubsourceOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    details.into_proto().encode_to_vec(),
+                )))),
+            },
+        ];
+
+        // Create the subsource statement
+        let subsource = CreateSubsourceStatement {
+            name: subsource_name,
+            columns,
+            of_source: Some(source_name.clone()),
+            constraints: vec![],
+            if_not_exists: false,
+            with_options,
+        };
+        subsources.push(subsource);
+    }
+
+    Ok(subsources)
+}
+
+struct SqlServerExportStatementValues {
+    pub columns: Vec<ColumnDef<Aug>>,
+    pub details: SourceExportStatementDetails,
+    pub external_reference: UnresolvedItemName,
+}
+
+fn generate_source_export_statement_values(
+    scx: &StatementContext,
+    purified_export: PurifiedSourceExport,
+) -> Result<SqlServerExportStatementValues, PlanError> {
+    let PurifiedExportDetails::SqlServer {
+        table,
+        capture_instance,
+    } = purified_export.details
+    else {
+        unreachable!("purified export details must be SQL Server")
+    };
+
+    let mut columns = vec![];
+    for c in table.columns.iter() {
+        let name = Ident::new(c.name.as_ref())?;
+        let ty = mz_pgrepr::Type::from(&c.column_type.scalar_type);
+        let data_type = scx.resolve_type(ty)?;
+        let mut col_options = vec![];
+
+        if !c.column_type.nullable {
+            col_options.push(mz_sql_parser::ast::ColumnOptionDef {
+                name: None,
+                option: mz_sql_parser::ast::ColumnOption::NotNull,
+            });
+        }
+        columns.push(ColumnDef {
+            name,
+            data_type,
+            collation: None,
+            options: col_options,
+        });
+    }
+
+    let values = SqlServerExportStatementValues {
+        columns,
+        details: SourceExportStatementDetails::SqlServer {
+            table,
+            capture_instance,
+        },
+        external_reference: purified_export.external_reference,
+    };
+    Ok(values)
+}

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use mz_proto::RustType;
 use mz_sql_parser::ast::display::AstDisplay;
@@ -27,6 +28,7 @@ use crate::pure::{
 
 /// Purify the requested [`ExternalReferences`] from the provided
 /// [`RetrievedSourceReferences`].
+#[allow(clippy::unused_async)]
 pub(super) async fn purify_source_exports(
     _client: &mut mz_sql_server_util::Client,
     retrieved_references: &RetrievedSourceReferences,
@@ -83,13 +85,12 @@ pub(super) async fn purify_source_exports(
             let capture_instance = requested
                 .meta
                 .sql_server_capture_instance()
-                .expect("sql server source")
-                .clone();
+                .expect("sql server source");
             let export = PurifiedSourceExport {
                 external_reference: requested.external_reference,
                 details: PurifiedExportDetails::SqlServer {
                     table,
-                    capture_instance,
+                    capture_instance: Arc::clone(capture_instance),
                 },
             };
 


### PR DESCRIPTION
This PR implements "purification" in the Adapter for a SQL Server source. For folks unfamiliar, purification is a step during object creation where we query external systems for any necessary information, with the goal of making our persisted SQL "pure".

During purification of a SQL Server source we do the following:
1. Ensure CDC is enabled for the current database
2. Ensure snapshot isolation is enabled for the current database
3. List all tables that currently have CDC enabled, and their capture instances
    * The specified capture instance for each subsource is then persisted in `PurifiedExportDetails

Left as a TODO is implementing support for `CREATE TABLE ... FROM SQL SERVER`. Nothing blocks our implementation of this feature although because it's not released yet I opted out of implementing it to keep the PR small.


### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
