### PR TITLE
[sql_server] Initial implementation for Source Rendering

### DIFF
--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -84,8 +84,8 @@ fn parse_lsn(result: &[tiberius::Row]) -> Result<Lsn, SqlServerError> {
     }
 }
 
-/// Queries the specified capture instance and returns all changes from `start_lsn` to
-/// `end_lsn`, ordered by `start_lsn` in an ascending fashion.
+/// Queries the specified capture instance and returns all changes from
+/// `[start_lsn, end_lsn)`, ordered by `start_lsn` in an ascending fashion.
 ///
 /// TODO(sql_server1): This presents an opportunity for SQL injection. We should create a stored
 /// procedure using `QUOTENAME` to sanitize the input for the capture instance provided by the

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -18,6 +18,7 @@ use derivative::Derivative;
 use futures::future::BoxFuture;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use mz_ore::result::ResultExt;
+use mz_repr::ScalarType;
 use smallvec::{SmallVec, smallvec};
 use tiberius::ToSql;
 use tokio::net::TcpStream;
@@ -34,6 +35,7 @@ pub use config::Config;
 pub use desc::{ProtoSqlServerColumnDesc, ProtoSqlServerTableDesc};
 
 use crate::config::TunnelConfig;
+use crate::desc::SqlServerColumnDecodeType;
 
 /// Higher level wrapper around a [`tiberius::Client`] that models transaction
 /// management like other database clients.
