### PR TITLE
controller: emit undefined lag for unreadable collections

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -5060,7 +5060,7 @@ pub static MZ_WALLCLOCK_GLOBAL_LAG_HISTORY: LazyLock<BuiltinView> = LazyLock::ne
     oid: oid::VIEW_MZ_WALLCLOCK_GLOBAL_LAG_HISTORY_OID,
     desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("lag", ScalarType::Interval.nullable(false))
+        .with_column("lag", ScalarType::Interval.nullable(true))
         .with_column(
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -5093,7 +5093,7 @@ pub static MZ_WALLCLOCK_GLOBAL_LAG_RECENT_HISTORY: LazyLock<BuiltinView> =
         oid: oid::VIEW_MZ_WALLCLOCK_GLOBAL_LAG_RECENT_HISTORY_OID,
         desc: RelationDesc::builder()
             .with_column("object_id", ScalarType::String.nullable(false))
-            .with_column("lag", ScalarType::Interval.nullable(false))
+            .with_column("lag", ScalarType::Interval.nullable(true))
             .with_column(
                 "occurred_at",
                 ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -5114,7 +5114,7 @@ pub static MZ_WALLCLOCK_GLOBAL_LAG: LazyLock<BuiltinView> = LazyLock::new(|| Bui
     oid: oid::VIEW_MZ_WALLCLOCK_GLOBAL_LAG_OID,
     desc: RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("lag", ScalarType::Interval.nullable(false))
+        .with_column("lag", ScalarType::Interval.nullable(true))
         .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -5162,7 +5162,7 @@ pub static MZ_WALLCLOCK_GLOBAL_LAG_HISTOGRAM: LazyLock<BuiltinView> =
                 ScalarType::TimestampTz { precision: None }.nullable(false),
             )
             .with_column("object_id", ScalarType::String.nullable(false))
-            .with_column("lag_seconds", ScalarType::UInt64.nullable(false))
+            .with_column("lag_seconds", ScalarType::UInt64.nullable(true))
             .with_column("labels", ScalarType::Jsonb.nullable(false))
             .with_column("count", ScalarType::Int64.nullable(false))
             .with_key(vec![0, 1, 2, 3, 4])

--- a/src/cluster-client/src/metrics.rs
+++ b/src/cluster-client/src/metrics.rs
@@ -9,8 +9,7 @@
 
 //! Metrics shared by both compute and storage.
 
-use std::time::Duration;
-
+use mz_ore::cast::CastLossy;
 use mz_ore::metric;
 use mz_ore::metrics::{
     CounterVec, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, IntCounterVec, MetricsRegistry,
@@ -116,8 +115,8 @@ pub struct WallclockLagMetrics {
 
 impl WallclockLagMetrics {
     /// Observe a new wallclock lag measurement.
-    pub fn observe(&mut self, lag: Duration) {
-        let lag_secs = lag.as_secs_f32();
+    pub fn observe(&mut self, lag_secs: u64) {
+        let lag_secs = f32::cast_lossy(lag_secs);
 
         self.wallclock_lag_minmax.add_sample(lag_secs);
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -571,9 +571,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     /// This method is invoked by `ComputeController::maintain`, which we expect to be called once
     /// per second during normal operation.
     fn refresh_wallclock_lag(&mut self) {
-        // Record lags to persist, if it's time.
-        self.maybe_record_wallclock_lag();
-
         let frontier_lag = |frontier: &Antichain<T>| match frontier.as_option() {
             Some(ts) => (self.wallclock_lag)(ts.clone()),
             None => Duration::ZERO,
@@ -642,6 +639,9 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                 };
             }
         }
+
+        // Record lags to persist, if it's time.
+        self.maybe_record_wallclock_lag();
     }
 
     /// Produce new wallclock lag introspection updates, provided enough time has passed since the

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -37,11 +37,10 @@ use mz_ore::channel::instrumented_unbounded_channel;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{soft_assert_or_log, soft_panic_or_log};
-use mz_repr::adt::interval::Interval;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row};
-use mz_storage_client::controller::{IntrospectionType, WallclockLagHistogramPeriod};
+use mz_storage_client::controller::{IntrospectionType, WallclockLag, WallclockLagHistogramPeriod};
 use mz_storage_types::read_holds::{self, ReadHold};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
@@ -555,6 +554,20 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
 
     /// Refresh the wallclock lag introspection and metrics with the current lag values.
     ///
+    /// This method produces wallclock lag metrics of two different shapes:
+    ///
+    /// * Histories: For each replica and each collection, we measure the lag of the write frontier
+    ///   behind the wallclock time every second. Every minute we emit the maximum lag observed
+    ///   over the last minute, together with the current time.
+    /// * Histograms: For each collection, we measure the lag of the write frontier behind
+    ///   wallclock time every second. Every minute we emit all lags observed over the last minute,
+    ///   together with the current histogram period.
+    ///
+    /// Histories are emitted to both Mz introspection and Prometheus, histograms only to
+    /// introspection. We treat lags of unreadable collections (i.e. collections that contain no
+    /// readable times) as undefined and set them to NULL in introspection and `u64::MAX` in
+    /// Prometheus.
+    ///
     /// This method is invoked by `ComputeController::maintain`, which we expect to be called once
     /// per second during normal operation.
     fn refresh_wallclock_lag(&mut self) {
@@ -566,20 +579,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             None => Duration::ZERO,
         };
 
-        for replica in self.replicas.values_mut() {
-            for collection in replica.collections.values_mut() {
-                let lag = frontier_lag(&collection.write_frontier);
-
-                if let Some(wallclock_lag_max) = &mut collection.wallclock_lag_max {
-                    *wallclock_lag_max = std::cmp::max(*wallclock_lag_max, lag);
-                }
-
-                if let Some(metrics) = &mut collection.metrics {
-                    metrics.wallclock_lag.observe(lag);
-                };
-            }
-        }
-
         let now_ms = (self.now)();
         let histogram_period = WallclockLagHistogramPeriod::from_epoch_millis(now_ms, &self.dyncfg);
         let histogram_labels = match &self.workload_class {
@@ -587,17 +586,60 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             None => BTreeMap::new(),
         };
 
-        for collection in self.collections.values_mut() {
+        // First, iterate over all collections and collect histogram measurements.
+        // We keep a record of unreadable collections, so we can emit undefined lags for those here
+        // and below when we collect history measurements.
+        let mut unreadable_collections = BTreeSet::new();
+        for (id, collection) in &mut self.collections {
+            // We need to ask the storage controller for the read frontiers of storage collections.
+            let read_frontier = match self.storage_collections.collection_frontiers(*id) {
+                Ok(f) => f.read_capabilities,
+                Err(_) => collection.read_frontier(),
+            };
+            let write_frontier = collection.write_frontier();
+            let collection_unreadable = PartialOrder::less_equal(&write_frontier, &read_frontier);
+            if collection_unreadable {
+                unreadable_collections.insert(id);
+            }
+
             if !ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION.get(&self.dyncfg) {
                 continue;
             }
 
             if let Some(stash) = &mut collection.wallclock_lag_histogram_stash {
-                let lag = collection.shared.lock_write_frontier(|f| frontier_lag(f));
-                let bucket = lag.as_secs().next_power_of_two();
+                let bucket = if collection_unreadable {
+                    WallclockLag::Undefined
+                } else {
+                    let lag = frontier_lag(&write_frontier);
+                    let lag = lag.as_secs().next_power_of_two();
+                    WallclockLag::Seconds(lag)
+                };
 
                 let key = (histogram_period, bucket, histogram_labels.clone());
                 *stash.entry(key).or_default() += Diff::ONE;
+            }
+        }
+
+        // Second, iterate over all per-replica collections and collect history measurements.
+        for replica in self.replicas.values_mut() {
+            for (id, collection) in &mut replica.collections {
+                let lag = if unreadable_collections.contains(&id) {
+                    WallclockLag::Undefined
+                } else {
+                    let lag = frontier_lag(&collection.write_frontier);
+                    WallclockLag::Seconds(lag.as_secs())
+                };
+
+                if let Some(wallclock_lag_max) = &mut collection.wallclock_lag_max {
+                    *wallclock_lag_max = (*wallclock_lag_max).max(lag);
+                }
+
+                if let Some(metrics) = &mut collection.metrics {
+                    // No way to specify values as undefined in Prometheus metrics, so we use the
+                    // maximum value instead.
+                    let secs = lag.unwrap_seconds_or(u64::MAX);
+                    metrics.wallclock_lag.observe(secs);
+                };
             }
         }
     }
@@ -639,12 +681,11 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                     continue;
                 };
 
-                let max_lag = std::mem::take(wallclock_lag_max);
-                let max_lag_us = i64::try_from(max_lag.as_micros()).expect("must fit");
+                let max_lag = std::mem::replace(wallclock_lag_max, WallclockLag::MIN);
                 let row = Row::pack_slice(&[
                     Datum::String(&collection_id.to_string()),
                     Datum::String(&replica_id.to_string()),
-                    Datum::Interval(Interval::new(0, 0, max_lag_us)),
+                    max_lag.into_interval_datum(),
                     Datum::TimestampTz(now_ts),
                 ]);
                 history_updates.push((row, Diff::ONE));
@@ -670,7 +711,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                     Datum::TimestampTz(period.start),
                     Datum::TimestampTz(period.end),
                     Datum::String(&collection_id.to_string()),
-                    Datum::UInt64(lag),
+                    lag.into_uint64_datum(),
                 ]);
                 let labels = labels.iter().map(|(k, v)| (*k, Datum::String(v)));
                 packer.push_dict(labels);
@@ -2259,7 +2300,7 @@ struct CollectionState<T: ComputeControllerTimestamp> {
         BTreeMap<
             (
                 WallclockLagHistogramPeriod,
-                u64,
+                WallclockLag,
                 BTreeMap<&'static str, String>,
             ),
             Diff,
@@ -2915,7 +2956,7 @@ struct ReplicaCollectionState<T: ComputeControllerTimestamp> {
     /// Maximum frontier wallclock lag since the last `WallclockLagHistory` introspection update.
     ///
     /// If this is `None`, wallclock lag is not tracked for this collection.
-    wallclock_lag_max: Option<Duration>,
+    wallclock_lag_max: Option<WallclockLag>,
 }
 
 impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
@@ -2933,7 +2974,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
             as_of,
             introspection,
             input_read_holds,
-            wallclock_lag_max: Some(Duration::ZERO),
+            wallclock_lag_max: Some(WallclockLag::MIN),
         }
     }
 

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -256,6 +256,14 @@ macro_rules! cast_lossy {
     };
 }
 
