### PR TITLE
tests: Use multiple replicas by default to exercise multi-replica sources

### DIFF
--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -15,8 +15,10 @@ class UnifiedCluster(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
             """
-            > CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 1;
-            > CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 1;
+            >[version>=13800] CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 2;
+            >[version<13800] CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 1;
+            >[version>=13800] CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 2;
+            >[version<13800] CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 1;
             """
         )
 

--- a/misc/python/materialize/checks/all_checks/load_generator.py
+++ b/misc/python/materialize/checks/all_checks/load_generator.py
@@ -69,8 +69,10 @@ class LoadGeneratorMultiReplica(Check):
         return Testdrive(
             dedent(
                 """
-            > CREATE CLUSTER multi_cluster1 SIZE '1', REPLICATION FACTOR 1;
-            > CREATE CLUSTER multi_cluster2 SIZE '1', REPLICATION FACTOR 1;
+            >[version>=13800] CREATE CLUSTER multi_cluster1 SIZE '1', REPLICATION FACTOR 2;
+            >[version<13800] CREATE CLUSTER multi_cluster1 SIZE '1', REPLICATION FACTOR 1;
+            >[version>=13800] CREATE CLUSTER multi_cluster2 SIZE '1', REPLICATION FACTOR 2;
+            >[version<13800] CREATE CLUSTER multi_cluster2 SIZE '1', REPLICATION FACTOR 1;
                 """
             )
         )
@@ -83,12 +85,12 @@ class LoadGeneratorMultiReplica(Check):
             > CREATE SOURCE multi_counter1 IN CLUSTER multi_cluster1 FROM LOAD GENERATOR COUNTER (UP TO 10);
             > CREATE SOURCE multi_counter2 IN CLUSTER multi_cluster2 FROM LOAD GENERATOR COUNTER (UP TO 10);
 
-            > ALTER CLUSTER multi_cluster1 SET (REPLICATION FACTOR 2);
+            > ALTER CLUSTER multi_cluster1 SET (REPLICATION FACTOR 4);
                 """,
                 """
             > CREATE SOURCE multi_counter3 IN CLUSTER multi_cluster1 FROM LOAD GENERATOR COUNTER (UP TO 10);
             > CREATE SOURCE multi_counter4 IN CLUSTER multi_cluster2 FROM LOAD GENERATOR COUNTER (UP TO 10);
-            > ALTER CLUSTER multi_cluster2 SET (REPLICATION FACTOR 2);
+            > ALTER CLUSTER multi_cluster2 SET (REPLICATION FACTOR 4);
                 """,
             ]
         ]

--- a/misc/python/materialize/checks/all_checks/managed_cluster.py
+++ b/misc/python/materialize/checks/all_checks/managed_cluster.py
@@ -18,10 +18,12 @@ class CreateManagedCluster(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > CREATE CLUSTER create_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version>=13800] CREATE CLUSTER create_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version<13800] CREATE CLUSTER create_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 1;
                 """,
                 """
-                > CREATE CLUSTER create_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version>=13800] CREATE CLUSTER create_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version<13800] CREATE CLUSTER create_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 1;
                 """,
             ]
         ]
@@ -73,8 +75,10 @@ class DropManagedCluster(Check):
                 > INSERT INTO drop_managed_cluster1_table VALUES (123);
                 > INSERT INTO drop_managed_cluster2_table VALUES (234);
 
-                > CREATE CLUSTER drop_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 2;
-                > CREATE CLUSTER drop_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version>=13800] CREATE CLUSTER drop_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version<13800] CREATE CLUSTER drop_managed_cluster1 SIZE '2-2', REPLICATION FACTOR 1;
+                >[version>=13800] CREATE CLUSTER drop_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 2;
+                >[version<13800] CREATE CLUSTER drop_managed_cluster2 SIZE '2-2', REPLICATION FACTOR 1;
 
                 > SET cluster=drop_managed_cluster1
                 > CREATE DEFAULT INDEX ON drop_managed_cluster1_table;

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -687,7 +687,7 @@ class AccumulateReductions(Dataflow):
 > INSERT INTO t (a, b) VALUES (0, 0);
 
 > DROP CLUSTER IF EXISTS idx_cluster CASCADE;
