### PR TITLE
ci: Bump cargo udeps version

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -296,7 +296,7 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version ="0.9.28" --locked cargo-hakari \
     && cargo install --root /usr/local --version "=0.9.72" --locked cargo-nextest \
     && cargo install --root /usr/local --version "=0.6.11" --locked cargo-llvm-cov \
-    && cargo install --root /usr/local --version "=0.1.50" --locked --features=vendored-openssl cargo-udeps \
+    && cargo install --root /usr/local --version "=0.1.55" --locked --features=vendored-openssl cargo-udeps \
     && cargo install --root /usr/local --version "=0.2.15" --locked --no-default-features --features=s3,openssl/vendored sccache \
     && cargo install --root /usr/local --version "=0.3.6" --locked cargo-binutils \
     && cargo install --root /usr/local --version "=0.13.0" --locked wasm-pack


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11783#01961ce8-bb55-4dce-9cc5-079e5639a001

Follow-up to https://github.com/MaterializeInc/materialize/pull/31574

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
