### PR TITLE
[sql_server] Report `ProgressStatisticsUpdate`s and cleanup committed data

### DIFF
--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -112,7 +112,16 @@ pub fn get_changes_asc(
 }
 
 /// Cleans up the change table associated with the specified `capture_instance` by
-/// deleting all entries with a `start_lsn` less than `low_water_mark`.
+/// deleting `max_deletes` entries with a `start_lsn` less than `low_water_mark`.
+///
+/// Note: At the moment cleanup is kind of "best effort".  If this query succeeds
+/// then at most `max_delete` rows were deleted, but the number of actual rows
+/// deleted is not returned as part of the query. The number of rows _should_ be
+/// present in an informational message (i.e. a Notice) that is returned, but
+/// [`tiberius`] doesn't expose these to us.
+///
+/// TODO(sql_server2): Update [`tiberius`] to return informational messages so we
+/// can determine how many rows got deleted.
 ///
 /// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-cdc-cleanup-change-table-transact-sql?view=sql-server-ver16>.
 pub async fn cleanup_change_table(

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -568,9 +568,7 @@ impl Connection {
 
                 let mut results = result.into_results().await.context("into results")?;
                 if results.is_empty() {
-                    Err(SqlServerError::InvariantViolated(
-                        "got empty response".into(),
-                    ))
+                    Ok((Response::Rows(smallvec![]), None))
                 } else if results.len() == 1 {
                     // TODO(sql_server3): Don't use `into_results()` above, instead directly
                     // push onto a SmallVec to avoid the heap allocations.

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -320,5 +320,9 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&WALLCLOCK_GLOBAL_LAG_HISTOGRAM_RETENTION_INTERVAL)
         .add(&WALLCLOCK_LAG_HISTORY_RETENTION_INTERVAL)
         .add(&crate::sources::sql_server::CDC_POLL_INTERVAL)
+        .add(&crate::sources::sql_server::CDC_CLEANUP_CHANGE_TABLE)
+        .add(&crate::sources::sql_server::CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES)
         .add(&crate::sources::sql_server::SNAPSHOT_MAX_LSN_WAIT)
+        .add(&crate::sources::sql_server::SNAPSHOT_STATS_GRANULARITY)
+        .add(&crate::sources::sql_server::OFFSET_KNOWN_INTERVAL)
 }

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -323,6 +323,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::sources::sql_server::CDC_CLEANUP_CHANGE_TABLE)
         .add(&crate::sources::sql_server::CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES)
         .add(&crate::sources::sql_server::SNAPSHOT_MAX_LSN_WAIT)
-        .add(&crate::sources::sql_server::SNAPSHOT_STATS_GRANULARITY)
+        .add(&crate::sources::sql_server::SNAPSHOT_PROGRESS_REPORT_INTERVAL)
         .add(&crate::sources::sql_server::OFFSET_KNOWN_INTERVAL)
 }

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -41,10 +41,10 @@ pub const SNAPSHOT_MAX_LSN_WAIT: Config<Duration> = Config::new(
     CDC to be fully enabled) before taking an initial snapshot.",
 );
 
