### PR TITLE
Persist source: retain row allocation

### DIFF
--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -658,7 +658,9 @@ impl PendingWork {
                     } else {
                         let mut emit_time = *self.capability.time();
                         emit_time.0 = time;
-                        session.give((Ok(row), emit_time, diff.into()));
+                        // Clone row so we retain our row allocation.
+                        session.give((Ok(row.clone()), emit_time, diff.into()));
+                        row_buf.replace(SourceData(Ok(row)));
                         *work += 1;
                     }
                 }


### PR DESCRIPTION
At the moment, the persist source would only retain a row allocation if it had an MFP. The MFP needs to write into a different allocation, so it makes sense to recycle the allocation here. The non-MFP path didn't retain the allocation. This is suboptimal because subsequently we have to right-size another row allocation to decode into, which can involve $log n$ reallocations, where $n$ is the size of the row. Instead, clone the output and retain the probably right-sized row allocation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
