### PR TITLE
Fix interface bugs for mz-debug

### DIFF
--- a/src/mz-debug/README.md
+++ b/src/mz-debug/README.md
@@ -1,3 +1,12 @@
 # `mz-debug`
 
 This tool allows us to debug a user's self-managed environment.
+
+## Run locally:
+To run locally, an example of a command is:
+
+```shell
+$ bin/mz-debug self-managed \
+    --k8s-namespace materialize \
+    --k8s-namespace materialize-environment
+```

--- a/src/mz-debug/src/main.rs
+++ b/src/mz-debug/src/main.rs
@@ -49,7 +49,13 @@ pub struct SelfManagedDebugMode {
     #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
     dump_k8s: bool,
     /// A list of namespaces to dump.
-    #[clap(long = "k8s-namespace", required_if_eq("dump_k8s", "true"), action = clap::ArgAction::Append)]
+    #[clap(
+        long = "k8s-namespace",
+        // We require both `require`s because `required_if_eq` doesn't work for default values.
+        required_unless_present = "dump_k8s",
+        required_if_eq("dump_k8s", "true"),
+        action = clap::ArgAction::Append
+    )]
     k8s_namespaces: Vec<String>,
     /// The kubernetes context to use.
     #[clap(long, env = "KUBERNETES_CONTEXT")]
@@ -69,8 +75,7 @@ pub struct SelfManagedDebugMode {
     port_forward_local_port: i32,
     /// The URL of the Materialize SQL connection used to dump the system catalog.
     /// An example URL is `postgres://root@127.0.0.1:6875/materialize?sslmode=disable`.
-    /// By default, we will create use the connection URL based on `port_forward_local_address` and `port_forward_local_port`.
-    /// and port_forward_local_port.
+    /// By default, we will create a connection URL based on `port_forward_local_address` and `port_forward_local_port`.
     // TODO(debug_tool3): Allow users to specify the pgconfig via separate variables
     #[clap(
         long,
@@ -86,7 +91,12 @@ pub struct EmulatorDebugMode {
     #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
     dump_docker: bool,
     /// The ID of the docker container to dump.
-    #[clap(long, required_if_eq("dump_docker", "true"))]
+    #[clap(
+        long,
+        // We require both `require`s because `required_if_eq` doesn't work for default values.
+        required_unless_present = "dump_docker",
+        required_if_eq("dump_docker", "true")
+    )]
     docker_container_id: Option<String>,
     /// The URL of the Materialize SQL connection used to dump the system catalog.
     /// An example URL is `postgres://root@127.0.0.1:6875/materialize?sslmode=disable`.
@@ -115,7 +125,7 @@ pub struct Args {
     #[clap(subcommand)]
     debug_mode: DebugMode,
     /// If true, the tool will dump the system catalog in Materialize.
-    #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
+    #[clap(long, default_value = "true", action = clap::ArgAction::Set, global = true)]
     dump_system_catalog: bool,
 }
 


### PR DESCRIPTION
- Added a section in `README.md` detailing how to run the `mz-debug` tool locally with an example command.
- required_if_eq wasn't working for default values. Chaining required_unless_present fixes this
- Makes 'dump-system-catalog' a global flag

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
