### PR TITLE
ci: Improve binary collection for coredump analysis

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -40,24 +40,26 @@ ps aux > ps-aux.log
 docker ps -a --no-trunc > docker-ps-a.log
 docker stats --all --no-stream > docker-stats.log
 
-echo "Downing docker containers"
-run down --volumes
-
 mv "$HOME"/cores .
 
 if find cores -name 'core.*' | grep -q .; then
     # Best effort attempt to fetch interesting executables to get backtrace of core files
     bin/ci-builder run stable cp /mnt/build/debug/clusterd cores/ || true
     bin/ci-builder run stable cp /mnt/build/debug/environmentd cores/ || true
+    bin/ci-builder run stable cp /mnt/build/debug/materialized cores/ || true
     bin/ci-builder run stable cp /mnt/build/debug/mz-balancerd cores/balancerd || true
     bin/ci-builder run stable cp /mnt/build/debug/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/clusterd cores/ || true
     run cp materialized:/usr/local/bin/environmentd cores/ || true
     run cp materialized:/usr/local/bin/clusterd cores/ || true
+    run cp materialized:/usr/local/bin/materialized cores/ || true
     run cp balancerd:/usr/local/bin/balancerd cores/ || true
     run cp testdrive:/usr/local/bin/testdrive cores/ || true
 fi
+
+echo "Downing docker containers"
+run down --volumes
 
 echo "Finding core files"
 find cores -name 'core.*' | while read -r core; do


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/C01LKF361MZ/p1744381055845859

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
