### PR TITLE
upgrade tests: Automatically fetch latest LTS versions

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -24,7 +24,7 @@ from materialize.checks.mzcompose_actions import (
 from materialize.checks.scenarios import Scenario
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.materialized import LEADER_STATUS_HEALTHCHECK
-from materialize.version_list import LTS_VERSIONS, get_published_minor_mz_versions
+from materialize.version_list import get_lts_versions, get_published_minor_mz_versions
 
 # late initialization
 _minor_versions: list[MzVersion] | None = None
@@ -88,7 +88,7 @@ class UpgradeEntireMzFromLatestLTS(Scenario):
     """Upgrade the entire Mz instance from the last LTS version without any intermediate steps. This makes sure our LTS releases for self-managed Materialize stay upgradable."""
 
     def base_version(self) -> MzVersion:
-        return LTS_VERSIONS[-1]
+        return get_lts_versions()[-1]
 
     def actions(self) -> list[Action]:
         print(f"Upgrading from tag {self.base_version()}")

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -29,9 +29,9 @@ from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.version_list import (
-    LTS_VERSIONS,
     VersionsFromDocs,
     get_all_published_mz_versions,
+    get_lts_versions,
     get_published_minor_mz_versions,
 )
 
@@ -154,7 +154,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         )
         if args.lts_upgrade:
             # Direct upgrade from latest LTS version without any inbetween versions
-            version = LTS_VERSIONS[-1]
+            version = get_lts_versions()[-1]
             priors = [v for v in all_versions if v <= version]
             test_upgrade_from_version(
                 c,
@@ -184,7 +184,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         )
         if args.lts_upgrade:
             # Direct upgrade from latest LTS version without any inbetween versions
-            version = LTS_VERSIONS[-1]
+            version = get_lts_versions()[-1]
             priors = [v for v in all_versions if v <= version]
             test_upgrade_from_version(
                 c,


### PR DESCRIPTION
So that we don't have to keep it up to date manually.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
