### PR TITLE
ci: Try using larger agents for all tests and less parallelism

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -55,7 +55,7 @@ from .deploy.deploy_util import rust_version
 # trying to capture that.)
 CI_GLUE_GLOBS = ["bin", "ci"]
 
-DEFAULT_AGENT = "hetzner-aarch64-4cpu-8gb"
+DEFAULT_AGENT = "hetzner-aarch64-16cpu-32gb"
 
 
 def steps(pipeline: Any) -> Iterator[dict[str, Any]]:

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -50,7 +50,7 @@ steps:
     command: bin/ci-builder run min bin/pyactivate -m ci.mkpipeline $pipeline $@
     priority: 200
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     retry:
       automatic:
         - exit_status: -1

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -49,7 +49,7 @@ steps:
         command: bin/ci-builder run stable bin/ci-closed-issues-detect
         depends_on: []
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         branches: "main"
         sanitizer: skip
 
@@ -59,7 +59,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         sanitizer: skip
 
       - id: cargo-deny-check-advisories
@@ -68,7 +68,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 20
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         sanitizer: skip
 
   - id: miri-test
@@ -192,9 +192,8 @@ steps:
         label: Kafka smoke test against previous Kafka versions
         depends_on: build-aarch64
         timeout_in_minutes: 120
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-matrix
@@ -204,7 +203,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-multi-broker
@@ -218,7 +217,7 @@ steps:
               composition: kafka-resumption
               args: [--redpanda]
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
 
   - group: Testdrive
@@ -229,7 +228,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -240,7 +239,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -263,7 +262,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 360
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -285,7 +284,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -297,7 +296,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -323,7 +322,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
@@ -362,9 +361,8 @@ steps:
         label: "Bounded Memory"
         depends_on: build-aarch64
         timeout_in_minutes: 90
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: bounded-memory
@@ -372,7 +370,6 @@ steps:
         label: "Bounded Memory Search (materialized only)"
         depends_on: build-aarch64
         timeout_in_minutes: 150
-        parallelism: 8
         # disabled by default
         skip: true
         agents:
@@ -400,7 +397,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: upsert
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: upsert-compaction-disabled
         label: Upsert (compaction disabled)
@@ -411,7 +408,7 @@ steps:
               composition: upsert
               args: [--compaction-disabled]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - id: ssh-connection-extended
     label: Extended SSH connection tests
@@ -422,7 +419,7 @@ steps:
           composition: ssh-connection
           args: [--extended]
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - group: Zippy
     key: zippy
@@ -432,7 +429,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -443,7 +440,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -454,7 +451,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -465,7 +462,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -476,7 +473,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -487,7 +484,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -498,7 +495,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -509,7 +506,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -520,7 +517,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -531,7 +528,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -561,7 +558,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: mysql-cdc-migration
         label: MySQL CDC source-versioning migration tests
@@ -572,7 +569,7 @@ steps:
               composition: mysql-cdc-old-syntax
               run: migration
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: mysql-cdc-resumption-old-syntax
         label: MySQL CDC resumption tests (before source versioning)
@@ -582,7 +579,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: mysql-rtr-old-syntax
         label: MySQL RTR tests (before source versioning)
@@ -592,7 +589,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-rtr-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: pg-cdc-old-syntax
         label: Postgres CDC tests (before source versioning)
@@ -602,7 +599,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         # the mzbuild postgres version will be used, which depends on the Dockerfile specification
 
       - id: pg-cdc-migration
@@ -614,7 +611,7 @@ steps:
               composition: pg-cdc-old-syntax
               run: migration
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: pg-cdc-resumption-old-syntax
         label: Postgres CDC resumption tests (before source versioning)
@@ -624,7 +621,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-resumption-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: pg-rtr-old-syntax
         label: Postgres RTR tests (before source versioning)
@@ -634,7 +631,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-rtr-old-syntax
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: testdrive-old-kafka-src-syntax
         label: "Testdrive (before Kafka source versioning) with :azure: blob store"
@@ -645,12 +642,12 @@ steps:
               composition: testdrive-old-kafka-src-syntax
               args: [--azurite]
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: testdrive-kafka-migration
         label: "Testdrive (before Kafka source versioning) migration tests"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 360
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive-old-kafka-src-syntax
@@ -682,7 +679,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: aws-localstack
@@ -692,7 +689,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: secrets-local-file
@@ -702,12 +699,11 @@ steps:
     steps:
       - id: checks-no-restart-no-upgrade-azurite
         label: "Checks without restart or upgrade with :azure: blob store"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
