### PR TITLE
[sql_server] add negative tests to ensure we don't allow some data types

### DIFF
--- a/src/sql-server-util/src/desc.proto
+++ b/src/sql-server-util/src/desc.proto
@@ -25,6 +25,7 @@ message ProtoSqlServerTableDesc {
 message ProtoSqlServerColumnDesc {
   string name = 1;
   mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
+  string raw_type = 21;
 
   oneof decode_type {
     google.protobuf.Empty bool = 4;

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -175,6 +175,10 @@ pub struct SqlServerColumnDesc {
     pub column_type: Option<ColumnType>,
     /// Rust type we should parse the data from a [`tiberius::Row`] as.
     pub decode_type: SqlServerColumnDecodeType,
+    /// Raw type of the column as we read it from upstream.
+    ///
+    /// This is useful to keep around for debugging purposes.
+    pub raw_type: Arc<str>,
 }
 
 impl SqlServerColumnDesc {
@@ -203,6 +207,7 @@ impl SqlServerColumnDesc {
             name: Arc::clone(&raw.name),
             column_type,
             decode_type,
+            raw_type: Arc::clone(&raw.data_type),
         }
     }
 
@@ -234,6 +239,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
             name: self.name.to_string(),
             column_type: self.column_type.into_proto(),
             decode_type: Some(self.decode_type.into_proto()),
+            raw_type: self.raw_type.to_string(),
         }
     }
 
@@ -244,6 +250,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
             decode_type: proto
                 .decode_type
                 .into_rust_if_some("ProtoSqlServerColumnDesc::decode_type")?,
+            raw_type: proto.raw_type.into(),
         })
     }
 }

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -373,6 +373,13 @@ pub enum SqlServerSourcePurificationError {
         option_name: String,
         items: Vec<UnresolvedItemName>,
     },
+    #[error("column {schema_name}.{tbl_name}.{col_name} of type {col_type} is not supported")]
+    UnsupportedColumn {
+        schema_name: Arc<str>,
+        tbl_name: Arc<str>,
+        col_name: Arc<str>,
+        col_type: Arc<str>,
+    },
     #[error("No tables found for provided reference")]
     NoTables,
     #[error("programming error: {0}")]
@@ -417,6 +424,9 @@ impl SqlServerSourcePurificationError {
                 the user does not have privileges on the intended tables."
                     .into(),
             ),
+            Self::UnsupportedColumn { .. } => {
+                Some("Use EXCLUDE COLUMNS (...) to exclude a column from this source".into())
+            }
             _ => None,
         }
     }

--- a/test/sql-server-cdc/50-unsupported-types.td
+++ b/test/sql-server-cdc/50-unsupported-types.td
@@ -1,0 +1,99 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# These goal of these tests is to exercise what isn't supported in the SQL
+# Server source and that we properly handle these scenarios.
+
+# Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+DROP DATABASE IF EXISTS test_50;
+CREATE DATABASE test_50;
+USE test_50;
+
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test_50 SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE table_text (good varchar(128), bad text);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_text', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO table_text VALUES ('i work', 'i do not'), ('maybe me', 'not so much');
+
+CREATE TABLE table_image (good int, bad image);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_image', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO table_image VALUES (42, NULL);
+
+CREATE TABLE table_geography (good int, bad geography);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_geography', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO table_geography VALUES (42, NULL);
+
+CREATE TABLE table_geometry (good int, bad geometry);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_geometry', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO table_geometry VALUES (42, NULL);
+
+CREATE TABLE table_varchar_max (good int, bad varchar(max));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_varchar_max', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO table_varchar_max VALUES (42, NULL);
+
+# Exercise Materialize.
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_sql_server_source = true;
+
+> CREATE CONNECTION sql_server_test_50_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_50,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+! CREATE SOURCE table_text_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection
+  FOR TABLES (dbo.table_text);
+contains: SQL SERVER source validation: column dbo.table_text.bad of type text is not supported
+
+> CREATE SOURCE table_text_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection (
+    EXCLUDE COLUMNS (dbo.table_text.bad)
+  )
+  FOR TABLES (dbo.table_text);
+
+> SHOW COLUMNS FROM table_text;
+good true "character varying" ""
+
+> SELECT * FROM table_text;
+"i work"
+"maybe me"
+
+! CREATE SOURCE table_image_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection
+  FOR TABLES (dbo.table_image);
+contains: SQL SERVER source validation: column dbo.table_image.bad of type image is not supported
+
+! CREATE SOURCE table_geography_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection
+  FOR TABLES (dbo.table_geography);
+contains: SQL SERVER source validation: column dbo.table_geography.bad of type geography is not supported
+
+! CREATE SOURCE table_geometry_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection
+  FOR TABLES (dbo.table_geometry);
+contains: SQL SERVER source validation: column dbo.table_geometry.bad of type geometry is not supported
+
+! CREATE SOURCE table_varchar_max_source
+  FROM SQL SERVER CONNECTION sql_server_test_50_connection
+  FOR TABLES (dbo.table_varchar_max);
+contains: SQL SERVER source validation: column dbo.table_varchar_max.bad of type varchar is not supported


### PR DESCRIPTION
We can't support replication of certain datatypes, e.g. `text`, because they don't provide us with the "before" value when replicating. This used to work but I accidentally regressed the behavior in https://github.com/MaterializeInc/materialize/pull/32181.

This PR re-adds the check to ensure all columns we're intending to replicate are supported. Also an mzcompose testdrive case to exercise these unsupported types.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
