### PR TITLE
helm-chart: Bump orchestratord version automatically

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -64,7 +64,7 @@ cargo update --workspace
 
 bin/bazel gen
 
-bin/helm-chart-version-bump "v$version"
+bin/helm-chart-version-bump --bump-orchestratord-version "v$version"
 
 helm_docs_version=1.14.2
 if ! helm-docs --help > /dev/null; then

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1188,7 +1188,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: terraform
             run: aws-temporary
-      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed*"
+      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-aws-upgrade
       label: "Terraform + Helm Chart Upgrade on AWS"
@@ -1204,7 +1204,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: terraform
             run: aws-upgrade
-      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed*"
+      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-gcp
       label: "Terraform + Helm Chart E2E on GCP"
@@ -1219,7 +1219,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: terraform
             run: gcp-temporary
-      branches: "main v*.* lts-v* *gcp* *tf* *terraform* *helm* *self-managed*"
+      branches: "main v*.* lts-v* *gcp* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-azure
       label: "Terraform + Helm Chart E2E on Azure"
@@ -1234,7 +1234,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: terraform
             run: azure-temporary
-      branches: "main v*.* lts-v* *azure* *tf* *terraform* *helm* *self-managed*"
+      branches: "main v*.* lts-v* *azure* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
   - group: "Output consistency"
     key: output-consistency

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -143,7 +143,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.features.authentication` | Whether to enable environmentd rbac checks TODO: this is not yet supported in the helm chart | ``false`` |
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
-| `operator.image.tag` | The tag/version of the operator image to be used | ``"v0.141.0"`` |
+| `operator.image.tag` | The tag/version of the operator image to be used | ``"v0.141.2"`` |
 | `operator.nodeSelector` |  | ``{}`` |
 | `operator.resources.limits` | Resource limits for the operator's CPU and memory | ``{"memory":"512Mi"}`` |
 | `operator.resources.requests` | Resources requested by the operator for CPU and memory | ``{"cpu":"100m","memory":"512Mi"}`` |

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
       of: Deployment
   - equal:
       path: spec.template.spec.containers[0].image
-      value: materialize/orchestratord:v0.141.0
+      value: materialize/orchestratord:v0.141.2
   - equal:
       path: spec.template.spec.containers[0].imagePullPolicy
       value: IfNotPresent

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # -- The Docker repository for the operator image
     repository: materialize/orchestratord
     # -- The tag/version of the operator image to be used
-    tag: v0.141.0
+    tag: v0.141.2
     # -- Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
 

--- a/test/terraform/aws-persistent/main.tf
+++ b/test/terraform/aws-persistent/main.tf
@@ -21,6 +21,11 @@ variable "operator_version" {
   default = "v25.2.0-beta.1.tgz"
 }
 
+variable "orchestratord_version" {
+  type    = string
+  default = null
+}
+
 module "materialize_infrastructure" {
   source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.2.7"
 
@@ -31,6 +36,7 @@ module "materialize_infrastructure" {
   use_local_chart = true
   helm_chart = "materialize-operator-v25.2.0-beta.1.tgz"
   operator_version = var.operator_version
+  orchestratord_version = var.orchestratord_version
 
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"

--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -45,6 +45,11 @@ variable "operator_version" {
   default = "v25.2.0-beta.1.tgz"
 }
 
+variable "orchestratord_version" {
+  type    = string
+  default = null
+}
+
 module "materialize_infrastructure" {
   source = "git::https://github.com/MaterializeInc/terraform-aws-materialize.git?ref=v0.4.2"
 
@@ -64,6 +69,7 @@ module "materialize_infrastructure" {
   use_local_chart = true
   helm_chart = "materialize-operator-v25.2.0-beta.1.tgz"
   operator_version = var.operator_version
+  orchestratord_version = var.orchestratord_version
 
   install_cert_manager = false
   use_self_signed_cluster_issuer = false

--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -48,6 +48,11 @@ variable "operator_version" {
   default = "v25.2.0-beta.1.tgz"
 }
 
+variable "orchestratord_version" {
+  type    = string
+  default = null
+}
+
 resource "azurerm_resource_group" "materialize" {
   name     = "mz-tf-test-rg"
   location = "eastus2"
@@ -64,6 +69,7 @@ module "materialize" {
   use_local_chart = true
   helm_chart = "materialize-operator-v25.2.0-beta.1.tgz"
   operator_version = var.operator_version
+  orchestratord_version = var.orchestratord_version
 
   install_cert_manager = false
   use_self_signed_cluster_issuer = false

--- a/test/terraform/gcp-temporary/main.tf
+++ b/test/terraform/gcp-temporary/main.tf
@@ -75,6 +75,7 @@ module "materialize" {
   use_local_chart = true
   helm_chart = "materialize-operator-v25.2.0-beta.1.tgz"
   operator_version = var.operator_version
+  orchestratord_version = var.orchestratord_version
 
   install_cert_manager = false
   use_self_signed_cluster_issuer = false
@@ -119,6 +120,11 @@ variable "database_password" {
 variable "operator_version" {
   type    = string
   default = "v25.2.0-beta.1.tgz"
+}
+
+variable "orchestratord_version" {
+  type    = string
+  default = null
 }
 
 output "gke_cluster" {


### PR DESCRIPTION
Discussed in https://materializeinc.slack.com/archives/C07PN7KSB0T/p1743231538417009

Green test run: https://buildkite.com/materialize/nightly/builds/11816
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
