### PR TITLE
terraform test: Collect logs

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -271,6 +271,35 @@ class AWS:
                     ["kubectl", "get", "pods", "-n", "materialize"],
                     cwd=self.path,
                 )
+                print("Logging all pods in materialize:")
+                pod_names = (
+                    spawn.capture(
+                        [
+                            "kubectl",
+                            "get",
+                            "pods",
+                            "-n",
+                            "materialize",
+                            "-o",
+                            "name",
+                        ],
+                        cwd=self.path,
+                    )
+                    .strip()
+                    .split("\n")
+                )
+                for pod_name in pod_names:
+                    spawn.runv(
+                        [
+                            "kubectl",
+                            "logs",
+                            "-n",
+                            "materialize",
+                            pod_name,
+                            "--all-containers=true",
+                        ],
+                        cwd=self.path,
+                    )
                 status = spawn.capture(
                     [
                         "kubectl",
@@ -1098,6 +1127,35 @@ def workflow_gcp_temporary(c: Composition, parser: WorkflowArgumentParser) -> No
                         ["kubectl", "get", "pods", "-n", "materialize"],
                         cwd=path,
                     )
+                    print("Logging all pods in materialize:")
+                    pod_names = (
+                        spawn.capture(
+                            [
+                                "kubectl",
+                                "get",
+                                "pods",
+                                "-n",
+                                "materialize",
+                                "-o",
+                                "name",
+                            ],
+                            cwd=path,
+                        )
+                        .strip()
+                        .split("\n")
+                    )
+                    for pod_name in pod_names:
+                        spawn.runv(
+                            [
+                                "kubectl",
+                                "logs",
+                                "-n",
+                                "materialize",
+                                pod_name,
+                                "--all-containers=true",
+                            ],
+                            cwd=path,
+                        )
                     status = spawn.capture(
                         [
                             "kubectl",
@@ -1632,6 +1690,35 @@ def workflow_azure_temporary(c: Composition, parser: WorkflowArgumentParser) -> 
                         cwd=path,
                         env=venv_env,
                     )
+                    print("Logging all pods in materialize:")
+                    pod_names = (
+                        spawn.capture(
+                            [
+                                "kubectl",
+                                "get",
+                                "pods",
+                                "-n",
+                                "materialize",
+                                "-o",
+                                "name",
+                            ],
+                            cwd=path,
+                        )
+                        .strip()
+                        .split("\n")
+                    )
+                    for pod_name in pod_names:
+                        spawn.runv(
+                            [
+                                "kubectl",
+                                "logs",
+                                "-n",
+                                "materialize",
+                                pod_name,
+                                "--all-containers=true",
+                            ],
+                            cwd=path,
+                        )
                     status = spawn.capture(
                         [
                             "kubectl",


### PR DESCRIPTION
Latest nightly had a failure, but locally I couldn't reproduce it: https://buildkite.com/materialize/nightly/builds/11918#01966a24-0eae-4762-92b2-058be540db6b
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
