### PR TITLE
[adapter] use a `SnapshotCursor` and consolidated snapshot for builtin table retractions

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2484,10 +2484,10 @@ impl Coordinator {
             debug!("coordinator init: resetting system table {full_name} ({table_id})");
 
             // Fetch the current contents of the table for retraction.
-            let stream_fut = self
+            let snapshot_fut = self
                 .controller
                 .storage_collections
-                .snapshot_and_stream(system_table.table.global_id_writes(), read_ts);
+                .snapshot_cursor(system_table.table.global_id_writes(), read_ts);
             let batch_fut = self
                 .controller
                 .storage_collections
@@ -2499,15 +2499,18 @@ impl Coordinator {
                     .await
                     .unwrap_or_terminate("cannot fail to create a batch for a BuiltinTable");
                 tracing::info!(?table_id, "starting snapshot");
-                // Start a stream of unconsolidated updates from the builtin table.
-                let mut contents = stream_fut
+                // Get a cursor which will emit a consolidated snapshot.
+                let mut snapshot_cursor = snapshot_fut
                     .await
-                    .unwrap_or_terminate("cannot fail to fetch snapshot");
+                    .unwrap_or_terminate("cannot fail to snapshot");
 
                 // Retract the current contents, spilling into our builder.
-                while let Some((data, _t, d)) = contents.next().await {
-                    let d_invert = d.neg();
-                    batch.add(&data, &(), &d_invert).await;
+                while let Some(values) = snapshot_cursor.next().await {
+                    for ((key, _val), _t, d) in values {
+                        let key = key.expect("builtin table had errors");
+                        let d_invert = d.neg();
+                        batch.add(&key, &(), &d_invert).await;
+                    }
                 }
                 tracing::info!(?table_id, "finished snapshot");
 

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -892,11 +892,14 @@ mod tests {
             unimplemented!()
         }
 
-        async fn snapshot_cursor(
-            &mut self,
+        fn snapshot_cursor(
+            &self,
             _id: GlobalId,
             _as_of: Self::Timestamp,
-        ) -> Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>
+        ) -> BoxFuture<
+            'static,
+            Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>,
+        >
         where
             Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
         {

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -215,7 +215,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             additional_system_parameter_defaults,
         ),
     ):
-        c.up("materialized")
+        while True:
+            c.up("materialized")
+            c.kill("materialized")
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -215,9 +215,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             additional_system_parameter_defaults,
         ),
     ):
-        while True:
-            c.up("materialized")
-            c.kill("materialized")
+        c.up("materialized")
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",


### PR DESCRIPTION
When the Coordinator starts we list the entire contents of each builtin table and retract them to make table migrations easier. This PR changes the retractions to operate on a consolidated snapshot as opposed to an unconsolidated one. 

We've observed (https://github.com/MaterializeInc/database-issues/issues/9155) that after restarting Materialize a number of times in a row (>100) startup becomes very slow and we suspect this is because when Materialize is restarted in a loop we never get a chance to consolidate the builtin shards.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/9155

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
