### PR TITLE
storage: flatten oneshot ingestion commands

### DIFF
--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -51,18 +51,6 @@ message ProtoRunOneshotIngestion {
   mz_storage_types.oneshot_sources.ProtoOneshotIngestionRequest request = 4;
 }
 
-message ProtoRunOneshotIngestionsCommand {
-  repeated ProtoRunOneshotIngestion ingestions = 1;
-}
-
-message ProtoCancelOneshotIngestionsCommand {
-  repeated mz_proto.ProtoU128 ingestions = 1;
-}
-
-message ProtoCreateSources {
-  repeated ProtoRunIngestionCommand sources = 1;
-}
-
 message ProtoRunSinkCommand {
   reserved 3;
   reserved "update";
@@ -85,8 +73,8 @@ message ProtoStorageCommand {
     google.protobuf.Empty allow_writes = 7;
     ProtoRunSinkCommand run_sink = 4;
     mz_storage_types.parameters.ProtoStorageParameters update_configuration = 5;
-    ProtoRunOneshotIngestionsCommand run_oneshot_ingestions = 10;
-    ProtoCancelOneshotIngestionsCommand cancel_oneshot_ingestions = 11;
+    ProtoRunOneshotIngestion run_oneshot_ingestion = 10;
+    mz_proto.ProtoU128 cancel_oneshot_ingestion = 11;
   }
 }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1556,7 +1556,7 @@ where
         };
 
         if !self.read_only {
-            instance.send(StorageCommand::RunOneshotIngestion(vec![oneshot_cmd]));
+            instance.send(StorageCommand::RunOneshotIngestion(oneshot_cmd));
             let pending = PendingOneshotIngestion {
                 result_tx,
                 cluster_id: instance_id,
@@ -1589,9 +1589,7 @@ where
 
         match self.instances.get_mut(&pending.cluster_id) {
             Some(instance) => {
-                instance.send(StorageCommand::CancelOneshotIngestion {
-                    ingestions: vec![ingestion_id],
-                });
+                instance.send(StorageCommand::CancelOneshotIngestion(ingestion_id));
             }
             None => {
                 mz_ore::soft_panic_or_log!(
@@ -2368,9 +2366,8 @@ where
                                 // avoid duplicate work once we have active replication.
                                 if let Some(instance) = self.instances.get_mut(&pending.cluster_id)
                                 {
-                                    instance.send(StorageCommand::CancelOneshotIngestion {
-                                        ingestions: vec![ingestion_id],
-                                    });
+                                    instance
+                                        .send(StorageCommand::CancelOneshotIngestion(ingestion_id));
                                 }
                                 // Send the results down our channel.
                                 (pending.result_tx)(batches)


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/31261 flattened most of the storage commands and responses, except for the oneshot-ingestion commands that were only added after that PR was opened. This PR flattens the two new command variants as well.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
