### PR TITLE
helm-chart publish: Fix arg name

### DIFF
--- a/misc/python/materialize/cli/helm_chart_version_bump.py
+++ b/misc/python/materialize/cli/helm_chart_version_bump.py
@@ -39,12 +39,14 @@ def main() -> int:
     mods = [
         (
             MZ_ROOT / "misc" / "helm-charts" / "operator" / "Chart.yaml",
-            lambda docs: docs[0].update({"appVersion": args.version}),
+            lambda docs: docs[0].update({"appVersion": args.environmentd_version}),
         ),
         (
             MZ_ROOT / "misc" / "helm-charts" / "testing" / "materialize.yaml",
             lambda docs: docs[2]["spec"].update(
-                {"environmentdImageRef": f"materialize/environmentd:{args.version}"}
+                {
+                    "environmentdImageRef": f"materialize/environmentd:{args.environmentd_version}"
+                }
             ),
         ),
     ]


### PR DESCRIPTION
As noticed by Kay: https://github.com/MaterializeInc/materialize/pull/32154#discussion_r2038710869

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
