### PR TITLE
Disable backtrace collection in `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,6 @@ name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arbitrary"
@@ -12330,7 +12327,6 @@ version = "0.0.0"
 dependencies = [
  "ahash",
  "aho-corasick",
- "anyhow",
  "async-compression",
  "aws-config",
  "aws-credential-types",

--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -11,6 +11,10 @@ FROM ubuntu:noble-20250404
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1
+# Disable backtrace collection in Rust libraries, such as `anyhow`. Collecting
+# backtraces at runtime can be expensive and is known to cause deadlocks
+# (database-issues#9159).
+ENV RUST_LIB_BACKTRACE=0
 
 RUN sed -i -e 's#http://archive\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \
            -e 's#http://security\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 async-trait = "0.1.88"
 axum = "0.7.5"
 bytes = "1.10.1"

--- a/src/dyncfg-launchdarkly/Cargo.toml
+++ b/src/dyncfg-launchdarkly/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 humantime = "2.2.0"
 hyper-tls = "0.5.0"
 launchdarkly-server-sdk = { version = "2.5.1", default-features = false }

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["typed-header"] }
 base64 = "0.22.0"

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "persistcli"
 bench = false
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.88"
 axum = "0.7.5"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -28,7 +28,7 @@ name = "benches"
 harness = false
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 arrayvec = "0.7.6"
 arrow = { version = "53.3.0", default-features = false }
 async-stream = "0.3.6"

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -625,7 +625,7 @@ where
                     self.leased_seqnos.keys().take(10).collect::<Vec<_>>(),
                     // The Debug impl of backtrace is less aesthetic, but will put the trace
                     // on a single line and play more nicely with our Honeycomb quota
-                    Backtrace::capture(),
+                    Backtrace::force_capture(),
                 );
             }
         }

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 # NB: This is meant to be a strong, independent abstraction boundary. Please
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 arrow = { version = "53.3.0", default-features = false }
 bytes = { version = "1.10.1", features = ["serde"] }
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 # NB: This is meant to be a strong, independent abstraction boundary. Please
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 arrow = { version = "53.3.0", default-features = false }
 async-trait = "0.1.88"
 async-stream = "0.3.6"

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 deadpool-postgres = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes"] }
 mz-tls-util = { path = "../tls-util" }

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = { version = "1.0.97", features = ["backtrace"] }
+anyhow = "1.0.97"
 openssl = { version = "0.10.71", features = ["vendored"] }
 openssl-sys = { version = "0.9.106", features = ["vendored"] }
 postgres-openssl = { version = "0.5.0" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [dependencies]
 ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
-anyhow = { version = "1.0.97", features = ["backtrace"] }
 async-compression = { version = "0.4.11", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.2", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -158,7 +157,6 @@ zstd-sys = { version = "2.0.13", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.11" }
 aho-corasick = { version = "1.1.3" }
-anyhow = { version = "1.0.97", features = ["backtrace"] }
 async-compression = { version = "0.4.11", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.2", default-features = false, features = ["hardcoded-credentials", "test-util"] }


### PR DESCRIPTION
The `anyhow` crate automatically collects backtraces when creating `anyhow::Error`s if the `RUST_BACKTRACE=1` env variable is set, and uses them to enhance the errors' Debug representation. This is a feature we don't actively rely on but that comes with significant costs:

 * Collecting backtraces significantly increases the memory and CPU costs of creating error values, which can be both expensive and surprising.
 * In rare cases, collecting backtraces can deadlock the process, if jemalloc decides to collect a profiling sample at the same time.

This PR therefore disables backtrace collection in `anyhow` by setting `RUST_LIB_BACKTRACE=0`.

This also disables backtrace collection in all other libraries that use `std::backtrace::Backtrace::capture`, but I'm not aware of any we use. Sentry does collect backtraces, but it uses the `backtrace` crate, which isn't affected by `RUST_LIB_BACKTRACE`.

### Motivation

  * This PR fixes a recognized bug.

Partially mitigates https://github.com/MaterializeInc/database-issues/issues/9159
Partially addresses the concerns raised in https://github.com/MaterializeInc/database-issues/issues/9092

### Tips for reviewer

@antiguru raised a concern that we might have persisted backtraces as part of `anyhow::Error` debug output in dataflow errors emitted to sources or MVs, in which case disabling them would change the serialized representation of the errors, making it impossible to retract them again. The concern is valid, but it's also the case that we can't expect backtraces to be stable across releases, so these error representations would already have been unstable. Switching off backtraces is no worse than having a new release that changes them.

It would be nice to be able to switch off backtraces in `anyhow` directly, instead of having to deal with the higher blast radius of `RUST_LIB_BACKTRACE`. There is no such way currently, but plenty discussion in the crate's Github issues, so we might get one eventually.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
