### PR TITLE
row_spine: Maintain separate counts

### DIFF
--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -28,7 +28,7 @@ mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-metrics = { path = "../metrics" }
-mz-ore = { path = "../ore", features = ["async", "process", "tracing", "columnar", "differential-dataflow"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing", "columnar", "differential-dataflow", "region"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-repr = { path = "../repr" }

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -438,6 +438,7 @@ mod bytes_container {
     pub struct BytesBatch {
         offsets: crate::row_spine::OffsetOptimized,
         storage: Region<u8>,
+        len: usize,
     }
 
     impl BytesBatch {
@@ -447,6 +448,7 @@ mod bytes_container {
             if self.storage.len() + slice.len() <= self.storage.capacity() {
                 self.storage.extend_from_slice(slice);
                 self.offsets.push(self.storage.len());
+                self.len += 1;
                 true
             } else {
                 false
@@ -457,8 +459,10 @@ mod bytes_container {
             let upper = self.offsets.index(index + 1);
             &self.storage[lower..upper]
         }
+        #[inline(always)]
         fn len(&self) -> usize {
-            self.offsets.len() - 1
+            debug_assert_eq!(self.len, self.offsets.len() - 1);
+            self.len
         }
 
         fn with_capacities(item_cap: usize, byte_cap: usize) -> Self {
@@ -468,6 +472,7 @@ mod bytes_container {
             Self {
                 offsets,
                 storage: Region::new_auto(byte_cap.next_power_of_two()),
+                len: 0,
             }
         }
     }

--- a/test/sqllogictest/introspection/attribution_sources.slt
+++ b/test/sqllogictest/introspection/attribution_sources.slt
@@ -204,7 +204,7 @@ SELECT mlm.global_id AS global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 
              mlm.operator_id_start <= megsa.region_id AND megsa.region_id < mlm.operator_id_end)
 ORDER BY mlm.global_id, lir_id DESC;
 ----
-u7  2  NULL  TopK::Basic␠1  8  7  3584  15.000
+u7  2  NULL  TopK::Basic␠1  8  7  3808  15.000
 u7  1  2  ␠␠Get::PassArrangements␠u6  NULL  NULL  NULL  NULL
 u8  4  NULL  Arrange␠3  NULL  NULL  NULL  NULL
 u8  3  4  ␠␠Get::PassArrangements␠u7  NULL  NULL  NULL  NULL


### PR DESCRIPTION
At the moment, various types in row_spine re-compute their length whenever asked, and this can take a surprising amount of time to compute. So, stash it and assert its correctness in debug mode.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
