### PR TITLE
mzbuild: Fix additive files for bazel build

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -309,8 +309,11 @@ class CargoPreImage(PreImage):
         # Bazel has some rules and additive files that aren't directly
         # associated with a crate, but can change how it's built.
         additive_path = self.rd.root / "misc" / "bazel"
-        additive_files = ["BUILD.bazel", "*.bzl"]
-        inputs |= set(git.expand_globs(additive_path, *additive_files))
+        additive_files = ["*.bazel", "*.bzl"]
+        inputs |= {
+            f"misc/bazel/{path}"
+            for path in git.expand_globs(additive_path, *additive_files)
+        }
 
         return inputs
 


### PR DESCRIPTION
I think this fixes https://materializeinc.slack.com/archives/C01LKF361MZ/p1744204953464749

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
