### PR TITLE
limits test: Also restart cockroach

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1829,6 +1829,7 @@ service_names = [
     "materialized",
     "balancerd",
     "frontegg-mock",
+    "cockroach",
     "clusterd_1_1_1",
     "clusterd_1_2_1",
     "clusterd_2_1_1",


### PR DESCRIPTION
Otherwise there is a discrepancy between persist and crdb state:
```
limits-materialized-1     | environmentd: 2025-04-09T16:07:42.449535Z  WARN environmentd::run:environmentd::serve:new: mz_persist_client::internal::state_versions: fetch_current_state refetch expects earliest live diff to advance: v1 vs v1. In dev and testing, this happens when persist's Blob (files in mzdata) is deleted out from under it or when two processes are talking to different Blobs (e.g. docker containers without it shared).
```
Noticed in https://buildkite.com/materialize/release-qualification/builds/776

I'm still bisecting when this started occurring, but if it's just a test issue, then not that important anyway.

Edit: Started with my change https://github.com/MaterializeInc/materialize/pull/31805

Test run for verification: https://buildkite.com/materialize/release-qualification/builds/793

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
