### PR TITLE
platform-checks: Disable stall validation in SourceErrors check

### DIFF
--- a/misc/python/materialize/checks/all_checks/source_errors.py
+++ b/misc/python/materialize/checks/all_checks/source_errors.py
@@ -112,14 +112,14 @@ class SourceErrors(Check):
                 # take precedence over errors. To fix this, we might want to
                 # rewrite this test to look at mz_source_status_history
                 # instead, which contains the full history.
+                # TODO: Reenable check when database-issues#9223 is fixed: bool_and(status IN ('stalled', 'created', 'paused')) as is_stalled
                 """
                 > SELECT
-                        coalesce(bool_and(error ~* 'publication .+ does not exist'), true) as matches,
-                        bool_and(status IN ('stalled', 'created', 'paused')) as is_stalled
+                        coalesce(bool_and(error ~* 'publication .+ does not exist'), true) as matches
                     FROM mz_internal.mz_source_statuses
                     WHERE
                         name IN ('source_errors_sourcea', 'source_errors_sourceb', 'source_errors_tablea', 'source_errors_tableb');
-                true true
+                true
                 """
             )
         )


### PR DESCRIPTION


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