+cast_lossy!(usize, f32);
+cast_lossy!(isize, f32);
+cast_lossy!(f32, usize);
+cast_lossy!(i64, f32);
+cast_lossy!(f32, i64);
+cast_lossy!(u64, f32);
+cast_lossy!(f32, u64);
+cast_lossy!(f32, u32);
 cast_lossy!(usize, f64);
 cast_lossy!(isize, f64);
 cast_lossy!(f64, usize);

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -173,7 +173,7 @@ pub static WALLCLOCK_LAG_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(||
     RelationDesc::builder()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("replica_id", ScalarType::String.nullable(true))
-        .with_column("lag", ScalarType::Interval.nullable(false))
+        .with_column("lag", ScalarType::Interval.nullable(true))
         .with_column(
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
@@ -192,7 +192,7 @@ pub static WALLCLOCK_GLOBAL_LAG_HISTOGRAM_RAW_DESC: LazyLock<RelationDesc> = Laz
             ScalarType::TimestampTz { precision: None }.nullable(false),
         )
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("lag_seconds", ScalarType::UInt64.nullable(false))
+        .with_column("lag_seconds", ScalarType::UInt64.nullable(true))
         .with_column("labels", ScalarType::Jsonb.nullable(false))
         .finish()
 });

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3515,9 +3515,6 @@ where
     /// This method is invoked by `Controller::maintain`, which we expect to be called once per
     /// second during normal operation.
     fn refresh_wallclock_lag(&mut self) {
-        // Record lags to persist, if it's time.
-        self.maybe_record_wallclock_lag();
-
         let now_ms = (self.now)();
         let histogram_period =
             WallclockLagHistogramPeriod::from_epoch_millis(now_ms, self.config.config_set());
@@ -3573,6 +3570,9 @@ where
                 *stash.entry(key).or_default() += Diff::ONE;
             }
         }
