### PR TITLE
parallel-benchmark: Try cleaning up better

### DIFF
--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -543,8 +543,14 @@ def run_once(
                 print(
                     "~~~ Resetting materialized to prevent interference between scenarios"
                 )
-                c.kill("cockroach", "materialized", "testdrive")
-                c.rm("cockroach", "materialized", "testdrive")
+                c.kill("cockroach", "materialized", "testdrive", "minio")
+                c.rm(
+                    "cockroach",
+                    "materialized",
+                    "testdrive",
+                    "minio",
+                    destroy_volumes=True,
+                )
                 c.rm_volumes("mzdata")
 
     return stats, failures


### PR DESCRIPTION
Test runs: https://buildkite.com/materialize/release-qualification/builds/803, https://buildkite.com/materialize/release-qualification/builds/802, https://buildkite.com/materialize/release-qualification/builds/801

Maybe helps with https://github.com/MaterializeInc/database-issues/issues/9162 ? Based on discussion in https://materializeinc.slack.com/archives/CTESPM7FU/p1744619426495409

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
