### PR TITLE
cloud canary test: Don't print tokens

### DIFF
--- a/misc/python/materialize/redpanda_cloud.py
+++ b/misc/python/materialize/redpanda_cloud.py
@@ -20,7 +20,7 @@ def get_result(response: requests.Response) -> dict[str, Any]:
             f"Redpanda API call failed: {response.status_code} {response.text}"
         )
     result = response.json()
-    print(result)
+    # Don't print result since it can contain access tokens
     return result
 
 


### PR DESCRIPTION
Noticed by @antiguru in https://materializeinc.slack.com/archives/C01LKF361MZ/p1745566243299639
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