-pub const SNAPSHOT_STATS_GRANULARITY: Config<usize> = Config::new(
-    "sql_server_snapshot_stats_granularity",
-    1000,
-    "Emit a progress update every X events when snapshotting.",
+pub const SNAPSHOT_PROGRESS_REPORT_INTERVAL: Config<Duration> = Config::new(
+    "sql_server_snapshot_progress_report_interval",
+    Duration::from_secs(2),
+    "Interval at which we'll report progress for currently running snapshots.",
 );
 
 pub const CDC_POLL_INTERVAL: Config<Duration> = Config::new(
@@ -65,8 +65,11 @@ pub const CDC_CLEANUP_CHANGE_TABLE: Config<bool> = Config::new(
 /// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-cdc-cleanup-change-table-transact-sql?view=sql-server-ver16>.
 pub const CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES: Config<u32> = Config::new(
     "sql_server_cdc_cleanup_change_table_max_deletes",
-    // This is the default documented by SQL Server.
-    5000,
+    // The default in SQL Server is 5,000 but until we change the cleanup
+    // function to call it iteratively we set a large value here.
+    //
+    // TODO(sql_server2): Call the cleanup function iteratively.
+    1_000_000,
     "Maximum number of entries that can be deleted by using a single statement.",
 );
 

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -41,10 +41,39 @@ pub const SNAPSHOT_MAX_LSN_WAIT: Config<Duration> = Config::new(
     CDC to be fully enabled) before taking an initial snapshot.",
 );
 
+pub const SNAPSHOT_STATS_GRANULARITY: Config<usize> = Config::new(
+    "sql_server_snapshot_stats_granularity",
+    1000,
+    "Emit a progress update every X events when snapshotting.",
+);
+
 pub const CDC_POLL_INTERVAL: Config<Duration> = Config::new(
     "sql_server_cdc_poll_interval",
     Duration::from_millis(500),
     "Interval at which we'll poll the upstream SQL Server instance to discover new changes.",
+);
+
+pub const CDC_CLEANUP_CHANGE_TABLE: Config<bool> = Config::new(
+    "sql_server_cdc_cleanup_change_table",
+    true,
+    "When enabled we'll notify SQL Server that it can cleanup the change tables \
+    as the source makes progress and commits data.",
+);
+
+/// Maximum number of deletes that we'll make from a single SQL Server change table.
+///
+/// See: <https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-cdc-cleanup-change-table-transact-sql?view=sql-server-ver16>.
+pub const CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES: Config<u32> = Config::new(
+    "sql_server_cdc_cleanup_change_table_max_deletes",
+    // This is the default documented by SQL Server.
+    5000,
+    "Maximum number of entries that can be deleted by using a single statement.",
+);
+
+pub const OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
+    "sql_server_offset_known_interval",
+    Duration::from_secs(10),
+    "Interval to fetch `offset_known`, from `sys.fn_cdc_get_max_lsn()`",
 );
 
 pub static SQL_SERVER_PROGRESS_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -1,0 +1,186 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A "non-critical" operator that tracks the progress of a [`SqlServerSource`].
+//!
+//! The operator does the following:
+//!
+//! * At some cadence [`OFFSET_KNOWN_INTERVAL`] will probe the source for the max
+//!   [`Lsn`] and emit a [`ProgressStatisticsUpdate`] to notify listeners of a
+//!   new "known LSN".
+//! * Listen to a provided [`futures::Stream`] of resume uppers, which represents
+//!   the durably committed upper for _all_ of the subsources/exports associated
+//!   with this source. As the source makes progress this operator does two
+//!   things:
+//!     1. If [`CDC_CLEANUP_CHANGE_TABLE`] is enabled, will delete entries from
+//!        the upstream change table that we've already ingested.
+//!     2. Emit a [`ProgressStatisticsUpdate`] to notify listeners of a new
+//!        "committed LSN".
+//!
+//! [`SqlServerSource`]: mz_storage_types::sources::SqlServerSource
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures::StreamExt;
+use mz_ore::future::InTask;
+use mz_repr::GlobalId;
+use mz_sql_server_util::cdc::Lsn;
+use mz_storage_types::connections::SqlServerConnectionDetails;
+use mz_storage_types::sources::sql_server::{
+    CDC_CLEANUP_CHANGE_TABLE, CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES, OFFSET_KNOWN_INTERVAL,
+};
+use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
+use timely::dataflow::operators::Map;
+use timely::dataflow::{Scope, Stream as TimelyStream};
+use timely::progress::Antichain;
+
+use crate::source::sql_server::{ReplicationError, SourceOutputInfo, TransientError};
+use crate::source::types::ProgressStatisticsUpdate;
+use crate::source::{RawSourceCreationConfig, probe};
+
+/// Used as a partition ID to determine the worker that is responsible for
+/// handling progress.
+static PROGRESS_WORKER: &str = "progress";
+
+pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
+    scope: G,
+    config: RawSourceCreationConfig,
+    connection: SqlServerConnectionDetails,
+    outputs: BTreeMap<GlobalId, SourceOutputInfo>,
+    resume_uppers: impl futures::Stream<Item = Antichain<Lsn>> + 'static,
+) -> (
+    TimelyStream<G, ProgressStatisticsUpdate>,
+    TimelyStream<G, ReplicationError>,
+    PressOnDropButton,
+) {
+    let op_name = format!("SqlServerProgress({})", config.id);
+    let mut builder = AsyncOperatorBuilder::new(op_name, scope);
+
+    let (stats_output, stats_stream) = builder.new_output();
+
+    let (button, transient_errors) = builder.build_fallible::<TransientError, _>(move |caps| {
+        Box::pin(async move {
+            let [stats_cap]: &mut [_; 1] = caps.try_into().unwrap();
+
+            // Small helper closure.
+            let emit_stats = |cap, known: u64, committed: u64| {
+                let update = ProgressStatisticsUpdate::SteadyState {
+                    offset_known: known,
+                    offset_committed: committed,
+                };
+                tracing::debug!(?config.id, %known, %committed, "steadystate progress");
+                stats_output.give(cap, update);
+            };
+
+            // Only a single worker is responsible for processing progress.
+            if !config.responsible_for(PROGRESS_WORKER) {
+                // Emit 0 to mark this worker as having started up correctly.
+                emit_stats(&stats_cap[0], 0, 0);
+            }
+
+            let conn_config = connection
+                .resolve_config(
+                    &config.config.connection_context.secrets_reader,
+                    &config.config,
+                    InTask::Yes,
+                )
+                .await?;
+            let (mut client, conn) = mz_sql_server_util::Client::connect(conn_config).await?;
+            // TODO(sql_server1): Move the connection into its own future.
+            mz_ore::task::spawn(|| "sql_server-progress-conn", async move { conn.await });
+
+            let probe_interval = OFFSET_KNOWN_INTERVAL.handle(config.config.config_set());
+            let mut probe_ticker = probe::Ticker::new(|| probe_interval.get(), config.now_fn);
+
+            // Offset that is measured from the upstream SQL Server instance.
+            let mut prev_offset_known: Option<Lsn> = None;
+            // Offset that we have observed from the `resume_uppers` stream.
+            let mut prev_offset_committed: Option<Lsn> = None;
+
+            // This stream of "resume uppers" tracks all of the Lsn's that we have durably
+            // committed for all subsources/exports and thus we can notify the upstream that the
+            // change tables can be cleaned up.
+            let mut resume_uppers = std::pin::pin!(resume_uppers);
+            let cleanup_change_table = CDC_CLEANUP_CHANGE_TABLE.handle(config.config.config_set());
+            let cleanup_max_deletes = CDC_CLEANUP_CHANGE_TABLE_MAX_DELETES.handle(config.config.config_set());
+            let capture_instances: BTreeSet<_> = outputs.into_values().map(|info| info.capture_instance).collect();
+
+            loop {
+                tokio::select! {
+                    // TODO(sql_server2): Emit probes here.
+                    _probe_ts = probe_ticker.tick() => {
+                        let known_lsn = mz_sql_server_util::inspect::get_max_lsn(&mut client).await?;
+
+                        // The DB should never go backwards, but it's good to know if it does.
+                        let prev_known_lsn = match prev_offset_known {
+                            None => {
+                                prev_offset_known = Some(known_lsn);
+                                known_lsn
+                            },
+                            Some(prev) => prev,
+                        };
+                        if known_lsn < prev_known_lsn {
+                            mz_ore::soft_panic_or_log!(
+                                "upstream SQL Server went backwards in time, current LSN: {known_lsn}, last known {prev_known_lsn}",
+                            );
+                            continue;
+                        }
+
+                        // Update any listeners with our most recently known LSN.
+                        if let Some(prev_commit_lsn) = prev_offset_committed {
+                            let known_lsn_abrv = known_lsn.abbreviate();
+                            let commit_lsn_abrv = prev_commit_lsn.abbreviate();
+                            emit_stats(&stats_cap[0], known_lsn_abrv, commit_lsn_abrv);
+                        }
+                        prev_offset_known = Some(known_lsn);
+                    },
+                    Some(resume_upper) = resume_uppers.next() => {
+                        let Some(resume_upper) = resume_upper.as_option() else {
+                            mz_ore::soft_panic_or_log!("empty resume upper? {resume_upper:?}");
+                            continue;
+                        };
+
+                        // If enabled, tell the upstream SQL Server instance to
+                        // cleanup the underlying change table.
+                        if cleanup_change_table.get() {
+                            for instance in &capture_instances {
+                                // TODO(sql_server3): The number of rows that got cleaned
+                                // up should be present in informational notices sent back
+                                // from the upstream, but the tiberius crate does not
+                                // expose these.
+                                let cleanup_result = mz_sql_server_util::inspect::cleanup_change_table(
+                                    &mut client,
+                                    instance,
+                                    resume_upper,
+                                    cleanup_max_deletes.get(),
+                                ).await;
+                                // TODO(sql_server2): Track this in a more user observable way.
+                                if let Err(err) = cleanup_result {
+                                    tracing::warn!(?err, %instance, "cleanup of change table failed!");
+                                }
+                            }
+                        }
+
+                        // Update any listeners with our most recently committed LSN.
+                        if let Some(prev_known_lsn) = prev_offset_known {
+                            let known_lsn_abrv = prev_known_lsn.abbreviate();
+                            let commit_lsn_abrv = resume_upper.abbreviate();
+                            emit_stats(&stats_cap[0], known_lsn_abrv, commit_lsn_abrv);
+                        }
+                        prev_offset_committed = Some(*resume_upper);
+                    }
+                };
+            }
+        })
+    });
+
+    let error_stream = transient_errors.map(ReplicationError::Transient);
+
+    (stats_stream, error_stream, button.press_on_drop())
+}

