### PR TITLE
allow disabling license key checks for now

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         {{- if .Values.operator.args.enableInternalStatementLogging }}
         - "--enable-internal-statement-logging"
         {{- end }}
+        - "--disable-license-key-checks"
 
         {{/* AWS Configuration */}}
         {{- if eq .Values.operator.cloudProvider.type "aws" }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[14]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[14]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[14]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[14]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -617,6 +617,9 @@ pub struct Args {
     /// File containing a valid Materialize license key.
     #[clap(long, env = "LICENSE_KEY")]
     license_key: Option<String>,
+    // TODO: temporary until we get the rest of the infrastructure in place
+    #[clap(long, hide = true)]
+    disable_license_key_checks: bool,
 
     // === AWS options. ===
     /// The AWS account ID, which will be used to generate ARNs for
@@ -700,7 +703,9 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     sys::enable_sigusr2_coverage_dump()?;
     sys::enable_termination_signal_cleanup()?;
 
-    let license_key = if let Some(license_key_file) = args.license_key {
+    let license_key = if args.disable_license_key_checks {
+        ValidatedLicenseKey::disabled()
+    } else if let Some(license_key_file) = args.license_key {
         let license_key_text = std::fs::read_to_string(&license_key_file)
             .context("failed to open license key file")?;
         let license_key = mz_license_keys::validate(

--- a/src/license-keys/src/lib.rs
+++ b/src/license-keys/src/lib.rs
@@ -54,6 +54,16 @@ impl ValidatedLicenseKey {
         }
     }
 
+    // TODO: temporary until we get the rest of the infrastructure in place
+    pub fn disabled() -> Self {
+        Self {
+            max_credit_consumption_rate: 999999.0,
+            allow_credit_consumption_override: true,
+            expiration_behavior: ExpirationBehavior::Warn,
+            expired: false,
+        }
+    }
+
     pub fn max_credit_consumption_rate(&self) -> Option<f64> {
         if self.expired
             && matches!(

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -150,6 +150,9 @@ pub struct MaterializeControllerArgs {
 
     #[clap(long, default_value = "{}")]
     default_certificate_specs: DefaultCertificateSpecs,
+
+    #[clap(long, hide = true)]
+    disable_license_key_checks: bool,
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -53,6 +53,7 @@ static V140_DEV0: LazyLock<Version> = LazyLock::new(|| Version {
     pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
 });
+const V143: Version = Version::new(0, 143, 0);
 
 /// Describes the status of a deployment.
 ///
@@ -1133,6 +1134,10 @@ fn create_environmentd_statefulset_object(
     }
     if config.enable_prometheus_scrape_annotations {
         args.push("--orchestrator-kubernetes-enable-prometheus-scrape-annotations".into());
+    }
+
+    if mz.meets_minimum_version(&V143) && config.disable_license_key_checks {
+        args.push("--disable-license-key-checks".into());
     }
 
     // Add user-specified extra arguments.


### PR DESCRIPTION
### Motivation

we may need to make a new lts release from main at some point soon, and license key issuing isn't ready yet

### Tips for reviewer

once we get license key issuing working, we can revert this

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
