### PR TITLE
[build] fix `mzbuild` by skipping `DependencySet` check if there are no deps

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1137,7 +1137,10 @@ class DependencySet:
     def check(self) -> bool:
         """Check all publishable images in this dependency set exist on Docker
         Hub. Don't try to download or build them."""
-        with ThreadPoolExecutor(max_workers=len(list(self))) as executor:
+        num_deps = len(list(self))
+        if num_deps == 0:
+            return True
+        with ThreadPoolExecutor(max_workers=num_deps) as executor:
             results = list(
                 executor.map(lambda dep: dep.is_published_if_necessary(), list(self))
             )


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/102470#0196493a-146a-4b71-b10a-706d6b497262

### Motivation

Fixes a slight regression introduced by https://github.com/MaterializeInc/materialize/pull/32212

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
