### PR TITLE
[sql_server] Enable platform checks

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -711,7 +711,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID", --azurite]
+              args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID", --features=azurite]
 
       - id: checks-restart-entire-mz
         label: "Checks + restart of the entire Mz"
@@ -725,7 +725,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID", --azurite]
+              args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID", --features=azurite]
 
       - id: checks-restart-environmentd-clusterd-storage-azurite
         label: "Checks + restart of environmentd & storage clusterd with :azure: blob store"
@@ -742,7 +742,7 @@ steps:
                 [
                   --scenario=RestartEnvironmentdClusterdStorage,
                   "--seed=$BUILDKITE_JOB_ID",
-                  --azurite,
+                  --features=azurite,
                 ]
 
       - id: checks-backup-rollback
@@ -768,6 +768,25 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
+
+      - id: checks-parallel-drop-create-default-replica-x86_64
+        label: "Checks parallel + DROP/CREATE replica (x86_64)"
+        depends_on: build-x86_64
+        timeout_in_minutes: 180
+        parallelism: 2
+        agents:
+          queue: hetzner-x86-64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args:
+                [
+                  --scenario=DropCreateDefaultReplica,
+                  --execution-mode=parallel,
+                  --features=sql_server,
+                  "--seed=$BUILDKITE_JOB_ID",
+                ]
+
 
       - id: checks-parallel-restart-clusterd-compute
         label: "Checks parallel + restart compute clusterd"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -616,6 +616,24 @@ steps:
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
+      - id: checks-restart-environmentd-clusterd-storage-x86_64
+        label: "Checks + restart of environmentd & storage clusterd (x86_64)"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 45
+        parallelism: 6
+        agents:
+          queue: hetzner-x86-64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args:
+                [
+                  --scenario=RestartEnvironmentdClusterdStorage,
+                  --features=sql_server,
+                  "--seed=$BUILDKITE_JOB_ID",
+                ]
+
       - id: checks-no-restart-no-upgrade
         label: "Checks without restart or upgrade"
         depends_on: build-aarch64

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -15,6 +15,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 
 
@@ -40,8 +41,9 @@ class AlterConnectionSshChangeBase(Check):
         index: int,
         base_version: MzVersion,
         rng: Random | None,
+        features: Features | None,
     ):
-        super().__init__(base_version, rng)
+        super().__init__(base_version, rng, features)
         self.ssh_change = ssh_change
         self.index = index
 
@@ -201,17 +203,23 @@ class AlterConnectionSshChangeBase(Check):
 
 @externally_idempotent(False)
 class AlterConnectionToSsh(AlterConnectionSshChangeBase):
-    def __init__(self, base_version: MzVersion, rng: Random | None):
-        super().__init__(SshChange.ADD_SSH, 1, base_version, rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ):
+        super().__init__(SshChange.ADD_SSH, 1, base_version, rng, features)
 
 
 @externally_idempotent(False)
 class AlterConnectionToNonSsh(AlterConnectionSshChangeBase):
-    def __init__(self, base_version: MzVersion, rng: Random | None):
-        super().__init__(SshChange.DROP_SSH, 2, base_version, rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ):
+        super().__init__(SshChange.DROP_SSH, 2, base_version, rng, features)
 
 
 @externally_idempotent(False)
 class AlterConnectionHost(AlterConnectionSshChangeBase):
-    def __init__(self, base_version: MzVersion, rng: Random | None):
-        super().__init__(SshChange.CHANGE_SSH_HOST, 3, base_version, rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ):
+        super().__init__(SshChange.CHANGE_SSH_HOST, 3, base_version, rng, features)

--- a/misc/python/materialize/checks/all_checks/identifiers.py
+++ b/misc/python/materialize/checks/all_checks/identifiers.py
@@ -15,6 +15,7 @@ from pg8000.converters import literal  # type: ignore
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 from materialize.util import naughty_strings
 
