### PR TITLE
compute,storage: reduce the size of cluster commands

### DIFF
--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -35,7 +35,7 @@ use crate::controller::{ComputeControllerTimestamp, ReplicaId};
 use crate::logging::LoggingConfig;
 use crate::metrics::IntCounter;
 use crate::metrics::ReplicaMetrics;
-use crate::protocol::command::{ComputeCommand, InitialComputeParameters, InstanceConfig};
+use crate::protocol::command::{ComputeCommand, InitialComputeParameters};
 use crate::protocol::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
@@ -277,7 +277,7 @@ where
     fn specialize_command(&self, command: &mut ComputeCommand<T>) {
         match command {
             ComputeCommand::CreateTimely { config, epoch } => {
-                *config = TimelyConfig {
+                **config = TimelyConfig {
                     workers: self.config.location.workers,
                     process: 0,
                     addresses: self.config.location.dataflow_addrs.clone(),
@@ -292,13 +292,10 @@ where
                 };
                 *epoch = self.epoch;
             }
-            ComputeCommand::CreateInstance(InstanceConfig {
-                logging,
-                expiration_offset,
-            }) => {
-                *logging = self.config.logging.clone();
+            ComputeCommand::CreateInstance(config) => {
+                config.logging = self.config.logging.clone();
                 if ENABLE_COMPUTE_REPLICA_EXPIRATION.get(&self.dyncfg) {
-                    *expiration_offset = self.config.expiration_offset;
+                    config.expiration_offset = self.config.expiration_offset;
                 }
             }
             _ => {}

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -118,7 +118,7 @@ where
                     initialization_complete = true;
                 }
                 ComputeCommand::UpdateConfiguration(params) => {
-                    final_configuration.update(params);
+                    final_configuration.update(*params);
                 }
                 ComputeCommand::CreateDataflow(dataflow) => {
                     created_dataflows.push(dataflow);
@@ -205,8 +205,9 @@ where
         let count = u64::from(!final_configuration.all_unset());
         command_counts.update_configuration.borrow().set(count);
         if !final_configuration.all_unset() {
+            let config = Box::new(final_configuration);
             self.commands
-                .push(ComputeCommand::UpdateConfiguration(final_configuration));
+                .push(ComputeCommand::UpdateConfiguration(config));
         }
 
         let count = u64::cast_from(created_dataflows.len());

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -659,6 +659,12 @@ mod tests {
 
     use super::*;
 
+    /// Test to ensure the size of the `ComputeResponse` enum doesn't regress.
+    #[mz_ore::test]
+    fn test_compute_response_size() {
+        assert_eq!(std::mem::size_of::<ComputeResponse>(), 120);
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
 

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -256,7 +256,12 @@ where
 
                 timely_cmds
                     .into_iter()
-                    .map(|config| Some(ComputeCommand::CreateTimely { config, epoch }))
+                    .map(|config| {
+                        Some(ComputeCommand::CreateTimely {
+                            config: Box::new(config),
+                            epoch,
+                        })
+                    })
                     .collect()
             }
             command @ ComputeCommand::UpdateConfiguration(_) => {

--- a/src/compute/src/command_channel.rs
+++ b/src/compute/src/command_channel.rs
@@ -157,6 +157,8 @@ fn split_command(
 
     let commands = match command {
         ComputeCommand::CreateDataflow(dataflow) => {
+            let dataflow = *dataflow;
+
             // A list of descriptions of objects for each part to build.
             let mut builds_parts = vec![Vec::new(); parts];
             // Partition each build description among `parts`.
@@ -187,6 +189,7 @@ fn split_command(
                     refresh_schedule: dataflow.refresh_schedule.clone(),
                     time_dependence: dataflow.time_dependence.clone(),
                 })
+                .map(Box::new)
                 .map(ComputeCommand::CreateDataflow);
             Either::Left(commands)
         }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -406,15 +406,15 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         match cmd {
             CreateTimely { .. } => panic!("CreateTimely must be captured before"),
-            CreateInstance(instance_config) => self.handle_create_instance(instance_config),
+            CreateInstance(instance_config) => self.handle_create_instance(*instance_config),
             InitializationComplete => (),
-            UpdateConfiguration(params) => self.handle_update_configuration(params),
-            CreateDataflow(dataflow) => self.handle_create_dataflow(dataflow),
+            UpdateConfiguration(params) => self.handle_update_configuration(*params),
+            CreateDataflow(dataflow) => self.handle_create_dataflow(*dataflow),
             Schedule(id) => self.handle_schedule(id),
             AllowCompaction { id, frontier } => self.handle_allow_compaction(id, frontier),
             Peek(peek) => {
                 peek.otel_ctx.attach_as_parent();
-                self.handle_peek(peek)
+                self.handle_peek(*peek)
             }
             CancelPeek { uuid } => self.handle_cancel_peek(uuid),
             AllowWrites => {

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -24,7 +24,7 @@ mz-controller-types = { path = "../controller-types" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["async", "process", "tracing"] }
+mz-ore = { path = "../ore", features = ["async", "chrono", "process", "tracing"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto", features = ["tokio-postgres"] }

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -51,18 +51,6 @@ message ProtoRunOneshotIngestion {
   mz_storage_types.oneshot_sources.ProtoOneshotIngestionRequest request = 4;
 }
 
-message ProtoRunOneshotIngestionsCommand {
-  repeated ProtoRunOneshotIngestion ingestions = 1;
-}
-
-message ProtoCancelOneshotIngestionsCommand {
-  repeated mz_proto.ProtoU128 ingestions = 1;
-}
-
-message ProtoCreateSources {
-  repeated ProtoRunIngestionCommand sources = 1;
-}
-
 message ProtoRunSinkCommand {
   reserved 3;
   reserved "update";
@@ -85,8 +73,8 @@ message ProtoStorageCommand {
     google.protobuf.Empty allow_writes = 7;
     ProtoRunSinkCommand run_sink = 4;
     mz_storage_types.parameters.ProtoStorageParameters update_configuration = 5;
-    ProtoRunOneshotIngestionsCommand run_oneshot_ingestions = 10;
-    ProtoCancelOneshotIngestionsCommand cancel_oneshot_ingestions = 11;
+    ProtoRunOneshotIngestion run_oneshot_ingestion = 10;
+    mz_proto.ProtoU128 cancel_oneshot_ingestion = 11;
   }
 }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1556,7 +1556,7 @@ where
         };
 
         if !self.read_only {
-            instance.send(StorageCommand::RunOneshotIngestion(vec![oneshot_cmd]));
+            instance.send(StorageCommand::RunOneshotIngestion(oneshot_cmd));
             let pending = PendingOneshotIngestion {
                 result_tx,
                 cluster_id: instance_id,
@@ -1589,9 +1589,7 @@ where
 
         match self.instances.get_mut(&pending.cluster_id) {
             Some(instance) => {
-                instance.send(StorageCommand::CancelOneshotIngestion {
-                    ingestions: vec![ingestion_id],
-                });
+                instance.send(StorageCommand::CancelOneshotIngestion(ingestion_id));
             }
             None => {
                 mz_ore::soft_panic_or_log!(
@@ -2368,9 +2366,8 @@ where
                                 // avoid duplicate work once we have active replication.
                                 if let Some(instance) = self.instances.get_mut(&pending.cluster_id)
                                 {
-                                    instance.send(StorageCommand::CancelOneshotIngestion {
-                                        ingestions: vec![ingestion_id],
-                                    });
+                                    instance
+                                        .send(StorageCommand::CancelOneshotIngestion(ingestion_id));
                                 }
                                 // Send the results down our channel.
                                 (pending.result_tx)(batches)

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1306,11 +1306,13 @@ impl StorageState {
                 if self.timely_worker_index == 0 {
                     self.internal_cmd_tx
                         .send(InternalStorageCommand::UpdateConfiguration {
-                            storage_parameters: params,
+                            storage_parameters: *params,
                         })
                 }
             }
-            StorageCommand::RunIngestion(RunIngestionCommand { id, description }) => {
+            StorageCommand::RunIngestion(ingestion) => {
+                let RunIngestionCommand { id, description } = *ingestion;
+
                 // Remember the ingestion description to facilitate possible
                 // reconciliation later.
                 self.ingestions.insert(id, description.clone());


### PR DESCRIPTION
`ComputeCommand` and `StorageCommand` are enums, so their size is dependent on the size of the largest variant. Both contain some huge variants, in particular `UpdateConfiguration` and the ones describing dataflows to install, bringing the size of the enums to 3-4 KB. In contrast, the variant we send most frequently, `AllowCompaction`, is only 40 bytes in size, so when handling an `AllowCompaction` command, we waste 3-4 KB of space. Commands are stored in histories and channels, so this amount of waste can have an impact on our memory usage.

This commit removes the waste and brings the size of the command enum down to 40 bytes by boxing large fields. This makes code creating commands a bit more noisy, but no way to avoid that I think.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I didn't try the reduce the size of the responses here for two reasons:
* They are only 120 bytes in size, so the waste is much smaller than for commands.
* At least for compute, the 120-bytes response is also the one we send most of the time (`Frontiers`), so moving its data to the heap wouldn't safe much memory overall.

That's not to say we shouldn't try to reduce the memory usage of responses too, just that it's less urgent.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
