### PR TITLE
jemalloc: use libunwind in profiling

### DIFF
--- a/misc/bazel/c_deps/BUILD.jemalloc.bazel
+++ b/misc/bazel/c_deps/BUILD.jemalloc.bazel
@@ -37,6 +37,9 @@ CONFIGURE_OPTIONS = [
     "--enable-prof",
     "--enable-stats",
     "--with-malloc-conf=background_thread:true",
+    # Workaround to avoid deadlocking when jemalloc profiling causes nested
+    # backtrace collection. See database-issues#9159.
+    "--enable-prof-libunwind",
 ]
 
 configure_make(

--- a/misc/bazel/c_deps/BUILD.jemalloc.bazel
+++ b/misc/bazel/c_deps/BUILD.jemalloc.bazel
@@ -40,6 +40,7 @@ CONFIGURE_OPTIONS = [
     # Workaround to avoid deadlocking when jemalloc profiling causes nested
     # backtrace collection. See database-issues#9159.
     "--enable-prof-libunwind",
+    "--with-lg-page=12",
 ]
 
 configure_make(
@@ -79,4 +80,5 @@ configure_make(
         "install_include",
     ],
     visibility = ["//visibility:public"],
+    deps = ["@libunwind-nognu//:unwind"],
 )

--- a/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
+++ b/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
@@ -81,7 +81,6 @@ arm64_srcs = select({
             "src/aarch64/*.c",
             "src/aarch64/*.h",
         ],
-        exclude = [],
     ) + [
         # The Makefile doesn't include this and only includes it if the OS
         # is FreeBSD. This is inconsistent with the other archs, not sure
@@ -98,7 +97,6 @@ arm64_textual_hdrs = select({
         [
             "src/aarch64/G*.c",
         ],
-        exclude = [],
     ) + [
         "src/elf64.c",
     ],
@@ -234,6 +232,15 @@ expand_template(
     },
     template = "include/libunwind-common.h.in",
 )
+expand_template(
+    name = "libunwind_config_h",
+    out = "include/config.h",
+    substitutions = {
+        "@PACKAGE_STRING@": "libunwind",
+        "@PACKAGE_BUGREPORT@": "",
+    },
+    template = "include/config.h.in",
+)
 
 cc_library(
     name = "unwind",
@@ -250,6 +257,7 @@ cc_library(
         "include/remote.h",
         "include/unwind.h",
         ":libunwind_common_h",
+        ":libunwind_config_h",
     ] + select({
         "@platforms//cpu:arm64": glob(["include/tdep-aarch64/*.h"]) + ["include/libunwind-aarch64.h"],
         "@platforms//cpu:arm": glob(["include/tdep-arm/*.h"]) + ["include/libunwind-arm.h"],

--- a/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
+++ b/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
@@ -38,6 +38,9 @@ libunwind_defines = [
     "HAVE_ZLIB",
     # TODO: Add support for LZMA compression.
     # "HAVE_LZMA",
+
+    'PACKAGE_STRING=\\"libunwind\\"',
+    'PACKAGE_BUGREPORT=\\"\\"',
 ]
 
 ### Common source files ########################################################
@@ -78,14 +81,7 @@ arm64_srcs = select({
             "src/aarch64/*.c",
             "src/aarch64/*.h",
         ],
-        exclude = [
-            "src/aarch64/Los-freebsd.c",
-            "src/aarch64/Los-linux.c",
-            "src/aarch64/Los-qnx.c",
-            "src/aarch64/Gos-freebsd.c",
-            "src/aarch64/Gos-linux.c",
-            "src/aarch64/Gos-qnx.c",
-        ],
+        exclude = [],
     ) + [
         # The Makefile doesn't include this and only includes it if the OS
         # is FreeBSD. This is inconsistent with the other archs, not sure
@@ -102,11 +98,7 @@ arm64_textual_hdrs = select({
         [
             "src/aarch64/G*.c",
         ],
-        exclude = [
-            "src/aarch64/Gos-freebsd.c",
-            "src/aarch64/Gos-linux.c",
-            "src/aarch64/Gos-qnx.c",
-        ],
+        exclude = [],
     ) + [
         "src/elf64.c",
     ],
@@ -203,10 +195,7 @@ linux_srcs = select({
     ],
     "//conditions:default": [],
 }) + select({
-    "@//misc/bazel/platforms:linux_arm": [
-        "src/aarch64/Los-linux.c",
-        "src/aarch64/Gos-linux.c",
-    ],
+    "@//misc/bazel/platforms:linux_arm": [],
     "//conditions:default": [],
 }) + select({
     "@//misc/bazel/platforms:linux_x86_64": [
@@ -217,7 +206,7 @@ linux_srcs = select({
 })
 
 linux_textual_hdrs = select({
-    "@//misc/bazel/platforms:linux_arm": ["src/aarch64/Gos-linux.c"],
+    "@//misc/bazel/platforms:linux_arm": [],
     "//conditions:default": [],
 }) + select({
     "@//misc/bazel/platforms:linux_x86_64": ["src/x86_64/Gos-linux.c"],
@@ -285,4 +274,5 @@ cc_library(
     deps = [
         "@zlib",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
+++ b/misc/bazel/c_deps/BUILD.libunwind-nognu.bazel
@@ -1,0 +1,288 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Builds libunwind-nognu.
+
+Copied from: <https://github.com/bazelbuild/bazel-central-registry/blob/6de1a4d523ecb4fc45fcc55a4a057628c424f79e/modules/libunwind/1.8.1/overlay/BUILD.bazel>
+"""
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+### Common defines #############################################################
+
+libunwind_defines = [
+    # Defaults based on configure.ac assuming we're on a modern Linux OS.
+    "_GNU_SOURCE",
+    "CONFIG_BLOCK_SIGNALS",
+    "CONFIG_WEAK_BACKTRACE",
+    "CONSERVATIVE_CHECKS",
+    "HAVE__BUILTIN___CLEAR_CACHE",
+    "HAVE__BUILTIN_UNREACHABLE",
+    "HAVE_ELF_H",
+    "HAVE_LINK_H",
+    "HAVE_ZLIB",
+    # TODO: Add support for LZMA compression.
+    # "HAVE_LZMA",
+]
+
+### Common source files ########################################################
+
+dwarf_srcs = glob(["src/dwarf/*.c"])
+
+dwarf_textual_hdrs = glob(["src/dwarf/G*.c"])
+
+mi_srcs = glob(
+    ["src/mi/*.c"],
+    exclude = [
+        # Only included if Linux.
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        # The Makefile does not include this, it's also broken as it can include
+        # Gdyn-remote.c in certain situations, which uses WSIZE, which will not
+        # be defined in the situations Gdyn-remote.c is included.
+        "src/mi/Ldyn-remote.c",
+        # TODO: for some reason these complain about duplicate definitions if
+        # included.
+        "src/mi/Gaddress_validator.c",
+        "src/mi/Gget_accessors.c",
+    ],
+)
+
+mi_textual_hdrs = glob(["src/mi/G*.c"])
+
+unwind_srcs = glob([
+    "src/unwind/*.c",
+    "src/unwind/*.h",
+])
+
+### Arch specific source files #################################################
+
+arm64_srcs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/*.c",
+            "src/aarch64/*.h",
+        ],
+        exclude = [
+            "src/aarch64/Los-freebsd.c",
+            "src/aarch64/Los-linux.c",
+            "src/aarch64/Los-qnx.c",
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        # The Makefile doesn't include this and only includes it if the OS
+        # is FreeBSD. This is inconsistent with the other archs, not sure
+        # whether this is intended.
+        # "src/aarch64/setcontext.S",
+        "src/aarch64/getcontext.S",
+        "src/elf64.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm64_textual_hdrs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/G*.c",
+        ],
+        exclude = [
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+arm_srcs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/*.c",
+            "src/arm/*.h",
+        ],
+        exclude = [
+            "src/arm/Los-freebsd.c",
+            "src/arm/Los-linux.c",
+            "src/arm/Los-other.c",
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/arm/getcontext.S",
+        "src/elf32.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm_textual_hdrs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/G*.c",
+        ],
+        exclude = [
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/elf32.c",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_srcs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/*.c",
+            "src/x86_64/*.h",
+        ],
+        exclude = [
+            "src/x86_64/Los-freebsd.c",
+            "src/x86_64/Los-linux.c",
+            "src/x86_64/Los-qnx.c",
+            "src/x86_64/Los-solaris.c",
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.h",
+        "src/x86_64/getcontext.S",
+        "src/x86_64/setcontext.S",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_textual_hdrs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/G*.c",
+        ],
+        exclude = [
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+### OS specific source files ###################################################
+
+linux_srcs = select({
+    "@platforms//os:linux": [
+        "src/dl-iterate-phdr.c",
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        "src/os-linux.c",
+        "src/os-linux.h",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@//misc/bazel/platforms:linux_arm": [
+        "src/aarch64/Los-linux.c",
+        "src/aarch64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@//misc/bazel/platforms:linux_x86_64": [
+        "src/x86_64/Los-linux.c",
+        "src/x86_64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+})
+
+linux_textual_hdrs = select({
+    "@//misc/bazel/platforms:linux_arm": ["src/aarch64/Gos-linux.c"],
+    "//conditions:default": [],
+}) + select({
+    "@//misc/bazel/platforms:linux_x86_64": ["src/x86_64/Gos-linux.c"],
+    "//conditions:default": [],
+})
+
+### libunwind ##################################################################
+
+libunwind_srcs = [
+    "src/elfxx.h",
+    "src/elfxx.c",
+] + dwarf_srcs + mi_srcs + unwind_srcs + arm64_srcs + arm_srcs + x86_64_srcs + linux_srcs
+
+libunwind_textual_hdrs = [
+    "src/elfxx.c",
+] + dwarf_textual_hdrs + mi_textual_hdrs + arm64_textual_hdrs + arm_textual_hdrs + x86_64_textual_hdrs + linux_textual_hdrs
+
+expand_template(
+    name = "libunwind_common_h",
+    out = "include/libunwind-common.h",
+    substitutions = {
+        "@PKG_MAJOR@": "1",
+        "@PKG_MINOR@": "8",
+        "@PKG_EXTRA@": "1",
+    },
+    template = "include/libunwind-common.h.in",
+)
+
+cc_library(
+    name = "unwind",
+    srcs = libunwind_srcs,
+    hdrs = glob(["include/tdep/*.h"]) + [
+        "include/compiler.h",
+        "include/dwarf.h",
+        "include/dwarf-eh.h",
+        "include/dwarf_i.h",
+        "include/libunwind.h",
+        "include/libunwind-dynamic.h",
+        "include/libunwind_i.h",
+        "include/mempool.h",
+        "include/remote.h",
+        "include/unwind.h",
+        ":libunwind_common_h",
+    ] + select({
+        "@platforms//cpu:arm64": glob(["include/tdep-aarch64/*.h"]) + ["include/libunwind-aarch64.h"],
+        "@platforms//cpu:arm": glob(["include/tdep-arm/*.h"]) + ["include/libunwind-arm.h"],
+        "@platforms//cpu:x86_64": ["include/libunwind-x86_64.h"] + glob(["include/tdep-x86_64/*.h"]),
+    }),
+    includes = [
+        "include",
+        "src",
+    ] + select({
+        "@platforms//cpu:arm64": [
+            "include/tdep-aarch64",
+        ],
+        "@platforms//cpu:arm": [
+            "include/tdep-arm",
+        ],
+        "@platforms//cpu:x86_64": [
+            "include/tdep-x86_64",
+        ],
+    }),
+    local_defines = libunwind_defines + ["HAVE_DL_ITERATE_PHDR"],
+    textual_hdrs = libunwind_textual_hdrs,
+    deps = [
+        "@zlib",
+    ],
+)

--- a/misc/bazel/c_deps/repositories.bzl
+++ b/misc/bazel/c_deps/repositories.bzl
@@ -40,7 +40,7 @@ def c_repositories():
         ],
     )
 
-    LIBUNWIND_NOGNU_VERSION = "1.8.1"
+    LIBUNWIND_NOGNU_VERSION = "1.7.2"
     LIBUNWIND_NOGNU_INTEGRITY = ""
 
     maybe(

--- a/misc/bazel/c_deps/repositories.bzl
+++ b/misc/bazel/c_deps/repositories.bzl
@@ -40,6 +40,20 @@ def c_repositories():
         ],
     )
 
+    LIBUNWIND_NOGNU_VERSION = "1.8.1"
+    LIBUNWIND_NOGNU_INTEGRITY = ""
+
+    maybe(
+        http_archive,
+        name = "libunwind-nognu",
+        build_file = Label("//misc/bazel/c_deps:BUILD.libunwind-nognu.bazel"),
+        integrity = LIBUNWIND_NOGNU_INTEGRITY,
+        strip_prefix = "libunwind-{0}".format(LIBUNWIND_NOGNU_VERSION),
+        urls = [
+            "https://github.com/libunwind/libunwind/releases/download/v{0}/libunwind-{0}.tar.gz".format(LIBUNWIND_NOGNU_VERSION),
+        ],
+    )
+
     LZ4_VERSION = "1.9.4"
     LZ4_INTEGRITY = "sha256-Cw46oHyMBj3fQLCCvffjehVivaQKD/UnKVfz6Yfg5Us="
     maybe(

--- a/src/license-keys/src/lib.rs
+++ b/src/license-keys/src/lib.rs
@@ -83,23 +83,19 @@ impl Default for ValidatedLicenseKey {
 }
 
 pub fn validate(license_key: &str, environment_id: &str) -> anyhow::Result<ValidatedLicenseKey> {
-    let mut err = None;
+    let mut err = anyhow!("no public key found");
     for pubkey in PUBLIC_KEYS {
         match validate_with_pubkey(license_key, pubkey, environment_id) {
             Ok(key) => {
                 return Ok(key);
             }
             Err(e) => {
-                err = Some(e);
+                err = e;
             }
         }
     }
 
-    if let Some(err) = err {
-        Err(err)
-    } else {
-        Err(anyhow!("no public key found"))
-    }
+    Err(err)
 }
 
 fn validate_with_pubkey(


### PR DESCRIPTION
This is a workaround for deadlocks caused by nested unwinding, recommended in https://github.com/jemalloc/jemalloc/issues/2282.

This is an attempt to fix https://github.com/MaterializeInc/database-issues/issues/9159

TODO: actually make this work, see [thread](https://materializeinc.slack.com/archives/C01LKF361MZ/p1744204953464749)

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9159

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
