### PR TITLE
Catch more panics when calling optimizer code

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -61,7 +61,6 @@ pub mod subscribe;
 pub mod view;
 
 use std::fmt::Debug;
-use std::panic::AssertUnwindSafe;
 
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::PERSIST_FAST_PATH_ORDER;
@@ -77,7 +76,7 @@ use mz_repr::{CatalogItemId, GlobalId};
 use mz_sql::names::{FullItemName, QualifiedItemName};
 use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
-use mz_transform::{TransformCtx, TransformError};
+use mz_transform::{MaybeShouldPanic, TransformCtx, TransformError};
 
 // Alias types
 // -----------
@@ -121,21 +120,12 @@ where
     /// Like [`Self::optimize`], but additionally ensures that panics occurring
     /// in the [`Self::optimize`] call are caught and demoted to an
     /// [`OptimizerError::Internal`] error.
+    ///
+    /// Additionally, if the result of the optimization is an error (not a panic) that indicates we
+    /// should panic, then panic.
     #[mz_ore::instrument(target = "optimizer", level = "debug", name = "optimize")]
     fn catch_unwind_optimize(&mut self, plan: From) -> Result<Self::To, OptimizerError> {
-        match mz_ore::panic::catch_unwind_str(AssertUnwindSafe(|| self.optimize(plan))) {
-            Ok(Err(OptimizerError::TransformError(TransformError::CallerShouldPanic(msg)))) => {
-                // Promote a `CallerShouldPanic` error from the result to a proper panic. This is
-                // needed in order to ensure that `mz_unsafe.mz_panic('forced panic')` calls still
-                // panic the caller.
-                panic!("{msg}");
-            }
-            Ok(result) => result,
-            Err(panic) => {
-                let msg = format!("unexpected panic during query optimization: {panic}");
-                Err(OptimizerError::Internal(msg))
-            }
-        }
+        mz_transform::catch_unwind_optimize(|| self.optimize(plan))
     }
 
     /// Execute the optimization stage and panic if an error occurs.
@@ -338,6 +328,17 @@ impl From<TimestampError> for OptimizerError {
 impl From<anyhow::Error> for OptimizerError {
     fn from(value: anyhow::Error) -> Self {
         OptimizerError::Internal(value.to_string())
+    }
+}
+
+impl MaybeShouldPanic for OptimizerError {
+    fn should_panic(&self) -> Option<String> {
+        match self {
+            OptimizerError::TransformError(TransformError::CallerShouldPanic(msg)) => {
+                Some(msg.to_string())
+            }
+            _ => None,
+        }
     }
 }
 

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -29,7 +29,7 @@ use mz_ore::assert_none;
 use mz_ore::{id_gen::IdGen, stack::RecursionLimitError};
 use mz_repr::optimize::OptimizerFeatures;
 
-use crate::TransformCtx;
+use crate::{TransformCtx, catch_unwind_optimize};
 
 pub use renumbering::renumber_bindings;
 
@@ -38,7 +38,7 @@ pub fn normalize_lets(
     expr: &mut MirRelationExpr,
     features: &OptimizerFeatures,
 ) -> Result<(), crate::TransformError> {
-    NormalizeLets::new(false).action(expr, features)
+    catch_unwind_optimize(|| NormalizeLets::new(false).action(expr, features))
 }
 
 /// Install replace certain `Get` operators with their `Let` value.


### PR DESCRIPTION
EXPLAIN (and other things) call into the optimizer at many points, and not all of these have been wrapped into `catch_unwind` so far. This PR attends to some of these. More specifically:
- `normalize_lets` is called at some places outside the normal optimizer pipelines, e.g., it's called by EXPLAIN. Therefore, the PR adds a `catch_unwind` in `normalize_lets`, so that we catch panics even when `normalize_lets` is called not through the normal optimizer pipelines. (I noticed this problem when working on https://github.com/MaterializeInc/database-issues/issues/9156: normally, the panic was caught, but sometimes it caused an actual panic in EXPLAIN commands.)
- The PR adds `catch_unwind` to the `normalize_subqueries` call. (This is also in EXPLAIN.)

I suggest reviewing commit-by-commit:
1. does a refactoring to make the 2. commit easy. I had to add the `MaybeShouldPanic` trait, because of needing to generalize over `TransformError` and `OptimizerError`.
2. attends to `normalize_lets`.
3. attends to the `normalize_subqueries` call.

### Motivation

  * We don't want to worry about EXPLAIN commands causing envd panics when impersonated into user envs.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
