### PR TITLE
controller: record wallclock lag at minute boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,6 +5336,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytesize",
+ "chrono",
  "crossbeam-channel",
  "derivative",
  "differential-dataflow",

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.97"
 async-trait = "0.1.88"
 bytesize = "1.3.0"
+chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.15"
 derivative = "2.2.0"
 differential-dataflow = "0.14.2"

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -26,22 +26,16 @@ pub const ENABLE_0DT_DEPLOYMENT_SOURCES: Config<bool> = Config::new(
     "Whether to enable zero-downtime deployments for sources that support it (experimental).",
 );
 
-pub const WALLCLOCK_LAG_HISTORY_REFRESH_INTERVAL: Config<Duration> = Config::new(
-    "wallclock_lag_history_refresh_interval",
+pub const WALLCLOCK_LAG_RECORDING_INTERVAL: Config<Duration> = Config::new(
+    "wallclock_lag_recording_interval",
     Duration::from_secs(60),
-    "The interval at which to refresh `WallclockLagHistory` introspection.",
+    "The interval at which to record `WallclockLagHistory` introspection.",
 );
 
 pub const ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION: Config<bool> = Config::new(
     "enable_wallclock_lag_histogram_collection",
     true,
     "Whether to record `WallclockLagHistogram` introspection.",
-);
-
-pub const WALLCLOCK_LAG_HISTOGRAM_REFRESH_INTERVAL: Config<Duration> = Config::new(
-    "wallclock_lag_histogram_refresh_interval",
-    Duration::from_secs(60),
-    "The interval at which to refresh `WallclockLagHistogram` introspection.",
 );
 
 pub const WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL: Config<Duration> = Config::new(
@@ -79,9 +73,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL)
         .add(&ENABLE_0DT_DEPLOYMENT_SOURCES)
-        .add(&WALLCLOCK_LAG_HISTORY_REFRESH_INTERVAL)
+        .add(&WALLCLOCK_LAG_RECORDING_INTERVAL)
         .add(&ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION)
-        .add(&WALLCLOCK_LAG_HISTOGRAM_REFRESH_INTERVAL)
         .add(&WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL)
         .add(&ENABLE_TIMELY_ZERO_COPY)
         .add(&ENABLE_TIMELY_ZERO_COPY_LGALLOC)

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -29,8 +29,7 @@ use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::metrics::{ControllerMetrics, WallclockLagMetrics};
 use mz_cluster_client::{ReplicaId, WallclockLagFn};
 use mz_controller_types::dyncfgs::{
-    ENABLE_0DT_DEPLOYMENT_SOURCES, ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION,
-    WALLCLOCK_LAG_HISTOGRAM_REFRESH_INTERVAL, WALLCLOCK_LAG_HISTORY_REFRESH_INTERVAL,
+    ENABLE_0DT_DEPLOYMENT_SOURCES, ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION, WALLCLOCK_LAG_RECORDING_INTERVAL,
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
@@ -224,10 +223,8 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// A function that computes the lag between the given time and wallclock time.
     #[derivative(Debug = "ignore")]
     wallclock_lag: WallclockLagFn<T>,
-    /// The last time `WallclockLagHistory` introspection was refreshed.
-    wallclock_lag_history_last_refresh: Instant,
-    /// The last time `WallclockLagHistogram` introspection was refreshed.
-    wallclock_lag_histogram_last_refresh: Instant,
+    /// The last time wallclock lag introspection was recorded.
+    wallclock_lag_last_recorded: Instant,
 
     /// Handle to a [StorageCollections].
     storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
@@ -2726,8 +2723,7 @@ where
             recorded_frontiers: BTreeMap::new(),
             recorded_replica_frontiers: BTreeMap::new(),
             wallclock_lag,
-            wallclock_lag_history_last_refresh: Instant::now(),
-            wallclock_lag_histogram_last_refresh: Instant::now(),
+            wallclock_lag_last_recorded: Instant::now(),
             storage_collections,
             migrated_storage_collections: BTreeSet::new(),
             maintenance_ticker,
@@ -3506,12 +3502,12 @@ where
     /// This method is invoked by `ComputeController::maintain`, which we expect to be called once
     /// per second during normal operation.
     fn refresh_wallclock_lag(&mut self) {
-        let refresh_history = !self.read_only
-            && self.wallclock_lag_history_last_refresh.elapsed()
-                >= WALLCLOCK_LAG_HISTORY_REFRESH_INTERVAL.get(self.config.config_set());
-        let refresh_histogram = !self.read_only
-            && self.wallclock_lag_histogram_last_refresh.elapsed()
-                >= WALLCLOCK_LAG_HISTOGRAM_REFRESH_INTERVAL.get(self.config.config_set());
+        let recording_interval = WALLCLOCK_LAG_RECORDING_INTERVAL.get(self.config.config_set());
+        let record_introspection =
+            !self.read_only && self.wallclock_lag_last_recorded.elapsed() >= recording_interval;
+        if record_introspection {
+            self.wallclock_lag_last_recorded = Instant::now();
+        }
 
         let now_ms = (self.now)();
         let now_dt = mz_ore::now::to_datetime(now_ms);
@@ -3537,7 +3533,7 @@ where
             let lag = frontier_lag(&frontiers.write_frontier);
             collection.wallclock_lag_max = std::cmp::max(collection.wallclock_lag_max, lag);
 
-            if refresh_history {
+            if record_introspection {
                 let max_lag = std::mem::take(&mut collection.wallclock_lag_max);
                 let max_lag_us = i64::try_from(max_lag.as_micros()).expect("must fit");
                 let row = Row::pack_slice(&[
@@ -3574,7 +3570,7 @@ where
                 let key = (histogram_period, bucket, labels);
                 *stash.entry(key).or_default() += Diff::ONE;
 
-                if refresh_histogram {
+                if record_introspection {
                     for ((period, lag, labels), count) in std::mem::take(stash) {
                         let mut packer = row_buf.packer();
                         packer.extend([
@@ -3597,14 +3593,12 @@ where
                 IntrospectionType::WallclockLagHistory,
                 history_updates,
             );
-            self.wallclock_lag_history_last_refresh = Instant::now();
         }
         if !histogram_updates.is_empty() {
             self.append_introspection_updates(
                 IntrospectionType::WallclockLagHistogram,
                 histogram_updates,
             );
-            self.wallclock_lag_histogram_last_refresh = Instant::now();
         }
     }
 

--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -15,8 +15,7 @@
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET wallclock_lag_history_refresh_interval = '1s'
-ALTER SYSTEM SET wallclock_lag_histogram_refresh_interval = '1s'
+ALTER SYSTEM SET wallclock_lag_recording_interval = '1s'
 
 > CREATE CLUSTER storage SIZE '1'
 > CREATE CLUSTER compute SIZE '1', REPLICATION FACTOR 2


### PR DESCRIPTION
This PR makes both controllers emit their pending wallclock lag introspection updates when time passes a minute boundary, instead of emitting them at some random moment every minute. This is meant to synchronize the two controllers, reducing the chance of inconsistent introspection data where lag spikes of dependent collections (e.g. a source and an index) are reported at different minutes.

To simplify the implementation, this PR includes two changes to reduce the complexity of the wallclock lag tracking code:
* It merges the feature flags controlling the wallclock lag recording interval (first commit).
* It factors out wallclock lag recording (as opposed to updating the in-memory tracking) into a separate method.

### Motivation

  * This PR fixes a previously unreported bug.

The two controllers can emit wallclock lag introspection updates at different moments within each minute, causing confusion because logically dependent lags of dependent collections can end up at different minutes in the introspection output. See [Slack thread](https://materializeinc.slack.com/archives/C08AENAP691/p1744989938902549).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
