### PR TITLE
[sql_server] support `ALTER SOURCE ... ADD SUBSOURCE`

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -117,7 +117,7 @@ pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::{
     AlterSourceAddSubsourceOptionExtracted, MySqlConfigOptionExtracted, PgConfigOptionExtracted,
-    PlannedAlterRoleOption, PlannedRoleVariable,
+    PlannedAlterRoleOption, PlannedRoleVariable, SqlServerConfigOptionExtracted,
 };
 pub use statement::{
     StatementClassification, StatementContext, StatementDesc, describe, plan, plan_copy_from,

--- a/test/sql-server-cdc/10-sql-server-cdc.td
+++ b/test/sql-server-cdc/10-sql-server-cdc.td
@@ -54,8 +54,6 @@ name                         type
 ---------------------------------------
 sql_server_test_connection   sql-server
 
-> SHOW CONNECTIONS;
-sql_server_test_connection sql-server ""
 
 # Create a SQL Server Source.
 

--- a/test/sql-server-cdc/30-add-subsource.td
+++ b/test/sql-server-cdc/30-add-subsource.td
@@ -41,7 +41,10 @@ INSERT INTO t2_add_subsource VALUES ('100'), ('200'), (NULL), ('300');
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_sql_server_source = true;
 
-> CREATE CONNECTION IF NOT EXISTS sql_server_test_connection TO SQL SERVER (
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET log_filter = 'mz_sql=debug,info';
+
+> CREATE CONNECTION IF NOT EXISTS sql_server_test_add_subsource_conn TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,
     DATABASE test_30,
@@ -52,7 +55,7 @@ ALTER SYSTEM SET enable_sql_server_source = true;
 # Create a SQL Server Source.
 
 > CREATE SOURCE my_source_add_subsources
-  FROM SQL SERVER CONNECTION sql_server_test_connection
+  FROM SQL SERVER CONNECTION sql_server_test_add_subsource_conn
   FOR TABLES (dbo.t1_add_subsource);
 
 

--- a/test/sql-server-cdc/30-add-subsource.td
+++ b/test/sql-server-cdc/30-add-subsource.td
@@ -1,0 +1,127 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+DROP DATABASE IF EXISTS test_30;
+CREATE DATABASE test_30;
+USE test_30;
+
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test_30 SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE t1_add_subsource (val VARCHAR(1024));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_add_subsource', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t1_add_subsource VALUES ('a'), ('b'), (NULL), ('c');
+
+CREATE TABLE t2_add_subsource (val VARCHAR(1024));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't2_add_subsource', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t2_add_subsource VALUES ('100'), ('200'), (NULL), ('300');
+
+
+# Exercise Materialize.
+
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_sql_server_source = true;
+
+> CREATE CONNECTION IF NOT EXISTS sql_server_test_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_30,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+# Create a SQL Server Source.
+
+> CREATE SOURCE my_source_add_subsources
+  FROM SQL SERVER CONNECTION sql_server_test_connection
+  FOR TABLES (dbo.t1_add_subsource);
+
+
+> SELECT * FROM t1_add_subsource;
+a
+b
+c
+<null>
+
+> ALTER SOURCE my_source_add_subsources ADD SUBSOURCE dbo.t2_add_subsource;
+
+> SELECT * FROM t2_add_subsource;
+100
+200
+300
+<null>
+
+# Add some more data to ensure the replication continues.
+
+$ sql-server-execute name=sql-server
+INSERT INTO t1_add_subsource VALUES ('d');
+INSERT INTO t2_add_subsource VALUES ('400');
+
+> SELECT * FROM t1_add_subsource;
+a
+b
+c
+d
+<null>
+
+> SELECT * FROM t2_add_subsource;
+100
+200
+300
+400
+<null>
+
+$ sql-server-execute name=sql-server
+INSERT INTO t1_add_subsource VALUES ('e');
+INSERT INTO t2_add_subsource VALUES ('500');
+
+> DROP SOURCE t1_add_subsource;
+
+> SELECT * FROM t2_add_subsource;
+100
+200
+300
+400
+500
+<null>
+
+> ALTER SOURCE my_source_add_subsources ADD SUBSOURCE dbo.t1_add_subsource;
+
+> SELECT * FROM t1_add_subsource;
+a
+b
+c
+d
+e
+<null>
+
+$ sql-server-execute name=sql-server
+INSERT INTO t1_add_subsource VALUES ('f');
+
+> SELECT * FROM t1_add_subsource;
+a
+b
+c
+d
+e
+f
+<null>


### PR DESCRIPTION
This PR adds support for adding subsources to a `SQL SERVER` source. All of the changes are in Adapter during purification. We also add a new testcase to the `sql-server-cdc` mzcompose flow to exercise adding and dropping subsources.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
