### PR TITLE
[sql_server] Refactor `CdcStream::into_stream` to better stream changes

### DIFF
--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -189,6 +189,8 @@ impl<'a> CdcStream<'a> {
                             // TODO(sql_server3): Can we maybe re-use this BTreeMap or these Vec
                             // allocations? Something to be careful of is shrinking the allocations
                             // if/when they grow to large, e.g. from a large spike of changes.
+                            // Alternatively we could also use a single Vec here since we know the
+                            // changes are ordered by LSN.
                             let mut events: BTreeMap<Lsn, Vec<Operation>> = BTreeMap::default();
                             for change in chunk {
                                 let (lsn, operation) = change.and_then(Operation::try_parse)?;

--- a/src/sql-server-util/src/cdc.rs
+++ b/src/sql-server-util/src/cdc.rs
@@ -170,43 +170,39 @@ impl<'a> CdcStream<'a> {
                             continue;
                         }
 
-                        // List all the changes for the current instance.
-                        let changes = crate::inspect::get_changes(
+                        // Get a stream of all the changes for the current instance.
+                        let changes = crate::inspect::get_changes_asc(
                             self.client,
                             &*instance,
                             *instance_lsn,
                             new_lsn,
                             RowFilterOption::AllUpdateOld,
                         )
-                        .await?;
+                        // TODO(sql_server3): Make this chunk size configurable.
+                        .ready_chunks(64);
+                        let mut changes = std::pin::pin!(changes);
 
-                        // TODO(sql_server1): For very large changes it feels bad collecting
-                        // them all in memory, it would be best if we streamed them to the
-                        // caller.
+                        // Map and stream all the rows to our listener.
+                        while let Some(chunk) = changes.next().await {
+                            // Group events by LSN.
+                            //
+                            // TODO(sql_server3): Can we maybe re-use this BTreeMap or these Vec
+                            // allocations? Something to be careful of is shrinking the allocations
+                            // if/when they grow to large, e.g. from a large spike of changes.
+                            let mut events: BTreeMap<Lsn, Vec<Operation>> = BTreeMap::default();
+                            for change in chunk {
+                                let (lsn, operation) = change.and_then(Operation::try_parse)?;
+                                events.entry(lsn).or_default().push(operation);
+                            }
 
-                        let mut events: BTreeMap<Lsn, Vec<Operation>> = BTreeMap::default();
-                        for change in changes {
-                            let (lsn, operation) = Operation::try_parse(change)?;
-                            // Group all the operations by their LSN.
-                            events.entry(lsn).or_default().push(operation);
-                        }
-
-                        for (lsn, changes) in events {
-                            // TODO(sql_server1): Handle these events and notify the upstream
-                            // that we can cleanup this LSN.
-                            let capture_instance = Arc::clone(instance);
-                            let mark_complete = Box::new(move || {
-                                let _capture_isntance = capture_instance;
-                                let _completed_lsn = lsn;
-                            });
-                            let event = CdcEvent::Data {
-                                capture_instance: Arc::clone(instance),
-                                lsn,
-                                changes,
-                                mark_complete,
-                            };
-
-                            yield event;
+                            // Emit the groups of events.
+                            for (lsn, changes) in events {
+                                yield CdcEvent::Data {
+                                    capture_instance: Arc::clone(instance),
+                                    lsn,
+                                    changes,
+                                };
+                            }
                         }
                     }
 
@@ -278,9 +274,6 @@ pub enum CdcEvent {
         lsn: Lsn,
         /// The change itself.
         changes: Vec<Operation>,
-        /// When called marks `lsn` as complete allowing the upstream DB to clean up the record.
-        #[derivative(Debug = "ignore")]
-        mark_complete: Box<dyn FnOnce() + Send + Sync>,
     },
     /// We've made progress and observed all the changes less than `next_lsn`.
     Progress {

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -199,11 +199,14 @@ impl Client {
     /// resulting rows.
     ///
     /// Passthrough method for [`tiberius::Client::query`].
-    pub fn query_streaming<'a>(
-        &mut self,
-        query: impl Into<Cow<'a, str>>,
+    pub fn query_streaming<'c, 'q, Q>(
+        &'c mut self,
+        query: Q,
         params: &[&dyn tiberius::ToSql],
-    ) -> impl Stream<Item = Result<tiberius::Row, SqlServerError>> + Send + '_ {
+    ) -> impl Stream<Item = Result<tiberius::Row, SqlServerError>> + Send + use<'c, Q>
+    where
+        Q: Into<Cow<'q, str>>,
+    {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let params = params
             .iter()
@@ -370,11 +373,14 @@ impl<'a> Transaction<'a> {
     }
 
     /// See [`Client::query_streaming`]
-    pub fn query_streaming<'q>(
-        &mut self,
-        query: impl Into<Cow<'q, str>>,
+    pub fn query_streaming<'c, 'p, 'q, Q>(
+        &'c mut self,
+        query: Q,
         params: &[&dyn tiberius::ToSql],
-    ) -> impl Stream<Item = Result<tiberius::Row, SqlServerError>> + Send + '_ {
+    ) -> impl Stream<Item = Result<tiberius::Row, SqlServerError>> + Send + use<'c, Q>
+    where
+        Q: Into<Cow<'q, str>>,
+    {
         self.client.query_streaming(query, params)
     }
 

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -373,7 +373,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// See [`Client::query_streaming`]
-    pub fn query_streaming<'c, 'p, 'q, Q>(
+    pub fn query_streaming<'c, 'q, Q>(
         &'c mut self,
         query: Q,
         params: &[&dyn tiberius::ToSql],


### PR DESCRIPTION
This PR changes the `CdcStream::into_stream` method use a streaming query so we no longer buffer an entire change set into memory and instead everything should be streamed in constant memory, with back pressure, from the network and to our caller.

It also removes `mark_complete` field on `CdcEvent::Data`, after chatting with Petros we'll handle cleaning up data in a slightly different way.

### Motivation

Fixes a `TODO(sql_server1)`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
