### PR TITLE
dependabot: Split dependencies in two parts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,42 @@ updates:
   open-pull-requests-limit: 50
   labels: [A-dependencies]
   groups:
-    simple:
+    simple1:
       applies-to: version-updates
       update-types:
         - patch
+      patterns:
+        - "a*"
+        - "b*"
+        - "c*"
+        - "d*"
+        - "e*"
+        - "f*"
+        - "g*"
+        - "h*"
+        - "i*"
+        - "j*"
+        - "k*"
+        - "l*"
+        - "m*"
+    simple2:
+      applies-to: version-updates
+      update-types:
+        - patch
+      patterns:
+        - "n*"
+        - "o*"
+        - "p*"
+        - "q*"
+        - "r*"
+        - "s*"
+        - "t*"
+        - "u*"
+        - "v*"
+        - "w*"
+        - "x*"
+        - "y*"
+        - "z*"
 - package-ecosystem: cargo
   directory: /misc/wasm
   schedule:


### PR DESCRIPTION
Keeps timing out with 55 min, but we don't want individual PRs since they use a lot of CI resources. Latest failure: https://github.com/MaterializeInc/materialize/actions/runs/14564076438/job/40850888224
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
