### PR TITLE
allow orchestratord to force a rollout to promote before it's ready

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -108,6 +108,12 @@ pub mod v1alpha1 {
         // generation rollout is automatically triggered.
         #[serde(default = "Uuid::new_v4")]
         pub request_rollout: Uuid,
+        // If force_promote is set to the same value as request_rollout, the
+        // current rollout will skip waiting for clusters in the new
+        // generation to rehydrate before promoting the new environmentd to
+        // leader.
+        #[serde(default)]
+        pub force_promote: Uuid,
         // This value will be written to an annotation in the generated
         // environmentd statefulset, in order to force the controller to
         // detect the generated resources as changed even if no other changes
@@ -318,6 +324,14 @@ pub mod v1alpha1 {
                     .status
                     .as_ref()
                     .map_or_else(Uuid::nil, |status| status.last_completed_rollout_request)
+        }
+
+        pub fn set_force_promote(&mut self) {
+            self.spec.force_promote = self.spec.request_rollout;
+        }
+
+        pub fn should_force_promote(&self) -> bool {
+            self.spec.force_promote == self.spec.request_rollout
         }
 
         pub fn conditions_need_update(&self) -> bool {

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -392,7 +392,13 @@ impl k8s_controller::Context for Context {
 
                 trace!("applying environment resources");
                 match resources
-                    .apply(&client, &self.config, increment_generation, &mz.namespace())
+                    .apply(
+                        &client,
+                        &self.config,
+                        increment_generation,
+                        mz.should_force_promote(),
+                        &mz.namespace(),
+                    )
                     .await
                 {
                     Ok(Some(action)) => {


### PR DESCRIPTION
### Motivation

this allows us to choose how to resolve a rollout which is stuck or taking too long - we can either cancel the rollout (by resetting the reconciliation_id to the last reconciliation id from the status) or now force it to complete by setting force_promote to the reconciliation_id value.

### Tips for reviewer

not planning on porting this to the environment controller since it we're so close to getting rid of it

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
