### PR TITLE
document alter role to set custom cluster on bi tools

### DIFF
--- a/doc/user/content/serve-results/deepnote.md
+++ b/doc/user/content/serve-results/deepnote.md
@@ -37,15 +37,7 @@ This guide walks you through the steps required to use the collaborative data no
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ## Execute and visualize a query
 

--- a/doc/user/content/serve-results/hex.md
+++ b/doc/user/content/serve-results/hex.md
@@ -38,15 +38,7 @@ This guide walks you through the steps required to use the collaborative data no
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ## Execute and visualize a query
 

--- a/doc/user/content/serve-results/looker.md
+++ b/doc/user/content/serve-results/looker.md
@@ -34,15 +34,7 @@ Database password      | App-specific password.
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ## Known limitations
 

--- a/doc/user/content/serve-results/metabase.md
+++ b/doc/user/content/serve-results/metabase.md
@@ -35,15 +35,7 @@ For more details and troubleshooting, check the
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ## Refresh rate
 

--- a/doc/user/content/serve-results/power-bi.md
+++ b/doc/user/content/serve-results/power-bi.md
@@ -33,15 +33,7 @@ Database password      | App-specific password.
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ## Troubleshooting
 

--- a/doc/user/content/serve-results/tableau.md
+++ b/doc/user/content/serve-results/tableau.md
@@ -106,15 +106,7 @@ connections"
 
 ## Configure a custom cluster
 
-To direct queries to a specific cluster, [set the cluster at the role level](/sql/alter-role) using the following SQL statement:
-
-```sql
-ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
-```
-
-Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
-
-Once set, all new sessions for that user will automatically run in the specified cluster, eliminating the need to manually specify it in each query or connection.
+{{% alter-cluster/configure-cluster %}}
 
 ### Troubleshooting
 

--- a/doc/user/layouts/shortcodes/alter-cluster/configure-cluster.html
+++ b/doc/user/layouts/shortcodes/alter-cluster/configure-cluster.html
@@ -1,0 +1,12 @@
+To direct queries to a specific cluster, [set the cluster at the role
+level](/sql/alter-role) using the following SQL statement:
+
+```sql
+ALTER ROLE <your_user> SET CLUSTER = <custom_cluster>;
+```
+
+Replace `<your_user>` with the name of your Materialize role and `<custom_cluster>` with the name of the cluster you want to use.
+
+Once set, all new sessions for that user will automatically run in the specified
+cluster, eliminating the need to manually specify it in each query or
+connection.


### PR DESCRIPTION
### Motivation

As it says on the tin. I tried making this a short code but couldn't get it working in my timebox. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
