### PR TITLE
docs: Updates for gcp lgalloc

### DIFF
--- a/doc/user/content/installation/install-on-gcp/_index.md
+++ b/doc/user/content/installation/install-on-gcp/_index.md
@@ -268,7 +268,7 @@ components:
    Upon successful completion, various fields and their values are output:
 
    ```bash
-   Apply complete! Resources: 22 added, 0 changed, 0 destroyed.
+   Apply complete! Resources: 27 added, 0 changed, 0 destroyed.
 
    Outputs:
 

--- a/doc/user/content/installation/install-on-gcp/appendix-deployment-guidelines.md
+++ b/doc/user/content/installation/install-on-gcp/appendix-deployment-guidelines.md
@@ -75,7 +75,7 @@ when operating on datasets larger than main memory as well as allows for a more
 graceful degradation rather than OOMing. Network-attached storage (like EBS
 volumes) can significantly degrade performance and is not supported.
 
-Starting in v0.3.5 of Materialize on Google Cloud Provider (GCP) Terraform,
+Starting in v0.4.0 of Materialize on Google Cloud Provider (GCP) Terraform,
 disk support (using OpenEBS and NVMe instance storage) is enabled, by default,
 for Materialize. With this change, the Terraform:
 

--- a/doc/user/content/installation/install-on-gcp/appendix-deployment-guidelines.md
+++ b/doc/user/content/installation/install-on-gcp/appendix-deployment-guidelines.md
@@ -16,6 +16,56 @@ As a general guideline, we recommend:
 
 - Sizing: 2:1 disk-to-RAM ratio with spill-to-disk enabled.
 
+When operating on GCP in production, we recommend the following machine types
+that support local SSD attachment:
+
+| Series | Examples   |
+| ------ | ---------- |
+| [N2 high-memory series] | `n2-highmem-16` or `n2-highmem-32` with local NVMe SSDs |
+| [N2D  high-memory series] | `n2d-highmem-16` or `n2d-highmem-32` with local NVMe SSDs |
+
+To maintain the recommended 2:1 disk-to-RAM ratio for your machine type, see
+[Number of local SSDs](#number-of-local-ssds) to determine the number of local
+SSDs
+([`disk_support_config.local_ssd_count`](https://github.com/MaterializeInc/terraform-google-materialize/blob/main/README.md#input_disk_support_config))
+to use.
+
+See also [Locally attached NVMe storage](#locally-attached-nvme-storage).
+
+## Number of local SSDs
+
+Each local NVMe SSD in GCP provides 375GB of storage. Use the appropriate number
+of local SSDs
+([`disk_support_config.local_ssd_count`](https://github.com/MaterializeInc/terraform-google-materialize/blob/main/README.md#input_disk_support_config))
+to ensure your total disk space is at least twice the amount of RAM in your
+machine type for optimal Materialize performance.
+
+{{< note >}}
+
+Your machine type may only supports predefined number of local SSDs. For instance, `n2d-highmem-32` allows only the following number of local
+SSDs: `4`,`8`,`16`, or `24`. To determine the valid number of Local SSDs to attach for your machine type, see the [GCP
+documentation](https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options).
+
+{{</ note >}}
+
+For example, the following table provides a minimum local SSD count to ensure
+the 2:1 disk-to-RAM ratio. Your actual
+count will depend on the [your machine
+type](https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options).
+
+| Machine Type    | RAM     | Required Disk | Minimum Local SSD Count | Total SSD Storage |
+|-----------------|---------|---------------|-----------------------------|-------------------|
+| `n2-highmem-8`  | `64GB`  | `128GB`       | 1                           | `375GB`           |
+| `n2-highmem-16` | `128GB` | `256GB`       | 1                           | `375GB`           |
+| `n2-highmem-32` | `256GB` | `512GB`       | 2                           | `750GB`           |
+| `n2-highmem-64` | `512GB` | `1024GB`      | 3                           | `1125GB`          |
+| `n2-highmem-80` | `640GB` | `1280GB`      | 4                           | `1500GB`          |
+
+[N2 high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#n2-high-mem
+
+[N2D high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machine_types
+
+[enables spill-to-disk]: https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#disk-support-for-materialize-on-gcp
 
 ## Locally-attached NVMe storage
 
@@ -25,7 +75,37 @@ when operating on datasets larger than main memory as well as allows for a more
 graceful degradation rather than OOMing. Network-attached storage (like EBS
 volumes) can significantly degrade performance and is not supported.
 
-*Additional documentation to come*
+Starting in v0.3.5 of Materialize on Google Cloud Provider (GCP) Terraform,
+disk support (using OpenEBS and NVMe instance storage) is enabled, by default,
+for Materialize. With this change, the Terraform:
+
+- Installs OpenEBS via Helm;
+
+- Configures NVMe instance store volumes using a bootstrap script;
+
+- Creates appropriate storage classes for Materialize.
+
+Associated with this change:
+
+- The following configuration options are available:
+
+  - [`enable_disk_support`]
+  - [`disk_support_config`]
+
+- The default [`gke_config.machine_type`] has changed from `e2-standard-4` to
+`n2-highmem-8`. See [Recommended instance types](#recommended-instance-types).
+
+[enable disk support]:
+    https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#disk-support-for-materialize-on-gcp
+
+[`enable_disk_support`]:
+    https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#input_enable_disk_support
+
+[`disk_support_config`]:
+    https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#input_disk_support_config
+
+[`gke_config.machine_type`]:
+    https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#input_gke_config
 
 ## CPU affinity
 

--- a/doc/user/content/release-notes/_index.md
+++ b/doc/user/content/release-notes/_index.md
@@ -83,7 +83,7 @@ for release specific notes.
 |-----------------------------------------|-------------|
 | **IAM** <br>Built-in authorization mechanisms. | In progress |
 | **License Compliance** <br>License key support to make it easier to comply with license terms. | In progress |
-| **Spill to disk** <br> Provide Terraform modules to set up  locally-attached NVMe storage to support workloads that are larger than can fit into memory. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.1+</li><li>GCP: In progress</li><li>Azure: In progress</li><ul> |
+| **Spill to disk** <br> Provide Terraform modules to set up  locally-attached NVMe storage to support workloads that are larger than can fit into memory. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.1+</li><li>GCP: Available in Materialize on GCP Terraform v0.3.5+</li><li>Azure: In progress</li><ul> |
 | **Ingress from outside cluster** <br> Provide Terraform modules to set up ingress from outside the Kubernetes cluster hosting self-managed Materialize. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.0+</li><li>GCP:Available in Materialize on GCP Terraform v0.3.0+</li><li>Azure: Available in Materialize on Azure Terraform v0.3.1+</li><ul> |
 | **AWS Connections** <br> AWS connections require backing cluster that hosts Materialize to be AWS EKS.  | |
 | **EKS/Azure Connections** | |

--- a/doc/user/content/release-notes/_index.md
+++ b/doc/user/content/release-notes/_index.md
@@ -83,7 +83,7 @@ for release specific notes.
 |-----------------------------------------|-------------|
 | **IAM** <br>Built-in authorization mechanisms. | In progress |
 | **License Compliance** <br>License key support to make it easier to comply with license terms. | In progress |
-| **Spill to disk** <br> Provide Terraform modules to set up  locally-attached NVMe storage to support workloads that are larger than can fit into memory. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.1+</li><li>GCP: Available in Materialize on GCP Terraform v0.3.5+</li><li>Azure: In progress</li><ul> |
+| **Spill to disk** <br> Provide Terraform modules to set up  locally-attached NVMe storage to support workloads that are larger than can fit into memory. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.1+</li><li>GCP: Available in Materialize on GCP Terraform v0.4.0+</li><li>Azure: In progress</li><ul> |
 | **Ingress from outside cluster** <br> Provide Terraform modules to set up ingress from outside the Kubernetes cluster hosting self-managed Materialize. | <ul><li>AWS: Available in Materialize on AWS Terraform v0.3.0+</li><li>GCP:Available in Materialize on GCP Terraform v0.3.0+</li><li>Azure: Available in Materialize on Azure Terraform v0.3.1+</li><ul> |
 | **AWS Connections** <br> AWS connections require backing cluster that hosts Materialize to be AWS EKS.  | |
 | **EKS/Azure Connections** | |

--- a/doc/user/data/self_managed/gcp_terraform_deployed_components.yml
+++ b/doc/user/data/self_managed/gcp_terraform_deployed_components.yml
@@ -30,3 +30,8 @@ rows:
       deployed on subsequent runs after the `cert-manager` is running.
     Version: |
       [v0.3.0+](/installation/appendix-terraforms/#materialize-on-gcp-terraform-module)
+
+  - Component: |
+      OpenEBS and NVMe instance storage to enable spill-to-disk
+    Version: |
+      [v0.3.5+](/installation/appendix-terraforms/#materialize-on-gcp-terraform-module)

--- a/doc/user/data/self_managed/gcp_terraform_deployed_components.yml
+++ b/doc/user/data/self_managed/gcp_terraform_deployed_components.yml
@@ -34,4 +34,4 @@ rows:
   - Component: |
       OpenEBS and NVMe instance storage to enable spill-to-disk
     Version: |
-      [v0.3.5+](/installation/appendix-terraforms/#materialize-on-gcp-terraform-module)
+      [v0.4.0+](/installation/appendix-terraforms/#materialize-on-gcp-terraform-module)

--- a/doc/user/data/self_managed/gcp_terraform_versions.yml
+++ b/doc/user/data/self_managed/gcp_terraform_versions.yml
@@ -5,14 +5,23 @@ columns:
 rows:
 
 - "Terraform version": |
+    [v0.3.5](https://github.com/MaterializeInc/terraform-google-materialize/releases/)
+
+  "Notable changes": |
+    - By default, deploys OpenEBS and NVMe instance storage to [enable
+    spill-to-disk](https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#disk-support-for-materialize-on-gcp).
+    Associated with this change, the default [`gke_config.machine_type`](https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#input_gke_config) has
+    changed from `e2-standard-4` to `n2-highmem-8`.
+
+- "Terraform version": |
     [v0.3.4](https://github.com/MaterializeInc/terraform-google-materialize/releases/tag/v0.3.4)
 
   "Notable changes": |
     - Defaults to using Materialize Operator v25.1.7 (via
-    `terraform-helm-materialize` v0.1.12).
+      `terraform-helm-materialize` v0.1.12).
 
       Versions v0.3.0-v0.3.3 defaulted to Materialize Operator v25.1.6 which
-      used an incorrect version of the `orchestratord`).
+      used an incorrect version of the `orchestratord`.
 
 - "Terraform version": |
     [v0.3.1](https://github.com/MaterializeInc/terraform-google-materialize/releases/tag/v0.3.1)

--- a/doc/user/data/self_managed/gcp_terraform_versions.yml
+++ b/doc/user/data/self_managed/gcp_terraform_versions.yml
@@ -5,7 +5,7 @@ columns:
 rows:
 
 - "Terraform version": |
-    [v0.3.5](https://github.com/MaterializeInc/terraform-google-materialize/releases/)
+    [v0.4.0](https://github.com/MaterializeInc/terraform-google-materialize/releases/)
 
   "Notable changes": |
     - By default, deploys OpenEBS and NVMe instance storage to [enable

--- a/doc/user/data/self_managed/latest_versions.yml
+++ b/doc/user/data/self_managed/latest_versions.yml
@@ -1,4 +1,4 @@
-terraform_gcp_version: v0.3.4
+terraform_gcp_version: v0.3.5
 terraform_azure_version: v0.3.4
 terraform_aws_version: v0.4.3
 terraform_helm_version: v0.1.12

--- a/doc/user/data/self_managed/latest_versions.yml
+++ b/doc/user/data/self_managed/latest_versions.yml
@@ -1,4 +1,4 @@
-terraform_gcp_version: v0.3.5
+terraform_gcp_version: v0.4.0
 terraform_azure_version: v0.3.4
 terraform_aws_version: v0.4.3
 terraform_helm_version: v0.1.12


### PR DESCRIPTION
Draft until we cut a release with the feature.  Currently, using v0.3.5 as the release version placeholder, but can be anything.  Also, added https://github.com/MaterializeInc/terraform-google-materialize/pull/45 for the readme on the terraform repo.