### PR TITLE
[persist] Fix a metric issue and clean up a flag

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -326,7 +326,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
-        .add(&crate::internal::machine::RECORD_COMPACTIONS)
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
         .add(&crate::read::READER_LEASE_DURATION)

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -76,12 +76,6 @@ impl<K, V, T: Clone, D> Clone for Machine<K, V, T, D> {
     }
 }
 
-pub(crate) const RECORD_COMPACTIONS: Config<bool> = Config::new(
-    "persist_record_compactions",
-    false,
-    "Record compaction requests in persistent spine state.",
-);
-
 pub(crate) const CLAIM_UNCLAIMED_COMPACTIONS: Config<bool> = Config::new(
     "persist_claim_unclaimed_compactions",
     false,
@@ -464,7 +458,6 @@ where
                         idempotency_token,
                         debug_info,
                         INLINE_WRITES_TOTAL_MAX_BYTES.get(cfg),
-                        RECORD_COMPACTIONS.get(cfg),
                         if CLAIM_UNCLAIMED_COMPACTIONS.get(cfg) {
                             CLAIM_COMPACTION_PERCENT.get(cfg)
                         } else {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1476,7 +1476,6 @@ where
         idempotency_token: &IdempotencyToken,
         debug_info: &HandleDebugState,
         inline_writes_total_max_bytes: usize,
-        record_compactions: bool,
         claim_compaction_percent: usize,
         claim_compaction_min_version: Option<&Version>,
     ) -> ControlFlow<CompareAndAppendBreak<T>, Vec<FueledMergeReq<T>>> {
@@ -1579,7 +1578,7 @@ where
         let all_empty_reqs = merge_reqs
             .iter()
             .all(|req| req.inputs.iter().all(|b| b.batch.is_empty()));
-        if record_compactions && all_empty_reqs && !batch.is_empty() {
+        if all_empty_reqs && !batch.is_empty() {
             let mut reqs_to_take = claim_compaction_percent / 100;
             if (usize::cast_from(idempotency_token.hashed()) % 100)
                 < (claim_compaction_percent % 100)
@@ -1597,15 +1596,13 @@ where
             )
         }
 
-        if record_compactions {
-            for req in &merge_reqs {
-                self.trace.claim_compaction(
-                    req.id,
-                    ActiveCompaction {
-                        start_ms: heartbeat_timestamp_ms,
-                    },
-                )
-            }
+        for req in &merge_reqs {
+            self.trace.claim_compaction(
+                req.id,
+                ActiveCompaction {
+                    start_ms: heartbeat_timestamp_ms,
+                },
+            )
         }
 
         debug_assert_eq!(self.trace.upper(), batch.desc.upper());
@@ -3103,7 +3100,6 @@ pub(crate) mod tests {
                 &IdempotencyToken::new(),
                 &debug_state(),
                 0,
-                true,
                 100,
                 None
             ),
@@ -3124,7 +3120,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3141,7 +3136,6 @@ pub(crate) mod tests {
                 &IdempotencyToken::new(),
                 &debug_state(),
                 0,
-                true,
                 100,
                 None
             ),
@@ -3161,7 +3155,6 @@ pub(crate) mod tests {
                 &IdempotencyToken::new(),
                 &debug_state(),
                 0,
-                true,
                 100,
                 None
             ),
@@ -3185,7 +3178,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3235,7 +3227,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3312,7 +3303,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3346,7 +3336,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3412,7 +3401,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3429,7 +3417,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3489,7 +3476,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3515,7 +3501,6 @@ pub(crate) mod tests {
                     &IdempotencyToken::new(),
                     &debug_state(),
                     0,
-                    true,
                     100,
                     None
                 )
@@ -3552,7 +3537,6 @@ pub(crate) mod tests {
             &IdempotencyToken::new(),
             &debug_state(),
             0,
-            true,
             100,
             None,
         );

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -91,7 +91,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 {
                     // Enable new compaction tracking / claiming
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_record_compactions", ::mz_dyncfg::ConfigVal::Bool(true));
                     x.add_dynamic("persist_claim_unclaimed_compactions", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
                 },


### PR DESCRIPTION
- In a recent refactoring, I changed where `part.maybe_optimize` was called to be _after_ `bytes` and `is_inline` were captured... which means that we were incrementing the wrong metric in some cases. Embarassing!
- The `persist_record_compactions` flag has been on for several months with no issues, and we're building on that pattern now. Remove it.

### Motivation

Small issues noticed today.

### Tips for reviewer

These are two logically separate changes; feel free to tell me to make two separate PRs if you don't like it this way!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
