### PR TITLE
ci: Move cleanup to end instead of beginning

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -38,12 +38,6 @@ fi
 
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
-ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
-sudo systemctl restart docker
-docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
-killall -9 clusterd || true # There might be remaining processes from a previous cargo-test run
-rm -rf ~/.kube # Remove potential state from E2E Terraform tests
-
 ci_collapsed_heading "kind: Increase system limits..."
 sudo sysctl fs.inotify.max_user_watches=524288
 sudo sysctl fs.inotify.max_user_instances=512

--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -103,3 +103,7 @@ if [ "$CI_ANNOTATE_ERRORS_RESULT" -ne 0 ]; then
 fi
 ci_unimportant_heading "cloudtest: Resetting..."
 bin/ci-builder run stable test/cloudtest/reset
+
+ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
+sudo systemctl restart docker
+docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -31,26 +31,9 @@ fi
 
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
-# Sometimes build cancellations prevent us from properly cleaning up the last
-# Docker Compose run, which can leave old containers or volumes around that will
-# interfere with this build.
-ci_collapsed_heading ":docker: Purging containers and volumes from previous builds"
-sudo systemctl restart docker
-# First time we are using ci-builder, allow retrying a few times in case dockerhub has network problems
-mzcompose --mz-quiet kill || mzcompose --mz-quiet kill || mzcompose --mz-quiet kill
-mzcompose --mz-quiet rm --force -v
-mzcompose --mz-quiet down --volumes
-killall -9 clusterd || true # There might be remaining processes from a previous cargo-test run
-if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
-  find . -name '*.profraw' -delete # Remove remaining profraw files from coverage runs
-fi
-
-ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
-docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
-rm -f services.log
-
 ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
-mzcompose --mz-quiet build
+# First time we are using ci-builder, allow retrying a few times in case dockerhub has network problems
+mzcompose --mz-quiet build || mzcompose --mz-quiet build || mzcompose --mz-quiet build
 
 # Clean up cores here so that just killed processes' core files are ignored
 cores="$HOME"/cores

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -142,9 +142,15 @@ ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 # docker-compose kill may fail attempting to kill containers
 # that have just exited on their own because of the
 # "shared-fate" mechanism employed by Mz clusters
-run kill || true
-run rm --force -v
-run down --volumes
+sudo systemctl restart docker
+killall -9 clusterd || true # There might be remaining processes from a cargo-test run
+if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
+  find . -name '*.profraw' -delete # Remove remaining profraw files from coverage runs
+fi
+
+ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
+docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+rm -f services.log
 
 if [[ "$BUILDKITE_LABEL" =~ Terraform\ .* ]]; then
   ci_unimportant_heading "terraform: Destroying leftover state in case job was cancelled or timed out..."
@@ -152,3 +158,4 @@ if [[ "$BUILDKITE_LABEL" =~ Terraform\ .* ]]; then
   bin/ci-builder run stable terraform -chdir=test/terraform/gcp-temporary destroy || true
   bin/ci-builder run stable terraform -chdir=test/terraform/azure-temporary destroy || true
 fi
+rm -rf ~/.kube # Remove potential state from E2E Terraform tests


### PR DESCRIPTION
So that we will get results faster. Ideally this would be happening in between runs without counting to any, but that's not easy, it would require us to pause the agent temporarily, run the cleanup, and then resume it: https://buildkite.com/docs/agent/v3/pausing-and-resuming

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