-        parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -715,13 +711,11 @@ steps:
 
       - id: checks-restart-entire-mz
         label: "Checks + restart of the entire Mz"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
-        parallelism: 2
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -729,12 +723,11 @@ steps:
 
       - id: checks-restart-environmentd-clusterd-storage-azurite
         label: "Checks + restart of environmentd & storage clusterd with :azure: blob store"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
-        parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -747,11 +740,10 @@ steps:
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -759,23 +751,10 @@ steps:
 
       - id: checks-parallel-drop-create-default-replica
         label: "Checks parallel + DROP/CREATE replica"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        parallelism: 2
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
-
-      - id: checks-parallel-drop-create-default-replica-x86_64
-        label: "Checks parallel + DROP/CREATE replica (x86_64)"
         depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-x86-64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -790,11 +769,10 @@ steps:
 
       - id: checks-parallel-restart-clusterd-compute
         label: "Checks parallel + restart compute clusterd"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -802,11 +780,10 @@ steps:
 
       - id: checks-parallel-restart-entire-mz
         label: "Checks parallel + restart of the entire Mz"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -814,11 +791,10 @@ steps:
 
       - id: checks-parallel-restart-environmentd-clusterd-storage
         label: "Checks parallel + restart of environmentd & storage clusterd"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -826,11 +802,10 @@ steps:
 
       - id: checks-parallel-kill-clusterd-storage
         label: "Checks parallel + kill storage clusterd"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -838,11 +813,10 @@ steps:
 
       - id: checks-upgrade-entire-mz
         label: "Checks upgrade, whole-Mz restart"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -850,11 +824,10 @@ steps:
 
       - id: checks-lts-upgrade
         label: "Checks LTS upgrade, whole-Mz restart"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -862,11 +835,10 @@ steps:
 
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -874,11 +846,10 @@ steps:
 
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -886,11 +857,10 @@ steps:
 
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -898,11 +868,10 @@ steps:
 
       - id: checks-0dt-restart-entire-mz-forced-migrations
         label: "Checks 0dt restart of the entire Mz with forced migrations"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -910,11 +879,10 @@ steps:
 
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -922,11 +890,10 @@ steps:
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -934,11 +901,10 @@ steps:
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -964,7 +930,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
@@ -988,7 +954,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64-medium
         inputs:
           - test/cloudtest
@@ -1014,7 +980,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1040,7 +1006,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1066,7 +1032,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1092,14 +1058,14 @@ steps:
               composition: persist
               args: [--consensus=mem, --blob=mem]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: persist-maelstrom-single-node
         label: Long single-node Maelstrom coverage of persist
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1111,7 +1077,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1123,7 +1089,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1135,7 +1101,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: persistence
@@ -1150,7 +1116,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sql-feature-flags
@@ -1265,7 +1231,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: output-consistency
@@ -1277,7 +1243,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 58
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: postgres-consistency
@@ -1289,7 +1255,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 58
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: version-consistency
@@ -1301,7 +1267,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 58
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: version-consistency
@@ -1313,7 +1279,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 58
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-flag-consistency
@@ -1329,7 +1295,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -1340,7 +1306,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -1354,7 +1320,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -1365,7 +1331,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -1377,7 +1343,7 @@ steps:
         timeout_in_minutes: 40
         agents:
           # Ran out of memory retrieving query results.
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -1388,7 +1354,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -1402,7 +1368,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1426,7 +1392,7 @@ steps:
         skip: "flaky until database-issues#7713 is fixed"
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1437,7 +1403,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1449,7 +1415,7 @@ steps:
         skip: "flaky until database-issues#8366 is fixed"
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1461,7 +1427,7 @@ steps:
         skip: "flaky until database-issues#7433 is fixed"
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1474,7 +1440,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1485,7 +1451,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1496,7 +1462,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: crdb-restarts
@@ -1506,7 +1472,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 60
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: pubsub-disruption
@@ -1517,7 +1483,7 @@ steps:
     skip: "database-issues#7310"
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: retain-history
@@ -1529,9 +1495,8 @@ steps:
       label: "Data Ingest (1 replica)"
       depends_on: build-aarch64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1542,9 +1507,8 @@ steps:
       label: "Data Ingest (2 replicas)"
       depends_on: build-aarch64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1555,7 +1519,6 @@ steps:
       label: "Data Ingest (8 replicas)"
       depends_on: build-aarch64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
         queue: hetzner-aarch64-16cpu-32gb
       plugins:
