### PR TITLE
controller: round wallclock lag measurements to seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,6 +5203,7 @@ dependencies = [
  "mz-build-tools",
  "mz-ore",
  "mz-proto",
+ "mz-repr",
  "prometheus",
  "proptest",
  "proptest-derive",

--- a/src/cluster-client/BUILD.bazel
+++ b/src/cluster-client/BUILD.bazel
@@ -34,6 +34,7 @@ rust_library(
         ":mz_cluster_client_build_script",
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
+        "//src/repr:mz_repr",
     ] + all_crate_deps(normal = True),
 )
 
@@ -67,6 +68,7 @@ rust_test(
     deps = [
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
+        "//src/repr:mz_repr",
     ] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -79,6 +81,7 @@ rust_doc_test(
     deps = [
         "//src/ore:mz_ore",
         "//src/proto:mz_proto",
+        "//src/repr:mz_repr",
     ] + all_crate_deps(
         normal = True,
         normal_dev = True,

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.97"
 http = "1.2.0"
 mz-ore = { path = "../ore", features = ["tracing"] }
 mz-proto = { path = "../proto" }
+mz-repr = { path = "../repr" }
 prometheus = { version = "0.13.4", default-features = false }
 proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }

--- a/src/cluster-client/src/lib.rs
+++ b/src/cluster-client/src/lib.rs
@@ -12,18 +12,47 @@
 #![warn(missing_docs)]
 
 use std::fmt;
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::bail;
+use mz_ore::now::NowFn;
 use serde::{Deserialize, Serialize};
 
 pub mod client;
 pub mod metrics;
 
 /// A function that computes the lag between the given time and wallclock time.
-pub type WallclockLagFn<T> = Arc<dyn Fn(&T) -> Duration + Send + Sync>;
+///
+/// Because sources usually tick once per second and we collect wallclock lag measurements once per
+/// second, the measured lag can be off by up to 1s. To reflect this uncertainty, we report lag
+/// values rounded to seconds. We always round up to avoid underreporting.
+#[derive(Clone)]
+pub struct WallclockLagFn<T>(Arc<dyn Fn(T) -> Duration + Send + Sync>);
+
+impl<T: Into<mz_repr::Timestamp>> WallclockLagFn<T> {
+    /// Create a new [`WallclockLagFn`].
+    pub fn new(now: NowFn) -> Self {
+        let inner = Arc::new(move |time: T| {
+            let time_ts: mz_repr::Timestamp = time.into();
+            let time_ms: u64 = time_ts.into();
+            let lag_ms = now().saturating_sub(time_ms);
+            let lag_s = lag_ms.div_ceil(1000);
+            Duration::from_secs(lag_s)
+        });
+        Self(inner)
+    }
+}
+
+impl<T> Deref for WallclockLagFn<T> {
+    type Target = dyn Fn(T) -> Duration + Send + Sync;
+
+    fn deref(&self) -> &Self::Target {
+        &(*self.0)
+    }
+}
 
 /// Identifier of a replica.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -586,7 +586,7 @@ where
             self.envd_epoch,
             self.metrics.for_instance(id),
             self.now.clone(),
-            Arc::clone(&self.wallclock_lag),
+            self.wallclock_lag.clone(),
             Arc::clone(&self.dyncfg),
             self.response_tx.clone(),
             self.introspection_tx.clone(),

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -573,8 +573,8 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         let now_dt = mz_ore::now::to_datetime(now_ms);
         let now_ts: CheckedTimestamp<_> = now_dt.try_into().expect("must fit");
 
-        let frontier_lag = |frontier: &Antichain<_>| match frontier.as_option() {
-            Some(ts) => (self.wallclock_lag)(ts),
+        let frontier_lag = |frontier: &Antichain<T>| match frontier.as_option() {
+            Some(ts) => (self.wallclock_lag)(ts.clone()),
             None => Duration::ZERO,
         };
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3518,8 +3518,8 @@ where
         let histogram_period =
             WallclockLagHistogramPeriod::from_epoch_millis(now_ms, self.config.config_set());
 
-        let frontier_lag = |frontier: &Antichain<_>| match frontier.as_option() {
-            Some(ts) => (self.wallclock_lag)(ts),
+        let frontier_lag = |frontier: &Antichain<T>| match frontier.as_option() {
+            Some(ts) => (self.wallclock_lag)(ts.clone()),
             None => Duration::ZERO,
         };
 

--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -124,6 +124,30 @@ src          true  {}
 src_progress true  {}
 tbl          true  {}
 
+# Test that history lag values are rounded to seconds.
+
+> SELECT DISTINCT ON(o.name, r.name)
+    o.name, r.name, l.lag = date_trunc('second', l.lag)
+  FROM mz_internal.mz_wallclock_lag_history l
+  JOIN mz_objects o ON o.id = l.object_id
+  LEFT JOIN mz_cluster_replicas r ON r.id = l.replica_id
+  WHERE l.object_id LIKE 'u%'
+  ORDER BY o.name, r.name, l.occurred_at DESC
+idx          r1     true
+idx          r2     true
+idx_const    r1     true
+idx_const    r2     true
+mv           r1     true
+mv           r2     true
+mv           <null> true
+mv_const     r1     true
+mv_const     r2     true
+mv_const     <null> true
+snk          <null> true
+src          <null> true
+src_progress <null> true
+tbl          <null> true
+
 # Test annotation of histogram measurements with labels.
 
 $ postgres-execute connection=mz_system


### PR DESCRIPTION
This is to avoid the impression of having sub-second wallclock lag accuracy.


### Motivation

  * This PR fixes a previously unreported bug.

The lag values in the wallclock lag history have millisecond precision, even though they don't provide this kind of accuracy. See [Slack thread](https://materializeinc.slack.com/archives/C08AENAP691/p1744706310908609).

### Tips for reviewer


I made `WallclockLagFn` a struct akin to `NowFn`, mostly to have a place to put the comment about rounding up.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
