### PR TITLE
optimizer: Guard `If` pushing by a type check

### DIFF
--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -2136,3 +2136,56 @@ query T
 SELECT '{}'::JSONB #> '{-9223372036854775808}';
 ----
 NULL
+
+## Regression test for https://github.com/MaterializeInc/database-issues/issues/9182
+
+statement ok
+CREATE TABLE t3(x int, y text, z bool);
+
+# Give inputs with different types to `to_jsonb` in different branches. In this case, the optimization where we pull out
+# `to_jsonb` from the CASE should not happen.
+
+query T multiline
+EXPLAIN
+SELECT
+  CASE x
+    WHEN 1 THEN to_jsonb(x)
+    WHEN 2 THEN to_jsonb(y)
+    WHEN 3 THEN to_jsonb(z)
+    ELSE to_jsonb(x+x)
+  END
+FROM t3;
+----
+Explained Query:
+  Project (#3)
+    Map (case when (#0 = 1) then jsonbable_to_jsonb(integer_to_numeric(#0)) else case when (#0 = 2) then jsonbable_to_jsonb(#1) else case when (#0 = 3) then jsonbable_to_jsonb(#2) else jsonbable_to_jsonb(integer_to_numeric((#0 + #0))) end end end)
+      ReadStorage materialize.public.t3
+
+Source materialize.public.t3
+
+Target cluster: quickstart
+
+EOF
+
+# Check that we are still doing the optimization when the types do match.
+query T multiline
+EXPLAIN
+SELECT
+  CASE x
+    WHEN 1 THEN to_jsonb(1*x)
+    WHEN 2 THEN to_jsonb(2*x)
+    WHEN 3 THEN to_jsonb(3*x)
+    ELSE to_jsonb(x+x)
+  END
+FROM t3;
+----
+Explained Query:
+  Project (#3)
+    Map (jsonbable_to_jsonb(integer_to_numeric(case when (#0 = 1) then (1 * #0) else case when (#0 = 2) then (2 * #0) else case when (#0 = 3) then (3 * #0) else (#0 + #0) end end end)))
+      ReadStorage materialize.public.t3
+
+Source materialize.public.t3
+
+Target cluster: quickstart
+
+EOF


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9182, which caused [incident-512](https://materializeinc.slack.com/archives/C08NDPVT8CT).

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9182

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
