### PR TITLE
persist: remove unused arrow decoding time metric

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -1129,16 +1129,12 @@ where
         key: &mut Option<K>,
         val: &mut Option<V>,
     ) -> (Result<K, String>, Result<V, String>) {
-        let key = self.metrics.columnar.arrow().key().measure_decoding(|| {
-            let mut key = key.take().unwrap_or_default();
-            keys.decode(idx, &mut key);
-            key
-        });
-        let val = self.metrics.columnar.arrow().val().measure_decoding(|| {
-            let mut val = val.take().unwrap_or_default();
-            vals.decode(idx, &mut val);
-            val
-        });
+        let mut key = key.take().unwrap_or_default();
+        keys.decode(idx, &mut key);
+
+        let mut val = val.take().unwrap_or_default();
+        vals.decode(idx, &mut val);
+
         (Ok(key), Ok(val))
     }
 }

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -16,7 +16,7 @@ use mz_dyncfg::ConfigSet;
 use mz_ore::lgbytes::{LgBytesMetrics, LgBytesOpMetrics};
 use mz_ore::metric;
 use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry};
-use prometheus::{CounterVec, IntCounterVec};
+use prometheus::IntCounterVec;
 
 /// Metrics specific to S3Blob's internal workings.
 #[derive(Debug, Clone)]
@@ -105,11 +105,6 @@ impl ArrowMetrics {
             help: "number of rows we've run the specified op on in our structured columnar format",
             var_labels: ["op", "column", "result"],
         ));
-        let op_seconds: CounterVec = registry.register(metric!(
-            name: "mz_persist_columnar_op_seconds",
-            help: "numer of seconds we've spent running the specified op on our structured columnar format",
-            var_labels: ["op", "column"],
-        ));
 
         let part_build_seconds: Counter = registry.register(metric!(
             name: "mz_persist_columnar_part_build_seconds",
@@ -125,8 +120,8 @@ impl ArrowMetrics {
         ));
 
         ArrowMetrics {
-            key: ArrowColumnMetrics::new(&op_count, &op_seconds, "key"),
-            val: ArrowColumnMetrics::new(&op_count, &op_seconds, "val"),
+            key: ArrowColumnMetrics::new(&op_count, "key"),
+            val: ArrowColumnMetrics::new(&op_count, "val"),
             part_build_seconds,
             part_build_count,
             concat_bytes,
@@ -159,32 +154,16 @@ impl ArrowMetrics {
 /// Metrics for a top-level [`arrow`] column in our structured representation.
 #[derive(Debug, Clone)]
 pub struct ArrowColumnMetrics {
-    decoding_count: IntCounter,
-    decoding_seconds: Counter,
     correct_count: IntCounter,
     invalid_count: IntCounter,
 }
 
 impl ArrowColumnMetrics {
-    fn new(count: &IntCounterVec, duration: &CounterVec, col: &'static str) -> Self {
+    fn new(count: &IntCounterVec, col: &'static str) -> Self {
         ArrowColumnMetrics {
-            decoding_count: count.with_label_values(&["decode", col, "success"]),
-            decoding_seconds: duration.with_label_values(&["decode", col]),
             correct_count: count.with_label_values(&["validation", col, "correct"]),
             invalid_count: count.with_label_values(&["validation", col, "invalid"]),
         }
-    }
-
-    /// Measure and report how long decoding takes.
-    pub fn measure_decoding<R, F: FnOnce() -> R>(&self, decode: F) -> R {
-        let start = Instant::now();
-        let result = decode();
-        let duration = start.elapsed();
-
-        self.decoding_count.inc();
-        self.decoding_seconds.inc_by(duration.as_secs_f64());
-
-        result
     }
 
     /// Measure and report statistics for validation.


### PR DESCRIPTION
removes a metric that does not appear to be used in any production dashboards. this is I believe the smallest possible changeset. but as noted below we may wish to follow up by removing other unused metrics and improving the performance of counter incrementing.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9196

### Tips for reviewer

I think we can actually remove a lot more stats. how much do we want to rip out?

also do we want to just improve our stat incrementing in general to minimise likelyhood of future contention?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