+
+        // Record lags to persist, if it's time.
+        self.maybe_record_wallclock_lag();
     }
 
     /// Produce new wallclock lag introspection updates, provided enough time has passed since the

--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -178,7 +178,7 @@ $ postgres-execute connection=mz_system
 ALTER SYSTEM SET wallclock_lag_histogram_period_interval = '1d'
 
 > CREATE TABLE tbl_1day (x int)
-> CREATE INDEX idx_1day ON tbl_1day (x)
+> CREATE INDEX idx_1day IN CLUSTER compute ON tbl_1day (x)
 > SELECT DISTINCT
     o.name,
     l.period_end - l.period_start,
@@ -194,7 +194,7 @@ $ postgres-execute connection=mz_system
 ALTER SYSTEM SET wallclock_lag_histogram_period_interval = '1h'
 
 > CREATE TABLE tbl_1hour (x int)
-> CREATE INDEX idx_1hour ON tbl_1day (x)
+> CREATE INDEX idx_1hour IN CLUSTER compute ON tbl_1day (x)
 > SELECT DISTINCT
     o.name,
     l.period_end - l.period_start,
@@ -205,3 +205,43 @@ ALTER SYSTEM SET wallclock_lag_histogram_period_interval = '1h'
   WHERE o.name LIKE '%_1hour'
 idx_1hour 01:00:00 true true
 tbl_1hour 01:00:00 true true
