### PR TITLE
[sql_server] change encryption to `Preferred`

### DIFF
--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -547,8 +547,8 @@ impl ConnectionOptionExtracted {
                     });
                 }
 
-                // TODO(sql_server1): Parse the encryption level from the create SQL.
-                let encryption = mz_sql_server_util::config::EncryptionLevel::None;
+                // TODO(sql_server2): Parse the encryption level from the create SQL.
+                let encryption = mz_sql_server_util::config::EncryptionLevel::Preferred;
 
                 // 1433 is the default port for SQL Server instances running over TCP.
                 //


### PR DESCRIPTION
Still need to fix this further, but this is better than setting `None`.

### Motivation

Progress towards https://github.com/MaterializeInc/database-issues/issues/9205

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
