### PR TITLE
[sql_server] Wire up replication errors to health status messages

### DIFF
--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use differential_dataflow::AsCollection;
 use itertools::Itertools;
 use mz_ore::cast::CastFrom;
+use mz_ore::error::ErrorExt;
 use mz_repr::{Diff, GlobalId};
 use mz_sql_server_util::SqlServerError;
 use mz_sql_server_util::cdc::Lsn;
@@ -28,8 +29,8 @@ use mz_storage_types::sources::{
 };
 use mz_timely_util::builder_async::PressOnDropButton;
 use timely::container::CapacityContainerBuilder;
-use timely::dataflow::operators::ToStream;
 use timely::dataflow::operators::core::Partition;
+use timely::dataflow::operators::{Concat, Map, ToStream};
 use timely::dataflow::{Scope, Stream as TimelyStream};
 use timely::progress::Antichain;
 
@@ -153,7 +154,7 @@ impl SourceRender for SqlServerSource {
             source_outputs.insert(*id, output_info);
         }
 
-        let (repl_updates, uppers, _repl_err, repl_token) = replication::render(
+        let (repl_updates, uppers, repl_errs, repl_token) = replication::render(
             scope.clone(),
             config.clone(),
             source_outputs.clone(),
@@ -182,12 +183,27 @@ impl SourceRender for SqlServerSource {
         })
         .to_stream(scope);
 
-        let health = std::iter::once(HealthStatusMessage {
+        let health_init = std::iter::once(HealthStatusMessage {
             id: None,
             namespace: Self::STATUS_NAMESPACE,
             update: HealthStatusUpdate::Running,
         })
         .to_stream(scope);
+        let health_errs = repl_errs.map(move |err| {
+            // This update will cause the dataflow to restart
+            let err_string = err.display_with_causes().to_string();
+            let update = HealthStatusUpdate::halting(err_string.clone(), None);
+            // TODO(sql_server2): If the error has anything to do with SSH
+            // connections we should use the SSH status namespace.
+            let namespace = Self::STATUS_NAMESPACE;
+
+            HealthStatusMessage {
+                id: None,
+                namespace: namespace.clone(),
+                update,
+            }
+        });
+        let health = health_init.concat(&health_errs);
 
         (
             data_collections,

--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -192,7 +192,7 @@ impl SourceRender for SqlServerSource {
         let health_errs = repl_errs.map(move |err| {
             // This update will cause the dataflow to restart
             let err_string = err.display_with_causes().to_string();
-            let update = HealthStatusUpdate::halting(err_string.clone(), None);
+            let update = HealthStatusUpdate::halting(err_string, None);
             // TODO(sql_server2): If the error has anything to do with SSH
             // connections we should use the SSH status namespace.
             let namespace = Self::STATUS_NAMESPACE;

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -177,19 +177,18 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
 
             // Set all of the LSNs to start replicating from.
             for output_info in outputs.values() {
-                // TODO(sql_server1): Better unify this with the check above.
-                match *output_info.resume_upper {
-                    [lsn] => {
-                        // We just snapshotted this instance, so use the snapshot LSN.
-                        let initial_lsn = if lsn == Lsn::minimum() {
+                match output_info.resume_upper.as_option() {
+                    // We just snapshotted this instance, so use the snapshot LSN.
+                    Some(lsn) => {
+                        let initial_lsn = if *lsn == Lsn::minimum() {
                             replication_start_lsn
                         } else {
-                            lsn
+                            *lsn
                         };
                         cdc_handle =
                             cdc_handle.start_lsn(&output_info.capture_instance, initial_lsn);
                     }
-                    _ => unreachable!(""),
+                    None => unreachable!("empty resume upper?"),
                 }
             }
 


### PR DESCRIPTION
This PR is a bit of plumbing that wires up the errors from the replication operator into the health status stream for the source.

FWIW it's the same pattern that Postgres ([code](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/postgres.rs#L220-L253)) and MySQL ([code](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/mysql.rs#L202-L232)) use.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