@@ -1696,7 +1659,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 60
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
@@ -1707,7 +1670,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: balancerd
@@ -1724,11 +1687,10 @@ steps:
               composition: legacy-upgrade
               args: ["--versions-source=git"]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: legacy-upgrade-docs
         label: "Legacy upgrade tests (last version from docs)"
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 60
         plugins:
@@ -1736,7 +1698,7 @@ steps:
               composition: legacy-upgrade
               args: ["--versions-source=docs", "--lts-upgrade"]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: Cloud tests
     key: cloudtests
@@ -1763,7 +1725,7 @@ steps:
                 ]
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64
         sanitizer: skip
 
@@ -1776,7 +1738,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO: Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-16cpu-32gb
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
@@ -1787,13 +1749,12 @@ steps:
     label: "Txn-wal fencing with :azure: blob store"
     depends_on: build-aarch64
     timeout_in_minutes: 120
-    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: txn-wal-fencing
           args: [--azurite]
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Copy To S3"
     key: copy-to-s3
@@ -1826,7 +1787,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: backup-restore
@@ -1836,7 +1797,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: backup-restore-postgres
@@ -1850,7 +1811,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: replica-isolation
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: 0dt
     label: Zero downtime
@@ -1870,13 +1831,13 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: emulator
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: sqllogictest
     label: ":bulb: SQL logic tests"
     depends_on: build-aarch64
     timeout_in_minutes: 240
-    parallelism: 10
+    parallelism: 5
     agents:
       # Runs faster/more consistently on larger agent
       queue: hetzner-aarch64-16cpu-32gb
@@ -1895,7 +1856,7 @@ steps:
           composition: cluster
           args: ["--azurite"]
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Race Condition"
     key: race-condition
@@ -1903,57 +1864,57 @@ steps:
        - id: race-condition-subsequent
          label: "Race Condition Test (subsequent)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 60
          agents:
            queue: hetzner-aarch64-16cpu-32gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent]
+               args: [--runtime=1800, --scenario=subsequent]
 
        - id: race-condition-subsequent-100
          label: "Race Condition Test (subsequent, 100 objects)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 60
          agents:
            queue: hetzner-aarch64-16cpu-32gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent, --num-objects=100]
+               args: [--runtime=1800, --scenario=subsequent, --num-objects=100]
 
        - id: race-condition-subsequent-chain
          label: "Race Condition Test (subsequent chain)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 60
          agents:
            queue: hetzner-aarch64-16cpu-32gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent-chain]
+               args: [--runtime=1800, --scenario=subsequent-chain]
 
        - id: race-condition-subsequent-chain-100
          label: "Race Condition Test (subsequent chain, 100 objects)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 60
          agents:
            queue: hetzner-aarch64-16cpu-32gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent-chain, --num-objects=100]
+               args: [--runtime=1800, --scenario=subsequent-chain, --num-objects=100]
 
        - id: race-condition-concurrent
          label: "Race Condition Test (concurrent)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 60
          agents:
            queue: hetzner-aarch64-16cpu-32gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=concurrent]
+               args: [--runtime=1800, --scenario=concurrent]
          skip: "Not stable yet, not clear if this is a product issue"
 
   - group: "Language tests"
@@ -1967,7 +1928,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: csharp
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: lang-js
         label: ":js: tests"
@@ -1977,7 +1938,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: js
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: lang-java
         label: ":java: tests"
@@ -1987,7 +1948,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: java
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: lang-python
         label: ":python: tests"
@@ -1997,7 +1958,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: python
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: lang-ruby
         label: ":ruby: tests"
@@ -2007,4 +1968,4 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ruby
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -199,7 +199,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -210,7 +210,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -260,7 +260,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -279,7 +279,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=16.6" ]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
       - id: pg-cdc-15
         label: "Postgres CDC w/ 15"
         depends_on: build-aarch64
@@ -290,7 +290,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=15.10" ]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
       - id: pg-cdc-14
         label: "Postgres CDC w/ 14"
         depends_on: build-aarch64
@@ -301,7 +301,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=14.15" ]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
       - id: pg-cdc-13
         label: "Postgres CDC w/ 13"
         depends_on: build-aarch64
