### PR TITLE
refactor reductionmonoid prevent clone of row on clone_from

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2348,9 +2348,9 @@ mod monoids {
         fn clone_from(&mut self, source: &Self) {
             use ReductionMonoid::*;
 
-            let mut row = match std::mem::replace(self, Max(Row::default())) {
+            let mut row = std::mem::take(match self {
                 Min(row) | Max(row) => row,
-            };
+            });
 
             let source_row = match source {
                 Min(row) | Max(row) => row,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2321,7 +2321,7 @@ mod monoids {
     use serde::{Deserialize, Serialize};
 
     /// A monoid containing a single-datum row.
-    #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
+    #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Serialize, Deserialize, Hash)]
     pub enum ReductionMonoid {
         Min(Row),
         Max(Row),
@@ -2332,6 +2332,25 @@ mod monoids {
             use ReductionMonoid::*;
             match self {
                 Min(row) | Max(row) => row,
+            }
+        }
+    }
+
+    impl Clone for ReductionMonoid {
+        fn clone(&self) -> Self {
+            use ReductionMonoid::*;
+            match self {
+                Min(row) => Min(row.clone()),
+                Max(row) => Max(row.clone()),
+            }
+        }
+
+        fn clone_from(&mut self, source: &Self) {
+            use ReductionMonoid::*;
+            match (self, source) {
+                (Min(row) | Max(row), Min(source_row) | Max(source_row)) => {
+                    row.clone_from(source_row);
+                }
             }
         }
     }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2358,8 +2358,8 @@ mod monoids {
                 // FIXME(ptravers): not sure what we want to do here we can't overwrite
                 // without having owned access to the Row in dest. I don't see a way to
                 // achieve that without a clone. Is it better to panic or clone? I would lean
-                // clone but for safety but I don't know how likely it is to hit the sad case
-                // in practice.
+                // clone for safety but I don't know how likely it is to hit the sad case
+                // in practice?
                 (dest, src) => soft_panic_or_log!(
                     "Mismatched monoid variants in clone_from! destination: {dest:?} source: {src:?}",
                 ),

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2345,24 +2345,22 @@ mod monoids {
             }
         }
 
-        // WARNING: Panics if self and source are of different `ReductionMonoid` enum entries.
         fn clone_from(&mut self, source: &Self) {
             use ReductionMonoid::*;
-            match (self, source) {
-                (Min(row), Min(source_row)) => {
-                    row.clone_from(source_row);
-                }
-                (Max(row), Max(source_row)) => {
-                    row.clone_from(source_row);
-                }
-                // FIXME(ptravers): not sure what we want to do here we can't overwrite
-                // without having owned access to the Row in dest. I don't see a way to
-                // achieve that without a clone. Is it better to panic or clone? I would lean
-                // clone for safety but I don't know how likely it is to hit the sad case
-                // in practice?
-                (dest, src) => soft_panic_or_log!(
-                    "Mismatched monoid variants in clone_from! destination: {dest:?} source: {src:?}",
-                ),
+
+            let mut row = match std::mem::take(self) {
+                Min(row) | Max(row) => row,
+            };
+
+            let source_row = match source {
+                Min(row) | Max(row) => row,
+            };
+
+            row.clone_from(source_row);
+
+            match source {
+                Min(_) => *self = Min(row),
+                Max(_) => *self = Max(row),
             }
         }
     }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2345,12 +2345,24 @@ mod monoids {
             }
         }
 
+        // WARNING: Panics if self and source are of different `ReductionMonoid` enum entries.
         fn clone_from(&mut self, source: &Self) {
             use ReductionMonoid::*;
             match (self, source) {
-                (Min(row) | Max(row), Min(source_row) | Max(source_row)) => {
+                (Min(row), Min(source_row)) => {
                     row.clone_from(source_row);
                 }
+                (Max(row), Max(source_row)) => {
+                    row.clone_from(source_row);
+                }
+                // FIXME(ptravers): not sure what we want to do here we can't overwrite
+                // without having owned access to the Row in dest. I don't see a way to
+                // achieve that without a clone. Is it better to panic or clone? I would lean
+                // clone but for safety but I don't know how likely it is to hit the sad case
+                // in practice.
+                (dest, src) => soft_panic_or_log!(
+                    "Mismatched monoid variants in clone_from! destination: {dest:?} source: {src:?}",
+                ),
             }
         }
     }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2348,7 +2348,7 @@ mod monoids {
         fn clone_from(&mut self, source: &Self) {
             use ReductionMonoid::*;
 
-            let mut row = match std::mem::take(self) {
+            let mut row = match std::mem::replace(self, Max(Row::default())) {
                 Min(row) | Max(row) => row,
             };
 


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9230

### Tips for reviewer

see: https://github.com/MaterializeInc/materialize/blob/be719a21a61b56b4afe9ee2852b84cb2b28fbd1c/src/repr/src/row.rs#L291

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