@@ -771,4 +773,73 @@ pub enum SqlServerError {
     Generic(#[from] anyhow::Error),
     #[error("programming error! {0}")]
     ProgrammingError(String),
+}
+
+/// Errors returned from decoding SQL Server rows.
+///
+/// **PLEASE READ**
+///
+/// The string representation of this error type is **durably stored** in a source and thus this
+/// error type needs to be **stable** across releases. For example, if in v11 of Materialize we
+/// fail to decode `Row(["foo bar"])` from SQL Server, we will record the error in the source's
+/// Persist shard. If in v12 of Materialize the user deletes the `Row(["foo bar"])` from their
+/// upstream instance, we need to perfectly retract the error we previously committed.
+///
+/// This means be **very** careful when changing this type.
+#[derive(Debug, thiserror::Error)]
+pub enum SqlServerDecodeError {
+    #[error("column '{column_name}' was invalid when getting as type '{as_type}'")]
+    InvalidColumn {
+        column_name: String,
+        as_type: &'static str,
+    },
+    #[error("found invalid data in the column '{column_name}': {error}")]
+    InvalidData { column_name: String, error: String },
+    #[error("can't decode {sql_server_type:?} as {mz_type:?}")]
+    Unsupported {
+        sql_server_type: SqlServerColumnDecodeType,
+        mz_type: ScalarType,
+    },
+}
+
+impl SqlServerDecodeError {
+    fn invalid_timestamp(name: &str, error: mz_repr::adt::timestamp::TimestampError) -> Self {
+        // These error messages need to remain stable, do not change them.
+        let error = match error {
+            mz_repr::adt::timestamp::TimestampError::OutOfRange => "out of range",
+        };
+        SqlServerDecodeError::InvalidData {
+            column_name: name.to_string(),
+            error: error.to_string(),
+        }
+    }
+
+    fn invalid_date(name: &str, error: mz_repr::adt::date::DateError) -> Self {
+        // These error messages need to remain stable, do not change them.
+        let error = match error {
+            mz_repr::adt::date::DateError::OutOfRange => "out of range",
+        };
+        SqlServerDecodeError::InvalidData {
+            column_name: name.to_string(),
+            error: error.to_string(),
+        }
+    }
+
+    fn invalid_decimal(name: &str, error: dec::ParseDecimalError) -> Self {
+        // These error messages need to remain stable. We're using our own message here
+        // but it's worthwhile to know if `dec` changes the message it returns.
+        let msg = "invalid decimal syntax";
+        mz_ore::soft_assert_eq_or_log!(error.to_string(), msg);
+        SqlServerDecodeError::InvalidData {
+            column_name: name.to_string(),
+            error: msg.to_string(),
+        }
+    }
+
+    fn invalid_column(name: &str, as_type: &'static str) -> Self {
+        SqlServerDecodeError::InvalidColumn {
+            column_name: name.to_string(),
+            as_type,
+        }
+    }
 }

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -757,6 +757,8 @@ pub enum SqlServerError {
     IO(#[from] tokio::io::Error),
     #[error("found invalid data in the column '{column_name}': {error}")]
     InvalidData { column_name: String, error: String },
+    #[error("got back a null value when querying for the max LSN")]
+    NullMaxLsn,
     #[error("invalid SQL Server system setting '{name}'. Expected '{expected}'. Got '{actual}'.")]
     InvalidSystemSetting {
         name: String,

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -319,4 +319,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&SUSPENDABLE_SOURCES)
         .add(&WALLCLOCK_GLOBAL_LAG_HISTOGRAM_RETENTION_INTERVAL)
         .add(&WALLCLOCK_LAG_HISTORY_RETENTION_INTERVAL)
+        .add(&crate::sources::sql_server::CDC_POLL_INTERVAL)
+        .add(&crate::sources::sql_server::SNAPSHOT_MAX_LSN_WAIT)
 }

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -257,7 +257,7 @@ impl RustType<ProtoSqlServerSourceExportDetails> for SqlServerSourceExportDetail
 
 impl SourceTimestamp for Lsn {
     fn encode_row(&self) -> mz_repr::Row {
-        Row::pack_slice(&[Datum::Bytes(self.as_bytes())])
+        Row::pack_slice(&[Datum::Bytes(&self.as_bytes())])
     }
 
     fn decode_row(row: &mz_repr::Row) -> Self {
@@ -265,7 +265,7 @@ impl SourceTimestamp for Lsn {
         match (datums.next(), datums.next()) {
             (Some(Datum::Bytes(bytes)), None) => {
                 let lsn: [u8; 10] = bytes.try_into().expect("invalid LSN, wrong length");
-                Lsn::interpret(lsn)
+                Lsn::try_from_bytes(&lsn).expect("invalid LSN")
             }
             _ => panic!("invalid row {row:?}"),
         }

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -10,7 +10,9 @@
 //! Types related to SQL Server sources
 
 use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
+use mz_dyncfg::Config;
 use mz_ore::future::InTask;
 use mz_proto::{IntoRustIfSome, RustType};
 use mz_repr::{CatalogItemId, Datum, GlobalId, RelationDesc, Row, ScalarType};
@@ -31,6 +33,19 @@ include!(concat!(
     env!("OUT_DIR"),
     "/mz_storage_types.sources.sql_server.rs"
 ));
+
+pub const SNAPSHOT_MAX_LSN_WAIT: Config<Duration> = Config::new(
+    "sql_server_snapshot_max_lsn_wait",
+    Duration::from_secs(30),
+    "Maximum amount of time we'll wait for SQL Server to report an LSN (in other words for \
+    CDC to be fully enabled) before taking an initial snapshot.",
+);
+
+pub const CDC_POLL_INTERVAL: Config<Duration> = Config::new(
+    "sql_server_cdc_poll_interval",
+    Duration::from_millis(500),
+    "Interval at which we'll poll the upstream SQL Server instance to discover new changes.",
+);
 
 pub static SQL_SERVER_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
     RelationDesc::builder()

--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -70,6 +70,8 @@ pub enum TransientError {
     ReplicationEOF,
     #[error(transparent)]
     SqlServer(#[from] SqlServerError),
+    #[error("programming error: {0}")]
+    ProgrammingError(String),
     #[error(transparent)]
     Generic(#[from] anyhow::Error),
 }

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -38,5 +38,6 @@ def workflow_default(c: Composition) -> None:
         f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
         f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
         f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",
+        "--default-timeout=10s",
         "sql-server-cdc.td",
     )

--- a/test/sql-server-cdc/sql-server-cdc.td
+++ b/test/sql-server-cdc/sql-server-cdc.td
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 # Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
@@ -17,6 +19,18 @@ DROP DATABASE IF EXISTS test;
 CREATE DATABASE test;
 USE test;
 
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE t1_pk (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_pk', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t1_pk VALUES ('a', 'hello world'), ('b', 'foobar');
+
+CREATE TABLE t2_no_cdc (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+
+CREATE TABLE t3_text (value VARCHAR(100));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't3_text', @role_name = 'SA', @supports_net_changes = 0;
 
 # Exercise Materialize.
 
@@ -42,3 +56,59 @@ sql_server_test_connection   sql-server
 
 > SHOW CONNECTIONS;
 sql_server_test_connection sql-server ""
+
+# Create a SQL Server Source.
+
+> CREATE SOURCE t1_pk_sql_server
+  FROM SQL SERVER CONNECTION sql_server_test_connection
+  FOR ALL TABLES;
+
+> SHOW SOURCES
+t1_pk subsource quickstart ""
+t1_pk_sql_server sql-server quickstart ""
+t1_pk_sql_server_progress progress <null> ""
+t3_text subsource quickstart ""
+
+> SELECT * FROM t1_pk;
+a "hello world"
+b "foobar"
+
+$ sql-server-execute name=sql-server
+UPDATE t1_pk SET val_col = 'I am an updated value' WHERE key_col = 'a';
+
+> SELECT * FROM t1_pk;
+a "I am an updated value"
+b "foobar"
+
+$ sql-server-execute name=sql-server
+DELETE t1_pk WHERE key_col = 'a';
+
+> SELECT * FROM t1_pk;
+b "foobar"
+
+$ sql-server-execute name=sql-server
+INSERT INTO t1_pk VALUES ('😊', 'lets see what happens');
+
+# Note: VARCHAR columns in SQL Server do not support emojis, hence the '??'.
+> SELECT * FROM t1_pk;
+b "foobar"
+"??" "lets see what happens"
+
+
+# Insert a lot of data upstream.
+
+$ sql-server-execute name=sql-server
+WITH Tally(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM Tally WHERE n < 1000) INSERT INTO t3_text (value) SELECT 'a longer string that will be a bit of data, cool ' + CAST(n AS VARCHAR) FROM Tally OPTION (MAXRECURSION 1000);
+
+> SELECT COUNT(*) FROM t3_text;
+1000
+
+$ sql-server-execute name=sql-server
+INSERT INTO t3_text (value) SELECT value FROM t3_text;
+INSERT INTO t3_text (value) SELECT value FROM t3_text;
+INSERT INTO t3_text (value) SELECT value FROM t3_text;
+INSERT INTO t3_text (value) SELECT value FROM t3_text;
+INSERT INTO t3_text (value) SELECT value FROM t3_text;
+
+> SELECT COUNT(*) FROM t3_text;
+32000


### PR DESCRIPTION
This PR adds an MVP implementation of the `SourceRender` trait for the SQL Server source. It also adds a testdrive test that exercises replicating data from SQL Server into Materialize.

TODO(parkmycar): I need to add some more detail here

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
