### PR TITLE
add some simple license key revocation

### DIFF
--- a/src/license-keys/src/lib.rs
+++ b/src/license-keys/src/lib.rs
@@ -25,6 +25,9 @@ const ANY_ENVIRONMENT_AUD: &str = "00000000-0000-0000-0000-000000000000";
 // list of public keys which are allowed to validate license keys. this is a
 // list to allow for key rotation if necessary.
 const PUBLIC_KEYS: &[&str] = &[include_str!("license_keys/production.pub")];
+// keys which we have issued but need to be revoked before their expiration
+// (due to being accidentally exposed or similar).
+const REVOKED_KEYS: &[&str] = &["eddaf004-dc1e-48cf-9cc1-41d1543d940a"];
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum ExpirationBehavior {
@@ -186,6 +189,10 @@ fn validate_with_pubkey_v1(
 
     if !(jwt.claims.nbf..=jwt.claims.exp).contains(&jwt.claims.iat) {
         bail!("invalid issuance time");
+    }
+
+    if REVOKED_KEYS.contains(&jwt.claims.jti.as_str()) {
+        bail!("revoked license key");
     }
 
     Ok(ValidatedLicenseKey {


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/materialize/pull/32117#discussion_r2034905183

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
