### PR TITLE
Prefer slices to offsets in `Row` parsing

### DIFF
--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -246,9 +246,7 @@ mod container {
             if self.bytes.is_empty() {
                 None
             } else {
-                let mut offset = 0;
-                let result = unsafe { read_datum(self.bytes, &mut offset) };
-                self.bytes = &self.bytes[offset..];
+                let result = unsafe { read_datum(&mut self.bytes) };
                 Some(result)
             }
         }


### PR DESCRIPTION
The way we parse rows as `&[u8]` to form `Datum` elements uses a bunch of `offset: &mut usize` to think about where we are in the parsing. It seems like it can be replaced with slices, using `bytes: &mut &'a [u8]` as the primary argument and advancing it as we read, rather than advancing the `offset`. This simplifies a fair bit of code, and potentially removes any number of bounds checks where the slice carries the information about its validity. E.g. several `data[*offset .. *offset + len]` things turn in to `data.split_at(len)`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