-> CREATE CLUSTER idx_cluster SIZE '1-8G', REPLICATION FACTOR 1;
+> CREATE CLUSTER idx_cluster SIZE '1-8G', REPLICATION FACTOR 2;
 
 > CREATE VIEW accumulable AS
   SELECT
@@ -1021,7 +1021,7 @@ $ kafka-ingest format=bytes topic=kafka-envelope-none-bytes repeat={self.n()}
 
 > CREATE CONNECTION s1_kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1067,7 +1067,7 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keys
     URL '${{testdrive.schema-registry-url}}'
   );
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1112,7 +1112,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{key
   TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');
   /* A */
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1160,7 +1160,7 @@ $ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{ke
 > CREATE CONNECTION IF NOT EXISTS s1_csr_conn
   TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1239,7 +1239,7 @@ class KafkaRestartBig(ScenarioBig):
 > CREATE CONNECTION s1_kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
 > DROP CLUSTER IF EXISTS source_cluster CASCADE
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1310,7 +1310,7 @@ $ kafka-create-topic topic=kafka-scalability partitions=8
 
 > CREATE CONNECTION s1_kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1369,7 +1369,7 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keysch
   FOR CONFLUENT SCHEMA REGISTRY
   URL '${{testdrive.schema-registry-url}}';
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE source1
   IN CLUSTER source_cluster
@@ -1392,7 +1392,7 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keysch
   /* A */
 
 > DROP CLUSTER IF EXISTS sink_cluster CASCADE
-> CREATE CLUSTER sink_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER sink_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SINK sink1
   IN CLUSTER sink_cluster
@@ -1466,7 +1466,7 @@ ALTER SYSTEM SET max_tables = {self.n() * 4};
   URL '${{testdrive.schema-registry-url}}';
 
 > DROP CLUSTER IF EXISTS kafka_source_cluster CASCADE;
-> CREATE CLUSTER kafka_source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER kafka_source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 """
         )
 
@@ -1562,7 +1562,7 @@ ALTER TABLE pk_table REPLICA IDENTITY FULL;
     PASSWORD SECRET pgpass
   )
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE mz_source_pgcdc
   IN CLUSTER source_cluster
@@ -1616,7 +1616,7 @@ ALTER TABLE t1 REPLICA IDENTITY FULL;
     PASSWORD SECRET pgpass
   )
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1694,7 +1694,7 @@ INSERT INTO pk_table SELECT @i:=@i+1, @i*@i FROM mysql.time_zone t1, mysql.time_
     PASSWORD SECRET mysqlpass
   )
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE mz_source_mysqlcdc
   IN CLUSTER source_cluster
@@ -1748,7 +1748,7 @@ CREATE TABLE t1 (pk SERIAL PRIMARY KEY, f2 BIGINT);
     PASSWORD SECRET mysqlpass
   )
 
-> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s1
   IN CLUSTER source_cluster
@@ -1901,7 +1901,7 @@ $ kafka-ingest format=avro topic=startup-time schema=${schema} repeat=1
         create_sources = "\n".join(
             f"""
 > DROP CLUSTER IF EXISTS source{i}_cluster CASCADE;
-> CREATE CLUSTER source{i}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER source{i}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE source{i}
   IN CLUSTER source{i}_cluster
@@ -1926,7 +1926,7 @@ $ kafka-ingest format=avro topic=startup-time schema=${schema} repeat=1
         create_sinks = "\n".join(
             f"""
 > DROP CLUSTER IF EXISTS sink{i}_cluster;
-> CREATE CLUSTER sink{i}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER sink{i}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 > CREATE SINK sink{i}
   IN CLUSTER sink{i}_cluster
   FROM source{i}_tbl
@@ -2100,7 +2100,7 @@ class HydrateIndex(Scenario):
             self.table_ten(),
             TdAction(
                 """
-> CREATE CLUSTER idx_cluster SIZE '16', REPLICATION FACTOR 1
+> CREATE CLUSTER idx_cluster SIZE '16', REPLICATION FACTOR 2
 """
             ),
         ]
@@ -2120,7 +2120,7 @@ class HydrateIndex(Scenario):
 > SELECT 1
   /* A */
 1
-> ALTER CLUSTER idx_cluster SET (REPLICATION FACTOR 1)
+> ALTER CLUSTER idx_cluster SET (REPLICATION FACTOR 2)
 > SET CLUSTER = idx_cluster
 ?[version>=13500] EXPLAIN OPTIMIZED PLAN AS VERBOSE TEXT FOR SELECT COUNT(*) FROM t1
 Explained Query:

--- a/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
@@ -59,7 +59,7 @@ $ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-sc
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
-> CREATE CLUSTER s{s}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+> CREATE CLUSTER s{s}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
 > CREATE SOURCE s{s}
   IN CLUSTER s{s}_cluster

--- a/misc/python/materialize/feature_benchmark/scenarios/subscribe.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/subscribe.py
@@ -117,7 +117,7 @@ class SubscribeParallelKafka(SubscribeParallel):
              > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
              > DROP CLUSTER IF EXISTS source_cluster CASCADE;
-             > CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
+             > CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
 
              > DROP SOURCE IF EXISTS s1 CASCADE;
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1094,7 +1094,7 @@ class Composition:
             CREATE CLUSTER quickstart REPLICAS ({replica_string});
             GRANT ALL PRIVILEGES ON CLUSTER quickstart TO materialize;
             DROP CLUSTER IF EXISTS singlereplica;
-            CREATE CLUSTER singlereplica SIZE '4', REPLICATION FACTOR 1;
+            CREATE CLUSTER singlereplica SIZE '4', REPLICATION FACTOR 2;
             GRANT ALL PRIVILEGES ON CLUSTER singlereplica TO materialize;
             """,
             user="mz_system",

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -94,6 +94,7 @@ class Materialized(Service):
         metadata_store: str = METADATA_STORE,
         cluster_replica_size: dict[str, dict[str, Any]] | None = None,
         bootstrap_replica_size: str | None = None,
+        default_cluster_replicas: int = 2,
     ) -> None:
         if name is None:
             name = "materialized"
@@ -140,8 +141,9 @@ class Materialized(Service):
             f"MZ_BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE={bootstrap_replica_size}",
             # Note(SangJunBak): mz_system and mz_probe have no replicas by default in materialized
             # but we re-enable them here since many of our tests rely on them.
-            "MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR=1",
-            "MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR=1",
+            f"MZ_BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICATION_FACTOR={default_cluster_replicas}",
+            f"MZ_BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICATION_FACTOR={default_cluster_replicas}",
+            f"MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICATION_FACTOR={default_cluster_replicas}",
             *environment_extra,
             *DEFAULT_CRDB_ENVIRONMENT,
         ]

--- a/src/adapter-types/src/bootstrap_builtin_cluster_config.rs
+++ b/src/adapter-types/src/bootstrap_builtin_cluster_config.rs
@@ -15,6 +15,7 @@ pub struct BootstrapBuiltinClusterConfig {
     pub replication_factor: u32,
 }
 
+pub const DEFAULT_REPLICATION_FACTOR: u32 = 1;
 pub const SYSTEM_CLUSTER_DEFAULT_REPLICATION_FACTOR: u32 = 1;
 pub const CATALOG_SERVER_CLUSTER_DEFAULT_REPLICATION_FACTOR: u32 = 1;
 pub const PROBE_CLUSTER_DEFAULT_REPLICATION_FACTOR: u32 = 1;

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -565,6 +565,7 @@ async fn upgrade_check(
             &BootstrapArgs {
                 default_cluster_replica_size:
                     "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
+                default_cluster_replication_factor: 1,
                 bootstrap_role: None,
                 cluster_replica_size_map: cluster_replica_sizes.clone(),
             },

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -76,6 +76,7 @@ pub const EXPRESSION_CACHE_SHARD_KEY: &str = "expression_cache_shard";
 pub struct BootstrapArgs {
     pub cluster_replica_size_map: ClusterReplicaSizeMap,
     pub default_cluster_replica_size: String,
+    pub default_cluster_replication_factor: u32,
     pub bootstrap_role: Option<String>,
 }
 
@@ -528,6 +529,7 @@ pub async fn persist_backed_catalog_state(
 pub fn test_bootstrap_args() -> BootstrapArgs {
     BootstrapArgs {
         default_cluster_replica_size: "1".into(),
+        default_cluster_replication_factor: 2,
         bootstrap_role: None,
         cluster_replica_size_map: ClusterReplicaSizeMap::for_tests(),
     }

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -783,7 +783,7 @@ fn default_cluster_config(args: &BootstrapArgs) -> Result<ClusterConfig, Catalog
     Ok(ClusterConfig {
         variant: ClusterVariant::Managed(ClusterVariantManaged {
             size: cluster_size,
-            replication_factor: 1,
+            replication_factor: args.default_cluster_replication_factor,
             availability_zones: vec![],
             logging: ReplicaLogging {
                 log_logging: false,

--- a/src/catalog/tests/snapshots/debug__opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__opened_trace.snap
@@ -568,7 +568,7 @@ Trace {
                                     Managed(
                                         ManagedCluster {
                                             size: "1",
-                                            replication_factor: 1,
+                                            replication_factor: 2,
                                             availability_zones: [],
                                             logging: Some(
                                                 ReplicaLogging {

--- a/src/catalog/tests/snapshots/open__initial_snapshot.snap
+++ b/src/catalog/tests/snapshots/open__initial_snapshot.snap
@@ -1207,7 +1207,7 @@ Snapshot {
                         Managed(
                             ManagedCluster {
                                 size: "1",
-                                replication_factor: 1,
+                                replication_factor: 2,
                                 availability_zones: [],
                                 logging: Some(
                                     ReplicaLogging {

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -30,8 +30,9 @@ use itertools::Itertools;
 use mz_adapter::ResultExt;
 use mz_adapter_types::bootstrap_builtin_cluster_config::{
     ANALYTICS_CLUSTER_DEFAULT_REPLICATION_FACTOR, BootstrapBuiltinClusterConfig,
-    CATALOG_SERVER_CLUSTER_DEFAULT_REPLICATION_FACTOR, PROBE_CLUSTER_DEFAULT_REPLICATION_FACTOR,
-    SUPPORT_CLUSTER_DEFAULT_REPLICATION_FACTOR, SYSTEM_CLUSTER_DEFAULT_REPLICATION_FACTOR,
+    CATALOG_SERVER_CLUSTER_DEFAULT_REPLICATION_FACTOR, DEFAULT_REPLICATION_FACTOR,
+    PROBE_CLUSTER_DEFAULT_REPLICATION_FACTOR, SUPPORT_CLUSTER_DEFAULT_REPLICATION_FACTOR,
+    SYSTEM_CLUSTER_DEFAULT_REPLICATION_FACTOR,
 };
 use mz_aws_secrets_controller::AwsSecretsController;
 use mz_build_info::BuildInfo;
@@ -550,6 +551,13 @@ pub struct Args {
         default_value = "1"
     )]
     bootstrap_builtin_analytics_cluster_replica_size: String,
+    #[clap(
+        long,
+        env = "BOOTSTRAP_DEFAULT_CLUSTER_REPLICATION_FACTOR",
+        default_value = DEFAULT_REPLICATION_FACTOR.to_string(),
+        value_parser = clap::value_parser!(u32).range(0..=2)
+    )]
+    bootstrap_default_cluster_replication_factor: u32,
     /// The replication factor of the builtin system cluster replicas if bootstrapping.
     #[clap(
         long,
@@ -1121,6 +1129,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 environment_id: args.environment_id,
                 bootstrap_role: args.bootstrap_role,
                 bootstrap_default_cluster_replica_size: args.bootstrap_default_cluster_replica_size,
+                bootstrap_default_cluster_replication_factor: args
+                    .bootstrap_default_cluster_replication_factor,
                 bootstrap_builtin_system_cluster_config: BootstrapBuiltinClusterConfig {
                     size: args.bootstrap_builtin_system_cluster_replica_size,
                     replication_factor: args.bootstrap_builtin_system_cluster_replication_factor,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -155,6 +155,8 @@ pub struct Config {
     pub bootstrap_role: Option<String>,
     /// The size of the default cluster replica if bootstrapping.
     pub bootstrap_default_cluster_replica_size: String,
+    /// The default number of replicas if bootstrapping.
+    pub bootstrap_default_cluster_replication_factor: u32,
     /// The config of the builtin system cluster replicas if bootstrapping.
     pub bootstrap_builtin_system_cluster_config: BootstrapBuiltinClusterConfig,
     /// The config of the builtin catalog server cluster replicas if bootstrapping.
@@ -553,6 +555,7 @@ impl Listeners {
         let mut caught_up_trigger = None;
         let bootstrap_args = BootstrapArgs {
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size.clone(),
+            default_cluster_replication_factor: config.bootstrap_default_cluster_replication_factor,
             bootstrap_role: config.bootstrap_role.clone(),
             cluster_replica_size_map: config.cluster_replica_sizes.clone(),
         };
@@ -590,6 +593,7 @@ impl Listeners {
 
         let bootstrap_args = BootstrapArgs {
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size.clone(),
+            default_cluster_replication_factor: config.bootstrap_default_cluster_replication_factor,
             bootstrap_role: config.bootstrap_role,
             cluster_replica_size_map: config.cluster_replica_sizes.clone(),
         };

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -100,6 +100,7 @@ pub struct TestHarness {
     storage_usage_collection_interval: Duration,
     storage_usage_retention_period: Option<Duration>,
     default_cluster_replica_size: String,
+    default_cluster_replication_factor: u32,
     builtin_system_cluster_config: BootstrapBuiltinClusterConfig,
     builtin_catalog_server_cluster_config: BootstrapBuiltinClusterConfig,
     builtin_probe_cluster_config: BootstrapBuiltinClusterConfig,
@@ -134,6 +135,7 @@ impl Default for TestHarness {
             storage_usage_collection_interval: Duration::from_secs(3600),
             storage_usage_retention_period: None,
             default_cluster_replica_size: "1".to_string(),
+            default_cluster_replication_factor: 2,
             builtin_system_cluster_config: BootstrapBuiltinClusterConfig {
                 size: "1".to_string(),
                 replication_factor: SYSTEM_CLUSTER_DEFAULT_REPLICATION_FACTOR,
@@ -546,6 +548,8 @@ impl Listeners {
                 cors_allowed_origin: AllowOrigin::list([]),
                 cluster_replica_sizes: ClusterReplicaSizeMap::for_tests(),
                 bootstrap_default_cluster_replica_size: config.default_cluster_replica_size,
+                bootstrap_default_cluster_replication_factor: config
+                    .default_cluster_replication_factor,
                 bootstrap_builtin_system_cluster_config: config.builtin_system_cluster_config,
                 bootstrap_builtin_catalog_server_cluster_config: config
                     .builtin_catalog_server_cluster_config,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1080,6 +1080,7 @@ impl<'a> RunnerInner<'a> {
             environment_id,
             cluster_replica_sizes: ClusterReplicaSizeMap::for_tests(),
             bootstrap_default_cluster_replica_size: config.replicas.to_string(),
+            bootstrap_default_cluster_replication_factor: 2,
             bootstrap_builtin_system_cluster_config: BootstrapBuiltinClusterConfig {
                 replication_factor: SYSTEM_CLUSTER_DEFAULT_REPLICATION_FACTOR,
                 size: config.replicas.to_string(),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -1135,6 +1135,7 @@ async fn create_materialize_state(
     let bootstrap_args = BootstrapArgs {
         cluster_replica_size_map: config.materialize_cluster_replica_sizes.clone(),
         default_cluster_replica_size: "ABC".to_string(),
+        default_cluster_replication_factor: 1,
         bootstrap_role: None,
     };
 

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -706,7 +706,7 @@ SCENARIOS = [
             > INSERT INTO t (a, b) VALUES (0, 0);
 
             > DROP CLUSTER IF EXISTS idx_cluster CASCADE;
-            > CREATE CLUSTER idx_cluster SIZE '1-8G', REPLICATION FACTOR 1;
+            > CREATE CLUSTER idx_cluster SIZE '1-8G', REPLICATION FACTOR 2;
 
             > CREATE VIEW accumulable AS
               SELECT

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -45,7 +45,7 @@ def test_testdrive(mz: MaterializeApplication) -> None:
                 > INSERT INTO t1 VALUES (1);
 
                 > CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2-2'));
-                > CREATE CLUSTER c2 SIZE '1', REPLICATION FACTOR 1;
+                > CREATE CLUSTER c2 SIZE '1', REPLICATION FACTOR 2;
                 > SET cluster=c1
 
                 > CREATE CONNECTION kafka TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4060,7 +4060,7 @@ def workflow_test_refresh_mv_restart(
 
         after_restart = dedent(
             """
-            > ALTER CLUSTER cluster_b SET (REPLICATION FACTOR 1);
+            > ALTER CLUSTER cluster_b SET (REPLICATION FACTOR 2);
 
             > SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE';
 
@@ -4236,7 +4236,7 @@ def workflow_test_refresh_mv_restart(
         c.testdrive(
             input=dedent(
                 """
-                > ALTER CLUSTER cluster_defgh SET (REPLICATION FACTOR 1);
+                > ALTER CLUSTER cluster_defgh SET (REPLICATION FACTOR 2);
 
                 > CREATE CLUSTER serving SIZE '1';
 

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -98,7 +98,7 @@ $ kafka-create-topic topic=input
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK output
-  IN CLUSTER singlereplica
+  IN CLUSTER quickstart
   FROM input_tbl
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -38,7 +38,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
-    c.setup_quickstart_cluster()
     c.run_testdrive_files(
         f"--seed={args.seed}",
         "--kafka-option=group.id=group1",

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -81,7 +81,6 @@ def workflow_default(c: Composition) -> None:
         with c.override(Redpanda(version=redpanda_version)):
             c.down(destroy_volumes=True)
             c.up("redpanda", "materialized")
-            c.setup_quickstart_cluster()
             c.run_testdrive_files(*TD_CMD)
 
     confluent_versions = buildkite.shard_list(CONFLUENT_PLATFORM_VERSIONS, lambda v: v)
@@ -98,5 +97,4 @@ def workflow_default(c: Composition) -> None:
         ):
             c.down(destroy_volumes=True)
             c.up("zookeeper", "kafka", "schema-registry", "materialized")
-            c.setup_quickstart_cluster()
             c.run_testdrive_files(*TD_CMD)

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -63,7 +63,6 @@ SERVICES = [
 TD_CMD = [
     f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
     f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}-1",
-    "--var=single-replica-cluster=singlereplica",
     *[f"testdrive/{td}" for td in ["kafka-sinks.td", "kafka-upsert-sources.td"]],
 ]
 

--- a/test/kafka-multi-broker/01-init.td
+++ b/test/kafka-multi-broker/01-init.td
@@ -47,7 +47,7 @@ $ kafka-ingest format=avro topic=kafka-multi-broker schema=${schema} timestamp=6
   );
 
 > CREATE SINK multi_broker_sink
-  IN CLUSTER singlereplica
+  IN CLUSTER quickstart
   FROM kafka_multi_broker_tbl
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-multi-broker-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -41,7 +41,6 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("zookeeper", "kafka1", "kafka2", "kafka3", "schema-registry", "materialized")
-    c.setup_quickstart_cluster()
     c.run_testdrive_files("--kafka-addr=kafka2", "01-init.td")
     time.sleep(10)
     c.kill("kafka1")

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -69,7 +69,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def workflow_sink_networking(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parse_args(parser)
     c.up(*(["materialized", "toxiproxy"] + get_kafka_services(args.redpanda)))
-    c.setup_quickstart_cluster()
 
     seed = random.getrandbits(16)
     for i, failure_mode in enumerate(
@@ -110,7 +109,6 @@ def workflow_sink_kafka_restart(c: Composition, parser: WorkflowArgumentParser) 
         )
     ):
         c.up(*(["materialized"] + get_kafka_services(args.redpanda)))
-        c.setup_quickstart_cluster()
 
         seed = random.getrandbits(16)
         c.run_testdrive_files(
@@ -142,7 +140,6 @@ def workflow_source_resumption(c: Composition, parser: WorkflowArgumentParser) -
         Testdrive(no_reset=True, consistent_seed=True),
     ):
         c.up(*(["materialized", "clusterd"] + get_kafka_services(args.redpanda)))
-        c.setup_quickstart_cluster()
 
         c.run_testdrive_files("source-resumption/setup.td")
         c.run_testdrive_files("source-resumption/verify.td")
@@ -199,7 +196,6 @@ def workflow_sink_queue_full(c: Composition, parser: WorkflowArgumentParser) -> 
     args = parse_args(parser)
     seed = random.getrandbits(16)
     c.up(*(["materialized", "toxiproxy"] + get_kafka_services(args.redpanda)))
-    c.setup_quickstart_cluster()
     c.run_testdrive_files(
         "--no-reset",
         "--max-errors=1",

--- a/test/kafka-resumption/sink-kafka-restart/setup.td
+++ b/test/kafka-resumption/sink-kafka-restart/setup.td
@@ -21,7 +21,7 @@ ALTER SYSTEM SET kafka_transaction_timeout = '10min';
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
 > CREATE SINK output
-  IN CLUSTER singlereplica
+  IN CLUSTER quickstart
   FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'table-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-resumption/sink-networking/setup.td
+++ b/test/kafka-resumption/sink-networking/setup.td
@@ -35,7 +35,7 @@ New York,NY,10004
   );
 
 > CREATE SINK output
-  IN CLUSTER singlereplica
+  IN CLUSTER quickstart
   FROM input_tbl
   INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-resumption/sink-queue-full/during.td
+++ b/test/kafka-resumption/sink-queue-full/during.td
@@ -18,7 +18,7 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="60s"
 11000001
 
 > CREATE SINK output
-  IN CLUSTER singlereplica
+  IN CLUSTER quickstart
   FROM largeinput_tbl
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -61,7 +61,6 @@ def workflow_default(c: Composition) -> None:
 def workflow_simple(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy")
-    c.setup_quickstart_cluster()
 
     seed = random.getrandbits(16)
     c.run_testdrive_files(
@@ -77,7 +76,6 @@ def workflow_simple(c: Composition) -> None:
 def workflow_resumption(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy")
-    c.setup_quickstart_cluster()
 
     priv_cursor = c.sql_cursor(service="materialized", user="mz_system", port=6877)
     priv_cursor.execute("ALTER SYSTEM SET allow_real_time_recency = true;")
@@ -156,7 +154,6 @@ def workflow_resumption(c: Composition) -> None:
 def workflow_multithreaded(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
-    c.setup_quickstart_cluster()
     c.up("testdrive", persistent=True)
 
     value = [201]

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -55,7 +55,7 @@ s2  mz_catalog_server  true  1  2
 s3  mz_probe  true  1  2
 s4  mz_support  true  0  2
 s5  mz_analytics  true  0  2
-u1  quickstart  true  1  2
+u1  quickstart  true  2  2
 
 
 query T rowsort

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -600,7 +600,7 @@ class AWS:
         ) as conn:
             with conn.cursor() as cur:
                 # Required for some testdrive tests
-                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)")
+                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)")
 
         c.up("testdrive", persistent=True)
         c.testdrive(
@@ -1294,7 +1294,7 @@ def workflow_gcp_temporary(c: Composition, parser: WorkflowArgumentParser) -> No
         ) as conn:
             with conn.cursor() as cur:
                 # Required for some testdrive tests
-                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)")
+                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)")
 
         with c.override(
             Testdrive(
@@ -1788,7 +1788,7 @@ def workflow_azure_temporary(c: Composition, parser: WorkflowArgumentParser) -> 
         ) as conn:
             with conn.cursor() as cur:
                 # Required for some testdrive tests
-                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)")
+                cur.execute("ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)")
 
         with c.override(
             Testdrive(


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9106

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
