### PR TITLE
[sql_server] Fix bug with empty query

### DIFF
--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -119,6 +119,11 @@ pub async fn get_tables_for_capture_instance<'a>(
     // SQL Server does not have support for array types, so we need to manually construct
     // the parameterized query.
     let params: SmallVec<[_; 1]> = capture_instances.into_iter().collect();
+    // If there are no tables to check for just return an empty list.
+    if params.is_empty() {
+        return Ok(Vec::default());
+    }
+
     // TODO(sql_server3): Remove this redundant collection.
     #[allow(clippy::as_conversions)]
     let params_dyn: SmallVec<[_; 1]> = params


### PR DESCRIPTION
I thought this was included in a different PR, but must have gotten lost in splitting and rebasing.

This PR fixes the function we call to get the upstream `TABLE`s that are associated with the capture instances the source reads from. Previously if provided with an empty set of capture instances the query would error. Now we return early without issuing the query at all.

### Motivation

Fixes a known bug.

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