@@ -69,7 +70,9 @@ class Identifiers(Check):
         "comment_column",
     ]
 
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
         strings = naughty_strings()
         values = (rng or Random(0)).sample(strings, len(self.IDENT_KEYS))
         self.ident = {
@@ -80,7 +83,7 @@ class Identifiers(Check):
         self.ident["secret_value"] = "secret_value"
         # https://github.com/MaterializeInc/database-issues/issues/6813
         self.ident["source"] = "source"
-        super().__init__(base_version, rng)
+        super().__init__(base_version, rng, features)
 
     def initialize(self) -> Testdrive:
         cmds = f"""

--- a/misc/python/materialize/checks/all_checks/mysql_cdc.py
+++ b/misc/python/materialize/checks/all_checks/mysql_cdc.py
@@ -15,6 +15,7 @@ from typing import Any
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.executors import Executor
+from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.mysql import MySql
 
@@ -249,14 +250,22 @@ class MySqlCdcBase:
 
 @externally_idempotent(False)
 class MySqlCdc(MySqlCdcBase, Check):
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
-        super().__init__(wait=True, base_version=base_version, rng=rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
+        super().__init__(
+            wait=True, base_version=base_version, rng=rng, features=features
+        )
 
 
 @externally_idempotent(False)
 class MySqlCdcNoWait(MySqlCdcBase, Check):
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
-        super().__init__(wait=False, base_version=base_version, rng=rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
+        super().__init__(
+            wait=False, base_version=base_version, rng=rng, features=features
+        )
 
 
 @externally_idempotent(False)

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check, externally_idempotent
+from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 
 
@@ -246,14 +247,22 @@ class PgCdcBase:
 
 @externally_idempotent(False)
 class PgCdc(PgCdcBase, Check):
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
-        super().__init__(wait=True, base_version=base_version, rng=rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
+        super().__init__(
+            wait=True, base_version=base_version, rng=rng, features=features
+        )
 
 
 @externally_idempotent(False)
 class PgCdcNoWait(PgCdcBase, Check):
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
-        super().__init__(wait=False, base_version=base_version, rng=rng)
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
+        super().__init__(
+            wait=False, base_version=base_version, rng=rng, features=features
+        )
 
 
 @externally_idempotent(False)

--- a/misc/python/materialize/checks/all_checks/sql_server_cdc.py
+++ b/misc/python/materialize/checks/all_checks/sql_server_cdc.py
@@ -76,7 +76,7 @@ class SqlServerCdcBase:
                 $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
                 ALTER SYSTEM SET enable_sql_server_source = true;
 
-                > VALIDATE CONNECTION sql_server_password_{self.suffix};
+                > VALIDATE CONNECTION sql_server_connection_{self.suffix};
                 """,
                 f"""
                 $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}

--- a/misc/python/materialize/checks/all_checks/sql_server_cdc.py
+++ b/misc/python/materialize/checks/all_checks/sql_server_cdc.py
@@ -82,7 +82,7 @@ class SqlServerCdcBase:
                 $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
                 ALTER SYSTEM SET enable_sql_server_source = true;
 
-                > DROP CONNECTION sql_server_password_{self.suffix};
+                > DROP CONNECTION sql_server_connection_{self.suffix};
                 > CREATE CONNECTION sql_server_connection2_{self.suffix} TO SQL SERVER (
                     HOST 'sql-server',
                     DATABASE test,

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -14,6 +14,7 @@ from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
 from materialize.checks.actions import Testdrive
 from materialize.checks.executors import Executor
+from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 
 if TYPE_CHECKING:
@@ -28,9 +29,12 @@ class Check:
     enabled: bool = True
     externally_idempotent: bool = True
 
-    def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
+    def __init__(
+        self, base_version: MzVersion, rng: Random | None, features: Features | None
+    ) -> None:
         self.base_version = base_version
         self.rng = rng
+        self.features = features
 
     def _can_run(self, e: Executor) -> bool:
         return True

--- a/misc/python/materialize/checks/features.py
+++ b/misc/python/materialize/checks/features.py
@@ -20,7 +20,7 @@ class Features:
         self.features = features
 
     def azurite_enabled(self) -> bool:
-        return self.AZURITE in self.features
+        return self.features and self.AZURITE in self.features
 
     def sql_server_enabled(self) -> bool:
-        return self.SQL_SERVER in self.features
+        return self.features and self.SQL_SERVER in self.features

--- a/misc/python/materialize/checks/features.py
+++ b/misc/python/materialize/checks/features.py
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# Features Materialize that require non-standard infrastructure to test.
+#
+# For example, the SQL Server Docker image is only supported on x86_64 so we
+# cannot enable that feature on ARM based runners.
+class Features:
+    AZURITE = "azurite"
+    SQL_SERVER = "sql_server"
+
+    def __init__(self, features):
+        self.features = features
+
+    def azurite_enabled(self) -> bool:
+        return self.AZURITE in self.features
+
+    def sql_server_enabled(self) -> bool:
+        return self.SQL_SERVER in self.features

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -74,7 +74,7 @@ class StartMz(MzcomposeAction):
             image=image,
             external_metadata_store=True,
             external_blob_store=True,
-            blob_store_is_azure=self.scenario.azurite,
+            blob_store_is_azure=self.scenario.features.azurite_enabled(),
             environment_extra=self.environment_extra,
             system_parameter_defaults=self.system_parameter_defaults,
             additional_system_parameter_defaults=self.additional_system_parameter_defaults,

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -14,6 +14,7 @@ from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
 from materialize.checks.executors import Executor
+from materialize.checks.features import Features
 from materialize.checks.mzcompose_actions import (
     ConfigureMz,
     KillClusterdCompute,
@@ -48,12 +49,12 @@ class Scenario:
         self,
         checks: list[type[Check]],
         executor: Executor,
-        azurite: bool,
+        features: Features,
         seed: str | None = None,
     ) -> None:
         self._checks = checks
         self.executor = executor
-        self.azurite = azurite
+        self.features = features
         self.rng = None if seed is None else Random(seed)
         self._base_version = MzVersion.parse_cargo()
 
@@ -66,7 +67,7 @@ class Scenario:
         # Use base_version() here instead of _base_version so that overwriting
         # upgrade scenarios can specify another base version.
         self.check_objects = [
-            check_class(self.base_version(), self.rng)
+            check_class(self.base_version(), self.rng, self.features)
             for check_class in filtered_check_classes
         ]
 
@@ -274,11 +275,11 @@ class SystemVarChange(Scenario):
         self,
         checks: list[type[Check]],
         executor: Executor,
-        azurite: bool,
+        features: Features,
         seed: str | None,
         change_entries: list[SystemVarChangeEntry],
     ):
-        super().__init__(checks, executor, azurite, seed)
+        super().__init__(checks, executor, features, seed)
         self.change_entries = change_entries
 
     def actions(self) -> list[Action]:

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -11,6 +11,7 @@
 from materialize.checks.actions import Action, Initialize, Manipulate, Sleep, Validate
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
+from materialize.checks.features import Features
 from materialize.checks.mzcompose_actions import (
     KillClusterdCompute,
     KillMz,
@@ -199,11 +200,11 @@ class UpgradeEntireMzFourVersions(Scenario):
         self,
         checks: list[type[Check]],
         executor: Executor,
-        azurite: bool,
+        features: Features,
         seed: str | None = None,
     ):
         self.minor_versions = get_minor_versions()
-        super().__init__(checks, executor, azurite, seed)
+        super().__init__(checks, executor, features, seed)
 
     def base_version(self) -> MzVersion:
         return self.minor_versions[3]

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -18,6 +18,7 @@ from materialize.checks.actions import (
 )
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
+from materialize.checks.features import Features
 from materialize.checks.mzcompose_actions import (
     MzcomposeAction,
     PromoteMz,
@@ -260,11 +261,11 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
         self,
         checks: list[type[Check]],
         executor: Executor,
-        azurite: bool,
+        features: Features,
         seed: str | None = None,
     ):
         self.minor_versions = get_minor_versions()
-        super().__init__(checks, executor, azurite, seed)
+        super().__init__(checks, executor, features, seed)
 
     def base_version(self) -> MzVersion:
         return self.minor_versions[3]

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -27,6 +27,7 @@ from materialize.checks.cloudtest_actions import (
     SetupSshTunnels,
 )
 from materialize.checks.executors import CloudtestExecutor
+from materialize.checks.features import Features
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.wait import wait
@@ -97,5 +98,5 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
         print(
             f"Checks in shard with index {buildkite.get_parallelism_index()}: {[c.__name__ for c in checks]}"
         )
-    scenario = CloudtestUpgrade(checks=checks, executor=executor, azurite=False)
+    scenario = CloudtestUpgrade(checks=checks, executor=executor, features=Features([]))
     scenario.run()

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -245,6 +245,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     else:
         checks = list(all_subclasses(Check))
 
+    if features.sql_server_enabled():
+        c.up("sql-server")
+
     checks.sort(key=lambda ch: ch.__name__)
     checks = buildkite.shard_list(checks, lambda ch: ch.__name__)
     if buildkite.get_parallelism_index() != 0 or buildkite.get_parallelism_count() != 1:


### PR DESCRIPTION
This PR enables SQL Server in platform checks by adding a new `--features` argument that supports "azurite" and "sql_server". Then we add new workflows in CI that run SQL Server on x86 which is the only arch that is supported by Microsoft's official SQL Server Docker image.

### Motivation

Test the SQL Server source with platform-checks

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
