### PR TITLE
adapter: refactor statement logging to use time ordred uuid

### DIFF
--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -48,7 +48,7 @@ mz-kafka-util = { path = "../kafka-util" }
 mz-metrics = { path = "../metrics" }
 mz-mysql-util = { path = "../mysql-util" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["chrono", "async", "process", "tracing"] }
+mz-ore = { path = "../ore", features = ["chrono", "async", "process", "tracing", "id_gen"] }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgcopy = { path = "../pgcopy" }
@@ -91,7 +91,7 @@ tracing-opentelemetry = { version = "0.25.0" }
 tracing-subscriber = "0.3.19"
 thiserror = "2.0.12"
 url = "2.3.1"
-uuid = { version = "1.16.0", features = ["v4", "v7"] }
+uuid = { version = "1.16.0" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -91,7 +91,7 @@ tracing-opentelemetry = { version = "0.25.0" }
 tracing-subscriber = "0.3.19"
 thiserror = "2.0.12"
 url = "2.3.1"
-uuid = { version = "1.16.0", features = ["v4"] }
+uuid = { version = "1.16.0", features = ["v4", "v7"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -33,7 +33,7 @@ mz-dyncfg = { path = "../dyncfg" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", default-features = false }
+mz-ore = { path = "../ore", default-features = false, features = ["id_gen"]}
 mz-server-core = { path = "../server-core" }
 mz-tracing = { path = "../tracing" }
 mz-pgwire-common = { path = "../pgwire-common" }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -46,6 +46,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::id_gen::conn_id_org_uuid;
 use mz_ore::metrics::{ComputedGauge, IntCounter, IntGauge, MetricsRegistry};
 use mz_ore::netio::AsyncReady;
+use mz_ore::now::NowFn;
 use mz_ore::task::{JoinSetExt, spawn};
 use mz_ore::tracing::TracingHandle;
 use mz_ore::{metric, netio};
@@ -292,6 +293,7 @@ impl BalancerService {
                 tls: pgwire_tls,
                 internal_tls: self.cfg.internal_tls,
                 metrics: ServerMetrics::new(metrics.clone(), "pgwire"),
+                now: mz_ore::now::SYSTEM_TIME.clone(),
             };
             let (handle, stream) = self.pgwire;
             server_handles.push(handle);
@@ -573,6 +575,7 @@ struct PgwireBalancer {
     cancellation_resolver: Arc<CancellationResolver>,
     resolver: Arc<Resolver>,
     metrics: ServerMetrics,
+    now: NowFn,
 }
 
 impl PgwireBalancer {
@@ -749,7 +752,7 @@ impl mz_server_core::Server for PgwireBalancer {
         let inner_metrics = self.metrics.clone();
         let outer_metrics = self.metrics.clone();
         let cancellation_resolver = Arc::clone(&self.cancellation_resolver);
-        let conn_uuid = Uuid::new_v4();
+        let conn_uuid = mz_ore::now::epoch_to_uuid_v7(&(self.now)());
         let peer_addr = conn.peer_addr();
         conn.uuid_handle().set(conn_uuid);
         Box::pin(async move {

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -46,7 +46,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::id_gen::conn_id_org_uuid;
 use mz_ore::metrics::{ComputedGauge, IntCounter, IntGauge, MetricsRegistry};
 use mz_ore::netio::AsyncReady;
-use mz_ore::now::NowFn;
+use mz_ore::now::{NowFn, SYSTEM_TIME, epoch_to_uuid_v7};
 use mz_ore::task::{JoinSetExt, spawn};
 use mz_ore::tracing::TracingHandle;
 use mz_ore::{metric, netio};
@@ -293,7 +293,7 @@ impl BalancerService {
                 tls: pgwire_tls,
                 internal_tls: self.cfg.internal_tls,
                 metrics: ServerMetrics::new(metrics.clone(), "pgwire"),
-                now: mz_ore::now::SYSTEM_TIME.clone(),
+                now: SYSTEM_TIME.clone(),
             };
             let (handle, stream) = self.pgwire;
             server_handles.push(handle);
@@ -752,7 +752,7 @@ impl mz_server_core::Server for PgwireBalancer {
         let inner_metrics = self.metrics.clone();
         let outer_metrics = self.metrics.clone();
         let cancellation_resolver = Arc::clone(&self.cancellation_resolver);
-        let conn_uuid = mz_ore::now::epoch_to_uuid_v7(&(self.now)());
+        let conn_uuid = epoch_to_uuid_v7(&(self.now)());
         let peer_addr = conn.peer_addr();
         conn.uuid_handle().set(conn_uuid);
         Box::pin(async move {

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -77,7 +77,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
     "json",
     "tracing-log",
 ], optional = true }
-uuid = { version = "1.16.0", optional = true }
+uuid = { version = "1.16.0", optional = true, features = ["v4", "v7"] }
 url = { version = "2.3.1", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -24,6 +24,9 @@ use std::time::SystemTime;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
 
+#[cfg(feature = "id_gen")]
+use uuid::{NoContext, Uuid};
+
 /// A type representing the number of milliseconds since the Unix epoch.
 pub type EpochMillis = u64;
 
@@ -42,6 +45,19 @@ pub fn to_datetime(millis: EpochMillis) -> DateTime<Utc> {
             panic!("Ambiguous timestamp: {millis} millis")
         }
     }
+}
+
+/// A function that converts an epoch timestamp to a UUID v7
+#[cfg(feature = "id_gen")]
+pub fn epoch_to_uuid_v7(epoch: &EpochMillis) -> Uuid {
+    let remainder: u32 = (*epoch % 1000)
+        .try_into()
+        .expect("modulo 1000 of prepared at millis is always within a 32bit unsigned integer.");
+    Uuid::new_v7(uuid::Timestamp::from_unix(
+        NoContext,
+        *epoch / 1000,
+        remainder * 1_000_000,
+    ))
 }
 
 /// A function that returns system or mocked time.

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -47,7 +47,7 @@ pub fn to_datetime(millis: EpochMillis) -> DateTime<Utc> {
     }
 }
 
-/// A function that converts an epoch timestamp to a UUID v7
+/// A function that converts an epoch timestamp to a UUID v7.
 #[cfg(feature = "id_gen")]
 pub fn epoch_to_uuid_v7(epoch: &EpochMillis) -> Uuid {
     let remainder: u32 = (*epoch % 1000)

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -148,7 +148,7 @@ uncased = { version = "0.9.10" }
 unicode-bidi = { version = "0.3.18" }
 unicode-normalization = { version = "0.1.24" }
 url = { version = "2.5.4", features = ["serde"] }
-uuid = { version = "1.16.0", features = ["serde", "v4", "v5"] }
+uuid = { version = "1.16.0", features = ["serde", "v4", "v5", "v7"] }
 zeroize = { version = "1.8.1", features = ["serde"] }
 zstd = { version = "0.13.3" }
 zstd-safe = { version = "7.2.1", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
@@ -289,7 +289,7 @@ uncased = { version = "0.9.10" }
 unicode-bidi = { version = "0.3.18" }
 unicode-normalization = { version = "0.1.24" }
 url = { version = "2.5.4", features = ["serde"] }
-uuid = { version = "1.16.0", features = ["serde", "v4", "v5"] }
+uuid = { version = "1.16.0", features = ["serde", "v4", "v5", "v7"] }
 zeroize = { version = "1.8.1", features = ["serde"] }
 zstd = { version = "0.13.3" }
 zstd-safe = { version = "7.2.1", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }


### PR DESCRIPTION
### Motivation

we want to use a uuid that is ordered based on a time to improve sorting of the statement log indexes.

https://github.com/MaterializeInc/database-issues/issues/8937

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
