### PR TITLE
[persist] Be defensive when we have structured only data

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -33,6 +33,7 @@ use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::arrow::ArrayOrd;
 use mz_persist_types::columnar::{ColumnDecoder, Schema};
 use mz_persist_types::part::Codec64Mut;
+use mz_persist_types::schema::SchemaId;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
@@ -162,7 +163,7 @@ where
         }
 
         let migration = PartMigration::new(
-            part.part.schema_id(),
+            &part.part,
             self.read_schemas.clone(),
             &mut self.schema_cache,
         )
@@ -372,7 +373,7 @@ where
         panic!("{} could not fetch batch part: {}", reader_id, blob_key)
     });
     let part_cfg = BatchFetcherConfig::new(cfg);
-    let migration = PartMigration::new(part.part.schema_id(), read_schemas, schema_cache)
+    let migration = PartMigration::new(&part.part, read_schemas, schema_cache)
         .await
         .unwrap_or_else(|read_schemas| {
             panic!(

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -33,7 +33,6 @@ use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::arrow::ArrayOrd;
 use mz_persist_types::columnar::{ColumnDecoder, Schema};
 use mz_persist_types::part::Codec64Mut;
-use mz_persist_types::schema::SchemaId;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -509,17 +509,19 @@ where
                     let start_index = parts.len();
                     for part in run {
                         if let (
-                            RunPart::Single(BatchPart::Inline {
-                                updates,
-                                ts_rewrite,
-                                schema_id,
-                                deprecated_schema_id: _,
-                            }),
+                            RunPart::Single(
+                                batch_part @ BatchPart::Inline {
+                                    updates,
+                                    ts_rewrite,
+                                    schema_id: _,
+                                    deprecated_schema_id: _,
+                                },
+                            ),
                             Some((schema_cache, builder)),
                         ) = (part, &mut inline_batch_builder)
                         {
                             let schema_migration = PartMigration::new(
-                                *schema_id,
+                                batch_part,
                                 self.write_schemas.clone(),
                                 schema_cache,
                             )


### PR DESCRIPTION
When creating a `PartMigration` if we don't have a `schema_id` but we do have structured only data, we'll fallback to the `deprecated_schema_id` field because this indicates the `persist_record_schema_id` and `persist_batch_columnar_format` flags did not propagate properly.

### Motivation

Fix an issue at least one customer has run into.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