@@ -312,20 +312,18 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=13.18" ]
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Platform checks"
     key: platform-checks
     steps:
       - id: checks-restart-cockroach
         label: "Checks + restart Cockroach"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
-        parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -333,11 +331,10 @@ steps:
 
       - id: checks-backup-restore-before-manipulate
         label: "Checks backup + restore between the two manipulate()"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -345,11 +342,10 @@ steps:
 
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -357,11 +353,10 @@ steps:
 
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -369,11 +364,10 @@ steps:
 
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -381,11 +375,10 @@ steps:
 
       - id: checks-upgrade-clusterd-compute-first
         label: "Platform checks upgrade, restarting compute clusterd first"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -393,11 +386,10 @@ steps:
 
       - id: checks-upgrade-clusterd-compute-last
         label: "Platform checks upgrade, restarting compute clusterd last"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -405,11 +397,10 @@ steps:
 
       - id: checks-kill-clusterd-storage
         label: "Checks + kill storage clusterd"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -417,10 +408,10 @@ steps:
 
       - id: checks-restart-source-postgres
         label: "Checks + restart source Postgres"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -428,11 +419,10 @@ steps:
 
       - id: checks-restart-clusterd-compute
         label: "Checks + restart clusterd compute"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -440,12 +430,10 @@ steps:
 
       - id: checks-drop-create-default-replica
         label: "Checks + DROP/CREATE replica"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 3
         agents:
-          # Seems to require more memory on aarch64
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -453,11 +441,10 @@ steps:
 
       - id: checks-0dt-restart-entire-mz
         label: "Checks 0dt restart of the entire Mz"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -219,7 +219,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         coverage: skip
         sanitizer: skip
 
@@ -238,7 +238,7 @@ steps:
         timeout_in_minutes: 30
         agents:
           # hugo: command not found
-          queue: hetzner-x86-64-4cpu-8gb
+          queue: hetzner-x86-64-16cpu-32gb
         coverage: skip
         sanitizer: skip
 
@@ -263,7 +263,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 15
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         coverage: skip
         sanitizer: skip
 
@@ -295,8 +295,8 @@ steps:
     label: "Testdrive"
     depends_on: build-aarch64
     timeout_in_minutes: 40
+    parallelism: 2
     inputs: [test/testdrive]
-    parallelism: 8
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
@@ -306,20 +306,20 @@ steps:
   - id: cluster-tests
     label: "Cluster tests"
     depends_on: build-aarch64
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
+    parallelism: 2
     inputs: [test/cluster]
-    parallelism: 4
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: sqllogictest-fast
     label: "Fast SQL logic tests"
     depends_on: build-aarch64
-    timeout_in_minutes: 30
-    parallelism: 6
+    timeout_in_minutes: 40
+    parallelism: 2
     inputs: [test/sqllogictest]
     plugins:
       - ./ci/plugins/mzcompose:
@@ -336,11 +336,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: legacy-upgrade-docs-ignore-missing
     label: "Legacy upgrade tests (last version from docs, ignore missing)"
-    parallelism: 2
     depends_on: build-aarch64
     timeout_in_minutes: 60
     plugins:
@@ -348,7 +347,7 @@ steps:
           composition: legacy-upgrade
           args: ["--versions-source=docs", "--ignore-missing-version"]
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Debezium tests"
     key: debezium-tests
@@ -363,7 +362,7 @@ steps:
               composition: debezium
               run: postgres
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: debezium-sql-server
         label: "Debezium SQL Server tests"
@@ -376,7 +375,7 @@ steps:
               run: sql-server
         agents:
           # too slow to run emulated on aarch64, SQL Server's docker image is not yet available for aarch64 natively yet: https://github.com/microsoft/mssql-docker/issues/802
-          queue: hetzner-x86-64-4cpu-8gb
+          queue: hetzner-x86-64-16cpu-32gb
 
       - id: debezium-mysql
         label: "Debezium MySQL tests"
@@ -388,14 +387,13 @@ steps:
               composition: debezium
               run: mysql
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: "MySQL tests"
     key: mysql-tests
     steps:
       - id: mysql-cdc
         label: "MySQL CDC tests"
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/mysql-cdc]
@@ -403,19 +401,19 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: mysql-cdc-resumption
         label: "MySQL CDC resumption tests"
-        parallelism: 6
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
+        parallelism: 2
         inputs: [test/mysql-cdc-resumption]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: mysql-rtr
         label: "MySQL RTR tests"
