### PR TITLE
Convert unary functions to new procmacro

### DIFF
--- a/ci/test/lint-main/checks/check-copyright.sh
+++ b/ci/test/lint-main/checks/check-copyright.sh
@@ -61,6 +61,7 @@ copyright_files=$(grep -vE \
     -e '^src/catalog/src/durable/upgrade/snapshots/.*' \
     -e '^src/catalog/src/durable/upgrade/persist/snapshots/.*\.snap' \
     -e '^src/expr-derive-impl/src/snapshots.*' \
+    -e '^src/expr/src/scalar/func/impls/snapshots/.*' \
     -e '^src/expr/src/scalar/func/snapshots/.*' \
     -e '^src/expr/src/scalar/snapshots/.*' \
     -e '^src/license-keys/src/license_keys/.*\.pub' \

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int32.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: "#[sqlfunc(\n    sqlname = \"boolean_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToBool),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_bool_to_int32<'a>(a: bool) -> i32 {\n    {\n        match a {\n            true => 1,\n            false => 0,\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastBoolToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastBoolToInt32 {
+    type Input = bool;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_bool_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToBool)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastBoolToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("boolean_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_bool_to_int32<'a>(a: bool) -> i32 {
+    {
+        match a {
+            true => 1,
+            false => 0,
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToBool(
+            CastInt32ToBool,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int64.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: "#[sqlfunc(\n    sqlname = \"boolean_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToBool),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_bool_to_int64<'a>(a: bool) -> i64 {\n    {\n        match a {\n            true => 1,\n            false => 0,\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastBoolToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastBoolToInt64 {
+    type Input = bool;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_bool_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToBool)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastBoolToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("boolean_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_bool_to_int64<'a>(a: bool) -> i64 {
+    {
+        match a {
+            true => 1,
+            false => 0,
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToBool(
+            CastInt64ToBool,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: "#[sqlfunc(\n    sqlname = \"boolean_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToBool),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_bool_to_string<'a>(a: bool) -> &'a str {\n    {\n        match a {\n            true => \"true\",\n            false => \"false\",\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastBoolToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastBoolToString {
+    type Input = bool;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_bool_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToBool)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastBoolToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("boolean_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_bool_to_string<'a>(a: bool) -> &'a str {
+    {
+        match a {
+            true => "true",
+            false => "false",
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToBool(
+            CastStringToBool,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string_nonstandard.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string_nonstandard.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: "#[sqlfunc(\n    sqlname = \"boolean_to_nonstandard_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToBool),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_bool_to_string_nonstandard<'a>(a: bool) -> &'a str {\n    { strconv::format_bool_static(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastBoolToStringNonstandard;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastBoolToStringNonstandard {
+    type Input = bool;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_bool_to_string_nonstandard(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToBool)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastBoolToStringNonstandard {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("boolean_to_nonstandard_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_bool_to_string_nonstandard<'a>(a: bool) -> &'a str {
+    { strconv::format_bool_static(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string_nonstandard__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__cast_bool_to_string_nonstandard__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToBool(
+            CastStringToBool,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__not.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__not.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: "#[sqlfunc(\n    sqlname = \"NOT\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(Not),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn not<'a>(a: bool) -> bool {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Not;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Not {
+    type Input = bool;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        not(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(Not)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Not {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("NOT")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn not<'a>(a: bool) -> bool {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__not__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__boolean__not__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/boolean.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        Not(
+            Not,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_count_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_count_bytes.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"bit_count\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_count_bytes<'a>(a: &'a [u8]) -> Result<i64, EvalError> {\n    {\n        let count: u64 = a.iter().map(|b| u64::cast_from(b.count_ones())).sum();\n        i64::try_from(count)\n            .or(Err(EvalError::Int64OutOfRange(count.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitCountBytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitCountBytes {
+    type Input = &'a [u8];
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_count_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for BitCountBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bit_count")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_count_bytes<'a>(a: &'a [u8]) -> Result<i64, EvalError> {
+    {
+        let count: u64 = a.iter().map(|b| u64::cast_from(b.count_ones())).sum();
+        i64::try_from(count)
+            .or(Err(EvalError::Int64OutOfRange(count.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_count_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_count_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_length_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_length_bytes.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"bit_length\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {\n    {\n        let val = a.len() * 8;\n        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitLengthBytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitLengthBytes {
+    type Input = &'a [u8];
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_length_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for BitLengthBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bit_length")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {
+    {
+        let val = a.len() * 8;
+        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_length_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__bit_length_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__byte_length_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__byte_length_bytes.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"octet_length\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn byte_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {\n    {\n        let val = a.len();\n        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ByteLengthBytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for ByteLengthBytes {
+    type Input = &'a [u8];
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        byte_length_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ByteLengthBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("octet_length")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn byte_length_bytes<'a>(a: &'a [u8]) -> Result<i32, EvalError> {
+    {
+        let val = a.len();
+        i32::try_from(val).or(Err(EvalError::Int32OutOfRange(val.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__byte_length_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__byte_length_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__cast_bytes_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__cast_bytes_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"bytea_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToBytes),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_bytes_to_string<'a>(a: &'a [u8]) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_bytes(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastBytesToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastBytesToString {
+    type Input = &'a [u8];
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_bytes_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToBytes)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastBytesToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bytea_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_bytes_to_string<'a>(a: &'a [u8]) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_bytes(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__cast_bytes_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__cast_bytes_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToBytes(
+            CastStringToBytes,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_bytes.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"crc32_bytes\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn crc32_bytes<'a>(a: &'a [u8]) -> u32 {\n    { crc32fast::hash(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Crc32Bytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Crc32Bytes {
+    type Input = &'a [u8];
+    type Output = u32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        crc32_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Crc32Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("crc32_bytes")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn crc32_bytes<'a>(a: &'a [u8]) -> u32 {
+    { crc32fast::hash(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_string.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"crc32_string\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn crc32_string<'a>(a: &'a str) -> u32 {\n    { crc32_bytes(a.as_bytes()) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Crc32String;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Crc32String {
+    type Input = &'a str;
+    type Output = u32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        crc32_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Crc32String {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("crc32_string")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn crc32_string<'a>(a: &'a str) -> u32 {
+    { crc32_bytes(a.as_bytes()) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__crc32_string__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_bytes.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"kafka_murmur2_bytes\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn kafka_murmur2_bytes<'a>(a: &'a [u8]) -> i32 {\n    {\n        i32::from_ne_bytes(\n            (murmur2::murmur2(a, murmur2::KAFKA_SEED) & 0x7fffffff).to_ne_bytes(),\n        )\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct KafkaMurmur2Bytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for KafkaMurmur2Bytes {
+    type Input = &'a [u8];
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        kafka_murmur2_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for KafkaMurmur2Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("kafka_murmur2_bytes")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn kafka_murmur2_bytes<'a>(a: &'a [u8]) -> i32 {
+    {
+        i32::from_ne_bytes(
+            (murmur2::murmur2(a, murmur2::KAFKA_SEED) & 0x7fffffff).to_ne_bytes(),
+        )
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_string.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"kafka_murmur2_string\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn kafka_murmur2_string<'a>(a: &'a str) -> i32 {\n    { kafka_murmur2_bytes(a.as_bytes()) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct KafkaMurmur2String;
+impl<'a> crate::func::EagerUnaryFunc<'a> for KafkaMurmur2String {
+    type Input = &'a str;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        kafka_murmur2_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for KafkaMurmur2String {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("kafka_murmur2_string")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn kafka_murmur2_string<'a>(a: &'a str) -> i32 {
+    { kafka_murmur2_bytes(a.as_bytes()) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__kafka_murmur2_string__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_bytes.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"seahash_bytes\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn seahash_bytes<'a>(a: &'a [u8]) -> u64 {\n    { seahash::hash(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SeahashBytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for SeahashBytes {
+    type Input = &'a [u8];
+    type Output = u64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        seahash_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for SeahashBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("seahash_bytes")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn seahash_bytes<'a>(a: &'a [u8]) -> u64 {
+    { seahash::hash(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_bytes__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_string.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: "#[sqlfunc(\n    sqlname = \"seahash_string\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn seahash_string<'a>(a: &'a str) -> u64 {\n    { seahash_bytes(a.as_bytes()) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SeahashString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for SeahashString {
+    type Input = &'a str;
+    type Output = u64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        seahash_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for SeahashString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("seahash_string")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn seahash_string<'a>(a: &'a str) -> u64 {
+    { seahash_bytes(a.as_bytes()) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__byte__seahash_string__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/byte.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__char__cast_char_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__char__cast_char_to_string.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/char.rs
+expression: "#[sqlfunc(\n    sqlname = \"char_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToChar{length:None, fail_on_len:false}),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_char_to_string<'a>(a: Char<&'a str>) -> &'a str {\n    { a.0 }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastCharToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastCharToString {
+    type Input = Char<&'a str>;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_char_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToChar { length : None, fail_on_len : false, })
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastCharToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("char_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_char_to_string<'a>(a: Char<&'a str>) -> &'a str {
+    { a.0 }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__char__cast_char_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__char__cast_char_to_string__impl.snap
@@ -1,0 +1,27 @@
+---
+source: src/expr/src/scalar/func/impls/char.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToChar(
+            CastStringToChar {
+                length: None,
+                fail_on_len: false,
+            },
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__date__cast_date_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__date__cast_date_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/date.rs
+expression: "#[sqlfunc(\n    sqlname = \"date_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToDate),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_date_to_string<'a>(a: Date) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_date(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastDateToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastDateToString {
+    type Input = Date;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_date_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToDate)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastDateToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_date_to_string<'a>(a: Date) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_date(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__date__cast_date_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__date__cast_date_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/date.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToDate(
+            CastStringToDate,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_false.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_false.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: "#[sqlfunc(\n    sqlname = \"isfalse\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn is_false<'a>(a: Datum<'a>) -> bool {\n    { a == Datum::False }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct IsFalse;
+impl<'a> crate::func::EagerUnaryFunc<'a> for IsFalse {
+    type Input = Datum<'a>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        is_false(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for IsFalse {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("isfalse")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn is_false<'a>(a: Datum<'a>) -> bool {
+    { a == Datum::False }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_false__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_false__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: false,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_null.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_null.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: "#[sqlfunc(\n    sqlname = \"isnull\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn is_null<'a>(a: Datum<'a>) -> bool {\n    { a.is_null() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct IsNull;
+impl<'a> crate::func::EagerUnaryFunc<'a> for IsNull {
+    type Input = Datum<'a>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        is_null(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for IsNull {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("isnull")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn is_null<'a>(a: Datum<'a>) -> bool {
+    { a.is_null() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_null__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_null__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: false,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_true.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_true.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: "#[sqlfunc(\n    sqlname = \"istrue\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn is_true<'a>(a: Datum<'a>) -> bool {\n    { a == Datum::True }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct IsTrue;
+impl<'a> crate::func::EagerUnaryFunc<'a> for IsTrue {
+    type Input = Datum<'a>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        is_true(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for IsTrue {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("istrue")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn is_true<'a>(a: Datum<'a>) -> bool {
+    { a == Datum::True }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_true__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__is_true__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: false,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__mz_row_size.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__mz_row_size.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(mz_row_size),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_row_size<'a>(a: DatumList<'a>) -> Result<i32, EvalError> {\n    {\n        let sz = mz_repr::row_size(a.iter());\n        i32::try_from(sz).or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzRowSize;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzRowSize {
+    type Input = DatumList<'a>;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_row_size(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzRowSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(mz_row_size))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_row_size<'a>(a: DatumList<'a>) -> Result<i32, EvalError> {
+    {
+        let sz = mz_repr::row_size(a.iter());
+        i32::try_from(sz).or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__mz_row_size__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__mz_row_size__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__pg_column_size.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__pg_column_size.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(pg_column_size),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn pg_column_size<'a>(a: Datum<'a>) -> Result<Option<i32>, EvalError> {\n    {\n        match a {\n            Datum::Null => Ok(None),\n            datum => {\n                let sz = mz_repr::datum_size(&datum);\n                i32::try_from(sz)\n                    .map(Some)\n                    .or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct PgColumnSize;
+impl<'a> crate::func::EagerUnaryFunc<'a> for PgColumnSize {
+    type Input = Datum<'a>;
+    type Output = Result<Option<i32>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        pg_column_size(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for PgColumnSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(pg_column_size))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn pg_column_size<'a>(a: Datum<'a>) -> Result<Option<i32>, EvalError> {
+    {
+        match a {
+            Datum::Null => Ok(None),
+            datum => {
+                let sz = mz_repr::datum_size(&datum);
+                i32::try_from(sz)
+                    .map(Some)
+                    .or(Err(EvalError::Int32OutOfRange(sz.to_string().into())))
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__pg_column_size__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__datum__pg_column_size__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/datum.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: false,
+    introduces_nulls: true,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__abs_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__abs_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_float32<'a>(a: f32) -> f32 {\n    { a.abs() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_float32<'a>(a: f32) -> f32 {
+    { a.abs() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__abs_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__abs_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_double\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat64ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_float64<'a>(a: f32) -> f64 {\n    { a.into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToFloat64 {
+    type Input = f32;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_float64<'a>(a: f32) -> f64 {
+    { a.into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat64ToFloat32(
+            CastFloat64ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int16.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt16ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_int16<'a>(a: f32) -> Result<i16, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {\n            Ok(f as i16)\n        } else {\n            Err(EvalError::Int16OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToInt16 {
+    type Input = f32;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_int16<'a>(a: f32) -> Result<i16, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt16ToFloat32(
+            CastInt16ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_integer\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt32ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_int32<'a>(a: f32) -> Result<i32, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {\n            Ok(f as i32)\n        } else {\n            Err(EvalError::Int32OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToInt32 {
+    type Input = f32;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_int32<'a>(a: f32) -> Result<i32, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i32::MIN as f32)) && (f < -(i32::MIN as f32)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt32ToFloat32(
+            CastInt32ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt64ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_int64<'a>(a: f32) -> Result<i64, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {\n            Ok(f as i64)\n        } else {\n            Err(EvalError::Int64OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToInt64 {
+    type Input = f32;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_int64<'a>(a: f32) -> Result<i64, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i64::MIN as f32)) && (f < -(i64::MIN as f32)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt64ToFloat32(
+            CastInt64ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_text\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastStringToFloat32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_string<'a>(a: f32) -> String {\n    {\n        let mut s = String::new();\n        strconv::format_float32(&mut s, a);\n        s\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToString {
+    type Input = f32;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_string<'a>(a: f32) -> String {
+    {
+        let mut s = String::new();
+        strconv::format_float32(&mut s, a);
+        s
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastStringToFloat32(
+            CastStringToFloat32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint16.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_uint2\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint16ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_uint16<'a>(a: f32) -> Result<u16, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u16::MAX as f32)) {\n            Ok(f as u16)\n        } else {\n            Err(EvalError::UInt16OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToUint16 {
+    type Input = f32;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_uint16<'a>(a: f32) -> Result<u16, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u16::MAX as f32)) {
+            Ok(f as u16)
+        } else {
+            Err(EvalError::UInt16OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint16ToFloat32(
+            CastUint16ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_uint4\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint32ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_uint32<'a>(a: f32) -> Result<u32, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u32::MAX as f32)) {\n            Ok(f as u32)\n        } else {\n            Err(EvalError::UInt32OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToUint32 {
+    type Input = f32;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_uint32<'a>(a: f32) -> Result<u32, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u32::MAX as f32)) {
+            Ok(f as u32)
+        } else {
+            Err(EvalError::UInt32OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint32ToFloat32(
+            CastUint32ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"real_to_uint8\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint64ToFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float32_to_uint64<'a>(a: f32) -> Result<u64, EvalError> {\n    {\n        let f = round_float32(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u64::MAX as f32)) {\n            Ok(f as u64)\n        } else {\n            Err(EvalError::UInt64OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat32ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat32ToUint64 {
+    type Input = f32;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float32_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat32ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("real_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float32_to_uint64<'a>(a: f32) -> Result<u64, EvalError> {
+    {
+        let f = round_float32(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u64::MAX as f32)) {
+            Ok(f as u64)
+        } else {
+            Err(EvalError::UInt64OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__cast_float32_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint64ToFloat32(
+            CastUint64ToFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__ceil_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__ceil_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"ceilf32\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ceil_float32<'a>(a: f32) -> f32 {\n    { a.ceil() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CeilFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CeilFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ceil_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CeilFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("ceilf32")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ceil_float32<'a>(a: f32) -> f32 {
+    { a.ceil() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__ceil_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__ceil_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__floor_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__floor_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"floorf32\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn floor_float32<'a>(a: f32) -> f32 {\n    { a.floor() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct FloorFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for FloorFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        floor_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for FloorFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("floorf32")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn floor_float32<'a>(a: f32) -> f32 {
+    { a.floor() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__floor_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__floor_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__neg_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__neg_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(NegFloat32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_float32<'a>(a: f32) -> f32 {\n    { -a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegFloat32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for NegFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_float32<'a>(a: f32) -> f32 {
+    { -a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__neg_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__neg_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        NegFloat32(
+            NegFloat32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__round_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__round_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"roundf32\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn round_float32<'a>(a: f32) -> f32 {\n    { a.round_ties_even() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RoundFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RoundFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        round_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RoundFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("roundf32")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn round_float32<'a>(a: f32) -> f32 {
+    { a.round_ties_even() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__round_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__round_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__trunc_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__trunc_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: "#[sqlfunc(\n    sqlname = \"truncf32\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trunc_float32<'a>(a: f32) -> f32 {\n    { a.trunc() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TruncFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TruncFloat32 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trunc_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TruncFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("truncf32")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trunc_float32<'a>(a: f32) -> f32 {
+    { a.trunc() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__trunc_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float32__trunc_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__abs_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__abs_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_float64<'a>(a: f64) -> f64 {\n    { a.abs() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_float64<'a>(a: f64) -> f64 {
+    { a.abs() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__abs_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__abs_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acos.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acos.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(acos),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn acos<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a < -1.0 || 1.0 < a {\n            return Err(\n                EvalError::OutOfDomain(\n                    DomainLimit::Inclusive(-1),\n                    DomainLimit::Inclusive(1),\n                    \"acos\".into(),\n                ),\n            );\n        }\n        Ok(a.acos())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Acos;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Acos {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        acos(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Acos {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(acos))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn acos<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a < -1.0 || 1.0 < a {
+            return Err(
+                EvalError::OutOfDomain(
+                    DomainLimit::Inclusive(-1),
+                    DomainLimit::Inclusive(1),
+                    "acos".into(),
+                ),
+            );
+        }
+        Ok(a.acos())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acos__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acos__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acosh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acosh.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(acosh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn acosh<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a < 1.0 {\n            return Err(\n                EvalError::OutOfDomain(\n                    DomainLimit::Inclusive(1),\n                    DomainLimit::None,\n                    \"acosh\".into(),\n                ),\n            );\n        }\n        Ok(a.acosh())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Acosh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Acosh {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        acosh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Acosh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(acosh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn acosh<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a < 1.0 {
+            return Err(
+                EvalError::OutOfDomain(
+                    DomainLimit::Inclusive(1),
+                    DomainLimit::None,
+                    "acosh".into(),
+                ),
+            );
+        }
+        Ok(a.acosh())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acosh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__acosh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asin.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asin.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(asin),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn asin<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a < -1.0 || 1.0 < a {\n            return Err(\n                EvalError::OutOfDomain(\n                    DomainLimit::Inclusive(-1),\n                    DomainLimit::Inclusive(1),\n                    \"asin\".into(),\n                ),\n            );\n        }\n        Ok(a.asin())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Asin;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Asin {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        asin(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Asin {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(asin))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn asin<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a < -1.0 || 1.0 < a {
+            return Err(
+                EvalError::OutOfDomain(
+                    DomainLimit::Inclusive(-1),
+                    DomainLimit::Inclusive(1),
+                    "asin".into(),
+                ),
+            );
+        }
+        Ok(a.asin())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asin__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asin__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asinh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asinh.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(asinh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn asinh<'a>(a: f64) -> f64 {\n    { a.asinh() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Asinh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Asinh {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        asinh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Asinh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(asinh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn asinh<'a>(a: f64) -> f64 {
+    { a.asinh() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asinh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__asinh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atan.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atan.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(atan),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn atan<'a>(a: f64) -> f64 {\n    { a.atan() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Atan;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Atan {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        atan(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Atan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(atan))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn atan<'a>(a: f64) -> f64 {
+    { a.atan() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atan__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atan__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atanh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atanh.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(atanh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn atanh<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a < -1.0 || 1.0 < a {\n            return Err(\n                EvalError::OutOfDomain(\n                    DomainLimit::Inclusive(-1),\n                    DomainLimit::Inclusive(1),\n                    \"atanh\".into(),\n                ),\n            );\n        }\n        Ok(a.atanh())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Atanh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Atanh {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        atanh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Atanh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(atanh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn atanh<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a < -1.0 || 1.0 < a {
+            return Err(
+                EvalError::OutOfDomain(
+                    DomainLimit::Inclusive(-1),
+                    DomainLimit::Inclusive(1),
+                    "atanh".into(),
+                ),
+            );
+        }
+        Ok(a.atanh())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atanh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__atanh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_float32.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_float32<'a>(a: f64) -> Result<f32, EvalError> {\n    {\n        #[allow(clippy::as_conversions)]\n        let result = a as f32;\n        if result.is_infinite() && !a.is_infinite() {\n            Err(EvalError::FloatOverflow)\n        } else if result == 0.0 && a != 0.0 {\n            Err(EvalError::FloatUnderflow)\n        } else {\n            Ok(result)\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToFloat32 {
+    type Input = f64;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_float32<'a>(a: f64) -> Result<f32, EvalError> {
+    {
+        #[allow(clippy::as_conversions)]
+        let result = a as f32;
+        if result.is_infinite() && !a.is_infinite() {
+            Err(EvalError::FloatOverflow)
+        } else if result == 0.0 && a != 0.0 {
+            Err(EvalError::FloatUnderflow)
+        } else {
+            Ok(result)
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToFloat64(
+            CastFloat32ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int16.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt16ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_int16<'a>(a: f64) -> Result<i16, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {\n            Ok(f as i16)\n        } else {\n            Err(EvalError::Int16OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToInt16 {
+    type Input = f64;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_int16<'a>(a: f64) -> Result<i16, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
+            Ok(f as i16)
+        } else {
+            Err(EvalError::Int16OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt16ToFloat64(
+            CastInt16ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_integer\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt32ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_int32<'a>(a: f64) -> Result<i32, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {\n            Ok(f as i32)\n        } else {\n            Err(EvalError::Int32OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToInt32 {
+    type Input = f64;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_int32<'a>(a: f64) -> Result<i32, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i32::MIN as f64)) && (f < -(i32::MIN as f64)) {
+            Ok(f as i32)
+        } else {
+            Err(EvalError::Int32OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt32ToFloat64(
+            CastInt32ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"f64toi64\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt64ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_int64<'a>(a: f64) -> Result<i64, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {\n            Ok(f as i64)\n        } else {\n            Err(EvalError::Int64OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToInt64 {
+    type Input = f64;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("f64toi64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_int64<'a>(a: f64) -> Result<i64, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= (i64::MIN as f64)) && (f < -(i64::MIN as f64)) {
+            Ok(f as i64)
+        } else {
+            Err(EvalError::Int64OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt64ToFloat64(
+            CastInt64ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_text\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastStringToFloat64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_string<'a>(a: f64) -> String {\n    {\n        let mut s = String::new();\n        strconv::format_float64(&mut s, a);\n        s\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToString {
+    type Input = f64;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_string<'a>(a: f64) -> String {
+    {
+        let mut s = String::new();
+        strconv::format_float64(&mut s, a);
+        s
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastStringToFloat64(
+            CastStringToFloat64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint16.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_uint2\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint16ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_uint16<'a>(a: f64) -> Result<u16, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u16::MAX as f64)) {\n            Ok(f as u16)\n        } else {\n            Err(EvalError::UInt16OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToUint16 {
+    type Input = f64;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_uint16<'a>(a: f64) -> Result<u16, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u16::MAX as f64)) {
+            Ok(f as u16)
+        } else {
+            Err(EvalError::UInt16OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint16ToFloat64(
+            CastUint16ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_uint4\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint32ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_uint32<'a>(a: f64) -> Result<u32, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u32::MAX as f64)) {\n            Ok(f as u32)\n        } else {\n            Err(EvalError::UInt32OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToUint32 {
+    type Input = f64;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_uint32<'a>(a: f64) -> Result<u32, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u32::MAX as f64)) {
+            Ok(f as u32)
+        } else {
+            Err(EvalError::UInt32OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint32ToFloat64(
+            CastUint32ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"double_to_uint8\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint64ToFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_float64_to_uint64<'a>(a: f64) -> Result<u64, EvalError> {\n    {\n        let f = round_float64(a);\n        #[allow(clippy::as_conversions)]\n        if (f >= 0.0) && (f <= (u64::MAX as f64)) {\n            Ok(f as u64)\n        } else {\n            Err(EvalError::UInt64OutOfRange(f.to_string().into()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastFloat64ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastFloat64ToUint64 {
+    type Input = f64;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_float64_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastFloat64ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("double_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_float64_to_uint64<'a>(a: f64) -> Result<u64, EvalError> {
+    {
+        let f = round_float64(a);
+        #[allow(clippy::as_conversions)]
+        if (f >= 0.0) && (f <= (u64::MAX as f64)) {
+            Ok(f as u64)
+        } else {
+            Err(EvalError::UInt64OutOfRange(f.to_string().into()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cast_float64_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint64ToFloat64(
+            CastUint64ToFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cbrt_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cbrt_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"cbrtf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cbrt_float64<'a>(a: f64) -> f64 {\n    { a.cbrt() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CbrtFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CbrtFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cbrt_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CbrtFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("cbrtf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cbrt_float64<'a>(a: f64) -> f64 {
+    { a.cbrt() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cbrt_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cbrt_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ceil_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ceil_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"ceilf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ceil_float64<'a>(a: f64) -> f64 {\n    { a.ceil() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CeilFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CeilFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ceil_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CeilFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("ceilf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ceil_float64<'a>(a: f64) -> f64 {
+    { a.ceil() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ceil_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ceil_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cos.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cos.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(cos),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cos<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_infinite() {\n            return Err(EvalError::InfinityOutOfDomain(\"cos\".into()));\n        }\n        Ok(a.cos())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Cos;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Cos {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cos(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Cos {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(cos))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cos<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("cos".into()));
+        }
+        Ok(a.cos())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cos__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cos__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cosh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cosh.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(cosh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cosh<'a>(a: f64) -> f64 {\n    { a.cosh() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Cosh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Cosh {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cosh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Cosh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(cosh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cosh<'a>(a: f64) -> f64 {
+    { a.cosh() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cosh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cosh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cot.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cot.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(cot),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cot<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_infinite() {\n            return Err(EvalError::InfinityOutOfDomain(\"cot\".into()));\n        }\n        Ok(1.0 / a.tan())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Cot;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Cot {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cot(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Cot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(cot))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cot<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("cot".into()));
+        }
+        Ok(1.0 / a.tan())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cot__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__cot__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__degrees.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__degrees.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(degrees),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn degrees<'a>(a: f64) -> f64 {\n    { a.to_degrees() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Degrees;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Degrees {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        degrees(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Degrees {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(degrees))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn degrees<'a>(a: f64) -> f64 {
+    { a.to_degrees() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__degrees__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__degrees__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__exp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__exp.snap
@@ -1,0 +1,59 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"expf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn exp<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        let r = a.exp();\n        if r.is_infinite() {\n            return Err(EvalError::FloatOverflow);\n        }\n        if r == 0.0 {\n            return Err(EvalError::FloatUnderflow);\n        }\n        Ok(r)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Exp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Exp {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        exp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Exp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("expf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn exp<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        let r = a.exp();
+        if r.is_infinite() {
+            return Err(EvalError::FloatOverflow);
+        }
+        if r == 0.0 {
+            return Err(EvalError::FloatUnderflow);
+        }
+        Ok(r)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__exp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__exp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__floor_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__floor_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"floorf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn floor_float64<'a>(a: f64) -> f64 {\n    { a.floor() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct FloorFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for FloorFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        floor_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for FloorFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("floorf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn floor_float64<'a>(a: f64) -> f64 {
+    { a.floor() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__floor_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__floor_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ln.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ln.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"lnf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ln<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_sign_negative() {\n            return Err(EvalError::NegativeOutOfDomain(\"ln\".into()));\n        }\n        if a == 0.0 {\n            return Err(EvalError::ZeroOutOfDomain(\"ln\".into()));\n        }\n        Ok(a.ln())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Ln;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Ln {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ln(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Ln {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("lnf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ln<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_sign_negative() {
+            return Err(EvalError::NegativeOutOfDomain("ln".into()));
+        }
+        if a == 0.0 {
+            return Err(EvalError::ZeroOutOfDomain("ln".into()));
+        }
+        Ok(a.ln())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ln__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__ln__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__log10.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__log10.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"log10f64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn log10<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_sign_negative() {\n            return Err(EvalError::NegativeOutOfDomain(\"log10\".into()));\n        }\n        if a == 0.0 {\n            return Err(EvalError::ZeroOutOfDomain(\"log10\".into()));\n        }\n        Ok(a.log10())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Log10;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Log10 {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        log10(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Log10 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("log10f64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn log10<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_sign_negative() {
+            return Err(EvalError::NegativeOutOfDomain("log10".into()));
+        }
+        if a == 0.0 {
+            return Err(EvalError::ZeroOutOfDomain("log10".into()));
+        }
+        Ok(a.log10())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__log10__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__log10__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__neg_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__neg_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(NegFloat64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_float64<'a>(a: f64) -> f64 {\n    { -a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegFloat64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for NegFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_float64<'a>(a: f64) -> f64 {
+    { -a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__neg_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__neg_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        NegFloat64(
+            NegFloat64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__radians.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__radians.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(radians),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn radians<'a>(a: f64) -> f64 {\n    { a.to_radians() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Radians;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Radians {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        radians(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Radians {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(radians))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn radians<'a>(a: f64) -> f64 {
+    { a.to_radians() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__radians__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__radians__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__round_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__round_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"roundf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn round_float64<'a>(a: f64) -> f64 {\n    { a.round_ties_even() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RoundFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RoundFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        round_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RoundFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("roundf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn round_float64<'a>(a: f64) -> f64 {
+    { a.round_ties_even() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__round_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__round_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sin.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sin.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(sin),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn sin<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_infinite() {\n            return Err(EvalError::InfinityOutOfDomain(\"sin\".into()));\n        }\n        Ok(a.sin())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Sin;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Sin {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        sin(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Sin {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(sin))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn sin<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("sin".into()));
+        }
+        Ok(a.sin())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sin__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sin__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sinh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sinh.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(sinh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn sinh<'a>(a: f64) -> f64 {\n    { a.sinh() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Sinh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Sinh {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        sinh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Sinh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(sinh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn sinh<'a>(a: f64) -> f64 {
+    { a.sinh() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sinh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sinh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sleep.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sleep.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_sleep\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn sleep<'a>(a: f64) -> Option<CheckedTimestamp<DateTime<Utc>>> {\n    {\n        let duration = std::time::Duration::from_secs_f64(a);\n        std::thread::sleep(duration);\n        None\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Sleep;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Sleep {
+    type Input = f64;
+    type Output = Option<CheckedTimestamp<DateTime<Utc>>>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        sleep(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Sleep {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_sleep")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn sleep<'a>(a: f64) -> Option<CheckedTimestamp<DateTime<Utc>>> {
+    {
+        let duration = std::time::Duration::from_secs_f64(a);
+        std::thread::sleep(duration);
+        None
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sleep__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sleep__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sqrt_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sqrt_float64.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"sqrtf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn sqrt_float64<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a < 0.0 {\n            return Err(EvalError::NegSqrt);\n        }\n        Ok(a.sqrt())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SqrtFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for SqrtFloat64 {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        sqrt_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for SqrtFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("sqrtf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn sqrt_float64<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a < 0.0 {
+            return Err(EvalError::NegSqrt);
+        }
+        Ok(a.sqrt())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sqrt_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__sqrt_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tan.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tan.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(tan),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn tan<'a>(a: f64) -> Result<f64, EvalError> {\n    {\n        if a.is_infinite() {\n            return Err(EvalError::InfinityOutOfDomain(\"tan\".into()));\n        }\n        Ok(a.tan())\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Tan;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Tan {
+    type Input = f64;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        tan(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Tan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(tan))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn tan<'a>(a: f64) -> Result<f64, EvalError> {
+    {
+        if a.is_infinite() {
+            return Err(EvalError::InfinityOutOfDomain("tan".into()));
+        }
+        Ok(a.tan())
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tan__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tan__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tanh.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tanh.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(tanh),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn tanh<'a>(a: f64) -> f64 {\n    { a.tanh() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Tanh;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Tanh {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        tanh(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Tanh {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(tanh))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn tanh<'a>(a: f64) -> f64 {
+    { a.tanh() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tanh__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__tanh__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__to_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__to_timestamp.snap
@@ -1,0 +1,82 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"tots\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn to_timestamp<'a>(f: f64) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {\n    {\n        const NANO_SECONDS_PER_SECOND: i64 = 1_000_000_000;\n        if f.is_nan() {\n            Err(EvalError::TimestampCannotBeNan)\n        } else if f.is_infinite() {\n            Err(EvalError::TimestampOutOfRange)\n        } else {\n            let mut secs = i64::try_cast_from(f.trunc())\n                .ok_or(EvalError::TimestampOutOfRange)?;\n            let microsecs = (f.fract() * 1_000_000.0).round();\n            let mut nanosecs = i64::try_cast_from(microsecs * 1_000.0)\n                .ok_or(EvalError::TimestampOutOfRange)?;\n            if nanosecs < 0 {\n                secs = secs.checked_sub(1).ok_or(EvalError::TimestampOutOfRange)?;\n                nanosecs = NANO_SECONDS_PER_SECOND\n                    .checked_add(nanosecs)\n                    .ok_or(EvalError::TimestampOutOfRange)?;\n            }\n            secs = secs\n                .checked_add(nanosecs / NANO_SECONDS_PER_SECOND)\n                .ok_or(EvalError::TimestampOutOfRange)?;\n            nanosecs %= NANO_SECONDS_PER_SECOND;\n            let nanosecs = u32::try_from(nanosecs)\n                .map_err(|_| EvalError::TimestampOutOfRange)?;\n            match DateTime::from_timestamp(secs, nanosecs) {\n                Some(dt) => {\n                    CheckedTimestamp::from_timestamplike(dt)\n                        .map_err(|_| EvalError::TimestampOutOfRange)\n                }\n                None => Err(EvalError::TimestampOutOfRange),\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ToTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for ToTimestamp {
+    type Input = f64;
+    type Output = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        to_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ToTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("tots")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn to_timestamp<'a>(f: f64) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
+    {
+        const NANO_SECONDS_PER_SECOND: i64 = 1_000_000_000;
+        if f.is_nan() {
+            Err(EvalError::TimestampCannotBeNan)
+        } else if f.is_infinite() {
+            Err(EvalError::TimestampOutOfRange)
+        } else {
+            let mut secs = i64::try_cast_from(f.trunc())
+                .ok_or(EvalError::TimestampOutOfRange)?;
+            let microsecs = (f.fract() * 1_000_000.0).round();
+            let mut nanosecs = i64::try_cast_from(microsecs * 1_000.0)
+                .ok_or(EvalError::TimestampOutOfRange)?;
+            if nanosecs < 0 {
+                secs = secs.checked_sub(1).ok_or(EvalError::TimestampOutOfRange)?;
+                nanosecs = NANO_SECONDS_PER_SECOND
+                    .checked_add(nanosecs)
+                    .ok_or(EvalError::TimestampOutOfRange)?;
+            }
+            secs = secs
+                .checked_add(nanosecs / NANO_SECONDS_PER_SECOND)
+                .ok_or(EvalError::TimestampOutOfRange)?;
+            nanosecs %= NANO_SECONDS_PER_SECOND;
+            let nanosecs = u32::try_from(nanosecs)
+                .map_err(|_| EvalError::TimestampOutOfRange)?;
+            match DateTime::from_timestamp(secs, nanosecs) {
+                Some(dt) => {
+                    CheckedTimestamp::from_timestamplike(dt)
+                        .map_err(|_| EvalError::TimestampOutOfRange)
+                }
+                None => Err(EvalError::TimestampOutOfRange),
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__to_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__to_timestamp__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__trunc_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__trunc_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: "#[sqlfunc(\n    sqlname = \"truncf64\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trunc_float64<'a>(a: f64) -> f64 {\n    { a.trunc() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TruncFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TruncFloat64 {
+    type Input = f64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trunc_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TruncFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("truncf64")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trunc_float64<'a>(a: f64) -> f64 {
+    { a.trunc() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__trunc_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__float64__trunc_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/float64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__abs_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__abs_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_int16<'a>(a: i16) -> Result<i16, EvalError> {\n    { a.checked_abs().ok_or(EvalError::Int16OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsInt16 {
+    type Input = i16;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_int16<'a>(a: i16) -> Result<i16, EvalError> {
+    { a.checked_abs().ok_or(EvalError::Int16OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__abs_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__abs_int16__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__bit_not_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__bit_not_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(BitNotInt16),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_int16<'a>(a: i16) -> i16 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotInt16 {
+    type Input = i16;
+    type Output = i16;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(BitNotInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_int16<'a>(a: i16) -> i16 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__bit_not_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__bit_not_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotInt16(
+            BitNotInt16,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_real\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat32ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_float32<'a>(a: i16) -> f32 {\n    { f32::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToFloat32 {
+    type Input = i16;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_float32<'a>(a: i16) -> f32 {
+    { f32::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat32ToInt16(
+            CastFloat32ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_double\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat64ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_float64<'a>(a: i16) -> f64 {\n    { f64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToFloat64 {
+    type Input = i16;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_float64<'a>(a: i16) -> f64 {
+    { f64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat64ToInt16(
+            CastFloat64ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_int32<'a>(a: i16) -> i32 {\n    { i32::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToInt32 {
+    type Input = i16;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_int32<'a>(a: i16) -> i32 {
+    { i32::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToInt16(
+            CastInt32ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_int64<'a>(a: i16) -> i64 {\n    { i64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToInt64 {
+    type Input = i16;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_int64<'a>(a: i16) -> i64 {
+    { i64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToInt16(
+            CastInt64ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToInt16),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_string<'a>(a: i16) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_int16(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToString {
+    type Input = i16;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_string<'a>(a: i16) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_int16(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToInt16(
+            CastStringToInt16,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_uint2\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint16ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_uint16<'a>(a: i16) -> Result<u16, EvalError> {\n    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToUint16 {
+    type Input = i16;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_uint16<'a>(a: i16) -> Result<u16, EvalError> {
+    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint16ToInt16(
+            CastUint16ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_uint4\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint32ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_uint32<'a>(a: i16) -> Result<u32, EvalError> {\n    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToUint32 {
+    type Input = i16;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_uint32<'a>(a: i16) -> Result<u32, EvalError> {
+    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint32ToInt16(
+            CastUint32ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"smallint_to_uint8\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint64ToInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int16_to_uint64<'a>(a: i16) -> Result<u64, EvalError> {\n    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt16ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt16ToUint64 {
+    type Input = i16;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int16_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt16ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("smallint_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int16_to_uint64<'a>(a: i16) -> Result<u64, EvalError> {
+    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__cast_int16_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint64ToInt16(
+            CastUint64ToInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__neg_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__neg_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(NegInt16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_int16<'a>(a: i16) -> Result<i16, EvalError> {\n    { a.checked_neg().ok_or(EvalError::Int16OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegInt16 {
+    type Input = i16;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegInt16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NegInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_int16<'a>(a: i16) -> Result<i16, EvalError> {
+    { a.checked_neg().ok_or(EvalError::Int16OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__neg_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int16__neg_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        NegInt16(
+            NegInt16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__abs_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__abs_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_int32<'a>(a: i32) -> Result<i32, EvalError> {\n    { a.checked_abs().ok_or(EvalError::Int32OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsInt32 {
+    type Input = i32;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_int32<'a>(a: i32) -> Result<i32, EvalError> {
+    { a.checked_abs().ok_or(EvalError::Int32OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__abs_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__abs_int32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__bit_not_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__bit_not_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(BitNotInt32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_int32<'a>(a: i32) -> i32 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotInt32 {
+    type Input = i32;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(BitNotInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_int32<'a>(a: i32) -> i32 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__bit_not_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__bit_not_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotInt32(
+            BitNotInt32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_bool.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_bool.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastBoolToInt32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_bool<'a>(a: i32) -> bool {\n    { a != 0 }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToBool;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToBool {
+    type Input = i32;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_bool(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastBoolToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastInt32ToBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_boolean")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_bool<'a>(a: i32) -> bool {
+    { a != 0 }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_bool__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_bool__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastBoolToInt32(
+            CastBoolToInt32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_float32<'a>(a: i32) -> f32 {\n    { #[allow(clippy::as_conversions)] { a as f32 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToFloat32 {
+    type Input = i32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastInt32ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_float32<'a>(a: i32) -> f32 {
+    { #[allow(clippy::as_conversions)] { a as f32 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToInt32(
+            CastFloat32ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_double\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat64ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_float64<'a>(a: i32) -> f64 {\n    { f64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToFloat64 {
+    type Input = i32;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_float64<'a>(a: i32) -> f64 {
+    { f64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat64ToInt32(
+            CastFloat64ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_smallint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt16ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_int16<'a>(a: i32) -> Result<i16, EvalError> {\n    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToInt16 {
+    type Input = i32;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_int16<'a>(a: i32) -> Result<i16, EvalError> {
+    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt16ToInt32(
+            CastInt16ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_int64<'a>(a: i32) -> i64 {\n    { i64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToInt64 {
+    type Input = i32;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_int64<'a>(a: i32) -> i64 {
+    { i64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToInt32(
+            CastInt64ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_oid\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastOidToInt32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_oid<'a>(a: i32) -> Oid {\n    { Oid(u32::reinterpret_cast(a)) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToOid {
+    type Input = i32;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_oid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_oid<'a>(a: i32) -> Oid {
+    { Oid(u32::reinterpret_cast(a)) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastOidToInt32(
+            CastOidToInt32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_pg_legacy_char.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_pg_legacy_char.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_\\\"char\\\"\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastPgLegacyCharToInt32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_pg_legacy_char<'a>(a: i32) -> Result<PgLegacyChar, EvalError> {\n    {\n        let a = i8::try_from(a).map_err(|_| EvalError::CharOutOfRange)?;\n        Ok(PgLegacyChar(u8::reinterpret_cast(a)))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToPgLegacyChar;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToPgLegacyChar {
+    type Input = i32;
+    type Output = Result<PgLegacyChar, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_pg_legacy_char(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastPgLegacyCharToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToPgLegacyChar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_\"char\"")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_pg_legacy_char<'a>(a: i32) -> Result<PgLegacyChar, EvalError> {
+    {
+        let a = i8::try_from(a).map_err(|_| EvalError::CharOutOfRange)?;
+        Ok(PgLegacyChar(u8::reinterpret_cast(a)))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_pg_legacy_char__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_pg_legacy_char__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: PgLegacyChar,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: PgLegacyChar,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastPgLegacyCharToInt32(
+            CastPgLegacyCharToInt32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToInt32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_string<'a>(a: i32) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_int32(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToString {
+    type Input = i32;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_string<'a>(a: i32) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_int32(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToInt32(
+            CastStringToInt32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_uint2\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint16ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_uint16<'a>(a: i32) -> Result<u16, EvalError> {\n    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToUint16 {
+    type Input = i32;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_uint16<'a>(a: i32) -> Result<u16, EvalError> {
+    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint16ToInt32(
+            CastUint16ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_uint4\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint32ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_uint32<'a>(a: i32) -> Result<u32, EvalError> {\n    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToUint32 {
+    type Input = i32;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_uint32<'a>(a: i32) -> Result<u32, EvalError> {
+    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint32ToInt32(
+            CastUint32ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_uint8\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint64ToInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_uint64<'a>(a: i32) -> Result<u64, EvalError> {\n    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToUint64 {
+    type Input = i32;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_uint64<'a>(a: i32) -> Result<u64, EvalError> {
+    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__cast_int32_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint64ToInt32(
+            CastUint64ToInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__chr.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__chr.snap
@@ -1,0 +1,62 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(chr),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn chr<'a>(a: i32) -> Result<String, EvalError> {\n    {\n        let codepoint = u32::try_from(a)\n            .map_err(|_| EvalError::CharacterTooLargeForEncoding(a))?;\n        if codepoint == 0 {\n            Err(EvalError::NullCharacterNotPermitted)\n        } else if 0xd800 <= codepoint && codepoint < 0xe000 {\n            Err(EvalError::CharacterNotValidForEncoding(a))\n        } else {\n            char::from_u32(codepoint)\n                .map(|u| u.to_string())\n                .ok_or(EvalError::CharacterTooLargeForEncoding(a))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Chr;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Chr {
+    type Input = i32;
+    type Output = Result<String, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        chr(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Chr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(chr))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn chr<'a>(a: i32) -> Result<String, EvalError> {
+    {
+        let codepoint = u32::try_from(a)
+            .map_err(|_| EvalError::CharacterTooLargeForEncoding(a))?;
+        if codepoint == 0 {
+            Err(EvalError::NullCharacterNotPermitted)
+        } else if 0xd800 <= codepoint && codepoint < 0xe000 {
+            Err(EvalError::CharacterNotValidForEncoding(a))
+        } else {
+            char::from_u32(codepoint)
+                .map(|u| u.to_string())
+                .ok_or(EvalError::CharacterTooLargeForEncoding(a))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__chr__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__chr__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__neg_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__neg_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(NegInt32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_int32<'a>(a: i32) -> Result<i32, EvalError> {\n    { a.checked_neg().ok_or(EvalError::Int32OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegInt32 {
+    type Input = i32;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegInt32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NegInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_int32<'a>(a: i32) -> Result<i32, EvalError> {
+    { a.checked_neg().ok_or(EvalError::Int32OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__neg_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int32__neg_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        NegInt32(
+            NegInt32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__abs_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__abs_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_int64<'a>(a: i64) -> Result<i64, EvalError> {\n    { a.checked_abs().ok_or(EvalError::Int64OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsInt64 {
+    type Input = i64;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_int64<'a>(a: i64) -> Result<i64, EvalError> {
+    { a.checked_abs().ok_or(EvalError::Int64OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__abs_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__abs_int64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__bit_not_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__bit_not_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(BitNotInt64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_int64<'a>(a: i64) -> i64 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotInt64 {
+    type Input = i64;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(BitNotInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_int64<'a>(a: i64) -> i64 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__bit_not_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__bit_not_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotInt64(
+            BitNotInt64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_bool.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_bool.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastBoolToInt64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_bool<'a>(a: i64) -> bool {\n    { a != 0 }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToBool;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToBool {
+    type Input = i64;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_bool(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastBoolToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastInt64ToBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_boolean")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_bool<'a>(a: i64) -> bool {
+    { a != 0 }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_bool__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_bool__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastBoolToInt64(
+            CastBoolToInt64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_float32<'a>(a: i64) -> f32 {\n    { #[allow(clippy::as_conversions)] { a as f32 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToFloat32 {
+    type Input = i64;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastInt64ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_float32<'a>(a: i64) -> f32 {
+    { #[allow(clippy::as_conversions)] { a as f32 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToInt64(
+            CastFloat32ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_double\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat64ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_float64<'a>(a: i64) -> f64 {\n    { #[allow(clippy::as_conversions)] { a as f64 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToFloat64 {
+    type Input = i64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastInt64ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_float64<'a>(a: i64) -> f64 {
+    { #[allow(clippy::as_conversions)] { a as f64 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat64ToInt64(
+            CastFloat64ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_smallint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt16ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_int16<'a>(a: i64) -> Result<i16, EvalError> {\n    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToInt16 {
+    type Input = i64;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_int16<'a>(a: i64) -> Result<i16, EvalError> {
+    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt16ToInt64(
+            CastInt16ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_int32<'a>(a: i64) -> Result<i32, EvalError> {\n    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToInt32 {
+    type Input = i64;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_int32<'a>(a: i64) -> Result<i32, EvalError> {
+    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToInt64(
+            CastInt32ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_oid\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastOidToInt64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_oid<'a>(a: i64) -> Result<Oid, EvalError> {\n    { u32::try_from(a).map(Oid).or(Err(EvalError::OidOutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToOid {
+    type Input = i64;
+    type Output = Result<Oid, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_oid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_oid<'a>(a: i64) -> Result<Oid, EvalError> {
+    { u32::try_from(a).map(Oid).or(Err(EvalError::OidOutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastOidToInt64(
+            CastOidToInt64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToInt64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_string<'a>(a: i64) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_int64(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToString {
+    type Input = i64;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_string<'a>(a: i64) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_int64(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToInt64(
+            CastStringToInt64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_uint2\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint16ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_uint16<'a>(a: i64) -> Result<u16, EvalError> {\n    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToUint16 {
+    type Input = i64;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_uint16<'a>(a: i64) -> Result<u16, EvalError> {
+    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint16ToInt64(
+            CastUint16ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_uint4\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint32ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_uint32<'a>(a: i64) -> Result<u32, EvalError> {\n    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToUint32 {
+    type Input = i64;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_uint32<'a>(a: i64) -> Result<u32, EvalError> {
+    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint32ToInt64(
+            CastUint32ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_uint8\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint64ToInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_uint64<'a>(a: i64) -> Result<u64, EvalError> {\n    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToUint64 {
+    type Input = i64;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_uint64<'a>(a: i64) -> Result<u64, EvalError> {
+    { u64::try_from(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__cast_int64_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint64ToInt64(
+            CastUint64ToInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__neg_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__neg_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(NegInt64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_int64<'a>(a: i64) -> Result<i64, EvalError> {\n    { a.checked_neg().ok_or(EvalError::Int64OutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegInt64 {
+    type Input = i64;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegInt64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NegInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_int64<'a>(a: i64) -> Result<i64, EvalError> {
+    { a.checked_neg().ok_or(EvalError::Int64OutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__neg_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__int64__neg_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/int64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        NegInt64(
+            NegInt64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"interval_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToInterval),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_interval_to_string<'a>(a: Interval) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_interval(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastIntervalToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastIntervalToString {
+    type Input = Interval;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_interval_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToInterval)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastIntervalToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("interval_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_interval_to_string<'a>(a: Interval) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_interval(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToInterval(
+            CastStringToInterval,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_time.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_time.snap
@@ -1,0 +1,80 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"interval_to_time\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastTimeToInterval),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_interval_to_time<'a>(i: Interval) -> NaiveTime {\n    {\n        let mut result = i.micros % *USECS_PER_DAY;\n        if result < 0 {\n            result += *USECS_PER_DAY;\n        }\n        let i = Interval::new(0, 0, result);\n        let hours: u32 = i\n            .hours()\n            .try_into()\n            .expect(\n                \"interval is positive and hours() returns a value in the range [-24, 24]\",\n            );\n        let minutes: u32 = i\n            .minutes()\n            .try_into()\n            .expect(\n                \"interval is positive and minutes() returns a value in the range [-60, 60]\",\n            );\n        let seconds: u32 = i64::cast_lossy(i.seconds::<f64>())\n            .try_into()\n            .expect(\n                \"interval is positive and seconds() returns a value in the range [-60.0, 60.0]\",\n            );\n        let nanoseconds: u32 = i\n            .nanoseconds()\n            .try_into()\n            .expect(\n                \"interval is positive and nanoseconds() returns a value in the range [-1_000_000_000, 1_000_000_000]\",\n            );\n        NaiveTime::from_hms_nano_opt(hours, minutes, seconds, nanoseconds).unwrap()\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastIntervalToTime;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastIntervalToTime {
+    type Input = Interval;
+    type Output = NaiveTime;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_interval_to_time(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastTimeToInterval)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastIntervalToTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("interval_to_time")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_interval_to_time<'a>(i: Interval) -> NaiveTime {
+    {
+        let mut result = i.micros % *USECS_PER_DAY;
+        if result < 0 {
+            result += *USECS_PER_DAY;
+        }
+        let i = Interval::new(0, 0, result);
+        let hours: u32 = i
+            .hours()
+            .try_into()
+            .expect(
+                "interval is positive and hours() returns a value in the range [-24, 24]",
+            );
+        let minutes: u32 = i
+            .minutes()
+            .try_into()
+            .expect(
+                "interval is positive and minutes() returns a value in the range [-60, 60]",
+            );
+        let seconds: u32 = i64::cast_lossy(i.seconds::<f64>())
+            .try_into()
+            .expect(
+                "interval is positive and seconds() returns a value in the range [-60.0, 60.0]",
+            );
+        let nanoseconds: u32 = i
+            .nanoseconds()
+            .try_into()
+            .expect(
+                "interval is positive and nanoseconds() returns a value in the range [-1_000_000_000, 1_000_000_000]",
+            );
+        NaiveTime::from_hms_nano_opt(hours, minutes, seconds, nanoseconds).unwrap()
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_time__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__cast_interval_to_time__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Time,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Time,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastTimeToInterval(
+            CastTimeToInterval,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_days.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_days.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"justify_days\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn justify_days<'a>(i: Interval) -> Result<Interval, EvalError> {\n    { i.justify_days().map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JustifyDays;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JustifyDays {
+    type Input = Interval;
+    type Output = Result<Interval, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        justify_days(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JustifyDays {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("justify_days")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn justify_days<'a>(i: Interval) -> Result<Interval, EvalError> {
+    { i.justify_days().map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_days__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_days__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_hours.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_hours.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"justify_hours\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn justify_hours<'a>(i: Interval) -> Result<Interval, EvalError> {\n    {\n        i.justify_hours()\n            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JustifyHours;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JustifyHours {
+    type Input = Interval;
+    type Output = Result<Interval, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        justify_hours(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JustifyHours {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("justify_hours")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn justify_hours<'a>(i: Interval) -> Result<Interval, EvalError> {
+    {
+        i.justify_hours()
+            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_hours__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_hours__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_interval.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_interval.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"justify_interval\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn justify_interval<'a>(i: Interval) -> Result<Interval, EvalError> {\n    {\n        i.justify_interval()\n            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JustifyInterval;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JustifyInterval {
+    type Input = Interval;
+    type Output = Result<Interval, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        justify_interval(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JustifyInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("justify_interval")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn justify_interval<'a>(i: Interval) -> Result<Interval, EvalError> {
+    {
+        i.justify_interval()
+            .map_err(|_| EvalError::IntervalOutOfRange(i.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_interval__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__justify_interval__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__neg_interval.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__neg_interval.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::NegInterval),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_interval<'a>(i: Interval) -> Result<Interval, EvalError> {\n    { i.checked_neg().ok_or(EvalError::IntervalOutOfRange(i.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegInterval;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegInterval {
+    type Input = Interval;
+    type Output = Result<Interval, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_interval(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::NegInterval)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NegInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_interval<'a>(i: Interval) -> Result<Interval, EvalError> {
+    { i.checked_neg().ok_or(EvalError::IntervalOutOfRange(i.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__neg_interval__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__interval__neg_interval__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/interval.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        NegInterval(
+            NegInterval,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::True => Ok(true),\n            Datum::False => Ok(false),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"boolean\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToBool;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToBool {
+    type Input = JsonbRef<'a>;
+    type Output = Result<bool, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_bool(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_boolean")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::True => Ok(true),
+            Datum::False => Ok(false),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "boolean".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_real\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"real\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToFloat32 {
+    type Input = JsonbRef<'a>;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "real".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_double\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"double precision\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToFloat64 {
+    type Input = JsonbRef<'a>;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "double precision".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"smallint\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToInt16 {
+    type Input = JsonbRef<'a>;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "smallint".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_integer\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"integer\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToInt32 {
+    type Input = JsonbRef<'a>;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "integer".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"bigint\".into(),\n                })\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToInt64 {
+    type Input = JsonbRef<'a>;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),
+            datum => {
+                Err(EvalError::InvalidJsonbCast {
+                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                    to: "bigint".into(),
+                })
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_text\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastStringToJsonb),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_string<'a>(a: JsonbRef<'a>) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_jsonb(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbToString {
+    type Input = JsonbRef<'a>;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonb_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToJsonb)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonb_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonb_to_string<'a>(a: JsonbRef<'a>) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_jsonb(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastStringToJsonb(
+            CastStringToJsonb,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonbable_to_jsonb.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonbable_to_jsonb.snap
@@ -1,0 +1,67 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = \"jsonbable_to_jsonb\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonbable_to_jsonb<'a>(a: JsonbRef<'a>) -> JsonbRef<'a> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(n) => {\n                let n = n.into_inner();\n                let datum = if n.is_finite() {\n                    Datum::from(n)\n                } else if n.is_nan() {\n                    Datum::String(\"NaN\")\n                } else if n.is_negative() {\n                    Datum::String(\"-Infinity\")\n                } else {\n                    Datum::String(\"Infinity\")\n                };\n                JsonbRef::from_datum(datum)\n            }\n            datum => JsonbRef::from_datum(datum),\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastJsonbableToJsonb;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastJsonbableToJsonb {
+    type Input = JsonbRef<'a>;
+    type Output = JsonbRef<'a>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_jsonbable_to_jsonb(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastJsonbableToJsonb {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("jsonbable_to_jsonb")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_jsonbable_to_jsonb<'a>(a: JsonbRef<'a>) -> JsonbRef<'a> {
+    {
+        match a.into_datum() {
+            Datum::Numeric(n) => {
+                let n = n.into_inner();
+                let datum = if n.is_finite() {
+                    Datum::from(n)
+                } else if n.is_nan() {
+                    Datum::String("NaN")
+                } else if n.is_negative() {
+                    Datum::String("-Infinity")
+                } else {
+                    Datum::String("Infinity")
+                };
+                JsonbRef::from_datum(datum)
+            }
+            datum => JsonbRef::from_datum(datum),
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonbable_to_jsonb__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonbable_to_jsonb__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_array_length.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_array_length.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(jsonb_array_length),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn jsonb_array_length<'a>(a: JsonbRef<'a>) -> Result<Option<i32>, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::List(list) => {\n                let count = list.iter().count();\n                match i32::try_from(count) {\n                    Ok(len) => Ok(Some(len)),\n                    Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n                }\n            }\n            _ => Ok(None),\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbArrayLength;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JsonbArrayLength {
+    type Input = JsonbRef<'a>;
+    type Output = Result<Option<i32>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        jsonb_array_length(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JsonbArrayLength {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(jsonb_array_length))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn jsonb_array_length<'a>(a: JsonbRef<'a>) -> Result<Option<i32>, EvalError> {
+    {
+        match a.into_datum() {
+            Datum::List(list) => {
+                let count = list.iter().count();
+                match i32::try_from(count) {
+                    Ok(len) => Ok(Some(len)),
+                    Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_array_length__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_array_length__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_pretty.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_pretty.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(jsonb_pretty),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn jsonb_pretty<'a>(a: JsonbRef<'a>) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_jsonb_pretty(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbPretty;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JsonbPretty {
+    type Input = JsonbRef<'a>;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        jsonb_pretty(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JsonbPretty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(jsonb_pretty))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn jsonb_pretty<'a>(a: JsonbRef<'a>) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_jsonb_pretty(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_pretty__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_pretty__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_strip_nulls.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_strip_nulls.snap
@@ -1,0 +1,79 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(jsonb_strip_nulls),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn jsonb_strip_nulls<'a>(a: JsonbRef<'a>) -> Jsonb {\n    {\n        fn strip_nulls(a: Datum, row: &mut RowPacker) {\n            match a {\n                Datum::Map(dict) => {\n                    row.push_dict_with(|row| {\n                        for (k, v) in dict.iter() {\n                            match v {\n                                Datum::JsonNull => {}\n                                _ => {\n                                    row.push(Datum::String(k));\n                                    strip_nulls(v, row);\n                                }\n                            }\n                        }\n                    })\n                }\n                Datum::List(list) => {\n                    row.push_list_with(|row| {\n                        for elem in list.iter() {\n                            strip_nulls(elem, row);\n                        }\n                    })\n                }\n                _ => row.push(a),\n            }\n        }\n        let mut row = Row::default();\n        strip_nulls(a.into_datum(), &mut row.packer());\n        Jsonb::from_row(row)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbStripNulls;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JsonbStripNulls {
+    type Input = JsonbRef<'a>;
+    type Output = Jsonb;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        jsonb_strip_nulls(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JsonbStripNulls {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(jsonb_strip_nulls))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn jsonb_strip_nulls<'a>(a: JsonbRef<'a>) -> Jsonb {
+    {
+        fn strip_nulls(a: Datum, row: &mut RowPacker) {
+            match a {
+                Datum::Map(dict) => {
+                    row.push_dict_with(|row| {
+                        for (k, v) in dict.iter() {
+                            match v {
+                                Datum::JsonNull => {}
+                                _ => {
+                                    row.push(Datum::String(k));
+                                    strip_nulls(v, row);
+                                }
+                            }
+                        }
+                    })
+                }
+                Datum::List(list) => {
+                    row.push_list_with(|row| {
+                        for elem in list.iter() {
+                            strip_nulls(elem, row);
+                        }
+                    })
+                }
+                _ => row.push(a),
+            }
+        }
+        let mut row = Row::default();
+        strip_nulls(a.into_datum(), &mut row.packer());
+        Jsonb::from_row(row)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_strip_nulls__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_strip_nulls__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_typeof.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_typeof.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(jsonb_typeof),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn jsonb_typeof<'a>(a: JsonbRef<'a>) -> &'a str {\n    {\n        match a.into_datum() {\n            Datum::Map(_) => \"object\",\n            Datum::List(_) => \"array\",\n            Datum::String(_) => \"string\",\n            Datum::Numeric(_) => \"number\",\n            Datum::True | Datum::False => \"boolean\",\n            Datum::JsonNull => \"null\",\n            d => panic!(\"Not jsonb: {:?}\", d),\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbTypeof;
+impl<'a> crate::func::EagerUnaryFunc<'a> for JsonbTypeof {
+    type Input = JsonbRef<'a>;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        jsonb_typeof(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for JsonbTypeof {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(jsonb_typeof))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn jsonb_typeof<'a>(a: JsonbRef<'a>) -> &'a str {
+    {
+        match a.into_datum() {
+            Datum::Map(_) => "object",
+            Datum::List(_) => "array",
+            Datum::String(_) => "string",
+            Datum::Numeric(_) => "number",
+            Datum::True | Datum::False => "boolean",
+            Datum::JsonNull => "null",
+            d => panic!("Not jsonb: {:?}", d),
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_typeof__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__jsonb_typeof__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/jsonb.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantee.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantee.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"aclitem_grantee\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn acl_item_grantee<'a>(acl_item: AclItem) -> Oid {\n    { acl_item.grantee }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AclItemGrantee;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AclItemGrantee {
+    type Input = AclItem;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        acl_item_grantee(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AclItemGrantee {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("aclitem_grantee")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn acl_item_grantee<'a>(acl_item: AclItem) -> Oid {
+    { acl_item.grantee }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantee__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantee__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantor.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantor.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"aclitem_grantor\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn acl_item_grantor<'a>(acl_item: AclItem) -> Oid {\n    { acl_item.grantor }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AclItemGrantor;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AclItemGrantor {
+    type Input = AclItem;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        acl_item_grantor(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AclItemGrantor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("aclitem_grantor")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn acl_item_grantor<'a>(acl_item: AclItem) -> Oid {
+    { acl_item.grantor }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantor__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_grantor__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_privileges.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_privileges.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"aclitem_privileges\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn acl_item_privileges<'a>(acl_item: AclItem) -> String {\n    { acl_item.acl_mode.to_string() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AclItemPrivileges;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AclItemPrivileges {
+    type Input = AclItem;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        acl_item_privileges(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AclItemPrivileges {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("aclitem_privileges")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn acl_item_privileges<'a>(acl_item: AclItem) -> String {
+    { acl_item.acl_mode.to_string() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_privileges__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__acl_item_privileges__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantee.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantee.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_aclitem_grantee\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_acl_item_grantee<'a>(mz_acl_item: MzAclItem) -> String {\n    { mz_acl_item.grantee.to_string() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzAclItemGrantee;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzAclItemGrantee {
+    type Input = MzAclItem;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_acl_item_grantee(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzAclItemGrantee {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_aclitem_grantee")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_acl_item_grantee<'a>(mz_acl_item: MzAclItem) -> String {
+    { mz_acl_item.grantee.to_string() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantee__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantee__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantor.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantor.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_aclitem_grantor\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_acl_item_grantor<'a>(mz_acl_item: MzAclItem) -> String {\n    { mz_acl_item.grantor.to_string() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzAclItemGrantor;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzAclItemGrantor {
+    type Input = MzAclItem;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_acl_item_grantor(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzAclItemGrantor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_aclitem_grantor")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_acl_item_grantor<'a>(mz_acl_item: MzAclItem) -> String {
+    { mz_acl_item.grantor.to_string() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantor__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_grantor__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_privileges.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_privileges.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_aclitem_privileges\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_acl_item_privileges<'a>(mz_acl_item: MzAclItem) -> String {\n    { mz_acl_item.acl_mode.to_string() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzAclItemPrivileges;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzAclItemPrivileges {
+    type Input = MzAclItem;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_acl_item_privileges(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzAclItemPrivileges {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_aclitem_privileges")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_acl_item_privileges<'a>(mz_acl_item: MzAclItem) -> String {
+    { mz_acl_item.acl_mode.to_string() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_privileges__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_acl_item_privileges__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_format_privileges.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_format_privileges.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_format_privileges\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_format_privileges<'a>(\n    privileges: String,\n) -> Result<ArrayRustType<String>, EvalError> {\n    {\n        AclMode::from_str(&privileges)\n            .map(|acl_mode| {\n                ArrayRustType(\n                    acl_mode\n                        .explode()\n                        .into_iter()\n                        .map(|privilege| privilege.to_string())\n                        .collect(),\n                )\n            })\n            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(\n                e.to_string().into(),\n            ))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzFormatPrivileges;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzFormatPrivileges {
+    type Input = String;
+    type Output = Result<ArrayRustType<String>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_format_privileges(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzFormatPrivileges {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_format_privileges")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_format_privileges<'a>(
+    privileges: String,
+) -> Result<ArrayRustType<String>, EvalError> {
+    {
+        AclMode::from_str(&privileges)
+            .map(|acl_mode| {
+                ArrayRustType(
+                    acl_mode
+                        .explode()
+                        .into_iter()
+                        .map(|privilege| privilege.to_string())
+                        .collect(),
+                )
+            })
+            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(
+                e.to_string().into(),
+            ))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_format_privileges__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_format_privileges__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Array(
+            String,
+        ),
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Array(
+            String,
+        ),
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_privileges.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_privileges.snap
@@ -1,0 +1,56 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_validate_privileges\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_validate_privileges<'a>(privileges: String) -> Result<bool, EvalError> {\n    {\n        AclMode::parse_multiple_privileges(&privileges)\n            .map(|_| true)\n            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(\n                e.to_string().into(),\n            ))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzValidatePrivileges;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzValidatePrivileges {
+    type Input = String;
+    type Output = Result<bool, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_validate_privileges(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzValidatePrivileges {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_validate_privileges")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_validate_privileges<'a>(privileges: String) -> Result<bool, EvalError> {
+    {
+        AclMode::parse_multiple_privileges(&privileges)
+            .map(|_| true)
+            .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(
+                e.to_string().into(),
+            ))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_privileges__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_privileges__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_role_privilege.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_role_privilege.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_validate_role_privilege\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_validate_role_privilege<'a>(privilege: String) -> Result<bool, EvalError> {\n    {\n        let privilege_upper = privilege.to_uppercase();\n        if privilege_upper != \"MEMBER\" && privilege_upper != \"USAGE\" {\n            Err(EvalError::InvalidPrivileges(format!(\"{}\", privilege.quoted()).into()))\n        } else {\n            Ok(true)\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzValidateRolePrivilege;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzValidateRolePrivilege {
+    type Input = String;
+    type Output = Result<bool, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_validate_role_privilege(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzValidateRolePrivilege {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_validate_role_privilege")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_validate_role_privilege<'a>(privilege: String) -> Result<bool, EvalError> {
+    {
+        let privilege_upper = privilege.to_uppercase();
+        if privilege_upper != "MEMBER" && privilege_upper != "USAGE" {
+            Err(EvalError::InvalidPrivileges(format!("{}", privilege.quoted()).into()))
+        } else {
+            Ok(true)
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_role_privilege__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_acl_item__mz_validate_role_privilege__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_acl_item.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_date_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_date_to_mz_timestamp.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"date_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_date_to_mz_timestamp<'a>(a: Date) -> Result<Timestamp, EvalError> {\n    {\n        let ts = CheckedTimestamp::try_from(\n            NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap(),\n        )?;\n        ts.and_utc()\n            .timestamp_millis()\n            .try_into()\n            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastDateToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastDateToMzTimestamp {
+    type Input = Date;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_date_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastDateToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_date_to_mz_timestamp<'a>(a: Date) -> Result<Timestamp, EvalError> {
+    {
+        let ts = CheckedTimestamp::try_from(
+            NaiveDate::from(a).and_hms_opt(0, 0, 0).unwrap(),
+        )?;
+        ts.and_utc()
+            .timestamp_millis()
+            .try_into()
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_date_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_date_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int32_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int32_to_mz_timestamp.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"integer_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int32_to_mz_timestamp<'a>(a: i32) -> Result<Timestamp, EvalError> {\n    {\n        i64::from(a)\n            .try_into()\n            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt32ToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt32ToMzTimestamp {
+    type Input = i32;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int32_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt32ToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("integer_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int32_to_mz_timestamp<'a>(a: i32) -> Result<Timestamp, EvalError> {
+    {
+        i64::from(a)
+            .try_into()
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int32_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int32_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int64_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int64_to_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"bigint_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_int64_to_mz_timestamp<'a>(a: i64) -> Result<Timestamp, EvalError> {\n    { a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastInt64ToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastInt64ToMzTimestamp {
+    type Input = i64;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_int64_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastInt64ToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bigint_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_int64_to_mz_timestamp<'a>(a: i64) -> Result<Timestamp, EvalError> {
+    { a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int64_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_int64_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_timestamp_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToMzTimestamp),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_mz_timestamp_to_string<'a>(a: Timestamp) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_mz_timestamp(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastMzTimestampToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastMzTimestampToString {
+    type Input = Timestamp;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_mz_timestamp_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToMzTimestamp)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastMzTimestampToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_timestamp_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_mz_timestamp_to_string<'a>(a: Timestamp) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_mz_timestamp(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToMzTimestamp(
+            CastStringToMzTimestamp,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_timestamp_to_timestamp\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastTimestampToMzTimestamp),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_mz_timestamp_to_timestamp<'a>(\n    a: Timestamp,\n) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {\n    {\n        let ms: i64 = a.try_into().map_err(|_| EvalError::TimestampOutOfRange)?;\n        let ct = DateTime::from_timestamp_millis(ms)\n            .and_then(|dt| {\n                let ct: Option<CheckedTimestamp<NaiveDateTime>> = dt\n                    .naive_utc()\n                    .try_into()\n                    .ok();\n                ct\n            });\n        ct.ok_or(EvalError::TimestampOutOfRange)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastMzTimestampToTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastMzTimestampToTimestamp {
+    type Input = Timestamp;
+    type Output = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_mz_timestamp_to_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastTimestampToMzTimestamp)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastMzTimestampToTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_timestamp_to_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_mz_timestamp_to_timestamp<'a>(
+    a: Timestamp,
+) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
+    {
+        let ms: i64 = a.try_into().map_err(|_| EvalError::TimestampOutOfRange)?;
+        let ct = DateTime::from_timestamp_millis(ms)
+            .and_then(|dt| {
+                let ct: Option<CheckedTimestamp<NaiveDateTime>> = dt
+                    .naive_utc()
+                    .try_into()
+                    .ok();
+                ct
+            });
+        ct.ok_or(EvalError::TimestampOutOfRange)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp__impl.snap
@@ -1,0 +1,28 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Timestamp {
+            precision: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Timestamp {
+            precision: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastTimestampToMzTimestamp(
+            CastTimestampToMzTimestamp,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp_tz.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp_tz.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_timestamp_to_timestamp_tz\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastTimestampTzToMzTimestamp),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_mz_timestamp_to_timestamp_tz<'a>(\n    a: Timestamp,\n) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {\n    {\n        let ms: i64 = a.try_into().map_err(|_| EvalError::TimestampOutOfRange)?;\n        let ct = DateTime::from_timestamp_millis(ms)\n            .and_then(|dt| {\n                let ct: Option<CheckedTimestamp<DateTime<Utc>>> = dt.try_into().ok();\n                ct\n            });\n        ct.ok_or(EvalError::TimestampOutOfRange)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastMzTimestampToTimestampTz;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastMzTimestampToTimestampTz {
+    type Input = Timestamp;
+    type Output = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_mz_timestamp_to_timestamp_tz(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastTimestampTzToMzTimestamp)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastMzTimestampToTimestampTz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_timestamp_to_timestamp_tz")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_mz_timestamp_to_timestamp_tz<'a>(
+    a: Timestamp,
+) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
+    {
+        let ms: i64 = a.try_into().map_err(|_| EvalError::TimestampOutOfRange)?;
+        let ct = DateTime::from_timestamp_millis(ms)
+            .and_then(|dt| {
+                let ct: Option<CheckedTimestamp<DateTime<Utc>>> = dt.try_into().ok();
+                ct
+            });
+        ct.ok_or(EvalError::TimestampOutOfRange)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp_tz__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_mz_timestamp_to_timestamp_tz__impl.snap
@@ -1,0 +1,28 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: TimestampTz {
+            precision: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastTimestampTzToMzTimestamp(
+            CastTimestampTzToMzTimestamp,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_numeric_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_numeric_to_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_mz_timestamp<'a>(a: Numeric) -> Result<Timestamp, EvalError> {\n    { a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into())) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToMzTimestamp {
+    type Input = Numeric;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastNumericToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_mz_timestamp<'a>(a: Numeric) -> Result<Timestamp, EvalError> {
+    { a.try_into().map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into())) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_numeric_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_numeric_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_string_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_string_to_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_mz_timestamp\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastMzTimestampToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_mz_timestamp<'a>(a: String) -> Result<Timestamp, EvalError> {\n    { strconv::parse_mz_timestamp(&a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToMzTimestamp {
+    type Input = String;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastMzTimestampToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_mz_timestamp<'a>(a: String) -> Result<Timestamp, EvalError> {
+    { strconv::parse_mz_timestamp(&a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_string_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_string_to_mz_timestamp__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastMzTimestampToString(
+            CastMzTimestampToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_to_mz_timestamp.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_to_mz_timestamp\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_to_mz_timestamp<'a>(\n    a: CheckedTimestamp<NaiveDateTime>,\n) -> Result<Timestamp, EvalError> {\n    {\n        a.and_utc()\n            .timestamp_millis()\n            .try_into()\n            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampToMzTimestamp {
+    type Input = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_to_mz_timestamp<'a>(
+    a: CheckedTimestamp<NaiveDateTime>,
+) -> Result<Timestamp, EvalError> {
+    {
+        a.and_utc()
+            .timestamp_millis()
+            .try_into()
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_tz_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_tz_to_mz_timestamp.snap
@@ -1,0 +1,56 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_tz_to_mz_timestamp\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_tz_to_mz_timestamp<'a>(\n    a: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<Timestamp, EvalError> {\n    {\n        a.timestamp_millis()\n            .try_into()\n            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampTzToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampTzToMzTimestamp {
+    type Input = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_tz_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampTzToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_tz_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_tz_to_mz_timestamp<'a>(
+    a: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<Timestamp, EvalError> {
+    {
+        a.timestamp_millis()
+            .try_into()
+            .map_err(|_| EvalError::MzTimestampOutOfRange(a.to_string().into()))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_tz_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_timestamp_tz_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint32_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint32_to_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_mz_timestamp<'a>(a: u32) -> Timestamp {\n    { u64::from(a).into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToMzTimestamp {
+    type Input = u32;
+    type Output = Timestamp;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_mz_timestamp<'a>(a: u32) -> Timestamp {
+    { u64::from(a).into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint32_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint32_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint64_to_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint64_to_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_mz_timestamp<'a>(a: u64) -> Timestamp {\n    { a.into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToMzTimestamp {
+    type Input = u64;
+    type Output = Timestamp;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_mz_timestamp<'a>(a: u64) -> Timestamp {
+    { a.into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint64_to_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__cast_uint64_to_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__step_mz_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__step_mz_timestamp.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"step_mz_timestamp\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn step_mz_timestamp<'a>(a: Timestamp) -> Result<Timestamp, EvalError> {\n    { a.checked_add(1).ok_or(EvalError::MzTimestampStepOverflow) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct StepMzTimestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for StepMzTimestamp {
+    type Input = Timestamp;
+    type Output = Result<Timestamp, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        step_mz_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for StepMzTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("step_mz_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn step_mz_timestamp<'a>(a: Timestamp) -> Result<Timestamp, EvalError> {
+    { a.checked_add(1).ok_or(EvalError::MzTimestampStepOverflow) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__step_mz_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__mz_timestamp__step_mz_timestamp__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/mz_timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: MzTimestamp,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__abs_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__abs_numeric.snap
@@ -1,0 +1,56 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"abs\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn abs_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            numeric::cx_datum().abs(&mut a);\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct AbsNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for AbsNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        abs_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for AbsNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("abs")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn abs_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            numeric::cx_datum().abs(&mut a);
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__abs_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__abs_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float32.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_float32<'a>(a: Numeric) -> Result<f32, EvalError> {\n    {\n        let i = a.to_string().parse::<f32>().unwrap();\n        if i.is_infinite() {\n            Err(EvalError::Float32OutOfRange(i.to_string().into()))\n        } else {\n            Ok(i)\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToFloat32 {
+    type Input = Numeric;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_float32<'a>(a: Numeric) -> Result<f32, EvalError> {
+    {
+        let i = a.to_string().parse::<f32>().unwrap();
+        if i.is_infinite() {
+            Err(EvalError::Float32OutOfRange(i.to_string().into()))
+        } else {
+            Ok(i)
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float32__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToNumeric(
+            CastFloat32ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float64.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_double\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat64ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_float64<'a>(a: Numeric) -> Result<f64, EvalError> {\n    {\n        let i = a.to_string().parse::<f64>().unwrap();\n        if i.is_infinite() {\n            Err(EvalError::Float64OutOfRange(i.to_string().into()))\n        } else {\n            Ok(i)\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToFloat64 {
+    type Input = Numeric;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_float64<'a>(a: Numeric) -> Result<f64, EvalError> {
+    {
+        let i = a.to_string().parse::<f64>().unwrap();
+        if i.is_infinite() {
+            Err(EvalError::Float64OutOfRange(i.to_string().into()))
+        } else {
+            Ok(i)
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_float64__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat64ToNumeric(
+            CastFloat64ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int16.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt16ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_int16<'a>(a: Numeric) -> Result<i16, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            let i = cx\n                .try_into_i32(a)\n                .or(Err(EvalError::Int16OutOfRange(a.to_string().into())))?;\n            i16::try_from(i).or(Err(EvalError::Int16OutOfRange(i.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToInt16 {
+    type Input = Numeric;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_int16<'a>(a: Numeric) -> Result<i16, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            let i = cx
+                .try_into_i32(a)
+                .or(Err(EvalError::Int16OutOfRange(a.to_string().into())))?;
+            i16::try_from(i).or(Err(EvalError::Int16OutOfRange(i.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int16__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt16ToNumeric(
+            CastInt16ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_integer\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt32ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_int32<'a>(a: Numeric) -> Result<i32, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            cx.try_into_i32(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToInt32 {
+    type Input = Numeric;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_int32<'a>(a: Numeric) -> Result<i32, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            cx.try_into_i32(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int32__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt32ToNumeric(
+            CastInt32ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt64ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_int64<'a>(a: Numeric) -> Result<i64, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            cx.try_into_i64(a).or(Err(EvalError::Int64OutOfRange(a.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToInt64 {
+    type Input = Numeric;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_int64<'a>(a: Numeric) -> Result<i64, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            cx.try_into_i64(a).or(Err(EvalError::Int64OutOfRange(a.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_int64__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt64ToNumeric(
+            CastInt64ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_text\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastStringToNumeric(None)),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_string<'a>(a: Numeric) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_numeric(&mut buf, &OrderedDecimal(a));\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToString {
+    type Input = Numeric;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_string<'a>(a: Numeric) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_numeric(&mut buf, &OrderedDecimal(a));
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_string__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastStringToNumeric(
+            CastStringToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint16.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_uint2\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint16ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_uint16<'a>(a: Numeric) -> Result<u16, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            let u = cx\n                .try_into_u32(a)\n                .or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))?;\n            u16::try_from(u).or(Err(EvalError::UInt16OutOfRange(u.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToUint16 {
+    type Input = Numeric;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_uint16<'a>(a: Numeric) -> Result<u16, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            let u = cx
+                .try_into_u32(a)
+                .or(Err(EvalError::UInt16OutOfRange(a.to_string().into())))?;
+            u16::try_from(u).or(Err(EvalError::UInt16OutOfRange(u.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint16__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint16ToNumeric(
+            CastUint16ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint32.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_uint4\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint32ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_uint32<'a>(a: Numeric) -> Result<u32, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            cx.try_into_u32(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToUint32 {
+    type Input = Numeric;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_uint32<'a>(a: Numeric) -> Result<u32, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            cx.try_into_u32(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint32__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint32ToNumeric(
+            CastUint32ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint64.snap
@@ -1,0 +1,58 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"numeric_to_uint8\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint64ToNumeric(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_numeric_to_uint64<'a>(a: Numeric) -> Result<u64, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.round(&mut a);\n            cx.clear_status();\n            cx.try_into_u64(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastNumericToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastNumericToUint64 {
+    type Input = Numeric;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_numeric_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToNumeric(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastNumericToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("numeric_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_numeric_to_uint64<'a>(a: Numeric) -> Result<u64, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.round(&mut a);
+            cx.clear_status();
+            cx.try_into_u64(a).or(Err(EvalError::UInt64OutOfRange(a.to_string().into())))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__cast_numeric_to_uint64__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint64ToNumeric(
+            CastUint64ToNumeric(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ceil_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ceil_numeric.snap
@@ -1,0 +1,62 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"ceilnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ceil_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            if a.exponent() >= 0 {\n                return a;\n            }\n            let mut cx = numeric::cx_datum();\n            cx.set_rounding(Rounding::Ceiling);\n            cx.round(&mut a);\n            numeric::munge_numeric(&mut a).unwrap();\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CeilNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CeilNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ceil_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CeilNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("ceilnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ceil_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            if a.exponent() >= 0 {
+                return a;
+            }
+            let mut cx = numeric::cx_datum();
+            cx.set_rounding(Rounding::Ceiling);
+            cx.round(&mut a);
+            numeric::munge_numeric(&mut a).unwrap();
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ceil_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ceil_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__exp_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__exp_numeric.snap
@@ -1,0 +1,65 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"expnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn exp_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            cx.exp(&mut a);\n            let cx_status = cx.status();\n            if cx_status.overflow() {\n                Err(EvalError::FloatOverflow)\n            } else if cx_status.subnormal() {\n                Err(EvalError::FloatUnderflow)\n            } else {\n                numeric::munge_numeric(&mut a).unwrap();\n                Ok(a)\n            }\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ExpNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for ExpNumeric {
+    type Input = Numeric;
+    type Output = Result<Numeric, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        exp_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ExpNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("expnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn exp_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            cx.exp(&mut a);
+            let cx_status = cx.status();
+            if cx_status.overflow() {
+                Err(EvalError::FloatOverflow)
+            } else if cx_status.subnormal() {
+                Err(EvalError::FloatUnderflow)
+            } else {
+                numeric::munge_numeric(&mut a).unwrap();
+                Ok(a)
+            }
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__exp_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__exp_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__floor_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__floor_numeric.snap
@@ -1,0 +1,62 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"floornumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn floor_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            if a.exponent() >= 0 {\n                return a;\n            }\n            let mut cx = numeric::cx_datum();\n            cx.set_rounding(Rounding::Floor);\n            cx.round(&mut a);\n            numeric::munge_numeric(&mut a).unwrap();\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct FloorNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for FloorNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        floor_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for FloorNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("floornumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn floor_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            if a.exponent() >= 0 {
+                return a;
+            }
+            let mut cx = numeric::cx_datum();
+            cx.set_rounding(Rounding::Floor);
+            cx.round(&mut a);
+            numeric::munge_numeric(&mut a).unwrap();
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__floor_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__floor_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ln_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ln_numeric.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"lnnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ln_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {\n    { log_numeric(a, dec::Context::ln, \"ln\") }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct LnNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for LnNumeric {
+    type Input = Numeric;
+    type Output = Result<Numeric, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ln_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for LnNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("lnnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ln_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {
+    { log_numeric(a, dec::Context::ln, "ln") }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ln_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__ln_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__log10_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__log10_numeric.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"log10numeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn log10_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {\n    { log_numeric(a, dec::Context::log10, \"log10\") }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Log10Numeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Log10Numeric {
+    type Input = Numeric;
+    type Output = Result<Numeric, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        log10_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Log10Numeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("log10numeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn log10_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {
+    { log_numeric(a, dec::Context::log10, "log10") }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__log10_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__log10_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__neg_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__neg_numeric.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"-\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(NegNumeric),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn neg_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            numeric::cx_datum().neg(&mut a);\n            numeric::munge_numeric(&mut a).unwrap();\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NegNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for NegNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        neg_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(NegNumeric)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NegNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn neg_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            numeric::cx_datum().neg(&mut a);
+            numeric::munge_numeric(&mut a).unwrap();
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__neg_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__neg_numeric__impl.snap
@@ -1,0 +1,28 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        NegNumeric(
+            NegNumeric,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__pg_size_pretty.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__pg_size_pretty.snap
@@ -1,0 +1,68 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"pg_size_pretty\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn pg_size_pretty<'a>(a: Numeric) -> Result<String, EvalError> {\n    {\n        let mut a = a;\n        {\n            let mut cx = numeric::cx_datum();\n            let units = [\"bytes\", \"kB\", \"MB\", \"GB\", \"TB\", \"PB\"];\n            for (pos, unit) in units.iter().rev().skip(1).rev().enumerate() {\n                if Numeric::from(-10239.5) < a && a < Numeric::from(10239.5) {\n                    if pos > 0 {\n                        cx.round(&mut a);\n                    }\n                    return Ok(format!(\"{} {unit}\", a.to_standard_notation_string()));\n                }\n                cx.div(&mut a, &Numeric::from(1024));\n                numeric::munge_numeric(&mut a).unwrap();\n            }\n            cx.round(&mut a);\n            Ok(format!(\"{} {}\", a.to_standard_notation_string(), units.last().unwrap()))\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct PgSizePretty;
+impl<'a> crate::func::EagerUnaryFunc<'a> for PgSizePretty {
+    type Input = Numeric;
+    type Output = Result<String, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        pg_size_pretty(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for PgSizePretty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("pg_size_pretty")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn pg_size_pretty<'a>(a: Numeric) -> Result<String, EvalError> {
+    {
+        let mut a = a;
+        {
+            let mut cx = numeric::cx_datum();
+            let units = ["bytes", "kB", "MB", "GB", "TB", "PB"];
+            for (pos, unit) in units.iter().rev().skip(1).rev().enumerate() {
+                if Numeric::from(-10239.5) < a && a < Numeric::from(10239.5) {
+                    if pos > 0 {
+                        cx.round(&mut a);
+                    }
+                    return Ok(format!("{} {unit}", a.to_standard_notation_string()));
+                }
+                cx.div(&mut a, &Numeric::from(1024));
+                numeric::munge_numeric(&mut a).unwrap();
+            }
+            cx.round(&mut a);
+            Ok(format!("{} {}", a.to_standard_notation_string(), units.last().unwrap()))
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__pg_size_pretty__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__pg_size_pretty__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__round_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__round_numeric.snap
@@ -1,0 +1,59 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"roundnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn round_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            if a.exponent() >= 0 {\n                return a;\n            }\n            numeric::cx_datum().round(&mut a);\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RoundNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RoundNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        round_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RoundNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("roundnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn round_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            if a.exponent() >= 0 {
+                return a;
+            }
+            numeric::cx_datum().round(&mut a);
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__round_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__round_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__sqrt_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__sqrt_numeric.snap
@@ -1,0 +1,61 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"sqrtnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn sqrt_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {\n    {\n        let mut a = a;\n        {\n            if a.is_negative() {\n                return Err(EvalError::NegSqrt);\n            }\n            let mut cx = numeric::cx_datum();\n            cx.sqrt(&mut a);\n            numeric::munge_numeric(&mut a).unwrap();\n            Ok(a)\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct SqrtNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for SqrtNumeric {
+    type Input = Numeric;
+    type Output = Result<Numeric, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        sqrt_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for SqrtNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("sqrtnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn sqrt_numeric<'a>(a: Numeric) -> Result<Numeric, EvalError> {
+    {
+        let mut a = a;
+        {
+            if a.is_negative() {
+                return Err(EvalError::NegSqrt);
+            }
+            let mut cx = numeric::cx_datum();
+            cx.sqrt(&mut a);
+            numeric::munge_numeric(&mut a).unwrap();
+            Ok(a)
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__sqrt_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__sqrt_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__trunc_numeric.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__trunc_numeric.snap
@@ -1,0 +1,62 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: "#[sqlfunc(\n    sqlname = \"truncnumeric\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trunc_numeric<'a>(a: Numeric) -> Numeric {\n    {\n        let mut a = a;\n        {\n            if a.exponent() >= 0 {\n                return a;\n            }\n            let mut cx = numeric::cx_datum();\n            cx.set_rounding(Rounding::Down);\n            cx.round(&mut a);\n            numeric::munge_numeric(&mut a).unwrap();\n            a\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TruncNumeric;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TruncNumeric {
+    type Input = Numeric;
+    type Output = Numeric;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trunc_numeric(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TruncNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("truncnumeric")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trunc_numeric<'a>(a: Numeric) -> Numeric {
+    {
+        let mut a = a;
+        {
+            if a.exponent() >= 0 {
+                return a;
+            }
+            let mut cx = numeric::cx_datum();
+            cx.set_rounding(Rounding::Down);
+            cx.round(&mut a);
+            numeric::munge_numeric(&mut a).unwrap();
+            a
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__trunc_numeric__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__numeric__trunc_numeric__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/numeric.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Numeric {
+            max_scale: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oid_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_int32<'a>(a: Oid) -> i32 {\n    { i32::reinterpret_cast(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToInt32 {
+    type Input = Oid;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oid_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_int32<'a>(a: Oid) -> i32 {
+    { i32::reinterpret_cast(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToOid(
+            CastInt32ToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oid_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_int64<'a>(a: Oid) -> i64 {\n    { i64::from(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToInt64 {
+    type Input = Oid;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oid_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_int64<'a>(a: Oid) -> i64 {
+    { i64::from(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToOid(
+            CastInt64ToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_class.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_class.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oidtoregclass\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastRegClassToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_reg_class<'a>(a: Oid) -> RegClass {\n    { RegClass(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToRegClass;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToRegClass {
+    type Input = Oid;
+    type Output = RegClass;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_reg_class(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastRegClassToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToRegClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oidtoregclass")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_reg_class<'a>(a: Oid) -> RegClass {
+    { RegClass(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_class__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_class__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: RegClass,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: RegClass,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastRegClassToOid(
+            CastRegClassToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_proc.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_proc.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oidtoregproc\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastRegProcToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_reg_proc<'a>(a: Oid) -> RegProc {\n    { RegProc(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToRegProc;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToRegProc {
+    type Input = Oid;
+    type Output = RegProc;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_reg_proc(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastRegProcToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToRegProc {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oidtoregproc")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_reg_proc<'a>(a: Oid) -> RegProc {
+    { RegProc(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_proc__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_proc__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: RegProc,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: RegProc,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastRegProcToOid(
+            CastRegProcToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_type.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_type.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oidtoregtype\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastRegTypeToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_reg_type<'a>(a: Oid) -> RegType {\n    { RegType(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToRegType;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToRegType {
+    type Input = Oid;
+    type Output = RegType;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_reg_type(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastRegTypeToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToRegType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oidtoregtype")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_reg_type<'a>(a: Oid) -> RegType {
+    { RegType(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_type__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_reg_type__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: RegType,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: RegType,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastRegTypeToOid(
+            CastRegTypeToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = \"oid_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToOid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_oid_to_string<'a>(a: Oid) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_uint32(&mut buf, a.0);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastOidToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastOidToString {
+    type Input = Oid;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_oid_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToOid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastOidToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("oid_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_oid_to_string<'a>(a: Oid) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_uint32(&mut buf, a.0);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__cast_oid_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToOid(
+            CastStringToOid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__mz_type_name.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__mz_type_name.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(mz_type_name),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn mz_type_name<'a>(oid: Oid) -> Option<String> {\n    { if let Ok(t) = Type::from_oid(oid.0) { Some(t.name().to_string()) } else { None } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzTypeName;
+impl<'a> crate::func::EagerUnaryFunc<'a> for MzTypeName {
+    type Input = Oid;
+    type Output = Option<String>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        mz_type_name(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for MzTypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(mz_type_name))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn mz_type_name<'a>(oid: Oid) -> Option<String> {
+    { if let Ok(t) = Type::from_oid(oid.0) { Some(t.name().to_string()) } else { None } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__mz_type_name__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__oid__mz_type_name__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/oid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_char.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_char.snap
@@ -1,0 +1,56 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: "#[sqlfunc(\n    sqlname = \"\\\"char\\\"_to_char\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToPgLegacyChar),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_pg_legacy_char_to_char<'a>(\n    a: PgLegacyChar,\n) -> Result<Char<String>, EvalError> {\n    {\n        let mut buf = String::new();\n        format_pg_legacy_char(&mut buf, a.0)?;\n        Ok(Char(buf))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastPgLegacyCharToChar;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastPgLegacyCharToChar {
+    type Input = PgLegacyChar;
+    type Output = Result<Char<String>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_pg_legacy_char_to_char(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToPgLegacyChar)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastPgLegacyCharToChar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("\"char\"_to_char")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_pg_legacy_char_to_char<'a>(
+    a: PgLegacyChar,
+) -> Result<Char<String>, EvalError> {
+    {
+        let mut buf = String::new();
+        format_pg_legacy_char(&mut buf, a.0)?;
+        Ok(Char(buf))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_char__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_char__impl.snap
@@ -1,0 +1,28 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Char {
+            length: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Char {
+            length: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToPgLegacyChar(
+            CastStringToPgLegacyChar,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: "#[sqlfunc(\n    sqlname = \"\\\"char\\\"_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToPgLegacyChar),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_pg_legacy_char_to_int32<'a>(a: PgLegacyChar) -> i32 {\n    { i32::from(i8::from_ne_bytes([a.0])) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastPgLegacyCharToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastPgLegacyCharToInt32 {
+    type Input = PgLegacyChar;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_pg_legacy_char_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToPgLegacyChar)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastPgLegacyCharToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("\"char\"_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_pg_legacy_char_to_int32<'a>(a: PgLegacyChar) -> i32 {
+    { i32::from(i8::from_ne_bytes([a.0])) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToPgLegacyChar(
+            CastInt32ToPgLegacyChar,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: "#[sqlfunc(\n    sqlname = \"\\\"char\\\"_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToPgLegacyChar),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_pg_legacy_char_to_string<'a>(a: PgLegacyChar) -> Result<String, EvalError> {\n    {\n        let mut buf = String::new();\n        format_pg_legacy_char(&mut buf, a.0)?;\n        Ok(buf)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastPgLegacyCharToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastPgLegacyCharToString {
+    type Input = PgLegacyChar;
+    type Output = Result<String, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_pg_legacy_char_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToPgLegacyChar)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastPgLegacyCharToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("\"char\"_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_pg_legacy_char_to_string<'a>(a: PgLegacyChar) -> Result<String, EvalError> {
+    {
+        let mut buf = String::new();
+        format_pg_legacy_char(&mut buf, a.0)?;
+        Ok(buf)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToPgLegacyChar(
+            CastStringToPgLegacyChar,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_var_char.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_var_char.snap
@@ -1,0 +1,59 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: "#[sqlfunc(\n    sqlname = \"\\\"char\\\"_to_varchar\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(\n        super::CastStringToVarChar{fail_on_len:false,\n        length:Some(VarCharMaxLength::try_from(1).unwrap())}\n    ),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_pg_legacy_char_to_var_char<'a>(\n    a: PgLegacyChar,\n) -> Result<VarChar<String>, EvalError> {\n    {\n        let mut buf = String::new();\n        format_pg_legacy_char(&mut buf, a.0)?;\n        Ok(VarChar(buf))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastPgLegacyCharToVarChar;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastPgLegacyCharToVarChar {
+    type Input = PgLegacyChar;
+    type Output = Result<VarChar<String>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_pg_legacy_char_to_var_char(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(
+            super::CastStringToVarChar { fail_on_len : false, length :
+            Some(VarCharMaxLength::try_from(1).unwrap()) }
+        )
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastPgLegacyCharToVarChar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("\"char\"_to_varchar")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_pg_legacy_char_to_var_char<'a>(
+    a: PgLegacyChar,
+) -> Result<VarChar<String>, EvalError> {
+    {
+        let mut buf = String::new();
+        format_pg_legacy_char(&mut buf, a.0)?;
+        Ok(VarChar(buf))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_var_char__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__pg_legacy_char__cast_pg_legacy_char_to_var_char__impl.snap
@@ -1,0 +1,35 @@
+---
+source: src/expr/src/scalar/func/impls/pg_legacy_char.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Char {
+            length: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Char {
+            length: None,
+        },
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToVarChar(
+            CastStringToVarChar {
+                length: Some(
+                    VarCharMaxLength(
+                        1,
+                    ),
+                ),
+                fail_on_len: false,
+            },
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_empty.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_empty.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: "#[sqlfunc(\n    sqlname = \"range_empty\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn range_empty<'a>(a: Range<Datum<'a>>) -> bool {\n    { a.inner.is_none() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeEmpty;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RangeEmpty {
+    type Input = Range<Datum<'a>>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        range_empty(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RangeEmpty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("range_empty")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn range_empty<'a>(a: Range<Datum<'a>>) -> bool {
+    { a.inner.is_none() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_empty__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_empty__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inc.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inc.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: "#[sqlfunc(\n    sqlname = \"range_lower_inc\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn range_lower_inc<'a>(a: Range<Datum<'a>>) -> bool {\n    {\n        match a.inner {\n            None => false,\n            Some(inner) => inner.lower.inclusive,\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeLowerInc;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RangeLowerInc {
+    type Input = Range<Datum<'a>>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        range_lower_inc(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RangeLowerInc {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("range_lower_inc")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn range_lower_inc<'a>(a: Range<Datum<'a>>) -> bool {
+    {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.lower.inclusive,
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inc__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inc__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inf.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inf.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: "#[sqlfunc(\n    sqlname = \"range_lower_inf\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn range_lower_inf<'a>(a: Range<Datum<'a>>) -> bool {\n    {\n        match a.inner {\n            None => false,\n            Some(inner) => inner.lower.bound.is_none(),\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeLowerInf;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RangeLowerInf {
+    type Input = Range<Datum<'a>>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        range_lower_inf(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RangeLowerInf {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("range_lower_inf")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn range_lower_inf<'a>(a: Range<Datum<'a>>) -> bool {
+    {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.lower.bound.is_none(),
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inf__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_lower_inf__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inc.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inc.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: "#[sqlfunc(\n    sqlname = \"range_upper_inc\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn range_upper_inc<'a>(a: Range<Datum<'a>>) -> bool {\n    {\n        match a.inner {\n            None => false,\n            Some(inner) => inner.upper.inclusive,\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeUpperInc;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RangeUpperInc {
+    type Input = Range<Datum<'a>>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        range_upper_inc(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RangeUpperInc {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("range_upper_inc")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn range_upper_inc<'a>(a: Range<Datum<'a>>) -> bool {
+    {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.upper.inclusive,
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inc__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inc__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inf.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inf.snap
@@ -1,0 +1,55 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: "#[sqlfunc(\n    sqlname = \"range_upper_inf\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn range_upper_inf<'a>(a: Range<Datum<'a>>) -> bool {\n    {\n        match a.inner {\n            None => false,\n            Some(inner) => inner.upper.bound.is_none(),\n        }\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeUpperInf;
+impl<'a> crate::func::EagerUnaryFunc<'a> for RangeUpperInf {
+    type Input = Range<Datum<'a>>;
+    type Output = bool;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        range_upper_inf(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for RangeUpperInf {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("range_upper_inf")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn range_upper_inf<'a>(a: Range<Datum<'a>>) -> bool {
+    {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.upper.bound.is_none(),
+        }
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inf__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__range__range_upper_inf__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/range.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_class_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_class_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: "#[sqlfunc(\n    sqlname = \"regclasstooid\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastOidToRegClass),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_reg_class_to_oid<'a>(a: RegClass) -> Oid {\n    { Oid(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastRegClassToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastRegClassToOid {
+    type Input = RegClass;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_reg_class_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToRegClass)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastRegClassToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("regclasstooid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_reg_class_to_oid<'a>(a: RegClass) -> Oid {
+    { Oid(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_class_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_class_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastOidToRegClass(
+            CastOidToRegClass,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_proc_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_proc_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: "#[sqlfunc(\n    sqlname = \"regproctooid\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastOidToRegProc),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_reg_proc_to_oid<'a>(a: RegProc) -> Oid {\n    { Oid(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastRegProcToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastRegProcToOid {
+    type Input = RegProc;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_reg_proc_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToRegProc)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastRegProcToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("regproctooid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_reg_proc_to_oid<'a>(a: RegProc) -> Oid {
+    { Oid(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_proc_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_proc_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastOidToRegProc(
+            CastOidToRegProc,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_type_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_type_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: "#[sqlfunc(\n    sqlname = \"regtypetooid\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastOidToRegType),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_reg_type_to_oid<'a>(a: RegType) -> Oid {\n    { Oid(a.0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastRegTypeToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastRegTypeToOid {
+    type Input = RegType;
+    type Output = Oid;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_reg_type_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToRegType)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastRegTypeToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("regtypetooid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_reg_type_to_oid<'a>(a: RegType) -> Oid {
+    { Oid(a.0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_type_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__regproc__cast_reg_type_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/regproc.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastOidToRegType(
+            CastOidToRegType,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__ascii.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__ascii.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"ascii\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn ascii<'a>(a: &'a str) -> i32 {\n    { a.chars().next().and_then(|c| i32::try_from(u32::from(c)).ok()).unwrap_or(0) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Ascii;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Ascii {
+    type Input = &'a str;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        ascii(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Ascii {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("ascii")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn ascii<'a>(a: &'a str) -> i32 {
+    { a.chars().next().and_then(|c| i32::try_from(u32::from(c)).ok()).unwrap_or(0) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__ascii__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__ascii__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__bit_length_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__bit_length_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"bit_length\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {\n    {\n        let length = a.as_bytes().len() * 8;\n        i32::try_from(length)\n            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitLengthString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitLengthString {
+    type Input = &'a str;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_length_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for BitLengthString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bit_length")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {
+    {
+        let length = a.as_bytes().len() * 8;
+        i32::try_from(length)
+            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__bit_length_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__bit_length_string__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__byte_length_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__byte_length_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"octet_length\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn byte_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {\n    {\n        let length = a.as_bytes().len();\n        i32::try_from(length)\n            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ByteLengthString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for ByteLengthString {
+    type Input = &'a str;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        byte_length_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ByteLengthString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("octet_length")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn byte_length_string<'a>(a: &'a str) -> Result<i32, EvalError> {
+    {
+        let length = a.as_bytes().len();
+        i32::try_from(length)
+            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__byte_length_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__byte_length_string__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bool.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bool.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastBoolToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {\n    { strconv::parse_bool(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToBool;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToBool {
+    type Input = &'a str;
+    type Output = Result<bool, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_bool(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastBoolToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_boolean")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {
+    { strconv::parse_bool(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bool__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bool__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bool,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bool,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastBoolToString(
+            CastBoolToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bytes.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bytes.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_bytea\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastBytesToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {\n    { strconv::parse_bytes(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToBytes;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToBytes {
+    type Input = &'a str;
+    type Output = Result<Vec<u8>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_bytes(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastBytesToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastStringToBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_bytea")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {
+    { strconv::parse_bytes(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bytes__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_bytes__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Bytes,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Bytes,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastBytesToString(
+            CastBytesToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_date.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_date.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_date\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastDateToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_date<'a>(a: &'a str) -> Result<Date, EvalError> {\n    { strconv::parse_date(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToDate;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToDate {
+    type Input = &'a str;
+    type Output = Result<Date, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_date(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastDateToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_date")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_date<'a>(a: &'a str) -> Result<Date, EvalError> {
+    { strconv::parse_date(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_date__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_date__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Date,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Date,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastDateToString(
+            CastDateToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_float32<'a>(a: &'a str) -> Result<f32, EvalError> {\n    { strconv::parse_float32(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToFloat32 {
+    type Input = &'a str;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_float32<'a>(a: &'a str) -> Result<f32, EvalError> {
+    { strconv::parse_float32(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToString(
+            CastFloat32ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_double\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat64ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_float64<'a>(a: &'a str) -> Result<f64, EvalError> {\n    { strconv::parse_float64(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToFloat64 {
+    type Input = &'a str;
+    type Output = Result<f64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_float64<'a>(a: &'a str) -> Result<f64, EvalError> {
+    { strconv::parse_float64(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat64ToString(
+            CastFloat64ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt16ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_int16<'a>(a: &'a str) -> Result<i16, EvalError> {\n    { strconv::parse_int16(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToInt16 {
+    type Input = &'a str;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_int16<'a>(a: &'a str) -> Result<i16, EvalError> {
+    { strconv::parse_int16(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt16ToString(
+            CastInt16ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_integer\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt32ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_int32<'a>(a: &'a str) -> Result<i32, EvalError> {\n    { strconv::parse_int32(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToInt32 {
+    type Input = &'a str;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_int32<'a>(a: &'a str) -> Result<i32, EvalError> {
+    { strconv::parse_int32(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt32ToString(
+            CastInt32ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastInt64ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_int64<'a>(a: &'a str) -> Result<i64, EvalError> {\n    { strconv::parse_int64(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToInt64 {
+    type Input = &'a str;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_int64<'a>(a: &'a str) -> Result<i64, EvalError> {
+    { strconv::parse_int64(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastInt64ToString(
+            CastInt64ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_interval.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_interval.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_interval\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastIntervalToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_interval<'a>(a: &'a str) -> Result<Interval, EvalError> {\n    { strconv::parse_interval(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToInterval;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToInterval {
+    type Input = &'a str;
+    type Output = Result<Interval, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_interval(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastIntervalToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_interval")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_interval<'a>(a: &'a str) -> Result<Interval, EvalError> {
+    { strconv::parse_interval(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_interval__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_interval__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastIntervalToString(
+            CastIntervalToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_jsonb.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_jsonb.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_jsonb\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastJsonbToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_jsonb<'a>(a: &'a str) -> Result<Jsonb, EvalError> {\n    { Ok(strconv::parse_jsonb(a)?) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToJsonb;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToJsonb {
+    type Input = &'a str;
+    type Output = Result<Jsonb, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_jsonb(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastJsonbToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToJsonb {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_jsonb")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_jsonb<'a>(a: &'a str) -> Result<Jsonb, EvalError> {
+    { Ok(strconv::parse_jsonb(a)?) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_jsonb__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_jsonb__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Jsonb,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastJsonbToString(
+            CastJsonbToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_oid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_oid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_oid\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastOidToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_oid<'a>(a: &'a str) -> Result<Oid, EvalError> {\n    { Ok(Oid(strconv::parse_oid(a)?)) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToOid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToOid {
+    type Input = &'a str;
+    type Output = Result<Oid, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_oid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastOidToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToOid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_oid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_oid<'a>(a: &'a str) -> Result<Oid, EvalError> {
+    { Ok(Oid(strconv::parse_oid(a)?)) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_oid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_oid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Oid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Oid,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastOidToString(
+            CastOidToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_char.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_char.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_\\\"char\\\"\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastPgLegacyCharToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {\n    { PgLegacyChar(a.as_bytes().get(0).copied().unwrap_or(0)) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToPgLegacyChar;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToPgLegacyChar {
+    type Input = &'a str;
+    type Output = PgLegacyChar;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_pg_legacy_char(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastPgLegacyCharToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastStringToPgLegacyChar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_\"char\"")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {
+    { PgLegacyChar(a.as_bytes().get(0).copied().unwrap_or(0)) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_char__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_char__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: PgLegacyChar,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: PgLegacyChar,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastPgLegacyCharToString(
+            CastPgLegacyCharToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_name.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_name.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_name\",\n    preserves_uniqueness = true,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_pg_legacy_name<'a>(a: &'a str) -> PgLegacyName<String> {\n    { PgLegacyName(strconv::parse_pg_legacy_name(a)) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToPgLegacyName;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToPgLegacyName {
+    type Input = &'a str;
+    type Output = PgLegacyName<String>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_pg_legacy_name(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastStringToPgLegacyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_name")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_pg_legacy_name<'a>(a: &'a str) -> PgLegacyName<String> {
+    { PgLegacyName(strconv::parse_pg_legacy_name(a)) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_name__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_pg_legacy_name__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: PgLegacyName,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: PgLegacyName,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_time.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_time.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_time\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastTimeToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_time<'a>(a: &'a str) -> Result<NaiveTime, EvalError> {\n    { strconv::parse_time(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToTime;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToTime {
+    type Input = &'a str;
+    type Output = Result<NaiveTime, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_time(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastTimeToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_time")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_time<'a>(a: &'a str) -> Result<NaiveTime, EvalError> {
+    { strconv::parse_time(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_time__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_time__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Time,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Time,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastTimeToString(
+            CastTimeToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_uint2\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint16ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_uint16<'a>(a: &'a str) -> Result<u16, EvalError> {\n    { strconv::parse_uint16(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToUint16 {
+    type Input = &'a str;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_uint16<'a>(a: &'a str) -> Result<u16, EvalError> {
+    { strconv::parse_uint16(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint16ToString(
+            CastUint16ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_uint4\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint32ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_uint32<'a>(a: &'a str) -> Result<u32, EvalError> {\n    { strconv::parse_uint32(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToUint32 {
+    type Input = &'a str;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_uint32<'a>(a: &'a str) -> Result<u32, EvalError> {
+    { strconv::parse_uint32(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint32ToString(
+            CastUint32ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_uint8\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUint64ToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_uint64<'a>(a: &'a str) -> Result<u64, EvalError> {\n    { strconv::parse_uint64(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToUint64 {
+    type Input = &'a str;
+    type Output = Result<u64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_uint64<'a>(a: &'a str) -> Result<u64, EvalError> {
+    { strconv::parse_uint64(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUint64ToString(
+            CastUint64ToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uuid.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uuid.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"text_to_uuid\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastUuidToString),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_string_to_uuid<'a>(a: &'a str) -> Result<Uuid, EvalError> {\n    { strconv::parse_uuid(a).err_into() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastStringToUuid;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastStringToUuid {
+    type Input = &'a str;
+    type Output = Result<Uuid, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_string_to_uuid(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUuidToString)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastStringToUuid {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("text_to_uuid")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_string_to_uuid<'a>(a: &'a str) -> Result<Uuid, EvalError> {
+    { strconv::parse_uuid(a).err_into() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uuid__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__cast_string_to_uuid__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Uuid,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Uuid,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastUuidToString(
+            CastUuidToString,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__char_length.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__char_length.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"char_length\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn char_length<'a>(a: &'a str) -> Result<i32, EvalError> {\n    {\n        let length = a.chars().count();\n        i32::try_from(length)\n            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CharLength;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CharLength {
+    type Input = &'a str;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        char_length(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CharLength {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("char_length")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn char_length<'a>(a: &'a str) -> Result<i32, EvalError> {
+    {
+        let length = a.chars().count();
+        i32::try_from(length)
+            .or(Err(EvalError::Int32OutOfRange(length.to_string().into())))
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__char_length__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__char_length__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__initcap.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__initcap.snap
@@ -1,0 +1,62 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"initcap\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn initcap<'a>(a: &'a str) -> String {\n    {\n        let mut out = String::new();\n        let mut capitalize_next = true;\n        for ch in a.chars() {\n            if capitalize_next {\n                out.extend(ch.to_uppercase())\n            } else {\n                out.extend(ch.to_lowercase())\n            };\n            capitalize_next = !ch.is_alphanumeric();\n        }\n        out\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Initcap;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Initcap {
+    type Input = &'a str;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        initcap(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Initcap {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("initcap")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn initcap<'a>(a: &'a str) -> String {
+    {
+        let mut out = String::new();
+        let mut capitalize_next = true;
+        for ch in a.chars() {
+            if capitalize_next {
+                out.extend(ch.to_uppercase())
+            } else {
+                out.extend(ch.to_lowercase())
+            };
+            capitalize_next = !ch.is_alphanumeric();
+        }
+        out
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__initcap__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__initcap__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__lower.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__lower.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(lower),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn lower<'a>(a: &'a str) -> String {\n    { a.to_lowercase() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Lower;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Lower {
+    type Input = &'a str;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        lower(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Lower {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(lower))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn lower<'a>(a: &'a str) -> String {
+    { a.to_lowercase() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__lower__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__lower__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__panic.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__panic.snap
@@ -1,0 +1,53 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_panic\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn panic<'a>(a: &'a str) -> String {\n    {\n        print!(\"{}\", a);\n        panic!(\"{}\", a)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Panic;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Panic {
+    type Input = &'a str;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        panic(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Panic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_panic")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn panic<'a>(a: &'a str) -> String {
+    {
+        print!("{}", a);
+        panic!("{}", a)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__panic__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__panic__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__reverse.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__reverse.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"reverse\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn reverse<'a>(a: &'a str) -> String {\n    { a.chars().rev().collect() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Reverse;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Reverse {
+    type Input = &'a str;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        reverse(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Reverse {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("reverse")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn reverse<'a>(a: &'a str) -> String {
+    { a.chars().rev().collect() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__reverse__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__reverse__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_leading_whitespace.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_leading_whitespace.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"ltrim\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trim_leading_whitespace<'a>(a: &'a str) -> &'a str {\n    { a.trim_start_matches(' ') }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TrimLeadingWhitespace;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TrimLeadingWhitespace {
+    type Input = &'a str;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trim_leading_whitespace(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TrimLeadingWhitespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("ltrim")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trim_leading_whitespace<'a>(a: &'a str) -> &'a str {
+    { a.trim_start_matches(' ') }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_leading_whitespace__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_leading_whitespace__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_trailing_whitespace.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_trailing_whitespace.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"rtrim\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trim_trailing_whitespace<'a>(a: &'a str) -> &'a str {\n    { a.trim_end_matches(' ') }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TrimTrailingWhitespace;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TrimTrailingWhitespace {
+    type Input = &'a str;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trim_trailing_whitespace(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TrimTrailingWhitespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("rtrim")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trim_trailing_whitespace<'a>(a: &'a str) -> &'a str {
+    { a.trim_end_matches(' ') }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_trailing_whitespace__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_trailing_whitespace__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_whitespace.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_whitespace.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"btrim\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn trim_whitespace<'a>(a: &'a str) -> &'a str {\n    { a.trim_matches(' ') }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TrimWhitespace;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TrimWhitespace {
+    type Input = &'a str;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        trim_whitespace(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TrimWhitespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("btrim")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn trim_whitespace<'a>(a: &'a str) -> &'a str {
+    { a.trim_matches(' ') }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_whitespace__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__trim_whitespace__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__try_parse_monotonic_iso8601_timestamp.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__try_parse_monotonic_iso8601_timestamp.snap
@@ -1,0 +1,57 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = \"try_parse_monotonic_iso8601_timestamp\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn try_parse_monotonic_iso8601_timestamp<'a>(\n    a: &'a str,\n) -> Option<CheckedTimestamp<NaiveDateTime>> {\n    {\n        let ts = mz_persist_types::timestamp::try_parse_monotonic_iso8601_timestamp(a)?;\n        let ts = CheckedTimestamp::from_timestamplike(ts)\n            .expect(\"monotonic_iso8601 range is a subset of CheckedTimestamp domain\");\n        Some(ts)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TryParseMonotonicIso8601Timestamp;
+impl<'a> crate::func::EagerUnaryFunc<'a> for TryParseMonotonicIso8601Timestamp {
+    type Input = &'a str;
+    type Output = Option<CheckedTimestamp<NaiveDateTime>>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        try_parse_monotonic_iso8601_timestamp(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for TryParseMonotonicIso8601Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("try_parse_monotonic_iso8601_timestamp")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn try_parse_monotonic_iso8601_timestamp<'a>(
+    a: &'a str,
+) -> Option<CheckedTimestamp<NaiveDateTime>> {
+    {
+        let ts = mz_persist_types::timestamp::try_parse_monotonic_iso8601_timestamp(a)?;
+        let ts = CheckedTimestamp::from_timestamplike(ts)
+            .expect("monotonic_iso8601 range is a subset of CheckedTimestamp domain");
+        Some(ts)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__try_parse_monotonic_iso8601_timestamp__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__try_parse_monotonic_iso8601_timestamp__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Timestamp {
+            precision: None,
+        },
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Timestamp {
+            precision: None,
+        },
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__upper.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__upper.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(upper),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn upper<'a>(a: &'a str) -> String {\n    { a.to_uppercase() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Upper;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Upper {
+    type Input = &'a str;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        upper(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Upper {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(upper))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn upper<'a>(a: &'a str) -> String {
+    { a.to_uppercase() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__upper__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__string__upper__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/string.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_interval.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_interval.snap
@@ -1,0 +1,60 @@
+---
+source: src/expr/src/scalar/func/impls/time.rs
+expression: "#[sqlfunc(\n    sqlname = \"time_to_interval\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastIntervalToTime),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_time_to_interval<'a>(t: NaiveTime) -> Interval {\n    {\n        let micros: i64 = Interval::convert_date_time_unit(\n                DateTimeField::Second,\n                DateTimeField::Microseconds,\n                i64::from(t.num_seconds_from_midnight()),\n            )\n            .unwrap()\n            + i64::from(t.nanosecond())\n                / i64::from(Interval::NANOSECOND_PER_MICROSECOND);\n        Interval::new(0, 0, micros)\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimeToInterval;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimeToInterval {
+    type Input = NaiveTime;
+    type Output = Interval;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_time_to_interval(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastIntervalToTime)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastTimeToInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("time_to_interval")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_time_to_interval<'a>(t: NaiveTime) -> Interval {
+    {
+        let micros: i64 = Interval::convert_date_time_unit(
+                DateTimeField::Second,
+                DateTimeField::Microseconds,
+                i64::from(t.num_seconds_from_midnight()),
+            )
+            .unwrap()
+            + i64::from(t.nanosecond())
+                / i64::from(Interval::NANOSECOND_PER_MICROSECOND);
+        Interval::new(0, 0, micros)
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_interval__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_interval__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/time.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Interval,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Interval,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastIntervalToTime(
+            CastIntervalToTime,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/time.rs
+expression: "#[sqlfunc(\n    sqlname = \"time_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToTime),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_time_to_string<'a>(a: NaiveTime) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_time(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimeToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimeToString {
+    type Input = NaiveTime;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_time_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToTime)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastTimeToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("time_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_time_to_string<'a>(a: NaiveTime) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_time(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__time__cast_time_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/time.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToTime(
+            CastStringToTime,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_date.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_date.snap
@@ -1,0 +1,52 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_to_date\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastDateToTimestamp(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_to_date<'a>(\n    a: CheckedTimestamp<NaiveDateTime>,\n) -> Result<Date, EvalError> {\n    { Ok(a.date().try_into()?) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampToDate;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampToDate {
+    type Input = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<Date, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_to_date(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastDateToTimestamp(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampToDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_to_date")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_to_date<'a>(
+    a: CheckedTimestamp<NaiveDateTime>,
+) -> Result<Date, EvalError> {
+    { Ok(a.date().try_into()?) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_date__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_date__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Date,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Date,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastDateToTimestamp(
+            CastDateToTimestamp(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToTimestamp(None)),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_to_string<'a>(a: CheckedTimestamp<NaiveDateTime>) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_timestamp(&mut buf, &a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampToString {
+    type Input = CheckedTimestamp<NaiveDateTime>;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToTimestamp(None))
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastTimestampToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_to_string<'a>(a: CheckedTimestamp<NaiveDateTime>) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_timestamp(&mut buf, &a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_string__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToTimestamp(
+            CastStringToTimestamp(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_time.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_time.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_to_time\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_to_time<'a>(a: CheckedTimestamp<NaiveDateTime>) -> NaiveTime {\n    { a.time() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampToTime;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampToTime {
+    type Input = CheckedTimestamp<NaiveDateTime>;
+    type Output = NaiveTime;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_to_time(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampToTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_to_time")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_to_time<'a>(a: CheckedTimestamp<NaiveDateTime>) -> NaiveTime {
+    { a.time() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_time__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_to_time__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Time,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Time,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_date.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_date.snap
@@ -1,0 +1,52 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_with_time_zone_to_date\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastDateToTimestampTz(None)),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_tz_to_date<'a>(\n    a: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<Date, EvalError> {\n    { Ok(a.naive_utc().date().try_into()?) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampTzToDate;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampTzToDate {
+    type Input = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<Date, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_tz_to_date(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastDateToTimestampTz(None))
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampTzToDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_with_time_zone_to_date")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_tz_to_date<'a>(
+    a: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<Date, EvalError> {
+    { Ok(a.naive_utc().date().try_into()?) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_date__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_date__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Date,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Date,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastDateToTimestampTz(
+            CastDateToTimestampTz(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_with_time_zone_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToTimestampTz(None)),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_tz_to_string<'a>(a: CheckedTimestamp<DateTime<Utc>>) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_timestamptz(&mut buf, &a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampTzToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampTzToString {
+    type Input = CheckedTimestamp<DateTime<Utc>>;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_tz_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToTimestampTz(None))
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastTimestampTzToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_with_time_zone_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_tz_to_string<'a>(a: CheckedTimestamp<DateTime<Utc>>) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_timestamptz(&mut buf, &a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_string__impl.snap
@@ -1,0 +1,26 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToTimestampTz(
+            CastStringToTimestampTz(
+                None,
+            ),
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_time.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_time.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: "#[sqlfunc(\n    sqlname = \"timestamp_with_time_zone_to_time\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_timestamp_tz_to_time<'a>(a: CheckedTimestamp<DateTime<Utc>>) -> NaiveTime {\n    { a.naive_utc().time() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastTimestampTzToTime;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastTimestampTzToTime {
+    type Input = CheckedTimestamp<DateTime<Utc>>;
+    type Output = NaiveTime;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_timestamp_tz_to_time(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastTimestampTzToTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("timestamp_with_time_zone_to_time")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_timestamp_tz_to_time<'a>(a: CheckedTimestamp<DateTime<Utc>>) -> NaiveTime {
+    { a.naive_utc().time() }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_time__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__timestamp__cast_timestamp_tz_to_time__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/impls/timestamp.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Time,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Time,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__bit_not_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__bit_not_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::BitNotUint16),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_uint16<'a>(a: u16) -> u16 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotUint16 {
+    type Input = u16;
+    type Output = u16;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::BitNotUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_uint16<'a>(a: u16) -> u16 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__bit_not_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__bit_not_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotUint16(
+            BitNotUint16,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_real\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat32ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_float32<'a>(a: u16) -> f32 {\n    { f32::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToFloat32 {
+    type Input = u16;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_float32<'a>(a: u16) -> f32 {
+    { f32::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat32ToUint16(
+            CastFloat32ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_double\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat64ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_float64<'a>(a: u16) -> f64 {\n    { f64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToFloat64 {
+    type Input = u16;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_float64<'a>(a: u16) -> f64 {
+    { f64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat64ToUint16(
+            CastFloat64ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_smallint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt16ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_int16<'a>(a: u16) -> Result<i16, EvalError> {\n    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToInt16 {
+    type Input = u16;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_int16<'a>(a: u16) -> Result<i16, EvalError> {
+    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt16ToUint16(
+            CastInt16ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_int32<'a>(a: u16) -> i32 {\n    { i32::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToInt32 {
+    type Input = u16;
+    type Output = i32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_int32<'a>(a: u16) -> i32 {
+    { i32::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToUint16(
+            CastInt32ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_int64<'a>(a: u16) -> i64 {\n    { i64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToInt64 {
+    type Input = u16;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_int64<'a>(a: u16) -> i64 {
+    { i64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToUint16(
+            CastInt64ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToUint16),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_string<'a>(a: u16) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_uint16(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToString {
+    type Input = u16;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_string<'a>(a: u16) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_uint16(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToUint16(
+            CastStringToUint16,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_uint4\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint32ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_uint32<'a>(a: u16) -> u32 {\n    { u32::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToUint32 {
+    type Input = u16;
+    type Output = u32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_uint32<'a>(a: u16) -> u32 {
+    { u32::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint32ToUint16(
+            CastUint32ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint2_to_uint8\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint64ToUint16),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint16_to_uint64<'a>(a: u16) -> u64 {\n    { u64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint16ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint16ToUint64 {
+    type Input = u16;
+    type Output = u64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint16_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToUint16)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint16ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint2_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint16_to_uint64<'a>(a: u16) -> u64 {
+    { u64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint16__cast_uint16_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint16.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint64ToUint16(
+            CastUint64ToUint16,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__bit_not_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__bit_not_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::BitNotUint32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_uint32<'a>(a: u32) -> u32 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotUint32 {
+    type Input = u32;
+    type Output = u32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::BitNotUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_uint32<'a>(a: u32) -> u32 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__bit_not_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__bit_not_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotUint32(
+            BitNotUint32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_float32<'a>(a: u32) -> f32 {\n    { #[allow(clippy::as_conversions)] { a as f32 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToFloat32 {
+    type Input = u32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastUint32ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_float32<'a>(a: u32) -> f32 {
+    { #[allow(clippy::as_conversions)] { a as f32 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToUint32(
+            CastFloat32ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_double\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastFloat64ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_float64<'a>(a: u32) -> f64 {\n    { f64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToFloat64 {
+    type Input = u32;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_float64<'a>(a: u32) -> f64 {
+    { f64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastFloat64ToUint32(
+            CastFloat64ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_smallint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt16ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_int16<'a>(a: u32) -> Result<i16, EvalError> {\n    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToInt16 {
+    type Input = u32;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_int16<'a>(a: u32) -> Result<i16, EvalError> {
+    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt16ToUint32(
+            CastInt16ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_int32<'a>(a: u32) -> Result<i32, EvalError> {\n    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToInt32 {
+    type Input = u32;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_int32<'a>(a: u32) -> Result<i32, EvalError> {
+    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToUint32(
+            CastInt32ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_int64<'a>(a: u32) -> i64 {\n    { i64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToInt64 {
+    type Input = u32;
+    type Output = i64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_int64<'a>(a: u32) -> i64 {
+    { i64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToUint32(
+            CastInt64ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToUint32),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_string<'a>(a: u32) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_uint32(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToString {
+    type Input = u32;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_string<'a>(a: u32) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_uint32(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToUint32(
+            CastStringToUint32,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_uint2\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint16ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_uint16<'a>(a: u32) -> Result<u16, EvalError> {\n    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToUint16 {
+    type Input = u32;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_uint16<'a>(a: u32) -> Result<u16, EvalError> {
+    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint16ToUint32(
+            CastUint16ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint4_to_uint8\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint64ToUint32),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint32_to_uint64<'a>(a: u32) -> u64 {\n    { u64::from(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint32ToUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint32ToUint64 {
+    type Input = u32;
+    type Output = u64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint32_to_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint64ToUint32)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint32ToUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint4_to_uint8")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint32_to_uint64<'a>(a: u32) -> u64 {
+    { u64::from(a) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint32__cast_uint32_to_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint32.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint64ToUint32(
+            CastUint64ToUint32,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__bit_not_uint64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__bit_not_uint64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"~\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::BitNotUint64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn bit_not_uint64<'a>(a: u64) -> u64 {\n    { !a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct BitNotUint64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for BitNotUint64 {
+    type Input = u64;
+    type Output = u64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        bit_not_uint64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::BitNotUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for BitNotUint64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("~")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn bit_not_uint64<'a>(a: u64) -> u64 {
+    { !a }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__bit_not_uint64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__bit_not_uint64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        BitNotUint64(
+            BitNotUint64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_real\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat32ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_float32<'a>(a: u64) -> f32 {\n    { #[allow(clippy::as_conversions)] { a as f32 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToFloat32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToFloat32 {
+    type Input = u64;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_float32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat32ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastUint64ToFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_real")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_float32<'a>(a: u64) -> f32 {
+    { #[allow(clippy::as_conversions)] { a as f32 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat32ToUint64(
+            CastFloat32ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_double\",\n    preserves_uniqueness = false,\n    inverse = to_unary!(super::CastFloat64ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_float64<'a>(a: u64) -> f64 {\n    { #[allow(clippy::as_conversions)] { a as f64 } }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToFloat64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToFloat64 {
+    type Input = u64;
+    type Output = f64;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_float64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastFloat64ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for CastUint64ToFloat64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_double")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_float64<'a>(a: u64) -> f64 {
+    { #[allow(clippy::as_conversions)] { a as f64 } }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_float64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float64,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: Some(
+        CastFloat64ToUint64(
+            CastFloat64ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_smallint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt16ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_int16<'a>(a: u64) -> Result<i16, EvalError> {\n    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToInt16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToInt16 {
+    type Input = u64;
+    type Output = Result<i16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_int16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt16ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToInt16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_smallint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_int16<'a>(a: u64) -> Result<i16, EvalError> {
+    { i16::try_from(a).or(Err(EvalError::Int16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt16ToUint64(
+            CastInt16ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_integer\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt32ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_int32<'a>(a: u64) -> Result<i32, EvalError> {\n    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToInt32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToInt32 {
+    type Input = u64;
+    type Output = Result<i32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_int32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt32ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToInt32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_integer")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_int32<'a>(a: u64) -> Result<i32, EvalError> {
+    { i32::try_from(a).or(Err(EvalError::Int32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt32ToUint64(
+            CastInt32ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int64.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_bigint\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastInt64ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_int64<'a>(a: u64) -> Result<i64, EvalError> {\n    { i64::try_from(a).or(Err(EvalError::Int64OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToInt64;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToInt64 {
+    type Input = u64;
+    type Output = Result<i64, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_int64(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt64ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_bigint")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_int64<'a>(a: u64) -> Result<i64, EvalError> {
+    { i64::try_from(a).or(Err(EvalError::Int64OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int64__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_int64__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Int64,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Int64,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastInt64ToUint64(
+            CastInt64ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToUint64),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_string<'a>(a: u64) -> String {\n    {\n        let mut buf = String::new();\n        strconv::format_uint64(&mut buf, a);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToString {
+    type Input = u64;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_string<'a>(a: u64) -> String {
+    {
+        let mut buf = String::new();
+        strconv::format_uint64(&mut buf, a);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToUint64(
+            CastStringToUint64,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint16.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_uint2\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint16ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_uint16<'a>(a: u64) -> Result<u16, EvalError> {\n    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToUint16;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToUint16 {
+    type Input = u64;
+    type Output = Result<u16, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_uint16(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint16ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToUint16 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_uint2")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_uint16<'a>(a: u64) -> Result<u16, EvalError> {
+    { u16::try_from(a).or(Err(EvalError::UInt16OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint16__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint16__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt16,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint16ToUint64(
+            CastUint16ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint32.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: "#[sqlfunc(\n    sqlname = \"uint8_to_uint4\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastUint32ToUint64),\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uint64_to_uint32<'a>(a: u64) -> Result<u32, EvalError> {\n    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUint64ToUint32;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUint64ToUint32 {
+    type Input = u64;
+    type Output = Result<u32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uint64_to_uint32(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastUint32ToUint64)
+    }
+    fn is_monotone(&self) -> bool {
+        true
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUint64ToUint32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uint8_to_uint4")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uint64_to_uint32<'a>(a: u64) -> Result<u32, EvalError> {
+    { u32::try_from(a).or(Err(EvalError::UInt32OutOfRange(a.to_string().into()))) }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint32__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uint64__cast_uint64_to_uint32__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uint64.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: UInt32,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastUint32ToUint64(
+            CastUint32ToUint64,
+        ),
+    ),
+    is_monotone: true,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uuid__cast_uuid_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uuid__cast_uuid_to_string.snap
@@ -1,0 +1,54 @@
+---
+source: src/expr/src/scalar/func/impls/uuid.rs
+expression: "#[sqlfunc(\n    sqlname = \"uuid_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToUuid),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_uuid_to_string<'a>(u: Uuid) -> String {\n    {\n        let mut buf = String::with_capacity(36);\n        strconv::format_uuid(&mut buf, u);\n        buf\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastUuidToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastUuidToString {
+    type Input = Uuid;
+    type Output = String;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_uuid_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToUuid)
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastUuidToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("uuid_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_uuid_to_string<'a>(u: Uuid) -> String {
+    {
+        let mut buf = String::with_capacity(36);
+        strconv::format_uuid(&mut buf, u);
+        buf
+    }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uuid__cast_uuid_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__uuid__cast_uuid_to_string__impl.snap
@@ -1,0 +1,24 @@
+---
+source: src/expr/src/scalar/func/impls/uuid.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToUuid(
+            CastStringToUuid,
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__varchar__cast_var_char_to_string.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__varchar__cast_var_char_to_string.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/impls/varchar.rs
+expression: "#[sqlfunc(\n    sqlname = \"varchar_to_text\",\n    preserves_uniqueness = true,\n    inverse = to_unary!(super::CastStringToVarChar{length:None, fail_on_len:false}),\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_var_char_to_string<'a>(a: VarChar<&'a str>) -> &'a str {\n    { a.0 }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct CastVarCharToString;
+impl<'a> crate::func::EagerUnaryFunc<'a> for CastVarCharToString {
+    type Input = VarChar<&'a str>;
+    type Output = &'a str;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        cast_var_char_to_string(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToVarChar { length : None, fail_on_len : false, })
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for CastVarCharToString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("varchar_to_text")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn cast_var_char_to_string<'a>(a: VarChar<&'a str>) -> &'a str {
+    { a.0 }
+}

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__varchar__cast_var_char_to_string__impl.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__varchar__cast_var_char_to_string__impl.snap
@@ -1,0 +1,27 @@
+---
+source: src/expr/src/scalar/func/impls/varchar.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: String,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: String,
+        nullable: false,
+    },
+    preserves_uniqueness: true,
+    inverse: Some(
+        CastStringToVarChar(
+            CastStringToVarChar {
+                length: None,
+                fail_on_len: false,
+            },
+        ),
+    ),
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -143,46 +143,12 @@ macro_rules! sqlfunc {
             $body:block
     ) => {
         paste::paste! {
-            #[derive(proptest_derive::Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Hash, mz_lowertest::MzReflect)]
-            pub struct [<$fn_name:camel>];
-
-            impl<'a> crate::func::EagerUnaryFunc<'a> for [<$fn_name:camel>] {
-                type Input = $input_ty;
-                type Output = $output_ty;
-
-                fn call(&self, a: Self::Input) -> Self::Output {
-                    $fn_name(a)
-                }
-
-                fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
-                    use mz_repr::AsColumnType;
-                    let output = Self::Output::as_column_type();
-                    let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
-                    let nullable = output.nullable;
-                    // The output is nullable if it is nullable by itself or the input is nullable
-                    // and this function propagates nulls
-                    output.nullable(nullable || (propagates_nulls && input_type.nullable))
-                }
-
-                fn preserves_uniqueness(&self) -> bool {
-                    $preserves_uniqueness
-                }
-
-                fn inverse(&self) -> Option<crate::UnaryFunc> {
-                    $inverse
-                }
-
-                fn is_monotone(&self) -> bool {
-                    $is_monotone
-                }
-            }
-
-            impl std::fmt::Display for [<$fn_name:camel>] {
-                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    f.write_str($name)
-                }
-            }
-
+            #[mz_expr_derive::sqlfunc(
+                sqlname = $name,
+                preserves_uniqueness = $preserves_uniqueness,
+                inverse = $inverse,
+                is_monotone = $is_monotone,
+            )]
             #[allow(clippy::extra_unused_lifetimes)]
             pub fn $fn_name<$lt>($param_name: $input_ty) -> $output_ty {
                 $body

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible1.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible1.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(fallible1),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn fallible1<'a>(a: f32) -> Result<f32, EvalError> {\n    { Ok(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Fallible1;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Fallible1 {
+    type Input = f32;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        fallible1(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Fallible1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(fallible1))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn fallible1<'a>(a: f32) -> Result<f32, EvalError> {
+    { Ok(a) }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible1__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible1__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible2.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible2.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(fallible2),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn fallible2<'a>(a: Option<f32>) -> Result<f32, EvalError> {\n    { Ok(a.unwrap_or_default()) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Fallible2;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Fallible2 {
+    type Input = Option<f32>;
+    type Output = Result<f32, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        fallible2(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Fallible2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(fallible2))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn fallible2<'a>(a: Option<f32>) -> Result<f32, EvalError> {
+    { Ok(a.unwrap_or_default()) }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible2__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible2__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: false,
+    introduces_nulls: false,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible3.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible3.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(fallible3),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn fallible3<'a>(a: f32) -> Result<Option<f32>, EvalError> {\n    { Ok(Some(a)) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Fallible3;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Fallible3 {
+    type Input = f32;
+    type Output = Result<Option<f32>, EvalError>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        fallible3(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Fallible3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(fallible3))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn fallible3<'a>(a: f32) -> Result<Option<f32>, EvalError> {
+    { Ok(Some(a)) }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible3__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__fallible3__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: true,
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible1.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible1.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = \"INFALLIBLE\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn infallible1<'a>(a: f32) -> f32 {\n    { a }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Infallible1;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Infallible1 {
+    type Input = f32;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        infallible1(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Infallible1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("INFALLIBLE")
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn infallible1<'a>(a: f32) -> f32 {
+    { a }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible1__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible1__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible2.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible2.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(infallible2),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn infallible2<'a>(a: Option<f32>) -> f32 {\n    { a.unwrap_or_default() }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Infallible2;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Infallible2 {
+    type Input = Option<f32>;
+    type Output = f32;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        infallible2(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Infallible2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(infallible2))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn infallible2<'a>(a: Option<f32>) -> f32 {
+    { a.unwrap_or_default() }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible2__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible2__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: false,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: false,
+    introduces_nulls: false,
+    could_error: false,
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible3.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible3.snap
@@ -1,0 +1,50 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: "#[sqlfunc(\n    sqlname = stringify!(infallible3),\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = false,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn infallible3<'a>(a: f32) -> Option<f32> {\n    { Some(a) }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Infallible3;
+impl<'a> crate::func::EagerUnaryFunc<'a> for Infallible3 {
+    type Input = f32;
+    type Output = Option<f32>;
+    fn call(&self, a: Self::Input) -> Self::Output {
+        infallible3(a)
+    }
+    fn output_type(&self, input_type: mz_repr::ColumnType) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+    fn is_monotone(&self) -> bool {
+        false
+    }
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for Infallible3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(infallible3))
+    }
+}
+#[allow(clippy::extra_unused_lifetimes)]
+pub fn infallible3<'a>(a: f32) -> Option<f32> {
+    { Some(a) }
+}

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible3__impl.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__macros__test__infallible3__impl.snap
@@ -1,0 +1,20 @@
+---
+source: src/expr/src/scalar/func/macros.rs
+expression: info
+---
+Info {
+    output_type_nullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    output_type_nonnullable: ColumnType {
+        scalar_type: Float32,
+        nullable: true,
+    },
+    preserves_uniqueness: false,
+    inverse: None,
+    is_monotone: false,
+    propagates_nulls: true,
+    introduces_nulls: true,
+    could_error: false,
+}


### PR DESCRIPTION
Convert existing unary functions to procmacro.

Changes the current macro for unary functions to delegate to the proc macro instead of generating the eager unary function implementation itself. The individual commits are meaningful and ensure that we do not regress over the status quo:
* First, we improve the handling of the `sqlname` parameter because there's a wider variety of how names can be provided.
* Then, we capture the current behavior using an insta snapshot.
* Next, we switch to the new implementation. No changes to the insta snapshot!
* Finally, we capture the new insta snapshot generated by the proc macro.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