--- a/test/sql-server-cdc/10-sql-server-cdc.td
+++ b/test/sql-server-cdc/10-sql-server-cdc.td
@@ -25,7 +25,7 @@ ALTER DATABASE test SET ALLOW_SNAPSHOT_ISOLATION ON;
 CREATE TABLE t1_pk (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_pk', @role_name = 'SA', @supports_net_changes = 0;
 
-INSERT INTO t1_pk VALUES ('a', 'hello world'), ('b', 'foobar');
+INSERT INTO t1_pk VALUES ('a', 'hello world'), ('b', 'foobar'), ('c', 'anotha one');
 
 CREATE TABLE t2_no_cdc (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
 
@@ -71,22 +71,43 @@ t3_text subsource quickstart ""
 dbo t1_pk
 dbo t3_text
 
+$ set-from-sql var=source-id
+SELECT id FROM mz_sources WHERE name = 't1_pk_sql_server';
+
+$ set-from-sql var=subsource-id
+SELECT id FROM mz_sources WHERE name = 't1_pk';
+
+> SELECT snapshot_records_known, snapshot_records_staged, snapshot_committed FROM mz_internal.mz_source_statistics WHERE id = '${source-id}';
+3 3 true
+
 > SELECT * FROM t1_pk;
 a "hello world"
 b "foobar"
+c "anotha one"
 
 $ sql-server-execute name=sql-server
 UPDATE t1_pk SET val_col = 'I am an updated value' WHERE key_col = 'a';
 
+> SELECT messages_received FROM mz_internal.mz_source_statistics WHERE id = '${source-id}';
+5
+
+> SELECT updates_staged, updates_committed FROM mz_internal.mz_source_statistics WHERE id = '${subsource-id}';
+5 5
+
+> SELECT offset_known IS NULL, offset_committed IS NULL FROM mz_internal.mz_source_statistics WHERE id = '${subsource-id}';
+false false
+
 > SELECT * FROM t1_pk;
 a "I am an updated value"
 b "foobar"
+c "anotha one"
 
 $ sql-server-execute name=sql-server
 DELETE t1_pk WHERE key_col = 'a';
 
 > SELECT * FROM t1_pk;
 b "foobar"
+c "anotha one"
 
 $ sql-server-execute name=sql-server
 INSERT INTO t1_pk VALUES ('😊', 'lets see what happens');
@@ -94,6 +115,7 @@ INSERT INTO t1_pk VALUES ('😊', 'lets see what happens');
 # Note: VARCHAR columns in SQL Server do not support emojis, hence the '??'.
 > SELECT * FROM t1_pk;
 b "foobar"
+c "anotha one"
 "??" "lets see what happens"
 
 


### PR DESCRIPTION
This PR does a few things:

1. In the "replication" operator, emits `ProgressStatisticsUpdate::Snapshot` as we're snapshotting tables.
2. Adds a new "progress" operator which does the following:
    a. On an interval configurable with dyncfg, probes the upstream SQL Server instance for the max LSN and emits `ProgressStatisticsUpdate::SteadyState` updates.
    b. Tracks the `resume_uppers` stream and as we learn about newly committed data, we emit `ProgressStatisticsUpdate::SteadyState` updates and call the upstream SQL Server instance to cleanup the change tables. This behavior is gated behind a dyncfg which is enabled by default but added just in case we find issues when deploying to customers.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
