### PR TITLE
[sql_server] Minor cleanups, readjust some `TODO(sql_server1)`

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -750,7 +750,7 @@ fn ast_rewrite_sources_to_tables(
                 changed_ids.insert(source_id, new_table_id);
             }
 
-            // TODO(sql_server1): Consider how to migrate SQL Server subsources
+            // TODO(sql_server2): Consider how to migrate SQL Server subsources
             // to the source table world.
             Statement::CreateSource(CreateSourceStatement {
                 connection: CreateSourceConnection::SqlServer { .. },

--- a/src/sql-server-util/examples/cdc.rs
+++ b/src/sql-server-util/examples/cdc.rs
@@ -58,8 +58,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Open one client to stream changes.
     let mz_config = Config::new(config.clone(), TunnelConfig::Direct, InTask::No);
-    let (mut client_1, connection) = Client::connect(mz_config).await?;
-    mz_ore::task::spawn(|| "sql-server connection", async move { connection.await });
+    let mut client_1 = Client::connect(mz_config).await?;
     tracing::info!("connection 1 successful!");
 
     let capture_instances = ["materialize_t1", "materialize_t2"];
@@ -67,8 +66,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Open a second client that we can use to cleanup the underlying change tables.
     let mz_config = Config::new(config.clone(), TunnelConfig::Direct, InTask::No);
-    let (mut client_2, connection) = Client::connect(mz_config).await?;
-    mz_ore::task::spawn(|| "sql-server connection", async move { connection.await });
+    let mut client_2 = Client::connect(mz_config).await?;
     tracing::info!("connection 2 successful!");
 
     // Get an initial snapshot of the table.

--- a/src/sql-server-util/src/config.rs
+++ b/src/sql-server-util/src/config.rs
@@ -69,7 +69,7 @@ pub enum TunnelConfig {
         manager: SshTunnelManager,
         /// Timeout config for the SSH tunnel.
         timeout: SshTimeoutConfig,
-        // TODO(sql_server1): Remove these fields by forking the `tiberius`
+        // TODO(sql_server3): Remove these fields by forking the `tiberius`
         // crate and expose the `get_host` and `get_port` methods.
         //
         // See: <https://github.com/MaterializeInc/tiberius/blob/406ad2780d206617bd41689b1b638bddf4538f89/src/client/config.rs#L174-L191>

--- a/src/sql-server-util/src/inspect.rs
+++ b/src/sql-server-util/src/inspect.rs
@@ -88,7 +88,7 @@ fn parse_lsn(result: &[tiberius::Row]) -> Result<Lsn, SqlServerError> {
 /// Queries the specified capture instance and returns all changes from
 /// `[start_lsn, end_lsn)`, ordered by `start_lsn` in an ascending fashion.
 ///
-/// TODO(sql_server1): This presents an opportunity for SQL injection. We should create a stored
+/// TODO(sql_server2): This presents an opportunity for SQL injection. We should create a stored
 /// procedure using `QUOTENAME` to sanitize the input for the capture instance provided by the
 /// user.
 pub fn get_changes_asc(

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -39,12 +39,6 @@ use crate::desc::SqlServerColumnDecodeType;
 
 /// Higher level wrapper around a [`tiberius::Client`] that models transaction
 /// management like other database clients.
-///
-/// When creating a [`Client`] we return a [`Connection`] which implements [`std::future::Future`]
-/// and must be polled for queries to make progress. Internally a [`Client`] holds the sending side
-/// of a channel and the [`Connection`] receives query requests to run. This enables us to
-/// introduce a [`Transaction`] type that when dropped will cause the `TRANSACTION` in the
-/// connected SQL Server instance to get rolled back.
 #[derive(Debug)]
 pub struct Client {
     tx: UnboundedSender<Request>,

--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -91,10 +91,10 @@ impl Client {
                 (tcp, Some(Box::new(tunnel)))
             }
             TunnelConfig::AwsPrivatelink { connection_id: _ } => {
-                // TODO(sql_server1): Getting this right is tricky because
+                // TODO(sql_server2): Getting this right is tricky because
                 // there is some subtle logic with hostname validation.
                 return Err(SqlServerError::Generic(anyhow::anyhow!(
-                    "TODO(sql_server1): Support PrivateLink connections"
+                    "Support PrivateLink connections"
                 )));
             }
         };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -976,7 +976,7 @@ pub fn plan_create_source(
                     scx.catalog.resolve_full_name(connection_item.name())
                 ),
             };
-            // TODO(sql_server1): Handle SQL Server connection options.
+            // TODO(sql_server2): Handle SQL Server connection options.
 
             let extras = SqlServerSourceExtras {};
             let connection =

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -538,7 +538,7 @@ impl ConnectionOptionExtracted {
                 scx.require_feature_flag(&vars::ENABLE_SQL_SERVER_SOURCE)?;
 
                 let aws_connection = get_aws_connection_reference(scx, &self)?;
-                // TODO(sql_server1): Support AWS connections for SQL Server. Nothing fundamental
+                // TODO(sql_server2): Support AWS connections for SQL Server. Nothing fundamental
                 // prevents this, just need to wire it up.
                 if aws_connection.is_some() {
                     return Err(PlanError::Unsupported {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -971,10 +971,7 @@ async fn purify_create_source(
                     InTask::No,
                 )
                 .await?;
-            let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
-            // TODO(sql_server1): Create a version of the client where we don't need to separately
-            // spawn this task.
-            mz_ore::task::spawn(|| "sql-server-conn", async move { conn.await });
+            let mut client = mz_sql_server_util::Client::connect(config).await?;
 
             // Ensure the upstream SQL Server instance is configured to allow CDC.
             //
@@ -1599,11 +1596,7 @@ async fn purify_alter_source_add_subsources(
                     InTask::No,
                 )
                 .await?;
-            let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
-            // TODO(sql_server1): Move the spawning of this task into the SQL Server client.
-            mz_ore::task::spawn(|| "sql-server-connection", async move {
-                conn.await;
-            });
+            let mut client = mz_sql_server_util::Client::connect(config).await?;
 
             // Query the upstream SQL Server instance for available tables to replicate.
             let database = sql_server_connection.database.clone().into();
@@ -1723,11 +1716,7 @@ async fn purify_alter_source_refresh_references(
                     InTask::No,
                 )
                 .await?;
-            let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
-            // TODO(sql_server1): Move the spawning of this task into the SQL Server client.
-            mz_ore::task::spawn(|| "sql-server-connection", async move {
-                conn.await;
-            });
+            let mut client = mz_sql_server_util::Client::connect(config).await?;
 
             // Query the upstream SQL Server instance for available tables to replicate.
             let source_references = SourceReferenceClient::SqlServer {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1956,7 +1956,7 @@ async fn purify_create_table_from_source(
             purified_export
         }
         GenericSourceConnection::SqlServer(_sql_server_source) => {
-            // TODO(sql_server1): Support CREATE TABLE ... FROM SOURCE.
+            // TODO(sql_server2): Support CREATE TABLE ... FROM SOURCE.
             return Err(PlanError::Unsupported {
                 feature: "CREATE TABLE ... FROM SQL SERVER SOURCE".to_string(),
                 discussion_no: None,
@@ -2124,7 +2124,7 @@ async fn purify_create_table_from_source(
             })
         }
         PurifiedExportDetails::SqlServer { .. } => {
-            // TODO(sql_server1): Support CREATE TABLE ... FROM SOURCE.
+            // TODO(sql_server2): Support CREATE TABLE ... FROM SOURCE.
             return Err(PlanError::Unsupported {
                 feature: "CREATE TABLE ... FROM SQL SERVER SOURCE".to_string(),
                 discussion_no: None,

--- a/src/sql/src/pure/references.rs
+++ b/src/sql/src/pure/references.rs
@@ -246,7 +246,7 @@ impl<'a> SourceReferenceClient<'a> {
             } => {
                 let tables = mz_sql_server_util::inspect::get_tables(client).await?;
 
-                // TODO(sql_server1): Figure out how to handle a single table with
+                // TODO(sql_server2): Figure out how to handle a single table with
                 // multiple capture instances.
                 let mut unique_tables = BTreeMap::default();
                 for table in tables {

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -144,7 +144,7 @@ pub(super) async fn purify_source_exports(
         }
     }
 
-    // TODO(sql_server1): Validate permissions on upstream tables.
+    // TODO(sql_server2): Validate permissions on upstream tables.
 
     let capture_instances: BTreeMap<_, _> = requested_exports
         .iter()

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -2158,7 +2158,6 @@ impl SqlServerConnectionDetails<InlinedConnection> {
                         .ssh_tunnel_manager
                         .clone(),
                     timeout: storage_configuration.parameters.ssh_timeout_config.clone(),
-                    // TODO(sql_server1): These should not be here.
                     host: self.host.clone(),
                     port: self.port,
                 }
@@ -2213,7 +2212,7 @@ impl<C: ConnectionAccess> AlterCompatible for SqlServerConnectionDetails<C> {
     ) -> Result<(), crate::controller::AlterError> {
         let SqlServerConnectionDetails {
             tunnel,
-            // TODO(sql_server1): Figure out how these variables are allowed to change.
+            // TODO(sql_server2): Figure out how these variables are allowed to change.
             host: _,
             port: _,
             database: _,

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -2073,7 +2073,7 @@ impl SqlServerConnectionDetails<InlinedConnection> {
         tracing::debug!(?config, "Validating SQL Server connection");
 
         // Just connecting is enough to validate, no need to send any queries.
-        let (_client, _conn) = mz_sql_server_util::Client::connect(config).await?;
+        let _client = mz_sql_server_util::Client::connect(config).await?;
 
         Ok(())
     }

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -109,9 +109,7 @@ impl SqlServerSource<InlinedConnection> {
                 InTask::No,
             )
             .await?;
-        let (mut client, conn) = mz_sql_server_util::Client::connect(config).await?;
-        // TODO(sql_server1): Make spawning this task automatic.
-        mz_ore::task::spawn(|| "sql server connection", async move { conn.await });
+        let mut client = mz_sql_server_util::Client::connect(config).await?;
 
         let max_lsn = mz_sql_server_util::inspect::get_max_lsn(&mut client).await?;
         Ok(Antichain::from_elem(max_lsn))

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -91,9 +91,7 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
                     InTask::Yes,
                 )
                 .await?;
-            let (mut client, conn) = mz_sql_server_util::Client::connect(conn_config).await?;
-            // TODO(sql_server1): Move the connection into its own future.
-            mz_ore::task::spawn(|| "sql_server-progress-conn", async move { conn.await });
+            let mut client = mz_sql_server_util::Client::connect(conn_config).await?;
 
             let probe_interval = OFFSET_KNOWN_INTERVAL.handle(config.config.config_set());
             let mut probe_ticker = probe::Ticker::new(|| probe_interval.get(), config.now_fn);

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -98,10 +98,7 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
                     InTask::Yes,
                 )
                 .await?;
-            let (mut client, connection) =
-                mz_sql_server_util::Client::connect(connection_config).await?;
-            // TODO(sql_server1): Move the connection into its own future.
-            mz_ore::task::spawn(|| "sql_server-connection", async move { connection.await });
+            let mut client = mz_sql_server_util::Client::connect(connection_config).await?;
 
             let output_indexes: Vec<_> = outputs
                 .values()

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -48,7 +48,7 @@ use crate::source::types::{
 /// Used as a partition ID to determine the worker that is responsible for
 /// reading data from SQL Server.
 ///
-/// TODO(sql_server1): It's possible we could have different workers
+/// TODO(sql_server2): It's possible we could have different workers
 /// replicate different tables, if we're using SQL Server's CDC features.
 static REPL_READER: &str = "reader";
 
@@ -85,7 +85,7 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
                 definite_error_cap_set,
             ]: &mut [_; 4] = caps.try_into().unwrap();
 
-            // TODO(sql_server1): Run ingestions across multiple workers.
+            // TODO(sql_server2): Run ingestions across multiple workers.
             if !config.responsible_for(REPL_READER) {
                 return Ok::<_, TransientError>(());
             }

--- a/src/testdrive/src/action/sql_server/connect.rs
+++ b/src/testdrive/src/action/sql_server/connect.rs
@@ -23,17 +23,10 @@ pub async fn run_connect(
     let ado_string = cmd.input.join("\n");
 
     let config = Config::from_ado_string(&ado_string).context("parsing ADO string: {}")?;
-    let (client, connection) = Client::connect(config)
+    let client = Client::connect(config)
         .await
         .context("connecting to SQL server")?;
     state.sql_server_clients.insert(name.clone(), client);
-
-    // Spawn the connection in a tokio task so it gets polled.
-    let task_name = format!("sql-server {name} connection");
-    mz_ore::task::spawn(|| task_name, async move {
-        connection.await;
-        tracing::info!("SQL Server connection '{name}' closed");
-    });
 
     Ok(ControlFlow::Continue)
 }


### PR DESCRIPTION
This PR fixes a `TODO(sql_server1)` related to our `mz_sql_server_util::Client` type and re-levels many of the existing `TODO(sql_server1)` notes to a better level. If folks feel like something should not be downgraded please feel free to say so!

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