@@ -426,14 +424,13 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-rtr
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Postgres tests"
     key: postgres-tests
     steps:
       - id: pg-cdc
         label: "Postgres CDC tests"
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/pg-cdc]
@@ -441,14 +438,14 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
         # the mzbuild postgres version will be used, which depends on the Dockerfile specification
 
       - id: pg-cdc-resumption
         label: "Postgres CDC resumption tests"
-        parallelism: 5
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        parallelism: 2
         inputs: [test/pg-cdc-resumption]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -466,7 +463,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-rtr
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - id: yugabyte-cdc
     label: "Yugabyte CDC tests"
@@ -477,14 +474,13 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: yugabyte-cdc
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - group: "SQL Server tests"
     key: sql-server-tests
     steps:
       - id: sql-server-cdc
         label: "SQL Server CDC tests"
-        parallelism: 1
         depends_on: build-x86_64
         timeout_in_minutes: 30
         inputs: [test/sql-server-cdc]
@@ -495,7 +491,7 @@ steps:
           # The SQL Server Docker image isn't available on ARM.
           #
           # See: <https://github.com/microsoft/mssql-docker/issues/864>
-          queue: hetzner-x86-64-4cpu-8gb
+          queue: hetzner-x86-64-16cpu-32gb
 
   - group: "Connection tests"
     key: connection-tests
@@ -509,7 +505,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ssh-connection
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: fivetran-destination-tests
         label: Fivetran Destination tests
@@ -520,7 +516,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: fivetran-destination
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Copy to S3 tests"
     key: copy-to-s3-tests
@@ -535,7 +531,7 @@ steps:
               composition: copy-to-s3
               run: ci
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - group: "Kafka tests"
     key: kafka-tests
@@ -548,7 +544,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-resumption
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: kafka-auth
         label: Kafka auth test
@@ -559,7 +555,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-auth
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: kafka-exactly-once
         label: Kafka exactly-once tests
@@ -569,20 +565,19 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-exactly-once
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-16cpu-32gb
 
       - id: kafka-rtr
         label: "Kafka RTR tests"
         depends_on: build-aarch64
         timeout_in_minutes: 30
-        parallelism: 2
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-rtr
         agents:
           # Larger agent to run test faster
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -590,7 +585,7 @@ steps:
     inputs: [misc/python/materialize/zippy]
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -601,12 +596,11 @@ steps:
     steps:
       - id: checks-restart-environmentd-clusterd-storage
         label: "Checks + restart of environmentd & storage clusterd"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
-        parallelism: 6
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -622,7 +616,6 @@ steps:
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
-        parallelism: 6
         agents:
           queue: hetzner-x86-64-16cpu-32gb
         plugins:
@@ -637,12 +630,11 @@ steps:
 
       - id: checks-no-restart-no-upgrade
         label: "Checks without restart or upgrade"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
-        parallelism: 6
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -655,10 +647,9 @@ steps:
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"
     depends_on: build-aarch64
-    parallelism: 2
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
@@ -690,7 +681,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persistence
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: cluster-isolation
     label: Cluster isolation test
@@ -701,7 +692,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster-isolation
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: chbench-demo
     label: chbench smoke test
@@ -713,7 +704,7 @@ steps:
           args: [--run-seconds=10, --wait]
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: metabase-demo
     label: Metabase smoke test
@@ -724,7 +715,7 @@ steps:
           composition: metabase
     agents:
       # too slow to run emulated on aarch64, Metabase'ss docker image is not yet available for aarch64 natively yet: https://github.com/metabase/metabase/issues/13119
-      queue: hetzner-x86-64-4cpu-8gb
+      queue: hetzner-x86-64-16cpu-32gb
 
   - id: dbt-materialize
     label: dbt-materialize tests
@@ -734,14 +725,14 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: dbt-materialize
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: storage-usage
     label: "Storage Usage Table Test"
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
@@ -767,7 +758,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: rtr-combined
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
     skip: "Flakes because of database-issues#8489"
 
   - id: skip-version-upgrade
@@ -779,7 +770,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: skip-version-upgrade
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-16cpu-32gb
     skip: "Version upgrade skips are allowed for LTS releases now"
 
   - id: mz-debug


### PR DESCRIPTION
Time might be more important than cost, they also have larger disk so higher chance of not requiring new downloads. We can also keep reusing agents for longer. If all of this combines, they might even be cheaper.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
