### PR TITLE
Fix positional argument name in `helm_chart_version_bump.py`

### DIFF
--- a/misc/python/materialize/cli/helm_chart_version_bump.py
+++ b/misc/python/materialize/cli/helm_chart_version_bump.py
@@ -27,7 +27,7 @@ def main() -> int:
         help="Helm-chart version to bump to, no change if not set.",
     )
     parser.add_argument(
-        "environmentd-version", type=str, help="environmentd version to bump to."
+        "environmentd_version", type=str, help="environmentd version to bump to."
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Our release cut script is failing. Last night's run:
```
  File "/home/runner/work/release/release/materialize/misc/python/materialize/cli/helm_chart_version_bump.py", line 42, in <lambda>
    lambda docs: docs[0].update({"appVersion": args.version}),
                                               ^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'version'
```
https://github.com/MaterializeInc/materialize/pull/32162 was meant to fix the arg name in `helm_chart_version_bump.py`, but the new run now failed with:
```
  File "/home/runner/work/release/release/materialize/misc/python/materialize/cli/helm_chart_version_bump.py", line 42, in <lambda>
    lambda docs: docs[0].update({"appVersion": args.environmentd_version}),
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'environmentd_version'. Did you mean: 'environmentd-version'?
```
It seems that argparse doesn't handle dashes in the names of _positional_ arguments well: It doesn't convert them to underscore when making the corresponding Python attribute, and then it's problematic to access the attribute, because a dash is parsed as an operator by Python, rather than part of the argument name. Though it's still possible to access the argument by using `getattr`, I guess it's easier to just rename the argument to have an underscore instead of a dash, so this is what this PR does. (There is a Python bug ticket: https://bugs.python.org/issue15125)

I tried the PR locally by running `bin/bump-version`, and it now succeeds.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
