### PR TITLE
Declutter "slow optimization" log msg

### DIFF
--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -75,20 +75,20 @@ impl OptimizerMetrics {
                     (
                         k,
                         v.into_iter()
-                            .map(|duration| duration.as_nanos())
+                            .map(|duration| duration.as_micros())
                             .collect::<Vec<_>>(),
                     )
                 })
                 .collect::<Vec<_>>();
             tracing::warn!(
-                object_type = object_type,
-                transform_times = serde_json::to_string(&transform_times)
-                    .unwrap_or_else(|_| format!("{:?}", transform_times)),
+                duration = format!("{}ms", duration.as_millis()),
                 threshold = format!(
                     "{}ms",
                     self.e2e_optimization_time_seconds_log_threshold.as_millis()
                 ),
-                duration = format!("{}ms", duration.as_millis()),
+                object_type = object_type,
+                transform_times_μs = serde_json::to_string(&transform_times)
+                    .unwrap_or_else(|_| format!("{:?}", transform_times)),
                 "slow optimization",
             );
         }


### PR DESCRIPTION
This PR makes the "slow optimization" log msgs easier to read and take up less space:
- Log micro-seconds instead of nano-seconds, so that 1) take up less space on the screen, 2) large ones stand out more. (Every number was large in nanoseconds, so it was hard to see at a glance which ones are the actually big ones.)
- Call out that it's μs by printing `transform_times_μs`, because sometimes I was forgetting what unit we were printing.
- Reorder fields to put the total duration at the beginning.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
