### PR TITLE
adapter: don't allow implicit read-then-write inside transactions

### DIFF
--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -627,6 +627,62 @@ SELECT INTERVAL '1 day'
 statement ok
 COMMIT
 
+# Verify that different kinds of INSERT INTO ... statements are correctly
+# rejected when a transaction is in read-only mode.
+#
+# At least inserts of non-constant values internally get translated to
+# read-then write statements, which has caused trouble with maintaining the
+# read-only bit in the past.
+
+statement ok
+CREATE TABLE baz(a text)
+
+statement ok
+BEGIN
+
+# A constant value
+statement ok
+INSERT INTO baz VALUES ('hello')
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+# A non-constant value
+statement ok
+INSERT INTO baz VALUES (now()::text)
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM baz
+
+# A constant value, should be rejected
+statement error transaction in read-only mode
+INSERT INTO baz VALUES ('ciao')
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM baz
+
+# A non-constant value, should be rejected as well
+statement error transaction in read-only mode
+INSERT INTO baz VALUES (now()::text)
+
+statement ok
+ROLLBACK
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET allow_real_time_recency = true
 ----


### PR DESCRIPTION
INSERTS of non-constant values internally get sequenced as read-then-write queries, which clear transaction ops so disable the checks we normally have in place about mixing reads and writes in transactions.

Now, we check that a transaction is in a valid state when sequencing a read-then-write.

@def- Tests didn't catch this before.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
