### PR TITLE
[sql_server] handle primary keys from SQL Server

### DIFF
--- a/src/sql-server-util/src/desc.proto
+++ b/src/sql-server-util/src/desc.proto
@@ -26,6 +26,7 @@ message ProtoSqlServerColumnDesc {
   string name = 1;
   mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
   string raw_type = 21;
+  optional string primary_key_constraint = 22;
 
   oneof decode_type {
     google.protobuf.Empty bool = 4;

--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -174,6 +174,8 @@ pub struct SqlServerColumnDesc {
     /// Note: This type might differ from the `decode_type`, e.g. a user can
     /// specify `TEXT COLUMNS` to decode columns as text.
     pub column_type: Option<ColumnType>,
+    /// If this column is part of the primary key for the table, and the name of the constraint.
+    pub primary_key_constraint: Option<Arc<str>>,
     /// Rust type we should parse the data from a [`tiberius::Row`] as.
     pub decode_type: SqlServerColumnDecodeType,
     /// Raw type of the column as we read it from upstream.
@@ -206,6 +208,7 @@ impl SqlServerColumnDesc {
         };
         SqlServerColumnDesc {
             name: Arc::clone(&raw.name),
+            primary_key_constraint: raw.primary_key_constraint.clone(),
             column_type,
             decode_type,
             raw_type: Arc::clone(&raw.data_type),
@@ -239,6 +242,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
         ProtoSqlServerColumnDesc {
             name: self.name.to_string(),
             column_type: self.column_type.into_proto(),
+            primary_key_constraint: self.primary_key_constraint.as_ref().map(|v| v.to_string()),
             decode_type: Some(self.decode_type.into_proto()),
             raw_type: self.raw_type.to_string(),
         }
@@ -248,6 +252,7 @@ impl RustType<ProtoSqlServerColumnDesc> for SqlServerColumnDesc {
         Ok(SqlServerColumnDesc {
             name: proto.name.into(),
             column_type: proto.column_type.into_rust()?,
+            primary_key_constraint: proto.primary_key_constraint.map(|v| v.into()),
             decode_type: proto
                 .decode_type
                 .into_rust_if_some("ProtoSqlServerColumnDesc::decode_type")?,
@@ -482,6 +487,8 @@ pub struct SqlServerColumnRaw {
     pub data_type: Arc<str>,
     /// Whether or not the column is nullable.
     pub is_nullable: bool,
+    /// If the column is part of the primary key for the table, and the name of the constraint.
+    pub primary_key_constraint: Option<Arc<str>>,
     /// Maximum length (in bytes) of the column.
     ///
     /// For `varchar(max)`, `nvarchar(max)`, `varbinary(max)`, or `xml` this will be `-1`. For
@@ -997,6 +1004,7 @@ mod tests {
                 name: name.into(),
                 data_type: data_type.into(),
                 is_nullable: false,
+                primary_key_constraint: None,
                 max_length: 0,
                 precision: 0,
                 scale: 0,

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -314,10 +314,7 @@ SELECT
     c.max_length as col_max_length,
     c.precision as col_precision,
     c.scale as col_scale,
-    CASE
-        WHEN tc.constraint_type = 'PRIMARY KEY' THEN tc.constraint_name
-        ELSE NULL
-    END AS col_primary_key_constraint
+    tc.constraint_name AS col_primary_key_constraint
 FROM sys.tables t
 JOIN sys.schemas s ON t.schema_id = s.schema_id
 JOIN sys.columns c ON t.object_id = c.object_id

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -373,6 +373,8 @@ pub enum SqlServerSourcePurificationError {
         option_name: String,
         items: Vec<UnresolvedItemName>,
     },
+    #[error("found multiple primary keys for a table. constraints {constraint_names:?}")]
+    MultiplePrimaryKeys { constraint_names: Vec<Arc<str>> },
     #[error("column {schema_name}.{tbl_name}.{col_name} of type {col_type} is not supported")]
     UnsupportedColumn {
         schema_name: Arc<str>,

--- a/test/sql-server-cdc/25-constraints.td
+++ b/test/sql-server-cdc/25-constraints.td
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+DROP DATABASE IF EXISTS test_25;
+CREATE DATABASE test_25;
+USE test_25;
+
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test_25 SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE t25_pk (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024) NOT NULL, extra VARCHAR(200));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't25_pk', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t25_pk VALUES ('a', 'hello world', NULL), ('b', 'foobar', 'apple'), ('c', 'anotha one', 'orange');
+
+CREATE TABLE t25_pk2 (id VARCHAR(20), seq_no VARCHAR(1024), extra VARCHAR(200), PRIMARY KEY(id, seq_no));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't25_pk2', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t25_pk2 VALUES ('i am an ID', '1000', 'uhhmmmm');
+
+# Exercise Materialize.
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_sql_server_source = true;
+
+> CREATE CONNECTION sql_server_test_25_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_25,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+> CREATE SOURCE t25_pk_sql_server
+  FROM SQL SERVER CONNECTION sql_server_test_25_connection
+  FOR ALL TABLES;
+
+> SELECT name, regexp_replace(create_sql, '[us]\d+|__.*__[A-F0-9]+|DETAILS = ''[a-f0-9]+''', '<VAR>', 'g') as sql FROM mz_sources WHERE name IN ('t25_pk', 't25_pk2');
+t25_pk "CREATE SUBSOURCE \"materialize\".\"public\".\"t25_pk\" (\"key_col\" [<VAR> AS \"pg_catalog\".\"varchar\"](20) NOT NULL, \"val_col\" [<VAR> AS \"pg_catalog\".\"varchar\"](1024) NOT NULL, \"extra\" [<VAR> AS \"pg_catalog\".\"varchar\"](200), CONSTRAINT \"PK<VAR>\" PRIMARY KEY (\"key_col\")) OF SOURCE [<VAR> AS \"materialize\".\"public\".\"t25_pk_sql_server\"] WITH (EXTERNAL REFERENCE = \"test_25\".\"dbo\".\"t25_pk\", <VAR>)"
+t25_pk2 "CREATE SUBSOURCE \"materialize\".\"public\".\"t25_pk2\" (\"id\" [<VAR> AS \"pg_catalog\".\"varchar\"](20) NOT NULL, \"seq_no\" [<VAR> AS \"pg_catalog\".\"varchar\"](1024) NOT NULL, \"extra\" [<VAR> AS \"pg_catalog\".\"varchar\"](200), CONSTRAINT \"PK<VAR>\" PRIMARY KEY (\"id\", \"seq_no\")) OF SOURCE [<VAR> AS \"materialize\".\"public\".\"t25_pk_sql_server\"] WITH (EXTERNAL REFERENCE = \"test_25\".\"dbo\".\"t25_pk2\", <VAR>)"
+
+> SHOW COLUMNS FROM t25_pk
+key_col false "character varying" ""
+val_col false "character varying" ""
+extra true "character varying" ""
+
+> SELECT * FROM t25_pk;
+a "hello world" <null>
+b foobar apple
+c "anotha one" orange


### PR DESCRIPTION
This PR updates the metadata we fetch for SQL Server tables to include which columns are primary keys and plumb this information into Materialize.

### Motivation

While Materialize does not enforce primary keys, we can trust the upstream system and having the Unique constraint in Materialize can improve query planning

Fixes https://github.com/MaterializeInc/database-issues/issues/9210

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
