### PR TITLE
More binary funcs using the proc macro

### DIFF
--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -422,7 +422,7 @@ mod test {
     /// whether the input colum is marked nullable or not.
     fn test_equivalence_inner(input_nullable: bool) {
         #[track_caller]
-        fn check<T: LazyBinaryFunc + std::fmt::Display>(
+        fn check<T: LazyBinaryFunc + std::fmt::Display + std::fmt::Debug>(
             new: T,
             old: BinaryFunc,
             column_a_ty: &ColumnType,
@@ -431,23 +431,40 @@ mod test {
             assert_eq!(
                 new.propagates_nulls(),
                 old.propagates_nulls(),
-                "propagates_nulls mismatch"
+                "{new:?} propagates_nulls mismatch"
             );
             assert_eq!(
                 new.introduces_nulls(),
                 old.introduces_nulls(),
-                "introduces_nulls mismatch"
+                "{new:?} introduces_nulls mismatch"
             );
-            assert_eq!(new.could_error(), old.could_error(), "could_error mismatch");
-            assert_eq!(new.is_monotone(), old.is_monotone(), "is_monotone mismatch");
-            assert_eq!(new.is_infix_op(), old.is_infix_op(), "is_infix_op mismatch");
+            assert_eq!(
+                new.could_error(),
+                old.could_error(),
+                "{new:?} could_error mismatch"
+            );
+            assert_eq!(
+                new.is_monotone(),
+                old.is_monotone(),
+                "{new:?} is_monotone mismatch"
+            );
+            assert_eq!(
+                new.is_infix_op(),
+                old.is_infix_op(),
+                "{new:?} is_infix_op mismatch"
+            );
             assert_eq!(
                 new.output_type(column_a_ty.clone(), column_b_ty.clone()),
                 old.output_type(column_a_ty.clone(), column_b_ty.clone()),
-                "output_type mismatch"
+                "{new:?} output_type mismatch"
             );
-            assert_eq!(format!("{}", new), format!("{}", old), "format mismatch");
+            assert_eq!(
+                format!("{}", new),
+                format!("{}", old),
+                "{new:?} format mismatch"
+            );
         }
+
         let i32_ty = ColumnType {
             nullable: input_nullable,
             scalar_type: ScalarType::Int32,
@@ -648,6 +665,90 @@ mod test {
         check(func::ModFloat32, BF::ModFloat32, &i32_ty, &i32_ty);
         check(func::ModFloat64, BF::ModFloat64, &i32_ty, &i32_ty);
         check(func::ModNumeric, BF::ModNumeric, &i32_ty, &i32_ty);
+
+        check(func::LogBaseNumeric, BF::LogNumeric, &i32_ty, &i32_ty);
+        check(func::Power, BF::Power, &i32_ty, &i32_ty);
+        check(func::PowerNumeric, BF::PowerNumeric, &i32_ty, &i32_ty);
+
+        check(func::UuidGenerateV5, BF::UuidGenerateV5, &i32_ty, &i32_ty);
+
+        check(func::GetBit, BF::GetBit, &i32_ty, &i32_ty);
+        check(func::GetByte, BF::GetByte, &i32_ty, &i32_ty);
+
+        check(
+            func::ConstantTimeEqBytes,
+            BF::ConstantTimeEqBytes,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ConstantTimeEqString,
+            BF::ConstantTimeEqString,
+            &i32_ty,
+            &i32_ty,
+        );
+
+        check(
+            func::RangeContainsRange,
+            BF::RangeContainsRange { rev: false },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsRangeRev,
+            BF::RangeContainsRange { rev: true },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::RangeOverlaps, BF::RangeOverlaps, &i32_ty, &i32_ty);
+        check(func::RangeAfter, BF::RangeAfter, &i32_ty, &i32_ty);
+        check(func::RangeBefore, BF::RangeBefore, &i32_ty, &i32_ty);
+        check(func::RangeOverleft, BF::RangeOverleft, &i32_ty, &i32_ty);
+        check(func::RangeOverright, BF::RangeOverright, &i32_ty, &i32_ty);
+        check(func::RangeAdjacent, BF::RangeAdjacent, &i32_ty, &i32_ty);
+
+        check(func::Eq, BF::Eq, &i32_ty, &i32_ty);
+        check(func::NotEq, BF::NotEq, &i32_ty, &i32_ty);
+        check(func::Lt, BF::Lt, &i32_ty, &i32_ty);
+        check(func::Lte, BF::Lte, &i32_ty, &i32_ty);
+        check(func::Gt, BF::Gt, &i32_ty, &i32_ty);
+        check(func::Gte, BF::Gte, &i32_ty, &i32_ty);
+
+        check(
+            func::JsonbContainsString,
+            BF::JsonbContainsString,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::MapContainsKey, BF::MapContainsKey, &i32_ty, &i32_ty);
+        check(
+            func::MapContainsAllKeys,
+            BF::MapContainsAllKeys,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::MapContainsAnyKeys,
+            BF::MapContainsAnyKeys,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::MapContainsMap, BF::MapContainsMap, &i32_ty, &i32_ty);
+
+        check(
+            func::JsonbContainsJsonb,
+            BF::JsonbContainsJsonb,
+            &i32_ty,
+            &i32_ty,
+        );
+
+        check(func::ExtractDateUnits, BF::ExtractDate, &i32_ty, &i32_ty);
+        check(
+            func::DateTruncInterval,
+            BF::DateTruncInterval,
+            &i32_ty,
+            &i32_ty,
+        );
 
         check(func::ArrayLength, BF::ArrayLength, &i32_ty, &i32_ty);
     }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_bytes.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_bytes.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = false,\n    sqlname = \"constant_time_compare_bytes\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_bytes<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a_bytes = a.unwrap_bytes();\n    let b_bytes = b.unwrap_bytes();\n    Ok(Datum::from(bool::from(a_bytes.ct_eq(b_bytes))))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ConstantTimeEqBytes;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConstantTimeEqBytes {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        constant_time_eq_bytes(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ConstantTimeEqBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("constant_time_compare_bytes")
+    }
+}
+pub fn constant_time_eq_bytes<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let a_bytes = a.unwrap_bytes();
+    let b_bytes = b.unwrap_bytes();
+    Ok(Datum::from(bool::from(a_bytes.ct_eq(b_bytes))))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_string.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = false,\n    sqlname = \"constant_time_compare_strings\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_string<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_str();\n    let b = b.unwrap_str();\n    Ok(Datum::from(bool::from(a.as_bytes().ct_eq(b.as_bytes()))))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ConstantTimeEqString;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConstantTimeEqString {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        constant_time_eq_string(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ConstantTimeEqString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("constant_time_compare_strings")
+    }
+}
+pub fn constant_time_eq_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_str();
+    let b = b.unwrap_str();
+    Ok(Datum::from(bool::from(a.as_bytes().ct_eq(b.as_bytes()))))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_interval.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Interval\",\n    is_infix_op = false,\n    sqlname = \"date_trunciv\",\n    propagates_nulls = true\n)]\nfn date_trunc_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut interval = b.unwrap_interval();\n    let units = a.unwrap_str();\n    let dtf = units.parse().map_err(|_| EvalError::UnknownUnits(units.into()))?;\n    interval\n        .truncate_low_fields(dtf, Some(0), RoundBehavior::Truncate)\n        .expect(\n            \"truncate_low_fields should not fail with max_precision 0 and RoundBehavior::Truncate\",\n        );\n    Ok(interval.into())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DateTruncInterval;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateTruncInterval {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_trunc_interval(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Interval>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DateTruncInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_trunciv")
+    }
+}
+fn date_trunc_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut interval = b.unwrap_interval();
+    let units = a.unwrap_str();
+    let dtf = units.parse().map_err(|_| EvalError::UnknownUnits(units.into()))?;
+    interval
+        .truncate_low_fields(dtf, Some(0), RoundBehavior::Truncate)
+        .expect(
+            "truncate_low_fields should not fail with max_precision 0 and RoundBehavior::Truncate",
+        );
+    Ok(interval.into())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"=\",\n    propagates_nulls = true\n)]\nfn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a == b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Eq;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Eq {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        eq(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Eq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("=")
+    }
+}
+fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a == b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__extract_date_units.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__extract_date_units.snap
@@ -1,0 +1,73 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    sqlname = \"extractd\",\n    propagates_nulls = true\n)]\nfn extract_date_units<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => Ok(extract_date_inner(units, b.unwrap_date().into())?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ExtractDateUnits;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ExtractDateUnits {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        extract_date_units(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ExtractDateUnits {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("extractd")
+    }
+}
+fn extract_date_units<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(extract_date_inner(units, b.unwrap_date().into())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
@@ -1,0 +1,80 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"i32\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,\n    };\n    let index = usize::try_from(index).map_err(|_| err.clone())?;\n    let byte_index = index / 8;\n    let bit_index = index % 8;\n    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;\n    assert!(i == 0 || i == 1);\n    Ok(Datum::from(i32::from(i)))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct GetBit;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for GetBit {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        get_bit(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for GetBit {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(get_bit))
+    }
+}
+fn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let bytes = a.unwrap_bytes();
+    let index = b.unwrap_int32();
+    let err = EvalError::IndexOutOfRange {
+        provided: index,
+        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,
+    };
+    let index = usize::try_from(index).map_err(|_| err.clone())?;
+    let byte_index = index / 8;
+    let bit_index = index % 8;
+    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;
+    assert!(i == 0 || i == 1);
+    Ok(Datum::from(i32::from(i)))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"i32\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len()).unwrap() - 1,\n    };\n    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;\n    Ok(Datum::from(i32::from(*i)))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct GetByte;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for GetByte {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        get_byte(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for GetByte {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(get_byte))
+    }
+}
+fn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let bytes = a.unwrap_bytes();
+    let index = b.unwrap_int32();
+    let err = EvalError::IndexOutOfRange {
+        provided: index,
+        valid_end: i32::try_from(bytes.len()).unwrap() - 1,
+    };
+    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;
+    Ok(Datum::from(i32::from(*i)))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gt.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gt.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">\",\n    propagates_nulls = true\n)]\nfn gt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a > b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Gt;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Gt {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        gt(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Gt {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">")
+    }
+}
+fn gt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a > b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gte.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">=\",\n    propagates_nulls = true\n)]\nfn gte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a >= b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Gte;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Gte {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        gte(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Gte {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">=")
+    }
+}
+fn gte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a >= b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_jsonb.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_jsonb.snap
@@ -1,0 +1,95 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {\n        match (a, b) {\n            (Datum::JsonNull, Datum::JsonNull) => true,\n            (Datum::False, Datum::False) => true,\n            (Datum::True, Datum::True) => true,\n            (Datum::Numeric(a), Datum::Numeric(b)) => a == b,\n            (Datum::String(a), Datum::String(b)) => a == b,\n            (Datum::List(a), Datum::List(b)) => {\n                b.iter()\n                    .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false)))\n            }\n            (Datum::Map(a), Datum::Map(b)) => {\n                b.iter()\n                    .all(|(b_key, b_val)| {\n                        a.iter()\n                            .any(|(a_key, a_val)| {\n                                (a_key == b_key) && contains(a_val, b_val, false)\n                            })\n                    })\n            }\n            (Datum::List(a), b) => {\n                at_top_level && a.iter().any(|a_elem| contains(a_elem, b, false))\n            }\n            _ => false,\n        }\n    }\n    contains(a, b, true).into()\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbContainsJsonb;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbContainsJsonb {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        jsonb_contains_jsonb(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for JsonbContainsJsonb {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {
+        match (a, b) {
+            (Datum::JsonNull, Datum::JsonNull) => true,
+            (Datum::False, Datum::False) => true,
+            (Datum::True, Datum::True) => true,
+            (Datum::Numeric(a), Datum::Numeric(b)) => a == b,
+            (Datum::String(a), Datum::String(b)) => a == b,
+            (Datum::List(a), Datum::List(b)) => {
+                b.iter()
+                    .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false)))
+            }
+            (Datum::Map(a), Datum::Map(b)) => {
+                b.iter()
+                    .all(|(b_key, b_val)| {
+                        a.iter()
+                            .any(|(a_key, a_val)| {
+                                (a_key == b_key) && contains(a_val, b_val, false)
+                            })
+                    })
+            }
+            (Datum::List(a), b) => {
+                at_top_level && a.iter().any(|a_elem| contains(a_elem, b, false))
+            }
+            _ => false,
+        }
+    }
+    contains(a, b, true).into()
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_string.snap
@@ -1,0 +1,75 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let k = b.unwrap_str();\n    match a {\n        Datum::List(list) => list.iter().any(|k2| b == k2).into(),\n        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),\n        Datum::String(string) => (string == k).into(),\n        _ => false.into(),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbContainsString;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbContainsString {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        jsonb_contains_string(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for JsonbContainsString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("?")
+    }
+}
+fn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let k = b.unwrap_str();
+    match a {
+        Datum::List(list) => list.iter().any(|k2| b == k2).into(),
+        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),
+        Datum::String(string) => (string == k).into(),
+        _ => false.into(),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__log_base_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__log_base_numeric.snap
@@ -1,0 +1,87 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    sqlname = \"log\",\n    propagates_nulls = true\n)]\nfn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    log_guard_numeric(&a, \"log\")?;\n    let mut b = b.unwrap_numeric().0;\n    log_guard_numeric(&b, \"log\")?;\n    let mut cx = numeric::cx_datum();\n    cx.ln(&mut a);\n    cx.ln(&mut b);\n    cx.div(&mut b, &a);\n    if a.is_zero() {\n        Err(EvalError::DivisionByZero)\n    } else {\n        cx.set_precision(usize::from(numeric::NUMERIC_DATUM_MAX_PRECISION - 1))\n            .expect(\"reducing precision below max always succeeds\");\n        let mut integral_check = b.clone();\n        cx.reduce(&mut integral_check);\n        let mut b = if integral_check.exponent() >= 0 { integral_check } else { b };\n        numeric::munge_numeric(&mut b).unwrap();\n        Ok(Datum::from(b))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct LogBaseNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for LogBaseNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        log_base_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for LogBaseNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("log")
+    }
+}
+fn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut a = a.unwrap_numeric().0;
+    log_guard_numeric(&a, "log")?;
+    let mut b = b.unwrap_numeric().0;
+    log_guard_numeric(&b, "log")?;
+    let mut cx = numeric::cx_datum();
+    cx.ln(&mut a);
+    cx.ln(&mut b);
+    cx.div(&mut b, &a);
+    if a.is_zero() {
+        Err(EvalError::DivisionByZero)
+    } else {
+        cx.set_precision(usize::from(numeric::NUMERIC_DATUM_MAX_PRECISION - 1))
+            .expect("reducing precision below max always succeeds");
+        let mut integral_check = b.clone();
+        cx.reduce(&mut integral_check);
+        let mut b = if integral_check.exponent() >= 0 { integral_check } else { b };
+        numeric::munge_numeric(&mut b).unwrap();
+        Ok(Datum::from(b))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lt.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lt.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<\",\n    propagates_nulls = true\n)]\nfn lt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a < b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Lt;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Lt {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        lt(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Lt {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<")
+    }
+}
+fn lt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a < b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lte.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<=\",\n    propagates_nulls = true\n)]\nfn lte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a <= b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Lte;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Lte {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        lte(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Lte {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<=")
+    }
+}
+fn lte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a <= b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_all_keys.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_all_keys.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?&\",\n    propagates_nulls = true\n)]\nfn map_contains_all_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .all(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MapContainsAllKeys;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsAllKeys {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        map_contains_all_keys(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MapContainsAllKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("?&")
+    }
+}
+fn map_contains_all_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let map = a.unwrap_map();
+    let keys = b.unwrap_array();
+    keys.elements()
+        .iter()
+        .all(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))
+        .into()
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_any_keys.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_any_keys.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?|\",\n    propagates_nulls = true\n)]\nfn map_contains_any_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .any(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MapContainsAnyKeys;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsAnyKeys {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        map_contains_any_keys(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MapContainsAnyKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("?|")
+    }
+}
+fn map_contains_any_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let map = a.unwrap_map();
+    let keys = b.unwrap_array();
+    keys.elements()
+        .iter()
+        .any(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))
+        .into()
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_key.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_key.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let k = b.unwrap_str();\n    map.iter().any(|(k2, _v)| k == k2).into()\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MapContainsKey;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsKey {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        map_contains_key(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MapContainsKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("?")
+    }
+}
+fn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let map = a.unwrap_map();
+    let k = b.unwrap_str();
+    map.iter().any(|(k2, _v)| k == k2).into()
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_map.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_map.snap
@@ -1,0 +1,75 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map_a = a.unwrap_map();\n    b.unwrap_map()\n        .iter()\n        .all(|(b_key, b_val)| {\n            map_a.iter().any(|(a_key, a_val)| (a_key == b_key) && (a_val == b_val))\n        })\n        .into()\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MapContainsMap;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsMap {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        map_contains_map(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MapContainsMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let map_a = a.unwrap_map();
+    b.unwrap_map()
+        .iter()
+        .all(|(b_key, b_val)| {
+            map_a.iter().any(|(a_key, a_val)| (a_key == b_key) && (a_val == b_val))
+        })
+        .into()
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"!=\",\n    propagates_nulls = true\n)]\nfn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a != b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct NotEq;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for NotEq {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        not_eq(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for NotEq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("!=")
+    }
+}
+fn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    Datum::from(a != b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power.snap
@@ -1,0 +1,84 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"f64\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    if a == 0.0 && b.is_sign_negative() {\n        return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n    }\n    if a.is_sign_negative() && b.fract() != 0.0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let res = a.powf(b);\n    if res.is_infinite() {\n        return Err(EvalError::FloatOverflow);\n    }\n    if res == 0.0 && a != 0.0 {\n        return Err(EvalError::FloatUnderflow);\n    }\n    Ok(Datum::from(res))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Power;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Power {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        power(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Power {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(power))
+    }
+}
+fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let a = a.unwrap_float64();
+    let b = b.unwrap_float64();
+    if a == 0.0 && b.is_sign_negative() {
+        return Err(EvalError::Undefined("zero raised to a negative power".into()));
+    }
+    if a.is_sign_negative() && b.fract() != 0.0 {
+        return Err(EvalError::ComplexOutOfRange("pow".into()));
+    }
+    let res = a.powf(b);
+    if res.is_infinite() {
+        return Err(EvalError::FloatOverflow);
+    }
+    if res == 0.0 && a != 0.0 {
+        return Err(EvalError::FloatUnderflow);
+    }
+    Ok(Datum::from(res))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power_numeric.snap
@@ -1,0 +1,92 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    let b = b.unwrap_numeric().0;\n    if a.is_zero() {\n        if b.is_zero() {\n            return Ok(Datum::from(Numeric::from(1)));\n        }\n        if b.is_negative() {\n            return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n        }\n    }\n    if a.is_negative() && b.exponent() < 0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let mut cx = numeric::cx_datum();\n    cx.pow(&mut a, &b);\n    let cx_status = cx.status();\n    if cx_status.overflow() || (cx_status.invalid_operation() && !b.is_negative()) {\n        Err(EvalError::FloatOverflow)\n    } else if cx_status.subnormal() || cx_status.invalid_operation() {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct PowerNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for PowerNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        power_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for PowerNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(power_numeric))
+    }
+}
+fn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let mut a = a.unwrap_numeric().0;
+    let b = b.unwrap_numeric().0;
+    if a.is_zero() {
+        if b.is_zero() {
+            return Ok(Datum::from(Numeric::from(1)));
+        }
+        if b.is_negative() {
+            return Err(EvalError::Undefined("zero raised to a negative power".into()));
+        }
+    }
+    if a.is_negative() && b.exponent() < 0 {
+        return Err(EvalError::ComplexOutOfRange("pow".into()));
+    }
+    let mut cx = numeric::cx_datum();
+    cx.pow(&mut a, &b);
+    let cx_status = cx.status();
+    if cx_status.overflow() || (cx_status.invalid_operation() && !b.is_negative()) {
+        Err(EvalError::FloatOverflow)
+    } else if cx_status.subnormal() || cx_status.invalid_operation() {
+        Err(EvalError::FloatUnderflow)
+    } else {
+        numeric::munge_numeric(&mut a).unwrap();
+        Ok(Datum::from(a))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_adjacent.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_adjacent.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"-|-\",\n    propagates_nulls = true\n)]\nfn range_adjacent<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::adjacent(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeAdjacent;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeAdjacent {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_adjacent(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeAdjacent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-|-")
+    }
+}
+fn range_adjacent<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::adjacent(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_after.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_after.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn range_after<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::after(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeAfter;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeAfter {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_after(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeAfter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(">>")
+    }
+}
+fn range_after<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::after(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_before.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_before.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn range_before<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::before(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeBefore;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeBefore {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_before(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeBefore {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<<")
+    }
+}
+fn range_before<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::before(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn range_contains_range<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsRange;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsRange {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_range(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_range<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range_rev.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<@\",\n    propagates_nulls = true\n)]\nfn range_contains_range_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsRangeRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsRangeRev {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_range_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsRangeRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_range_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overlaps.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overlaps.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&&\",\n    propagates_nulls = true\n)]\nfn range_overlaps<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overlaps(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeOverlaps;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverlaps {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_overlaps(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeOverlaps {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&&")
+    }
+}
+fn range_overlaps<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::overlaps(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overleft.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overleft.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&<\",\n    propagates_nulls = true\n)]\nfn range_overleft<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overleft(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeOverleft;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverleft {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_overleft(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeOverleft {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&<")
+    }
+}
+fn range_overleft<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::overleft(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overright.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overright.snap
@@ -1,0 +1,71 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&>\",\n    propagates_nulls = true\n)]\nfn range_overright<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overright(&l, &r))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeOverright;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverright {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_overright(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeOverright {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("&>")
+    }
+}
+fn range_overright<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    Datum::from(Range::<Datum<'a>>::overright(&l, &r))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__uuid_generate_v5.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__uuid_generate_v5.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"uuid::Uuid\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_uuid();\n    let b = b.unwrap_str();\n    let res = uuid::Uuid::new_v5(&a, b.as_bytes());\n    Datum::Uuid(res)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct UuidGenerateV5;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for UuidGenerateV5 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        uuid_generate_v5(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <uuid::Uuid>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <uuid::Uuid as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, false)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for UuidGenerateV5 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(uuid_generate_v5))
+    }
+}
+fn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let a = a.unwrap_uuid();
+    let b = b.unwrap_str();
+    let res = uuid::Uuid::new_v5(&a, b.as_bytes());
+    Datum::Uuid(res)
+}


### PR DESCRIPTION
Convert more binary functions to the proc macro.

Part of MaterializeInc/database-issues#9138

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
