### PR TITLE
[sql_server] support `SHOW CREATE SOURCE ...`

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1104,13 +1104,15 @@ fn humanize_sql_for_show_create(
                     });
                 }
                 CreateSourceConnection::SqlServer { options, .. } => {
-                    // TODO(sql_server2): TEXT and EXCLUDE columns operate on 'schema.table.column'
-                    // names, but our references are also qualified by 'database'. We handle the
-                    // mismatch here but should improve the situation.
+                    // TODO(sql_server2): TEXT and EXCLUDE columns are represented by
+                    // `schema.table.column` whereas our external table references are
+                    // `database.schema.table`. We handle the mismatch here but should
+                    // probably fully qualify our TEXT and EXCLUDE column references.
                     let adjusted_references: BTreeSet<_> = curr_references
                         .keys()
                         .map(|name| {
                             if name.0.len() == 3 {
+                                // Strip the database component of the name.
                                 let adjusted_name = name.0[1..].to_vec();
                                 UnresolvedItemName(adjusted_name)
                             } else {

--- a/test/sql-server-cdc/20-column-options.td
+++ b/test/sql-server-cdc/20-column-options.td
@@ -47,6 +47,9 @@ INSERT INTO t1_columns VALUES (1.444889, '12:00:00', '$100.99', 0x1100AB);
   )
   FOR TABLES (dbo.t1_columns);
 
+> SHOW CREATE SOURCE t1_columns_sql_server;
+materialize.public.t1_columns_sql_server "CREATE SOURCE materialize.public.t1_columns_sql_server\nIN CLUSTER quickstart\nFROM\n    SQL SERVER CONNECTION materialize.public.sql_server_columns_connection (TEXT COLUMNS = (dbo.t1_columns.c1, dbo.t1_columns.c2, dbo.t1_columns.c4), EXCLUDE COLUMNS = (dbo.t1_columns.c3))\nFOR TABLES (test_column_options.dbo.t1_columns AS materialize.public.t1_columns)\nEXPOSE PROGRESS AS materialize.public.t1_columns_sql_server_progress;"
+
 > SHOW COLUMNS FROM t1_columns;
 c1 true text ""
 c2 true text ""

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -61,7 +61,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
             f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
             f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",
-            "--default-timeout=10s",
             str(file),
         ),
     )


### PR DESCRIPTION
As it says on the tin!

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/8762

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
