### PR TITLE
testdrive: Fix default-storage-size parameter

### DIFF
--- a/test/testdrive/github-6942.td
+++ b/test/testdrive/github-6942.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-arg-default default-storage-size=1
+
 > DROP CLUSTER IF EXISTS gh_6942_cluster CASCADE;
 > CREATE CLUSTER gh_6942_cluster SIZE '${arg.default-storage-size}', REPLICATION FACTOR 1;
 

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ set-arg-default replicas=1
+$ set-arg-default default-storage-size=1
 
 # Exercises Webhook sources.
 


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/11914#019664fd-9b58-4c90-a37c-ddadfba34360

Follow-up to https://github.com/MaterializeInc/materialize/pull/32228

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
