### PR TITLE
[sql_server] Support `TEXT COLUMNS` and  `EXCLUDE COLUMNS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7105,6 +7105,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "base64 0.13.1",
  "chrono",
  "columnation",
  "dec",

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1188,12 +1188,30 @@ pub enum SqlServerConfigOptionName {
     /// Hex encoded string of binary serialization of
     /// `mz_storage_types::sources::sql_server::SqlServerSourceDetails`.
     Details,
+    /// Columns whose types you want to unconditionally format as text.
+    ///
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
+    TextColumns,
+    /// Columns you want to exclude.
+    ///
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
+    ExcludeColumns,
 }
 
 impl AstDisplay for SqlServerConfigOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             SqlServerConfigOptionName::Details => "DETAILS",
+            SqlServerConfigOptionName::TextColumns => "TEXT COLUMNS",
+            SqlServerConfigOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
         })
     }
 }
@@ -1207,7 +1225,9 @@ impl WithOptionName for SqlServerConfigOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
-            SqlServerConfigOptionName::Details => false,
+            SqlServerConfigOptionName::Details
+            | SqlServerConfigOptionName::TextColumns
+            | SqlServerConfigOptionName::ExcludeColumns => false,
         }
     }
 }

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -15,6 +15,7 @@ name = "cdc"
 [dependencies]
 anyhow = "1.0.97"
 async-stream = "0.3.3"
+base64 = "0.13.1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 columnation = "0.1.0"
 dec = "0.4.8"

--- a/src/sql-server-util/src/desc.proto
+++ b/src/sql-server-util/src/desc.proto
@@ -25,6 +25,7 @@ message ProtoSqlServerTableDesc {
 message ProtoSqlServerColumnDesc {
   string name = 1;
   mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
+
   oneof decode_type {
     google.protobuf.Empty bool = 4;
     google.protobuf.Empty u8 = 5;
@@ -42,5 +43,6 @@ message ProtoSqlServerColumnDesc {
     google.protobuf.Empty naive_time = 17;
     google.protobuf.Empty date_time = 18;
     google.protobuf.Empty naive_date_time = 19;
+    string unsupported = 20;
   }
 }

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -202,7 +202,7 @@ impl SqlServerColumnDesc {
         }
     }
 
-    /// Returns if this column can be replicated into Materialize.
+    /// Returns true if this column can be replicated into Materialize.
     pub fn is_supported(&self) -> bool {
         !matches!(
             self.decode_type,

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -26,10 +26,11 @@ use dec::OrderedDecimal;
 use mz_ore::cast::CastFrom;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType};
 use mz_repr::adt::numeric::{Dec, Numeric, NumericMaxScale};
-use mz_repr::{ColumnType, Datum, RelationDesc, Row, ScalarType};
+use mz_repr::{ColumnType, Datum, RelationDesc, Row, RowArena, ScalarType};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::{SqlServerDecodeError, SqlServerError};
@@ -40,6 +41,11 @@ include!(concat!(env!("OUT_DIR"), "/mz_sql_server_util.rs"));
 ///
 /// See [`SqlServerTableRaw`] for the raw information we read from the upstream
 /// system.
+///
+/// Note: We map a [`SqlServerTableDesc`] to a Materialize [`RelationDesc`] as
+/// part of purification. Specifically we use this description to generate a
+/// SQL statement for subsource and it's the _parsing of that statement_ which
+/// actually generates a [`RelationDesc`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
 pub struct SqlServerTableDesc {
     /// Name of the schema that the table belongs to.
@@ -47,24 +53,53 @@ pub struct SqlServerTableDesc {
     /// Name of the table.
     pub name: Arc<str>,
     /// Columns for the table.
-    pub columns: Arc<[SqlServerColumnDesc]>,
+    pub columns: Box<[SqlServerColumnDesc]>,
 }
 
 impl SqlServerTableDesc {
-    /// Try creating a [`SqlServerTableDesc`] from a [`SqlServerTableRaw`] description.
+    /// Creating a [`SqlServerTableDesc`] from a [`SqlServerTableRaw`] description.
     ///
-    /// Returns an error if the raw table description is not compatible with Materialize.
-    pub fn try_new(raw: SqlServerTableRaw) -> Result<Self, SqlServerError> {
-        let columns: Arc<[_]> = raw
+    /// Note: Not all columns from SQL Server can be ingested into Materialize. To determine if a
+    /// column is supported see [`SqlServerColumnDesc::is_supported`].
+    pub fn new(raw: SqlServerTableRaw) -> Self {
+        let columns: Box<[_]> = raw
             .columns
             .into_iter()
-            .map(SqlServerColumnDesc::try_new)
-            .collect::<Result<_, _>>()?;
-        Ok(SqlServerTableDesc {
+            .map(SqlServerColumnDesc::new)
+            .collect();
+        SqlServerTableDesc {
             schema_name: raw.schema_name,
             name: raw.name,
             columns,
-        })
+        }
+    }
+
+    /// Returns the [`SqlServerQualifiedTableName`] for this [`SqlServerTableDesc`].
+    pub fn qualified_name(&self) -> SqlServerQualifiedTableName {
+        SqlServerQualifiedTableName {
+            schema_name: Arc::clone(&self.schema_name),
+            table_name: Arc::clone(&self.name),
+        }
+    }
+
+    /// Update this [`SqlServerTableDesc`] to represent the specified columns
+    /// as text in Materialize.
+    pub fn apply_text_columns(&mut self, text_columns: &BTreeSet<&str>) {
+        for column in &mut self.columns {
+            if text_columns.contains(column.name.as_ref()) {
+                column.represent_as_text();
+            }
+        }
+    }
+
+    /// Update this [`SqlServerTableDesc`] to exclude the specified columns from being
+    /// replicated into Materialize.
+    pub fn apply_excl_columns(&mut self, excl_columns: &BTreeSet<&str>) {
+        for column in &mut self.columns {
+            if excl_columns.contains(column.name.as_ref()) {
+                column.exclude();
+            }
+        }
     }
 
     /// Returns a [`SqlServerRowDecoder`] which can be used to decode [`tiberius::Row`]s into
@@ -98,6 +133,15 @@ impl RustType<ProtoSqlServerTableDesc> for SqlServerTableDesc {
     }
 }
 
+/// Partially qualified name of a table from Microsoft SQL Server.
+///
+/// TODO(sql_server3): Change this to use a &str.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SqlServerQualifiedTableName {
+    pub schema_name: Arc<str>,
+    pub table_name: Arc<str>,
+}
+
 /// Raw metadata for a table from Microsoft SQL Server.
 ///
 /// See [`SqlServerTableDesc`] for a refined description that is compatible
@@ -119,24 +163,64 @@ pub struct SqlServerTableRaw {
 pub struct SqlServerColumnDesc {
     /// Name of the column.
     pub name: Arc<str>,
-    /// The intended data type of the this column in Materialize.
-    pub column_type: ColumnType,
+    /// The intended data type of the this column in Materialize. `None` indicates this
+    /// column should be excluded when replicating into Materialize.
+    ///
+    /// Note: This type might differ from the `decode_type`, e.g. a user can
+    /// specify `TEXT COLUMNS` to decode columns as text.
+    pub column_type: Option<ColumnType>,
     /// Rust type we should parse the data from a [`tiberius::Row`] as.
     pub decode_type: SqlServerColumnDecodeType,
 }
 
 impl SqlServerColumnDesc {
-    /// Try creating a [`SqlServerColumnDesc`] from a [`SqlServerColumnRaw`] description.
-    ///
-    /// Returns an error if the upstream column is not compatible with Materialize, e.g. the
-    /// data type doesn't support CDC.
-    pub fn try_new(raw: &SqlServerColumnRaw) -> Result<Self, SqlServerError> {
-        let (scalar_type, decode_type) = parse_data_type(raw)?;
-        Ok(SqlServerColumnDesc {
+    /// Create a [`SqlServerColumnDesc`] from a [`SqlServerColumnRaw`] description.
+    pub fn new(raw: &SqlServerColumnRaw) -> Self {
+        let (column_type, decode_type) = match parse_data_type(raw) {
+            Ok((scalar_type, decode_type)) => {
+                let column_type = scalar_type.nullable(raw.is_nullable);
+                (Some(column_type), decode_type)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    ?raw,
+                    "found an unsupported data type when parsing raw data"
+                );
+                (
+                    None,
+                    SqlServerColumnDecodeType::Unsupported {
+                        context: err.reason,
+                    },
+                )
+            }
+        };
+        SqlServerColumnDesc {
             name: Arc::clone(&raw.name),
-            column_type: scalar_type.nullable(raw.is_nullable),
+            column_type,
             decode_type,
-        })
+        }
+    }
+
+    /// Returns if this column can be replicated into Materialize.
+    pub fn is_supported(&self) -> bool {
+        !matches!(
+            self.decode_type,
+            SqlServerColumnDecodeType::Unsupported { .. }
+        )
+    }
+
+    /// Change this [`SqlServerColumnDesc`] to be represented as text in Materialize.
+    pub fn represent_as_text(&mut self) {
+        self.column_type = self
+            .column_type
+            .as_ref()
+            .map(|ct| ScalarType::String.nullable(ct.nullable));
+    }
+
+    /// Exclude this [`SqlServerColumnDesc`] from being replicated into Materialize.
+    pub fn exclude(&mut self) {
+        self.column_type = None;
     }
 }
 
@@ -144,7 +228,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
     fn into_proto(&self) -> ProtoSqlServerColumnDesc {
         ProtoSqlServerColumnDesc {
             name: self.name.to_string(),
-            column_type: Some(self.column_type.into_proto()),
+            column_type: self.column_type.into_proto(),
             decode_type: Some(self.decode_type.into_proto()),
         }
     }
@@ -152,14 +236,21 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
     fn from_proto(proto: ProtoSqlServerColumnDesc) -> Result<Self, mz_proto::TryFromProtoError> {
         Ok(SqlServerColumnDesc {
             name: proto.name.into(),
-            column_type: proto
-                .column_type
-                .into_rust_if_some("ProtoSqlServerColumnDesc::column_type")?,
+            column_type: proto.column_type.into_rust()?,
             decode_type: proto
                 .decode_type
                 .into_rust_if_some("ProtoSqlServerColumnDesc::decode_type")?,
         })
     }
+}
+
+/// The raw datatype from SQL Server is not supported in Materialize.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct UnsupportedDataType {
+    column_name: String,
+    column_type: String,
+    reason: String,
 }
 
 /// Parse a raw data type from SQL Server into a Materialize [`ScalarType`].
@@ -168,7 +259,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
 /// that we use to decode the raw value.
 fn parse_data_type(
     raw: &SqlServerColumnRaw,
-) -> Result<(ScalarType, SqlServerColumnDecodeType), SqlServerError> {
+) -> Result<(ScalarType, SqlServerColumnDecodeType), UnsupportedDataType> {
     let scalar = match raw.data_type.to_lowercase().as_str() {
         "tinyint" => (ScalarType::Int16, SqlServerColumnDecodeType::U8),
         "smallint" => (ScalarType::Int16, SqlServerColumnDecodeType::I16),
@@ -194,7 +285,7 @@ fn parse_data_type(
                     "precision of {} is greater than our maximum of 39",
                     raw.precision
                 );
-                return Err(SqlServerError::UnsupportedDataType {
+                return Err(UnsupportedDataType {
                     column_name: raw.name.to_string(),
                     column_type: raw.data_type.to_string(),
                     reason,
@@ -202,13 +293,12 @@ fn parse_data_type(
             }
 
             let raw_scale = usize::cast_from(raw.scale);
-            let max_scale = NumericMaxScale::try_from(raw_scale).map_err(|_| {
-                SqlServerError::UnsupportedDataType {
+            let max_scale =
+                NumericMaxScale::try_from(raw_scale).map_err(|_| UnsupportedDataType {
                     column_type: raw.data_type.to_string(),
                     column_name: raw.name.to_string(),
                     reason: format!("scale of {} is too large", raw.scale),
-                }
-            })?;
+                })?;
             let column_type = ScalarType::Numeric {
                 max_scale: Some(max_scale),
             };
@@ -223,7 +313,7 @@ fn parse_data_type(
             //
             // TODO(sql_server3): Support UPSERT semantics for SQL Server.
             if raw.max_length == -1 {
-                return Err(SqlServerError::UnsupportedDataType {
+                return Err(UnsupportedDataType {
                     column_name: raw.name.to_string(),
                     column_type: raw.data_type.to_string(),
                     reason: "columns with unlimited size do not support CDC".to_string(),
@@ -238,7 +328,7 @@ fn parse_data_type(
             mz_ore::soft_assert_eq_no_log!(raw.max_length, 16);
 
             // TODO(sql_server3): Support UPSERT semantics for SQL Server.
-            return Err(SqlServerError::UnsupportedDataType {
+            return Err(UnsupportedDataType {
                 column_name: raw.name.to_string(),
                 column_type: raw.data_type.to_string(),
                 reason: "columns with unlimited size do not support CDC".to_string(),
@@ -250,7 +340,7 @@ fn parse_data_type(
             //
             // TODO(sql_server3): Support UPSERT semantics for SQL Server.
             if raw.max_length == -1 {
-                return Err(SqlServerError::UnsupportedDataType {
+                return Err(UnsupportedDataType {
                     column_name: raw.name.to_string(),
                     column_type: raw.data_type.to_string(),
                     reason: "columns with unlimited size do not support CDC".to_string(),
@@ -265,7 +355,7 @@ fn parse_data_type(
             //
             // TODO(sql_server3): Support UPSERT semantics for SQL Server.
             if raw.max_length == -1 {
-                return Err(SqlServerError::UnsupportedDataType {
+                return Err(UnsupportedDataType {
                     column_name: raw.name.to_string(),
                     column_type: raw.data_type.to_string(),
                     reason: "columns with unlimited size do not support CDC".to_string(),
@@ -290,10 +380,10 @@ fn parse_data_type(
         "uniqueidentifier" => (ScalarType::Uuid, SqlServerColumnDecodeType::Uuid),
         // TODO(sql_server1): Support more data types.
         other => {
-            return Err(SqlServerError::UnsupportedDataType {
+            return Err(UnsupportedDataType {
                 column_type: other.to_string(),
                 column_name: raw.name.to_string(),
-                reason: "unimplemented".to_string(),
+                reason: format!("'{other}' is unimplemented"),
             });
         }
     };
@@ -328,7 +418,7 @@ pub struct SqlServerColumnRaw {
 }
 
 /// Rust type that we should use when reading a column from SQL Server.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
 pub enum SqlServerColumnDecodeType {
     Bool,
     U8,
@@ -353,15 +443,21 @@ pub enum SqlServerColumnDecodeType {
     DateTime,
     /// [`chrono::NaiveDateTime`].
     NaiveDateTime,
+    /// Decoding this type isn't supported.
+    Unsupported {
+        /// Any additional context as to why this type isn't supported.
+        context: String,
+    },
 }
 
 impl SqlServerColumnDecodeType {
     /// Decode the column with `name` out of the provided `data`.
     pub fn decode<'a>(
-        self,
+        &self,
         data: &'a tiberius::Row,
         name: &'a str,
         column: &'a ColumnType,
+        arena: &'a RowArena,
     ) -> Result<Datum<'a>, SqlServerDecodeError> {
         let maybe_datum = match (&column.scalar_type, self) {
             (ScalarType::Bool, SqlServerColumnDecodeType::Bool) => data
@@ -458,9 +554,99 @@ impl SqlServerColumnDecodeType {
                     Ok::<_, SqlServerDecodeError>(Datum::TimestampTz(ts))
                 })
                 .transpose()?,
+            // We support mapping any type to a string.
+            (ScalarType::String, SqlServerColumnDecodeType::Bool) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "bool-text"))?
+                .map(|val: bool| {
+                    if val {
+                        Datum::String("true")
+                    } else {
+                        Datum::String("false")
+                    }
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::U8) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "u8-text"))?
+                .map(|val: u8| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::I16) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "i16-text"))?
+                .map(|val: i16| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::I32) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "i32-text"))?
+                .map(|val: i32| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::I64) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "i64-text"))?
+                .map(|val: i64| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::F32) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "f32-text"))?
+                .map(|val: f32| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::F64) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "f64-text"))?
+                .map(|val: f64| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::Uuid) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "uuid-text"))?
+                .map(|val: uuid::Uuid| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::Bytes) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "bytes-text"))?
+                .map(|val: &[u8]| {
+                    let encoded = base64::encode(val);
+                    arena.make_datum(|packer| packer.push(Datum::String(&encoded)))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::Numeric) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "numeric-text"))?
+                .map(|val: tiberius::numeric::Numeric| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::NaiveDate) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "naivedate-text"))?
+                .map(|val: chrono::NaiveDate| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::NaiveTime) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "naivetime-text"))?
+                .map(|val: chrono::NaiveTime| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::DateTime) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "datetime-text"))?
+                .map(|val: chrono::DateTime<chrono::Utc>| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
+            (ScalarType::String, SqlServerColumnDecodeType::NaiveDateTime) => data
+                .try_get(name)
+                .map_err(|_| SqlServerDecodeError::invalid_column(name, "naivedatetime-text"))?
+                .map(|val: chrono::NaiveDateTime| {
+                    arena.make_datum(|packer| packer.push(Datum::String(&val.to_string())))
+                }),
             (column_type, decode_type) => {
                 return Err(SqlServerDecodeError::Unsupported {
-                    sql_server_type: decode_type,
+                    sql_server_type: decode_type.clone(),
                     mz_type: column_type.clone(),
                 });
             }
@@ -509,6 +695,9 @@ impl RustType<proto_sql_server_column_desc::DecodeType> for SqlServerColumnDecod
             SqlServerColumnDecodeType::NaiveDateTime => {
                 proto_sql_server_column_desc::DecodeType::NaiveDateTime(())
             }
+            SqlServerColumnDecodeType::Unsupported { context } => {
+                proto_sql_server_column_desc::DecodeType::Unsupported(context.clone())
+            }
         }
     }
 
@@ -543,6 +732,9 @@ impl RustType<proto_sql_server_column_desc::DecodeType> for SqlServerColumnDecod
             }
             proto_sql_server_column_desc::DecodeType::NaiveDateTime(()) => {
                 SqlServerColumnDecodeType::NaiveDateTime
+            }
+            proto_sql_server_column_desc::DecodeType::Unsupported(context) => {
+                SqlServerColumnDecodeType::Unsupported { context }
             }
         };
         Ok(val)
@@ -582,7 +774,7 @@ impl SqlServerRowDecoder {
                 //
                 // TODO(sql_server2): Maybe allow the Materialize column type to be more nullable
                 // than our decoding type?
-                if &sql_server_col.column_type != col_type {
+                if sql_server_col.column_type.as_ref() != Some(col_type) {
                     return Err(SqlServerError::ProgrammingError(format!(
                         "programming error, {col_name} has mismatched type {:?} vs {:?}",
                         sql_server_col.column_type, col_type
@@ -590,7 +782,7 @@ impl SqlServerRowDecoder {
                 }
 
                 let name = Arc::clone(&sql_server_col.name);
-                let decoder = sql_server_col.decode_type;
+                let decoder = sql_server_col.decode_type.clone();
 
                 Ok::<_, SqlServerError>((name, col_type.clone(), decoder))
             })
@@ -600,10 +792,15 @@ impl SqlServerRowDecoder {
     }
 
     /// Decode data from the provided [`tiberius::Row`] into the provided [`Row`].
-    pub fn decode(&self, data: &tiberius::Row, row: &mut Row) -> Result<(), SqlServerDecodeError> {
+    pub fn decode(
+        &self,
+        data: &tiberius::Row,
+        row: &mut Row,
+        arena: &RowArena,
+    ) -> Result<(), SqlServerDecodeError> {
         let mut packer = row.packer();
         for (col_name, col_type, decoder) in &self.decoders {
-            let datum = decoder.decode(data, col_name, col_type)?;
+            let datum = decoder.decode(data, col_name, col_type, arena)?;
             packer.push(datum);
         }
         Ok(())
@@ -612,14 +809,17 @@ impl SqlServerRowDecoder {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use crate::desc::{
         SqlServerColumnDecodeType, SqlServerColumnDesc, SqlServerTableDesc, SqlServerTableRaw,
     };
 
     use super::SqlServerColumnRaw;
     use mz_ore::assert_contains;
+    use mz_ore::collections::CollectionExt;
     use mz_repr::adt::numeric::NumericMaxScale;
-    use mz_repr::{Datum, RelationDesc, Row, ScalarType};
+    use mz_repr::{Datum, RelationDesc, Row, RowArena, ScalarType};
     use tiberius::RowTestExt;
 
     impl SqlServerColumnRaw {
@@ -660,46 +860,46 @@ mod tests {
     #[mz_ore::test]
     fn smoketest_column_raw() {
         let raw = SqlServerColumnRaw::new("foo", "bit");
-        let col = SqlServerColumnDesc::try_new(&raw).unwrap();
+        let col = SqlServerColumnDesc::new(&raw);
 
         assert_eq!(&*col.name, "foo");
-        assert_eq!(col.column_type, ScalarType::Bool.nullable(false));
+        assert_eq!(col.column_type, Some(ScalarType::Bool.nullable(false)));
         assert_eq!(col.decode_type, SqlServerColumnDecodeType::Bool);
 
         let raw = SqlServerColumnRaw::new("foo", "decimal")
             .precision(20)
             .scale(10);
-        let col = SqlServerColumnDesc::try_new(&raw).unwrap();
+        let col = SqlServerColumnDesc::new(&raw);
 
         let col_type = ScalarType::Numeric {
             max_scale: Some(NumericMaxScale::try_from(10i64).expect("known valid")),
         }
         .nullable(false);
-        assert_eq!(col.column_type, col_type);
+        assert_eq!(col.column_type, Some(col_type));
         assert_eq!(col.decode_type, SqlServerColumnDecodeType::Numeric);
     }
 
     #[mz_ore::test]
     fn smoketest_column_raw_invalid() {
         let raw = SqlServerColumnRaw::new("foo", "bad_data_type");
-        let err = SqlServerColumnDesc::try_new(&raw).unwrap_err();
-        assert_contains!(err.to_string(), "'bad_data_type' from column 'foo'");
+        let desc = SqlServerColumnDesc::new(&raw);
+        let SqlServerColumnDecodeType::Unsupported { context } = desc.decode_type else {
+            panic!("unexpected decode type {desc:?}");
+        };
+        assert_contains!(context, "'bad_data_type' is unimplemented");
 
         let raw = SqlServerColumnRaw::new("foo", "decimal")
             .precision(100)
             .scale(10);
-        let err = SqlServerColumnDesc::try_new(&raw).unwrap_err();
-        assert_contains!(
-            err.to_string(),
-            "precision of 100 is greater than our maximum of 39"
-        );
+        let desc = SqlServerColumnDesc::new(&raw);
+        assert!(!desc.is_supported());
 
         let raw = SqlServerColumnRaw::new("foo", "varchar").max_length(-1);
-        let err = SqlServerColumnDesc::try_new(&raw).unwrap_err();
-        assert_contains!(
-            err.to_string(),
-            "columns with unlimited size do not support CDC"
-        );
+        let desc = SqlServerColumnDesc::new(&raw);
+        let SqlServerColumnDecodeType::Unsupported { context } = desc.decode_type else {
+            panic!("unexpected decode type {desc:?}");
+        };
+        assert_contains!(context, "columns with unlimited size do not support CDC");
     }
 
     #[mz_ore::test]
@@ -715,7 +915,7 @@ mod tests {
             capture_instance: "my_table_CT".into(),
             columns: sql_server_columns.into(),
         };
-        let sql_server_desc = SqlServerTableDesc::try_new(sql_server_desc).expect("known valid");
+        let sql_server_desc = SqlServerTableDesc::new(sql_server_desc);
 
         let relation_desc = RelationDesc::builder()
             .with_column("a", ScalarType::String.nullable(false))
@@ -752,17 +952,82 @@ mod tests {
             tiberius::Row::build(sql_server_columns.into_iter().zip(data_b.into_iter()));
 
         let mut rnd_row = Row::default();
-        decoder.decode(&sql_server_row_a, &mut rnd_row).unwrap();
+        let arena = RowArena::default();
+
+        decoder
+            .decode(&sql_server_row_a, &mut rnd_row, &arena)
+            .unwrap();
         assert_eq!(
             &rnd_row,
             &Row::pack_slice(&[Datum::String("hello world"), Datum::True, Datum::Int32(42)])
         );
 
-        decoder.decode(&sql_server_row_b, &mut rnd_row).unwrap();
+        decoder
+            .decode(&sql_server_row_b, &mut rnd_row, &arena)
+            .unwrap();
         assert_eq!(
             &rnd_row,
             &Row::pack_slice(&[Datum::String("foo bar"), Datum::False, Datum::Null])
         );
+    }
+
+    #[mz_ore::test]
+    fn smoketest_decode_to_string() {
+        #[track_caller]
+        fn testcase(
+            data_type: &'static str,
+            col_type: tiberius::ColumnType,
+            col_data: tiberius::ColumnData<'static>,
+        ) {
+            let columns = [SqlServerColumnRaw::new("a", data_type)];
+            let sql_server_desc = SqlServerTableRaw {
+                schema_name: "my_schema".into(),
+                name: "my_table".into(),
+                capture_instance: "my_table_CT".into(),
+                columns: columns.into(),
+            };
+            let mut sql_server_desc = SqlServerTableDesc::new(sql_server_desc);
+            sql_server_desc.apply_text_columns(&BTreeSet::from(["a"]));
+
+            // We should support decoding every datatype to a string.
+            let relation_desc = RelationDesc::builder()
+                .with_column("a", ScalarType::String.nullable(false))
+                .finish();
+
+            // This decoder should shape the SQL Server Rows into Rows compatible with the RelationDesc.
+            let decoder = sql_server_desc
+                .decoder(&relation_desc)
+                .expect("known valid");
+
+            let sql_server_row = tiberius::Row::build([(
+                tiberius::Column::new("a".to_string(), col_type),
+                col_data,
+            )]);
+            let mut mz_row = Row::default();
+            let arena = RowArena::new();
+            decoder
+                .decode(&sql_server_row, &mut mz_row, &arena)
+                .unwrap();
+
+            let str_datum = mz_row.into_element();
+            assert!(matches!(str_datum, Datum::String(_)));
+        }
+
+        use tiberius::{ColumnData, ColumnType};
+
+        testcase("bit", ColumnType::Bit, ColumnData::Bit(Some(true)));
+        testcase("bit", ColumnType::Bit, ColumnData::Bit(Some(false)));
+        testcase("tinyint", ColumnType::Int1, ColumnData::U8(Some(33)));
+        testcase("smallint", ColumnType::Int2, ColumnData::I16(Some(101)));
+        testcase("int", ColumnType::Int4, ColumnData::I32(Some(-42)));
+        {
+            let datetime = tiberius::time::DateTime::new(10, 300);
+            testcase(
+                "datetime",
+                ColumnType::Datetime,
+                ColumnData::DateTime(Some(datetime)),
+            );
+        }
     }
 
     // TODO(sql_server2): Proptest the decoder.

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -749,12 +749,6 @@ pub enum SqlServerError {
     CdcError(#[from] crate::cdc::CdcError),
     #[error("expected column '{0}' to be present")]
     MissingColumn(&'static str),
-    #[error("'{column_type}' from column '{column_name}' is not supported: {reason}")]
-    UnsupportedDataType {
-        column_name: String,
-        column_type: String,
-        reason: String,
-    },
     #[error("sql server client encountered I/O error: {0}")]
     IO(#[from] tokio::io::Error),
     #[error("found invalid data in the column '{column_name}': {error}")]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -533,7 +533,12 @@ generate_extracted_config!(
     (ExcludeColumns, Vec::<UnresolvedItemName>, Default(vec![]))
 );
 
-generate_extracted_config!(SqlServerConfigOption, (Details, String));
+generate_extracted_config!(
+    SqlServerConfigOption,
+    (Details, String),
+    (TextColumns, Vec::<UnresolvedItemName>, Default(vec![])),
+    (ExcludeColumns, Vec::<UnresolvedItemName>, Default(vec![]))
+);
 
 pub fn plan_create_webhook_source(
     scx: &StatementContext,
@@ -1621,16 +1626,15 @@ pub fn plan_create_subsource(
             SourceExportStatementDetails::SqlServer {
                 table,
                 capture_instance,
-            } => {
-                SourceExportDetails::SqlServer(SqlServerSourceExportDetails {
-                    capture_instance,
-                    table,
-                    // TODO(sql_server1): Support text columns.
-                    text_columns: Vec::default(),
-                    // TODO(sql_server1): Support exclude columns.
-                    exclude_columns: Vec::default(),
-                })
-            }
+            } => SourceExportDetails::SqlServer(SqlServerSourceExportDetails {
+                capture_instance,
+                table,
+                text_columns: text_columns.into_iter().map(|c| c.into_string()).collect(),
+                exclude_columns: exclude_columns
+                    .into_iter()
+                    .map(|c| c.into_string())
+                    .collect(),
+            }),
             SourceExportStatementDetails::LoadGenerator { output } => {
                 SourceExportDetails::LoadGenerator(LoadGeneratorSourceExportDetails { output })
             }
@@ -1774,16 +1778,15 @@ pub fn plan_create_table_from_source(
         SourceExportStatementDetails::SqlServer {
             table,
             capture_instance,
-        } => {
-            SourceExportDetails::SqlServer(SqlServerSourceExportDetails {
-                table,
-                capture_instance,
-                // TODO(sql_server1): Support text columns.
-                text_columns: Vec::default(),
-                // TODO(sql_server1): Support exclude columns.
-                exclude_columns: Vec::default(),
-            })
-        }
+        } => SourceExportDetails::SqlServer(SqlServerSourceExportDetails {
+            table,
+            capture_instance,
+            text_columns: text_columns.into_iter().map(|c| c.into_string()).collect(),
+            exclude_columns: exclude_columns
+                .into_iter()
+                .map(|c| c.into_string())
+                .collect(),
+        }),
         SourceExportStatementDetails::LoadGenerator { output } => {
             SourceExportDetails::LoadGenerator(LoadGeneratorSourceExportDetails { output })
         }

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -362,10 +362,21 @@ pub enum SqlServerSourcePurificationError {
     NotSqlServerConnection(FullItemName),
     #[error("CREATE SOURCE specifies DETAILS option")]
     UserSpecifiedDetails,
+    #[error("{0} option is unnecessary when no tables are added")]
+    UnnecessaryOptionsWithoutReferences(String),
     #[error("Invalid SQL Server system replication settings")]
     ReplicationSettingsError(Vec<(String, String, String)>),
     #[error("missing TABLES specification")]
     RequiresExternalReferences,
+    #[error("{option_name} refers to table not currently being added")]
+    DanglingColumns {
+        option_name: String,
+        items: Vec<UnresolvedItemName>,
+    },
+    #[error("No tables found for provided reference")]
+    NoTables,
+    #[error("programming error: {0}")]
+    ProgrammingError(String),
 }
 
 impl SqlServerSourcePurificationError {
@@ -381,6 +392,13 @@ impl SqlServerSourcePurificationError {
                     "; "
                 )
             )),
+            Self::DanglingColumns {
+                option_name: _,
+                items,
+            } => Some(format!(
+                "the following columns are referenced but not added: {}",
+                itertools::join(items, ", ")
+            )),
             _ => None,
         }
     }
@@ -390,6 +408,15 @@ impl SqlServerSourcePurificationError {
             Self::RequiresExternalReferences => {
                 Some("provide a FOR TABLES (..), FOR SCHEMAS (..), or FOR ALL TABLES clause".into())
             }
+            Self::UnnecessaryOptionsWithoutReferences(option) => Some(format!(
+                "Remove the {} option, as no tables are being added.",
+                option
+            )),
+            Self::NoTables => Some(
+                "No tables were found to replicate. This could be because \
+                the user does not have privileges on the intended tables."
+                    .into(),
+            ),
             _ => None,
         }
     }

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use mz_ore::now::SYSTEM_TIME;
 use mz_repr::RelationDesc;
 use mz_sql_parser::ast::{ExternalReferences, Ident, IdentError, UnresolvedItemName};
-use mz_sql_server_util::SqlServerError;
 use mz_storage_types::sources::load_generator::{LoadGenerator, LoadGeneratorOutput};
 use mz_storage_types::sources::{ExternalReferenceResolutionError, SourceReferenceResolver};
 
@@ -264,14 +263,14 @@ impl<'a> SourceReferenceClient<'a> {
                     .map(|raw| {
                         let capture_instance = Arc::clone(&raw.capture_instance);
                         let database = Arc::clone(database);
-                        let table = mz_sql_server_util::desc::SqlServerTableDesc::try_new(raw)?;
-                        Ok::<_, SqlServerError>(ReferenceMetadata::SqlServer {
+                        let table = mz_sql_server_util::desc::SqlServerTableDesc::new(raw);
+                        ReferenceMetadata::SqlServer {
                             table,
                             database,
                             capture_instance,
-                        })
+                        }
                     })
-                    .collect::<Result<_, _>>()?
+                    .collect()
             }
             SourceReferenceClient::Kafka { topic } => {
                 vec![ReferenceMetadata::Kafka(topic.to_string())]

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -98,6 +98,8 @@ pub(super) async fn purify_source_exports(
         }
     };
 
+    // TODO(sql_server2): Should we check if these have overlapping columns?
+    // What do our other sources do?
     let text_cols_map = map_column_refs(text_columns, SqlServerConfigOptionName::TextColumns)?;
     let excl_cols_map = map_column_refs(excl_columns, SqlServerConfigOptionName::ExcludeColumns)?;
 
@@ -144,6 +146,8 @@ pub(super) async fn purify_source_exports(
             if let Some(text_cols) = maybe_text_cols {
                 table.apply_text_columns(text_cols);
             }
+            // TODO(sql_server2): Should we prevent excluding all columns? What do our other
+            // sources do?
             if let Some(excl_cols) = maybe_excl_cols {
                 table.apply_excl_columns(excl_cols);
             }

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -7,37 +7,57 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use mz_proto::RustType;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement,
-    ExternalReferences, Ident, UnresolvedItemName, Value, WithOptionValue,
+    ExternalReferences, Ident, SqlServerConfigOptionName, UnresolvedItemName, Value,
+    WithOptionValue,
 };
-use mz_storage_types::sources::SourceExportStatementDetails;
+use mz_sql_server_util::desc::{SqlServerQualifiedTableName, SqlServerTableDesc};
+use mz_storage_types::sources::{SourceExportStatementDetails, SourceReferenceResolver};
 use prost::Message;
 
 use crate::names::{Aug, ResolvedItemName};
 use crate::plan::{PlanError, StatementContext};
 use crate::pure::{
-    PurifiedExportDetails, PurifiedSourceExport, RetrievedSourceReferences, SourceReferencePolicy,
-    SqlServerSourcePurificationError,
+    PurifiedExportDetails, PurifiedSourceExport, RequestedSourceExport, RetrievedSourceReferences,
+    SourceReferencePolicy, SqlServerSourcePurificationError,
 };
+
+pub(super) struct PurifiedSourceExports {
+    /// Map of source export names to details of the export.
+    pub(super) source_exports: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
+    /// Normalized list of columns that we'll decode as text.
+    ///
+    /// Note: Each source export (i.e. subsource) also tracks which of its
+    /// columns we decode as text, but we also return this normalized list so
+    /// we can roundtrip a `CREATE SOURCE` statement.
+    pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
+    /// Normalized list of columns that we'll exclude.
+    ///
+    /// Note: Each source export (i.e. subsource) also tracks which of its
+    /// columns we should exlude, but we also return this normalized list so
+    /// we can roundtrip a `CREATE SOURCE` statement.
+    pub(super) normalized_excl_columns: Vec<WithOptionValue<Aug>>,
+}
 
 /// Purify the requested [`ExternalReferences`] from the provided
 /// [`RetrievedSourceReferences`].
 #[allow(clippy::unused_async)]
 pub(super) async fn purify_source_exports(
+    database: &str,
     _client: &mut mz_sql_server_util::Client,
     retrieved_references: &RetrievedSourceReferences,
     requested_references: &Option<ExternalReferences>,
-    _text_columns: &[UnresolvedItemName],
-    _exclude_columns: &[UnresolvedItemName],
+    text_columns: &[UnresolvedItemName],
+    excl_columns: &[UnresolvedItemName],
     unresolved_source_name: &UnresolvedItemName,
     reference_policy: &SourceReferencePolicy,
-) -> Result<BTreeMap<UnresolvedItemName, PurifiedSourceExport>, PlanError> {
+) -> Result<PurifiedSourceExports, PlanError> {
     let requested_exports = match requested_references.as_ref() {
         Some(requested) => {
             if *reference_policy == SourceReferencePolicy::NotAllowed {
@@ -53,13 +73,33 @@ pub(super) async fn purify_source_exports(
                 return Err(SqlServerSourcePurificationError::RequiresExternalReferences.into());
             }
 
-            // TODO(sql_server1): Check text columns and exclude columns here.
-            // If source references are empty it doesn't make sense to have
-            // those specified.
+            // If no external reference is specified, it does not make sense to include
+            // or text or exclude columns.
+            if !text_columns.is_empty() {
+                Err(
+                    SqlServerSourcePurificationError::UnnecessaryOptionsWithoutReferences(
+                        "TEXT COLUMNS".to_string(),
+                    ),
+                )?
+            }
+            if !excl_columns.is_empty() {
+                Err(
+                    SqlServerSourcePurificationError::UnnecessaryOptionsWithoutReferences(
+                        "EXCLUDE COLUMNS".to_string(),
+                    ),
+                )?
+            }
 
-            return Ok(BTreeMap::default());
+            return Ok(PurifiedSourceExports {
+                source_exports: BTreeMap::default(),
+                normalized_text_columns: Vec::default(),
+                normalized_excl_columns: Vec::default(),
+            });
         }
     };
+
+    let text_cols_map = map_column_refs(text_columns, SqlServerConfigOptionName::TextColumns)?;
+    let excl_cols_map = map_column_refs(excl_columns, SqlServerConfigOptionName::ExcludeColumns)?;
 
     if requested_exports.is_empty() {
         sql_bail!(
@@ -71,34 +111,107 @@ pub(super) async fn purify_source_exports(
         )
     }
 
-    // TODO(sql_server1): Handle text and exclude columns.
     // TODO(sql_server1): Validate permissions on upstream tables.
 
-    let exports = requested_exports
-        .into_iter()
+    let capture_instances: BTreeMap<_, _> = requested_exports
+        .iter()
         .map(|requested| {
             let table = requested
                 .meta
                 .sql_server_table()
-                .expect("sql server source")
-                .clone();
+                .expect("sql server source");
             let capture_instance = requested
                 .meta
                 .sql_server_capture_instance()
                 .expect("sql server source");
+
+            (table.qualified_name(), Arc::clone(capture_instance))
+        })
+        .collect();
+
+    let tables: Vec<_> = requested_exports
+        .into_iter()
+        .map(|requested| {
+            let mut table = requested
+                .meta
+                .sql_server_table()
+                .expect("sql server source")
+                .clone();
+
+            let maybe_text_cols = text_cols_map.get(&table.qualified_name());
+            let maybe_excl_cols = excl_cols_map.get(&table.qualified_name());
+
+            if let Some(text_cols) = maybe_text_cols {
+                table.apply_text_columns(text_cols);
+            }
+            if let Some(excl_cols) = maybe_excl_cols {
+                table.apply_excl_columns(excl_cols);
+            }
+
+            requested.change_meta(table)
+        })
+        .collect();
+
+    if tables.is_empty() {
+        Err(SqlServerSourcePurificationError::NoTables)?;
+    }
+
+    let reference_resolver = SourceReferenceResolver::new(
+        database,
+        &tables.iter().map(|r| &r.meta).collect::<Vec<_>>(),
+    )?;
+
+    // Normalize column options and remove unused column references.
+    let normalized_text_columns = normalize_column_refs(
+        text_columns,
+        &reference_resolver,
+        &tables,
+        SqlServerConfigOptionName::TextColumns,
+    )?;
+    let normalized_excl_columns = normalize_column_refs(
+        excl_columns,
+        &reference_resolver,
+        &tables,
+        SqlServerConfigOptionName::ExcludeColumns,
+    )?;
+
+    let exports = tables
+        .into_iter()
+        .map(|reference| {
+            let table_reference = reference.meta.qualified_name();
+            let text_columns = text_cols_map.get(&table_reference).map(|cols| {
+                cols.iter()
+                    .map(|c| Ident::new(*c).expect("validated above"))
+                    .collect()
+            });
+            let excl_columns = excl_cols_map.get(&table_reference).map(|cols| {
+                cols.iter()
+                    .map(|c| Ident::new(*c).expect("validated above"))
+                    .collect()
+            });
+            let capture_instance = capture_instances
+                .get(&reference.meta.qualified_name())
+                .expect("capture instance should exist");
+
             let export = PurifiedSourceExport {
-                external_reference: requested.external_reference,
+                external_reference: reference.external_reference,
                 details: PurifiedExportDetails::SqlServer {
-                    table,
+                    table: reference.meta,
+                    text_columns,
+                    excl_columns,
                     capture_instance: Arc::clone(capture_instance),
                 },
             };
 
-            (requested.name, export)
+            (reference.name, export)
         })
         .collect();
 
-    Ok(exports)
+    Ok(PurifiedSourceExports {
+        source_exports: exports,
+        normalized_text_columns,
+        normalized_excl_columns,
+    })
 }
 
 pub fn generate_create_subsource_statements(
@@ -111,11 +224,13 @@ pub fn generate_create_subsource_statements(
     for (subsource_name, purified_export) in requested_subsources {
         let SqlServerExportStatementValues {
             columns,
+            text_columns,
+            excl_columns,
             details,
             external_reference,
         } = generate_source_export_statement_values(scx, purified_export)?;
 
-        let with_options = vec![
+        let mut with_options = vec![
             CreateSubsourceOption {
                 name: CreateSubsourceOptionName::ExternalReference,
                 value: Some(WithOptionValue::UnresolvedItemName(external_reference)),
@@ -128,11 +243,25 @@ pub fn generate_create_subsource_statements(
             },
         ];
 
+        if let Some(text_columns) = text_columns {
+            with_options.push(CreateSubsourceOption {
+                name: CreateSubsourceOptionName::TextColumns,
+                value: Some(WithOptionValue::Sequence(text_columns)),
+            });
+        }
+        if let Some(excl_columns) = excl_columns {
+            with_options.push(CreateSubsourceOption {
+                name: CreateSubsourceOptionName::ExcludeColumns,
+                value: Some(WithOptionValue::Sequence(excl_columns)),
+            });
+        }
+
         // Create the subsource statement
         let subsource = CreateSubsourceStatement {
             name: subsource_name,
             columns,
             of_source: Some(source_name.clone()),
+            // TODO(sql_server2): Support contraints from the upstream SQL Server instasnce.
             constraints: vec![],
             if_not_exists: false,
             with_options,
@@ -145,6 +274,8 @@ pub fn generate_create_subsource_statements(
 
 struct SqlServerExportStatementValues {
     pub columns: Vec<ColumnDef<Aug>>,
+    pub text_columns: Option<Vec<WithOptionValue<Aug>>>,
+    pub excl_columns: Option<Vec<WithOptionValue<Aug>>>,
     pub details: SourceExportStatementDetails,
     pub external_reference: UnresolvedItemName,
 }
@@ -155,26 +286,34 @@ fn generate_source_export_statement_values(
 ) -> Result<SqlServerExportStatementValues, PlanError> {
     let PurifiedExportDetails::SqlServer {
         table,
+        text_columns,
+        excl_columns,
         capture_instance,
     } = purified_export.details
     else {
         unreachable!("purified export details must be SQL Server")
     };
 
-    let mut columns = vec![];
-    for c in table.columns.iter() {
-        let name = Ident::new(c.name.as_ref())?;
-        let ty = mz_pgrepr::Type::from(&c.column_type.scalar_type);
+    // Filter out columns that the user wanted to exclude.
+    let included_columns = table
+        .columns
+        .iter()
+        .filter_map(|c| c.column_type.as_ref().map(|ct| (c.name.as_ref(), ct)));
+    let mut column_defs = vec![];
+
+    for (col_name, col_type) in included_columns {
+        let name = Ident::new(col_name)?;
+        let ty = mz_pgrepr::Type::from(&col_type.scalar_type);
         let data_type = scx.resolve_type(ty)?;
         let mut col_options = vec![];
 
-        if !c.column_type.nullable {
+        if !col_type.nullable {
             col_options.push(mz_sql_parser::ast::ColumnOptionDef {
                 name: None,
                 option: mz_sql_parser::ast::ColumnOption::NotNull,
             });
         }
-        columns.push(ColumnDef {
+        column_defs.push(ColumnDef {
             name,
             data_type,
             collation: None,
@@ -182,13 +321,109 @@ fn generate_source_export_statement_values(
         });
     }
 
+    // TODO(sql_server2): Support table contraints like primary key or unique.
+
+    let details = SourceExportStatementDetails::SqlServer {
+        table,
+        capture_instance,
+    };
+    let text_columns = text_columns.map(|mut columns| {
+        columns.sort();
+        columns
+            .into_iter()
+            .map(WithOptionValue::Ident::<Aug>)
+            .collect()
+    });
+    let excl_columns = excl_columns.map(|mut columns| {
+        columns.sort();
+        columns
+            .into_iter()
+            .map(WithOptionValue::Ident::<Aug>)
+            .collect()
+    });
+
     let values = SqlServerExportStatementValues {
-        columns,
-        details: SourceExportStatementDetails::SqlServer {
-            table,
-            capture_instance,
-        },
+        columns: column_defs,
+        text_columns,
+        excl_columns,
+        details,
         external_reference: purified_export.external_reference,
     };
     Ok(values)
+}
+
+/// Create a [`BTreeMap`] of [`SqlServerQualifiedTableName`] to a [`BTreeSet`] of column names.
+fn map_column_refs<'a>(
+    cols: &'a [UnresolvedItemName],
+    option_type: SqlServerConfigOptionName,
+) -> Result<BTreeMap<SqlServerQualifiedTableName, BTreeSet<&'a str>>, PlanError> {
+    let mut table_to_cols: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+    for name in cols.iter() {
+        // We only support fully qualified references for now (e.g. `schema_name.table_name.column_name`)
+        if name.0.len() == 3 {
+            let key = mz_sql_server_util::desc::SqlServerQualifiedTableName {
+                schema_name: name.0[0].as_str().into(),
+                table_name: name.0[1].as_str().into(),
+            };
+            let new = table_to_cols
+                .entry(key)
+                .or_default()
+                .insert(name.0[2].as_str());
+            if !new {
+                return Err(PlanError::InvalidOptionValue {
+                    option_name: option_type.to_ast_string_simple(),
+                    err: Box::new(PlanError::UnexpectedDuplicateReference { name: name.clone() }),
+                });
+            }
+        } else {
+            return Err(PlanError::InvalidOptionValue {
+                option_name: option_type.to_ast_string_simple(),
+                err: Box::new(PlanError::UnderqualifiedColumnName(name.to_string())),
+            });
+        }
+    }
+    Ok(table_to_cols)
+}
+
+/// Normalize the provided `cols` references to a sorted and deduplicated list of
+/// [`WithOptionValue`]s.
+///
+/// Returns an error if any column reference in `cols` is not part of a table in the
+/// provided `tables`.
+fn normalize_column_refs(
+    cols: &[UnresolvedItemName],
+    reference_resolver: &SourceReferenceResolver,
+    tables: &[RequestedSourceExport<SqlServerTableDesc>],
+    option_name: SqlServerConfigOptionName,
+) -> Result<Vec<WithOptionValue<Aug>>, SqlServerSourcePurificationError> {
+    let (seq, unknown): (Vec<_>, Vec<_>) = cols.into_iter().partition(|name| {
+        let (column_name, qual) = name.0.split_last().expect("non-empty");
+        match reference_resolver.resolve_idx(qual) {
+            // TODO(sql_server3): This needs to also introduce the maximum qualification
+            // on  the columns, i.e. ensure they have the schema name.
+            Ok(idx) => tables[idx]
+                .meta
+                .columns
+                .iter()
+                .any(|n| &*n.name == column_name.as_str()),
+            Err(_) => false,
+        }
+    });
+
+    if !unknown.is_empty() {
+        return Err(SqlServerSourcePurificationError::DanglingColumns {
+            option_name: option_name.to_string(),
+            items: unknown.into_iter().cloned().collect(),
+        });
+    }
+
+    let mut seq: Vec<_> = seq
+        .into_iter()
+        .cloned()
+        .map(WithOptionValue::UnresolvedItemName)
+        .collect();
+
+    seq.sort();
+    seq.dedup();
+    Ok(seq)
 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1480,6 +1480,16 @@ impl ExternalCatalogReference for mz_postgres_util::desc::PostgresTableDesc {
     }
 }
 
+impl ExternalCatalogReference for &mz_sql_server_util::desc::SqlServerTableDesc {
+    fn schema_name(&self) -> &str {
+        &*self.schema_name
+    }
+
+    fn item_name(&self) -> &str {
+        &*self.name
+    }
+}
+
 // This implementation provides a means of converting arbitrary objects into a
 // `SubsourceCatalogReference`, e.g. load generator view names.
 impl<'a> ExternalCatalogReference for (&'a str, &'a str) {

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -19,7 +19,7 @@ use differential_dataflow::containers::TimelyStack;
 use futures::StreamExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::future::InTask;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row, RowArena};
 use mz_sql_server_util::cdc::{CdcEvent, Lsn, Operation as CdcOperation};
 use mz_storage_types::errors::{DataflowError, DecodeError, DecodeErrorKind};
 use mz_storage_types::sources::SqlServerSource;
@@ -144,7 +144,8 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
 
                     // Try to decode a row, returning a SourceError if it fails.
                     let mut mz_row = Row::default();
-                    let message = match decoder.decode(&sql_server_row, &mut mz_row) {
+                    let arena = RowArena::default();
+                    let message = match decoder.decode(&sql_server_row, &mut mz_row, &arena) {
                         Ok(()) => Ok(SourceMessage {
                             key: Row::default(),
                             value: mz_row,
@@ -249,7 +250,8 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
 
                     // Try to decode a row, returning a SourceError if it fails.
                     let mut mz_row = Row::default();
-                    let message = match decoder.decode(&sql_server_row, &mut mz_row) {
+                    let arena = RowArena::default();
+                    let message = match decoder.decode(&sql_server_row, &mut mz_row, &arena) {
                         Ok(()) => Ok(SourceMessage {
                             key: Row::default(),
                             value: mz_row,

--- a/test/sql-server-cdc/10-sql-server-cdc.td
+++ b/test/sql-server-cdc/10-sql-server-cdc.td
@@ -34,7 +34,7 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't3_text', @
 
 # Exercise Materialize.
 
-> CREATE SECRET sql_server_pass AS '${arg.default-sql-server-password}'
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_sql_server_source = true;
@@ -49,7 +49,7 @@ ALTER SYSTEM SET enable_sql_server_source = true;
 
 > VALIDATE CONNECTION sql_server_test_connection;
 
-> SELECT name, type from mz_connections WHERE id LIKE 'u%';
+> SELECT name, type from mz_connections WHERE name = 'sql_server_test_connection';
 name                         type
 ---------------------------------------
 sql_server_test_connection   sql-server

--- a/test/sql-server-cdc/20-column-options.td
+++ b/test/sql-server-cdc/20-column-options.td
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_sql_server_source = true;
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+DROP DATABASE IF EXISTS test_column_options;
+CREATE DATABASE test_column_options;
+USE test_column_options;
+
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test_column_options SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE t1_columns (c1 decimal(20, 10), c2 time, c3 money, c4 varbinary(100));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_columns', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t1_columns VALUES (1.444889, '12:00:00', '$100.99', 0x1100AB);
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+> CREATE CONNECTION sql_server_columns_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_column_options,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+> CREATE SOURCE t1_columns_sql_server
+  FROM SQL SERVER CONNECTION sql_server_columns_connection (
+    TEXT COLUMNS (dbo.t1_columns.c1, dbo.t1_columns.c2, dbo.t1_columns.c4),
+    EXCLUDE COLUMNS (dbo.t1_columns.c3)
+  )
+  FOR TABLES (dbo.t1_columns);
+
+> SHOW COLUMNS FROM t1_columns;
+c1 true text ""
+c2 true text ""
+c4 true text ""
+
+> SELECT c1, c2, c4 FROM t1_columns;
+1.4448890000 12:00:00 EQCr
+
+$ sql-server-execute name=sql-server
+INSERT INTO t1_columns VALUES (2.000001, '01:59:32.99901', '$0.89', 0x1122AABBCC00DD), (NULL, NULL, '$99.99', NULL);
+
+> SELECT c1, c2, c4 FROM t1_columns;
+1.4448890000 12:00:00 EQCr
+2.0000010000 01:59:32.999010 ESKqu8wA3Q==
+<null> <null> <null>

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -1,7 +1,7 @@
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
-# included in the LICENSE file at the rogitot of this repository.
+# included in the LICENSE file at the root of this repository.
 #
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -1,7 +1,7 @@
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
-# included in the LICENSE file at the root of this repository.
+# included in the LICENSE file at the rogitot of this repository.
 #
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
@@ -11,9 +11,11 @@
 Native SQL Server source tests, functional.
 """
 
+import glob
 import random
 
-from materialize.mzcompose.composition import Composition
+from materialize import MZ_ROOT
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -28,15 +30,35 @@ SERVICES = [
 #
 # Test that SQL Server ingestion works
 #
-def workflow_default(c: Composition) -> None:
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "filter",
+        nargs="*",
+        default=["*.td"],
+        help="limit to only the files matching filter",
+    )
+    args = parser.parse_args()
+
+    matching_files = []
+    for filter in args.filter:
+        matching_files.extend(
+            glob.glob(filter, root_dir=MZ_ROOT / "test" / "sql-server-cdc")
+        )
+    matching_files = sorted(matching_files)
+    print(f"Filter: {args.filter} Files: {matching_files}")
+
     c.up("materialized", "sql-server")
     seed = random.getrandbits(16)
-    c.run_testdrive_files(
-        "--no-reset",
-        "--max-errors=1",
-        f"--seed={seed}",
-        f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
-        f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
-        f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",
-        "sql-server-cdc.td",
+
+    c.test_parts(
+        matching_files,
+        lambda file: c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={seed}",
+            f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
+            f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
+            f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",
+            str(file),
+        ),
     )

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -17,10 +17,12 @@ import random
 from materialize import MZ_ROOT
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
+    Mz(app_password=""),
     Materialized(),
     Testdrive(),
     SqlServer(),


### PR DESCRIPTION
This PR updates the SQL Server source to support excluding columns or decoding them as text, specifically it does the following:

* Updates `SqlServerColumnDesc` to support representing unknown columns. This allows users to replicate tables with a column type we don't recognize and specify said column in `EXCLUDE COLUMNS`.
* Update `SqlServerRowDecoder` to support decoding from any type to text, adds some limited testing.
* Updates parsing and purification to include `TEXT COLUMNS` and `EXCLUDE COLUMNS` in both the primary `CREATE SOURCE` statement (for round-tripping) and the generated subsource statements.

### Tips for reviewers

I would start with `sql-server-util/src/desc.rs`, that's where the bulk of the changes are. This file contains the types that we use to represent columns and tables from SQL Server.

### Motivation

Fixes a `TODO(sql_server1)` and adds a known feature.

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
