### PR TITLE
cargo test: Bump timeout for test_create_sockets

### DIFF
--- a/src/cluster/src/communication_v2.rs
+++ b/src/cluster/src/communication_v2.rs
@@ -527,8 +527,8 @@ mod turmoil_tests {
             }
 
             sim.step().unwrap();
-            if sim.elapsed() > Duration::from_secs(60) {
-                panic!("simulation not finished after 60s");
+            if sim.elapsed() > Duration::from_secs(120) {
+                panic!("simulation not finished after 120s");
             }
         }
     }


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/102628#01965bf5-7f8f-4a16-9517-7e3a14da2699

Follow-up to https://github.com/MaterializeInc/materialize/pull/31982

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
