### PR TITLE
Require `RowArena::clear` to take a `&mut self`

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -903,7 +903,7 @@ where
                         let mut key_buf = Row::default();
                         let mut val_buf = Row::default();
                         let mut datums = DatumVec::new();
-                        let temp_storage = RowArena::new();
+                        let mut temp_storage = RowArena::new();
                         while let Some((time, data)) = input.next() {
                             let mut ok_session = ok.session_with_builder(&time);
                             let mut err_session = err.session(&time);

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -368,7 +368,7 @@ where
                     name,
                     |_, _| {
                         Box::new(move |input, ok, errs| {
-                            let temp_storage = RowArena::new();
+                            let mut temp_storage = RowArena::new();
                             let mut key_buf = Row::default();
                             let mut val_buf = Row::default();
                             let mut datums = DatumVec::new();

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -804,7 +804,6 @@ pub fn decode_copy_format_csv(
 
     let mut record = ByteRecord::new();
 
-    let buf = RowArena::new();
     while rdr.read_byte_record(&mut record)? {
         if record.len() == 1 && record.iter().next() == Some(END_OF_COPY_MARKER) {
             break;
@@ -825,7 +824,6 @@ pub fn decode_copy_format_csv(
         let binding = SharedRow::get();
         let mut row_builder = binding.borrow_mut();
         let mut row_packer = row_builder.packer();
-        buf.clear();
 
         for (typ, raw_value) in column_types.iter().zip(record.iter()) {
             if raw_value == null_as_bytes {

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2796,7 +2796,7 @@ impl RowArena {
     }
 
     /// Clear the contents of the arena.
-    pub fn clear(&self) {
+    pub fn clear(&mut self) {
         self.inner.borrow_mut().clear();
     }
 }


### PR DESCRIPTION
The `RowArena` type has unsafe internals, and in particular wraps `Vec<u8>` stuffs with a `RefCell`, but wants to return `&'a [u8]` that outlives `borrow_mut()` calls. This works as long as we don't de/re-allocate the `Vec<u8>` for the lifetime of the type, because the `'a` comes from `&'a self`.

The `RowArena::clear` method upsets this, by deallocating the memory under a `&self` reference. If we change that to be a `&mut self` reference, it seems like this should be .. more safe, at least. The mutable reference should require that all borrowed references have expired.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