+
+# Test that lags of unreadable collections are NULL.
+
+> DROP CLUSTER storage CASCADE
+> DROP CLUSTER compute CASCADE
+> CREATE CLUSTER storage SIZE '1', REPLICATION FACTOR 0
+> CREATE CLUSTER compute SIZE '1'
+
+> CREATE SOURCE src IN CLUSTER storage FROM LOAD GENERATOR counter (UP TO 100)
+> CREATE INDEX idx IN CLUSTER compute ON src (counter)
+> CREATE MATERIALIZED VIEW mv IN CLUSTER compute AS SELECT * FROM src
+> CREATE SINK snk
+  IN CLUSTER storage
+  FROM mv
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> SELECT DISTINCT o.name, r.name, l.lag
+  FROM mz_internal.mz_wallclock_lag_history l
+  JOIN mz_objects o ON o.id = l.object_id
+  LEFT JOIN mz_cluster_replicas r ON r.id = l.replica_id
+  WHERE l.object_id LIKE 'u%' AND o.cluster_id IS NOT NULL
+idx           r1      <null>
+mv            r1      <null>
+mv            <null>  <null>
+snk           <null>  <null>
+src           <null>  <null>
+
+> SELECT DISTINCT o.name, l.lag_seconds
+  FROM mz_internal.mz_wallclock_global_lag_histogram l
+  JOIN mz_objects o ON o.id = l.object_id
+  WHERE l.object_id LIKE 'u%' AND o.cluster_id IS NOT NULL
+idx  <null>
+mv   <null>
+snk  <null>
+src  <null>
+
+> DROP CLUSTER storage CASCADE
+> DROP CLUSTER compute CASCADE


### PR DESCRIPTION
This PR changes the wallclock lag measurement logic in the two controllers to emit "undefined" lag measurements for collections that are unreadable, i.e., contain no readable times. The intention is to avoid glitches where wallclock lag for unhydrated collections is nonsensical (e.g. 55 years).

The "undefined" value is represented differently for introspection and for Prometheus metrics. For introspection, we can use the SQL `NULL` value, but Prometheus metrics values are integers, so we have to use `u64::MAX` instead.

Note that this changes the schema of a builtin source and deploying it will truncate any existing wallclock lag measurements. The current thinking is that this is fine and it's not worth spending time on implementing a proper migration. Feel free to weigh in on [this Slack thread](https://materializeinc.slack.com/archives/C08AENAP691/p1747320669826109) if you have thoughts!

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/9215
[Relevant Slack thread.](https://materializeinc.slack.com/archives/C08AENAP691/p1744706310908609)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
