### PR TITLE
cloudtest: Bump agent size for k8s recovery test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -968,7 +968,7 @@ steps:
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: linux-aarch64-medium
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11783#01961ce8-bbdf-4aee-ae13-b73d0d0c05f4
```
local-path-storage/local-path-provisioner-888b7757b-mprxv[local-path-provisioner]: E0410 00:36:47.675551       1 controller.go:1481] delete "pvc-3e293334-ae62-486e-9446-706693d5a42d": volume deletion failed: failed to delete volume pvc-3e293334-ae62-486e-9446-706693d5a42d: failed to delete volume pvc-3e293334-ae62-486e-9446-706693d5a42d: create process timeout after 120 seconds
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
