### PR TITLE
optimizer: Fix JoinImplementation's MFP lifting's inlining

### DIFF
--- a/test/sqllogictest/github-8261-8463-9156.slt
+++ b/test/sqllogictest/github-8261-8463-9156.slt
@@ -297,3 +297,21 @@ ON (NULLIF (a1.f2, a2.f2) = a1.f1 + a2.f2);
 ----
 NULL
 NULL
+
+# database-issues#9156
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_eager_delta_joins TO true;
+----
+COMPLETE 0
+
+query
+SELECT
+FROM
+    (
+      SELECT a2.f2 AS f1, a2.f1 AS f2
+      FROM t2 AS a1 JOIN pk1 AS a2 USING(f1, f2)
+      WHERE a2.f1 = (NULLIF (a1.f2, a2.f2)) AND (a1.f1 + a2.f2) = a2.f2
+    ) AS a1
+    JOIN (SELECT a2.f2 AS f1, avg(a2.f2) AS f2 FROM t1 AS a2 GROUP BY 1) AS a2 USING(f1, f2);
+----


### PR DESCRIPTION
When `JoinImplementation` lifts an MFP from a join input to after the join (to be able to reuse an arrangement), it needs to permute the join equivalences by the projection of the lifted MFP. Moreover, it can happen that a column reference that we get from the permutation refers to a column that is built by a map expression of the MFP that is being lifted. This requires further treatment, because the lifted MFP will happen _after_ the equivalences, so the equivalences can't refer to a column that is built only in the MFP. What the code does (already before this PR) is simply inline the referred Map expression in place of the problematic column reference.

But, there was a bug in the inlining logic: After substituting a problematic column reference with a new expression, we have to look at the new expression again, because it might itself be a problematic column reference. (Note that the new expression's children were already being visited, it's just that the new expression itself was not being visited again. So, the problematic case was when the inlined expression itself was again a problematic column reference.)

Example: On the reduced query in https://github.com/MaterializeInc/database-issues/issues/9156, we had the column reference `#5` in a Join equivalence before MFP lifting. The lifted MFP was
```
MapFilterProject(
  expressions:
    #7 <- case when (#4 = #4) then null else #4 end,
    #8 <- #7,
  predicates:
    <before: 2> (#1 = (#0 + #1)),
    <before: 2> (#0 = case when (#1 = #1) then null else #1 end),
    <before: 7> (#4 = ((#5 / bigint_to_double(case when (#6 = 0) then null else #6 end)) + #4)),
    <before: 7> ((#5 / bigint_to_double(case when (#6 = 0) then null else #6 end)) = case when (#4 = #4) then null else #4 end),
  projection: [0, 1, 2, 3, 4, 8]
  input_arity: 7
)
```
so the `#5` was permuted to `#8`. The inlining logic then changed the `#8` to `#7`, but this was not enough, because `#7` also happens to be built by the MFP. After the PR, we go around the added loop a second time, so that `#7` is further substituted with the `case ...` expression.

Nightly (subset): https://buildkite.com/materialize/nightly/builds/11839

(I'll do some follow-up PRs shortly: 1. use a modern visitation instead of the deprecated `visit_mut_pre_post`, 2. Log the backtrace when catching an optimizer panic, 3. catch optimizer panics that happen in `as_explain_single_plan`'s `normalize_lets` call.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9156

### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
