### PR TITLE
license keys: Remove initial anyhow! call

### DIFF
--- a/src/license-keys/src/lib.rs
+++ b/src/license-keys/src/lib.rs
@@ -80,19 +80,23 @@ impl Default for ValidatedLicenseKey {
 }
 
 pub fn validate(license_key: &str, environment_id: &str) -> anyhow::Result<ValidatedLicenseKey> {
-    let mut err = anyhow!("no public key found");
+    let mut err = None;
     for pubkey in PUBLIC_KEYS {
         match validate_with_pubkey(license_key, pubkey, environment_id) {
             Ok(key) => {
                 return Ok(key);
             }
             Err(e) => {
-                err = e;
+                err = Some(e);
             }
         }
     }
 
-    Err(err)
+    if let Some(err) = err {
+        Err(err)
+    } else {
+        Err(anyhow!("no public key found"))
+    }
 }
 
 fn validate_with_pubkey(


### PR DESCRIPTION
Hopefully helps with https://github.com/MaterializeInc/database-issues/issues/9159, but more of a bandaid to get CI to be less flaky.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
