### PR TITLE
Cluster transport protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7223,6 +7223,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "bincode",
  "clap",
  "crossbeam-channel",
  "futures",
@@ -7244,6 +7245,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "prost-build",
+ "rand 0.8.5",
  "semver",
  "sentry-tracing",
  "serde",
@@ -7255,6 +7257,8 @@ dependencies = [
  "tonic-build",
  "tower 0.5.2",
  "tracing",
+ "tracing-subscriber",
+ "turmoil",
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7240,6 +7240,7 @@ dependencies = [
  "mz-repr",
  "mz-secrets",
  "os_info",
+ "pin-project",
  "prometheus",
  "proptest",
  "proptest-derive",

--- a/src/ore/src/netio.rs
+++ b/src/ore/src/netio.rs
@@ -20,9 +20,11 @@ mod dns;
 mod framed;
 mod read_exact;
 mod socket;
+mod timeout;
 
 pub use crate::netio::async_ready::AsyncReady;
 pub use crate::netio::dns::{DnsResolutionError, resolve_address};
 pub use crate::netio::framed::{FrameTooBig, MAX_FRAME_SIZE};
 pub use crate::netio::read_exact::{ReadExactOrEof, read_exact_or_eof};
 pub use crate::netio::socket::{Listener, SocketAddr, SocketAddrType, Stream, UnixSocketAddr};
+pub use crate::netio::timeout::{TimedReader, TimedWriter};

--- a/src/ore/src/netio/timeout.rs
+++ b/src/ore/src/netio/timeout.rs
@@ -1,0 +1,163 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `Async{Read,Write}` wrappers that enforce a configurable timeout on each I/O operation.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::Sleep;
+
+/// An [`AsyncRead`] wrapper that enforces a timeout on each read.
+#[derive(Debug)]
+pub struct TimedReader<R> {
+    reader: R,
+    timeout: Duration,
+    sleep: Option<Pin<Box<Sleep>>>,
+}
+
+impl<R> TimedReader<R> {
+    /// Wrap a reader with a timeout.
+    pub fn new(reader: R, timeout: Duration) -> Self {
+        Self {
+            reader,
+            timeout,
+            sleep: None,
+        }
+    }
+
+    /// Poll the sleep future, creating it if necessary.
+    fn poll_sleep(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let timeout = self.timeout;
+        let sleep = self.sleep.get_or_insert_with(|| {
+            let sleep = tokio::time::sleep(timeout);
+            Box::pin(sleep)
+        });
+
+        sleep.as_mut().poll(cx)
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for TimedReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let poll = if self.poll_sleep(cx).is_ready() {
+            Poll::Ready(Err(io::ErrorKind::TimedOut.into()))
+        } else if let Poll::Ready(result) = Pin::new(&mut self.reader).poll_read(cx, buf) {
+            Poll::Ready(result)
+        } else {
+            Poll::Pending
+        };
+
+        if poll.is_ready() {
+            self.sleep = None;
+        }
+
+        poll
+    }
+}
+
+/// An [`AsyncWrite`] wrapper that enforces a timeout on each write.
+#[derive(Debug)]
+pub struct TimedWriter<W> {
+    writer: W,
+    timeout: Duration,
+    sleep: Option<Pin<Box<Sleep>>>,
+}
+
+impl<W> TimedWriter<W> {
+    /// Wrap a writer with a timeout.
+    pub fn new(writer: W, timeout: Duration) -> Self {
+        Self {
+            writer,
+            timeout,
+            sleep: None,
+        }
+    }
+
+    /// Poll the sleep future, creating it if necessary.
+    fn poll_sleep(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let timeout = self.timeout;
+        let sleep = self.sleep.get_or_insert_with(|| {
+            let sleep = tokio::time::sleep(timeout);
+            Box::pin(sleep)
+        });
+
+        sleep.as_mut().poll(cx)
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for TimedWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let poll = if self.poll_sleep(cx).is_ready() {
+            Poll::Ready(Err(io::ErrorKind::TimedOut.into()))
+        } else if let Poll::Ready(result) = Pin::new(&mut self.writer).poll_write(cx, buf) {
+            Poll::Ready(result)
+        } else {
+            Poll::Pending
+        };
+
+        if poll.is_ready() {
+            self.sleep = None;
+        }
+
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let poll = if self.poll_sleep(cx).is_ready() {
+            Poll::Ready(Err(io::ErrorKind::TimedOut.into()))
+        } else if let Poll::Ready(result) = Pin::new(&mut self.writer).poll_flush(cx) {
+            Poll::Ready(result)
+        } else {
+            Poll::Pending
+        };
+
+        if poll.is_ready() {
+            self.sleep = None;
+        }
+
+        poll
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let poll = if self.poll_sleep(cx).is_ready() {
+            Poll::Ready(Err(io::ErrorKind::TimedOut.into()))
+        } else if let Poll::Ready(result) = Pin::new(&mut self.writer).poll_shutdown(cx) {
+            Poll::Ready(result)
+        } else {
+            Poll::Pending
+        };
+
+        if poll.is_ready() {
+            self.sleep = None;
+        }
+
+        poll
+    }
+}

--- a/src/service/BUILD.bazel
+++ b/src/service/BUILD.bazel
@@ -123,6 +123,45 @@ cargo_build_script(
     deps = ["//src/build-tools:mz_build_tools"] + all_crate_deps(build = True),
 )
 
+rust_test(
+    name = "mz_service_transport_tests",
+    size = "large",
+    srcs = ["tests/transport.rs"],
+    aliases = aliases(
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    compile_data = [],
+    crate_features = [],
+    crate_name = "transport",
+    data = [],
+    env = {},
+    lint_config = ":lints",
+    proc_macro_deps = [] + all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    rustc_env = {},
+    rustc_flags = [],
+    version = "0.0.0",
+    deps = [
+        ":mz_service",
+        "//src/aws-secrets-controller:mz_aws_secrets_controller",
+        "//src/build-info:mz_build_info",
+        "//src/orchestrator-kubernetes:mz_orchestrator_kubernetes",
+        "//src/orchestrator-process:mz_orchestrator_process",
+        "//src/ore:mz_ore",
+        "//src/proto:mz_proto",
+        "//src/repr:mz_repr",
+        "//src/secrets:mz_secrets",
+    ] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
 extract_cargo_lints(
     name = "lints",
     manifest = "Cargo.toml",

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -29,6 +29,7 @@ mz-orchestrator-process = { path = "../orchestrator-process", default-features =
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes", default-features = false }
 mz-ore = { path = "../ore", default-features = false }
 os_info = "3.11.0"
+pin-project = "1.1.10"
 prometheus = { version = "0.13.4", default-features = false }
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.98"
 async-stream = "0.3.6"
 async-trait = "0.1.88"
+bincode = "1.3.3"
 clap = { version = "4.5.23", features = ["env", "derive"] }
 crossbeam-channel = "0.5.15"
 futures = "0.3.31"
@@ -48,6 +49,12 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 mz-build-tools = { path = "../build-tools", default-features = false, features = ["protobuf-src"] }
 prost-build = "0.13.5"
 tonic-build = "0.12.3"
+
+[dev-dependencies]
+mz-ore = { path = "../ore", features = ["turmoil"] }
+rand = "0.8.5"
+tracing-subscriber = "0.3.19"
+turmoil = "0.6.6"
 
 [features]
 default = ["mz-build-tools/default", "workspace-hack"]

--- a/src/service/src/lib.rs
+++ b/src/service/src/lib.rs
@@ -22,3 +22,4 @@ pub mod params;
 pub mod retry;
 pub mod secrets;
 pub mod tracing;
+pub mod transport;

--- a/src/service/src/transport.rs
+++ b/src/service/src/transport.rs
@@ -1,0 +1,392 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! The Cluster Transport Protocol (CTP).
+//!
+//! CTP is the protocol used to transmit commands from controllers to replicas and responses from
+//! replicas to controllers. It runs on top of a reliable bidirectional connection stream, as
+//! provided by TCP or UDS, and adds message framing as well as heartbeating.
+//!
+//! CTP supports any message type that implements the serde [`Serialize`] and [`Deserialize`]
+//! traits. Messages are encoded using the [`bincode`] format and then sent over the wire with a
+//! length prefix.
+
+use std::convert::Infallible;
+use std::fmt::Debug;
+
+use anyhow::{anyhow, bail};
+use async_trait::async_trait;
+use bincode::Options;
+use futures::future;
+use mz_ore::cast::CastInto;
+use mz_ore::netio::{Listener, SocketAddr, Stream};
+use mz_ore::task::AbortOnDropHandle;
+use semver::Version;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, info, trace};
+
+use crate::client::{GenericClient, Partitionable, Partitioned};
+
+/// Trait for messages that can be sent over CTP.
+pub trait Message: Debug + Send + Sync + Serialize + DeserializeOwned + 'static {}
+impl<T: Debug + Send + Sync + Serialize + DeserializeOwned + 'static> Message for T {}
+
+/// A client for a CTP connection.
+#[derive(Debug)]
+pub struct Client<Out, In> {
+    conn: Connection<Out, In>,
+}
+
+impl<Out: Message, In: Message> Client<Out, In> {
+    /// Connect to the server at the given address.
+    pub async fn connect(address: &str, version: Version) -> anyhow::Result<Self> {
+        let stream = Stream::connect(address).await?;
+        info!(%address, "ctp: connected to server");
+
+        let conn = Connection::start(stream, version).await?;
+        Ok(Self { conn })
+    }
+}
+
+impl<Out, In> Client<Out, In>
+where
+    Out: Message,
+    In: Message,
+    (Out, In): Partitionable<Out, In>,
+{
+    /// Create a `Partitioned` client that connects through CTP.
+    pub async fn connect_partitioned(
+        addresses: Vec<String>,
+        version: Version,
+    ) -> anyhow::Result<Partitioned<Self, Out, In>> {
+        let connects = addresses
+            .iter()
+            .map(|addr| Self::connect(addr, version.clone()));
+        let clients = future::try_join_all(connects).await?;
+        Ok(Partitioned::new(clients))
+    }
+}
+
+#[async_trait]
+impl<Out: Message, In: Message> GenericClient<Out, In> for Client<Out, In> {
+    async fn send(&mut self, cmd: Out) -> anyhow::Result<()> {
+        self.conn.send(cmd).await
+    }
+
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    async fn recv(&mut self) -> anyhow::Result<Option<In>> {
+        // `Connection::recv` is documented to be cancel safe.
+        self.conn.recv().await.map(Some)
+    }
+}
+
+/// Spawn a CTP server that serves connections at the given address.
+pub async fn serve<In, Out, H>(
+    address: SocketAddr,
+    version: Version,
+    handler_fn: impl Fn() -> H,
+) -> anyhow::Result<()>
+where
+    In: Message,
+    Out: Message,
+    H: GenericClient<In, Out> + 'static,
+{
+    let listener = Listener::bind(&address).await?;
+    info!(%address, "ctp: listening for client connections");
+
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        info!(%peer, "ctp: accepted client connection");
+
+        let handler = handler_fn();
+        let version = version.clone();
+
+        mz_ore::task::spawn(|| "ctp::connection", async {
+            let Err(error) = serve_connection(stream, handler, version).await;
+            info!("ctp: connection failed: {error}");
+        });
+    }
+}
+
+/// Serve a single CTP connection.
+async fn serve_connection<In, Out, H>(
+    stream: Stream,
+    mut handler: H,
+    version: Version,
+) -> anyhow::Result<Infallible>
+where
+    In: Message,
+    Out: Message,
+    H: GenericClient<In, Out>,
+{
+    let mut conn = Connection::start(stream, version).await?;
+
+    loop {
+        tokio::select! {
+            // `Connection::recv` is documented to be cancel safe.
+            inbound = conn.recv() => {
+                let msg = inbound?;
+                handler.send(msg).await?;
+            },
+            // `GenericClient::recv` is documented to be cancel safe.
+            outbound = handler.recv() => match outbound? {
+                Some(msg) => conn.send(msg).await?,
+                None => bail!("client disconnected"),
+            },
+        }
+    }
+}
+
+/// An active CTP connection.
+///
+/// This type encapsulates the core connection logic. It is used by both the client and the server
+/// implementation, with swapped `Out`/`In` types.
+///
+/// Each connection spawns two tasks:
+///
+///  * The send task is responsible for encoding and sending enqueued messages.
+///  * The recv task is responsible for receiving and decoding messages from the peer.
+///
+/// The separation into tasks provides some performance isolation between the sending and the
+/// receiving half of the connection.
+#[derive(Debug)]
+struct Connection<Out, In> {
+    /// Message sender connected to the send task.
+    msg_tx: mpsc::Sender<Out>,
+    /// Message receiver connected to the receive task.
+    msg_rx: mpsc::Receiver<In>,
+    /// Receiver for errors encountered by connection tasks.
+    error_rx: watch::Receiver<String>,
+
+    /// Handles to connection tasks.
+    _tasks: [AbortOnDropHandle<()>; 2],
+}
+
+impl<Out: Message, In: Message> Connection<Out, In> {
+    /// Start a new connection wrapping the given stream.
+    async fn start(stream: Stream, version: Version) -> anyhow::Result<Self> {
+        let (mut reader, mut writer) = stream.split();
+
+        handshake(&mut reader, &mut writer, version).await?;
+
+        let (out_tx, out_rx) = mpsc::channel(1024);
+        let (in_tx, in_rx) = mpsc::channel(1024);
+        // Initialize the error channel with a default error to return if none of the tasks
+        // produced an error.
+        let (error_tx, error_rx) = watch::channel("connection closed".into());
+
+        let send_task = mz_ore::task::spawn(
+            || "ctp::send",
+            Self::run_send_task(writer, out_rx, error_tx.clone()),
+        );
+        let recv_task =
+            mz_ore::task::spawn(|| "ctp::recv", Self::run_recv_task(reader, in_tx, error_tx));
+
+        Ok(Self {
+            msg_tx: out_tx,
+            msg_rx: in_rx,
+            error_rx,
+            _tasks: [send_task.abort_on_drop(), recv_task.abort_on_drop()],
+        })
+    }
+
+    /// Enqueue a message for sending.
+    async fn send(&mut self, msg: Out) -> anyhow::Result<()> {
+        match self.msg_tx.send(msg).await {
+            Ok(()) => Ok(()),
+            Err(_) => bail!(self.collect_error().await),
+        }
+    }
+
+    /// Return a received message.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    async fn recv(&mut self) -> anyhow::Result<In> {
+        // `mpcs::Receiver::recv` is documented to be cancel safe.
+        match self.msg_rx.recv().await {
+            Some(msg) => Ok(msg),
+            None => bail!(self.collect_error().await),
+        }
+    }
+
+    /// Return a connection error.
+    async fn collect_error(&mut self) -> String {
+        // Wait for the first error to be reported, or for all connection tasks to shut down.
+        let _ = self.error_rx.changed().await;
+        // Mark the current value as unseen, so the next `collect_error` call can return
+        // immediately.
+        self.error_rx.mark_changed();
+
+        self.error_rx.borrow().clone()
+    }
+
+    /// Run a connection's send task.
+    async fn run_send_task<W: AsyncWrite + Unpin>(
+        mut writer: W,
+        mut msg_rx: mpsc::Receiver<Out>,
+        error_tx: watch::Sender<String>,
+    ) {
+        while let Some(msg) = msg_rx.recv().await {
+            trace!(?msg, "ctp: sending message");
+
+            if let Err(error) = write_message(&mut writer, &msg).await {
+                debug!("ctp: send error: {error}");
+                let _ = error_tx.send(error.to_string());
+                break;
+            };
+        }
+    }
+
+    /// Run a connection's recv task.
+    async fn run_recv_task<R: AsyncRead + Unpin>(
+        mut reader: R,
+        msg_tx: mpsc::Sender<In>,
+        error_tx: watch::Sender<String>,
+    ) {
+        loop {
+            match read_message(&mut reader).await {
+                Ok(msg) => {
+                    trace!(?msg, "ctp: received message");
+
+                    if msg_tx.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    debug!("ctp: recv error: {error}");
+                    let _ = error_tx.send(error.to_string());
+                    break;
+                }
+            };
+        }
+    }
+}
+
+/// A connection handler that simply forwards messages over channels.
+#[derive(Debug)]
+pub struct ChannelHandler<In, Out> {
+    tx: mpsc::UnboundedSender<In>,
+    rx: mpsc::UnboundedReceiver<Out>,
+}
+
+impl<In, Out> ChannelHandler<In, Out> {
+    pub fn new(tx: mpsc::UnboundedSender<In>, rx: mpsc::UnboundedReceiver<Out>) -> Self {
+        Self { tx, rx }
+    }
+}
+
+#[async_trait]
+impl<In: Message, Out: Message> GenericClient<In, Out> for ChannelHandler<In, Out> {
+    async fn send(&mut self, cmd: In) -> anyhow::Result<()> {
+        let result = self.tx.send(cmd);
+        result.map_err(|_| anyhow!("client channel disconnected"))
+    }
+
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    async fn recv(&mut self) -> anyhow::Result<Option<Out>> {
+        // `mpsc::UnboundedReceiver::recv` is cancel safe.
+        match self.rx.recv().await {
+            Some(resp) => Ok(Some(resp)),
+            None => bail!("client channel disconnected"),
+        }
+    }
+}
+
+/// Perform the CTP handshake.
+///
+/// To perform the handshake, each endpoint sends the protocol magic number, followed by a
+/// `Hello` message. The `Hello` message contains information about the originating endpoint that
+/// is used by the receiver to validate compatibility with its peer. Only if both endpoints
+/// determine that they are compatible does the handshake succeed.
+async fn handshake<R, W>(mut reader: R, mut writer: W, version: Version) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    /// A randomly chosen magic number identifying CTP connections.
+    const MAGIC: u64 = 0x477574656e546167;
+
+    writer.write_u64(MAGIC).await?;
+
+    let hello = Hello {
+        version: version.clone(),
+    };
+    write_message(&mut writer, &hello).await?;
+
+    let peer_magic = reader.read_u64().await?;
+    if peer_magic != MAGIC {
+        bail!("invalid protocol magic: {peer_magic:#x}");
+    }
+
+    let Hello {
+        version: peer_version,
+    } = read_message(&mut reader).await?;
+
+    if peer_version != version {
+        bail!("version mismatch: {peer_version} != {version}");
+    }
+
+    Ok(())
+}
+
+/// A message for exchanging compatibility information during the CTP handshake.
+#[derive(Debug, Serialize, Deserialize)]
+struct Hello {
+    /// The version of the originating endpoint.
+    version: Version,
+}
+
+/// Write a message into the given writer.
+async fn write_message<W, M>(mut writer: W, msg: &M) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    M: Message,
+{
+    let bytes = wire_encode(msg)?;
+
+    let len = bytes.len().cast_into();
+    writer.write_u64(len).await?;
+    writer.write_all(&bytes).await?;
+
+    Ok(())
+}
+
+/// Read a message from the given reader.
+async fn read_message<R, M>(mut reader: R) -> anyhow::Result<M>
+where
+    R: AsyncRead + Unpin,
+    M: Message,
+{
+    let len = reader.read_u64().await?;
+    let mut bytes = vec![0; len.cast_into()];
+    reader.read_exact(&mut bytes).await?;
+
+    wire_decode(&bytes)
+}
+
+/// Encode a message for wire transport.
+fn wire_encode<M: Message>(msg: &M) -> anyhow::Result<Vec<u8>> {
+    let bytes = bincode::DefaultOptions::new().serialize(msg)?;
+    Ok(bytes)
+}
+
+/// Decode a wire frame back into a message.
+fn wire_decode<M: Message>(bytes: &[u8]) -> anyhow::Result<M> {
+    let msg = bincode::DefaultOptions::new().deserialize(bytes)?;
+    Ok(msg)
+}

--- a/src/service/src/transport/metrics.rs
+++ b/src/service/src/transport/metrics.rs
@@ -1,0 +1,133 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Metrics support for the Cluster Transport Protocol.
+
+use std::io;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// A trait for types that observe connection metric events.
+pub trait Metrics<Out, In>: Clone + Send + 'static {
+    /// Callback reporting numbers of bytes sent.
+    fn bytes_sent(&mut self, len: usize);
+    /// Callback reporting numbers of bytes received.
+    fn bytes_received(&mut self, len: usize);
+    /// Callback reporting messages sent.
+    fn message_sent(&mut self, msg: &Out);
+    /// Callback reporting messages received.
+    fn message_received(&mut self, msg: &In);
+}
+
+/// No-op [`Metrics`] implementation that ignores all events.
+#[derive(Clone)]
+pub struct NoopMetrics;
+
+impl<Out, In> Metrics<Out, In> for NoopMetrics {
+    fn bytes_sent(&mut self, _len: usize) {}
+    fn bytes_received(&mut self, _len: usize) {}
+    fn message_sent(&mut self, _msg: &Out) {}
+    fn message_received(&mut self, _msg: &In) {}
+}
+
+/// [`AsyncRead`] wrapper that transparently logs `bytes_received` metrics.
+#[pin_project::pin_project]
+pub(super) struct Reader<R, M, Out, In> {
+    #[pin]
+    reader: R,
+    metrics: M,
+    _phantom: PhantomData<(Out, In)>,
+}
+
+impl<R, M, Out, In> Reader<R, M, Out, In> {
+    pub fn new(reader: R, metrics: M) -> Self {
+        Self {
+            reader,
+            metrics,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<R, M, Out, In> AsyncRead for Reader<R, M, Out, In>
+where
+    R: AsyncRead,
+    M: Metrics<Out, In>,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let initial_len = buf.filled().len();
+
+        let this = self.project();
+        let poll = this.reader.poll_read(cx, buf);
+
+        let len = buf.filled().len() - initial_len;
+        if len > 0 {
+            this.metrics.bytes_received(len);
+        }
+
+        poll
+    }
+}
+
+/// [`AsyncWrite`] wrapper that transparently logs `bytes_sent` metrics.
+#[pin_project::pin_project]
+pub(super) struct Writer<W, M, Out, In> {
+    #[pin]
+    writer: W,
+    metrics: M,
+    _phantom: PhantomData<(Out, In)>,
+}
+
+impl<W, M, Out, In> Writer<W, M, Out, In> {
+    pub fn new(writer: W, metrics: M) -> Self {
+        Self {
+            writer,
+            metrics,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<W, M, Out, In> AsyncWrite for Writer<W, M, Out, In>
+where
+    W: AsyncWrite,
+    M: Metrics<Out, In>,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.project();
+        let poll = this.writer.poll_write(cx, buf);
+
+        if let Poll::Ready(Ok(len)) = &poll
+            && *len > 0
+        {
+            this.metrics.bytes_sent(*len);
+        }
+
+        poll
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().writer.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().writer.poll_shutdown(cx)
+    }
+}

--- a/src/service/tests/transport.rs
+++ b/src/service/tests/transport.rs
@@ -1,0 +1,280 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests for the Cluster Transport Protocol.
+
+use std::sync::{Arc, Mutex, Once};
+
+use futures::future;
+use mz_ore::assert_none;
+use mz_ore::netio::Listener;
+use mz_ore::retry::Retry;
+use mz_service::client::GenericClient;
+use mz_service::transport::{self, ChannelHandler, Message};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use semver::Version;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt::time::FormatTime;
+
+const VERSION: Version = Version::new(1, 2, 3);
+
+/// Common setup for turmoil tests.
+fn setup() -> turmoil::Sim<'static> {
+    configure_tracing_for_turmoil();
+
+    let seed = std::env::var("SEED")
+        .ok()
+        .and_then(|x| x.parse().ok())
+        .unwrap_or_else(rand::random);
+
+    info!("initializing rng with seed {seed}");
+    let rng = SmallRng::seed_from_u64(seed);
+
+    turmoil::Builder::new()
+        .enable_random_order()
+        .build_with_rng(Box::new(rng.clone()))
+}
+
+/// Helper for connecting to a CTP server that retries until it succeeds.
+async fn connect_ctp<Out: Message, In: Message>(
+    address: &str,
+    version: Version,
+) -> transport::Client<Out, In> {
+    Retry::default()
+        .retry_async(|_| transport::Client::connect(address, version.clone()))
+        .await
+        .expect("retries forever")
+}
+
+/// Helper for connecting to a CTP server that retries until it encounters the expected error.
+async fn connect_ctp_error<Out: Message, In: Message>(
+    address: &str,
+    version: Version,
+    expected_error: &str,
+) -> anyhow::Result<()> {
+    Retry::default()
+        .retry_async(async |_| {
+            let result = transport::Client::<(), ()>::connect(address, version.clone()).await;
+            let error = result.expect_err("connection must fail");
+            if error.to_string() == expected_error {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        })
+        .await
+}
+
+#[test] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+fn test_bidirectional_communication() {
+    let mut sim = setup();
+
+    sim.host("server", move || async {
+        let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        let handler = ChannelHandler::new(in_tx, out_rx);
+        let handler = Arc::new(Mutex::new(Some(handler)));
+
+        mz_ore::task::spawn(
+            || "serve",
+            transport::serve(
+                "turmoil:0.0.0.0:7777".parse().unwrap(),
+                VERSION,
+                move || handler.lock().unwrap().take().unwrap(),
+            ),
+        );
+
+        out_tx.send("a".to_string())?;
+        out_tx.send("b".to_string())?;
+        out_tx.send("c".to_string())?;
+
+        assert_eq!(in_rx.recv().await, Some(1));
+        assert_eq!(in_rx.recv().await, Some(2));
+        assert_eq!(in_rx.recv().await, Some(3));
+
+        out_tx.send("done".to_string())?;
+        future::pending().await
+    });
+
+    sim.client("client", async move {
+        let mut client = connect_ctp("turmoil:server:7777", VERSION).await;
+
+        client.send(1).await?;
+        client.send(2).await?;
+        client.send(3).await?;
+
+        assert_eq!(client.recv().await?, Some("a".to_string()));
+        assert_eq!(client.recv().await?, Some("b".to_string()));
+        assert_eq!(client.recv().await?, Some("c".to_string()));
+
+        // Wait for the server to finish.
+        assert_eq!(client.recv().await?, Some("done".to_string()));
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+#[test] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+fn test_server_error() {
+    let mut sim = setup();
+
+    sim.host("server", move || async {
+        let (in_tx, mut in_rx) = mpsc::unbounded_channel();
+        let (_out_tx, out_rx) = mpsc::unbounded_channel::<()>();
+        let handler = ChannelHandler::new(in_tx, out_rx);
+        let handler = Arc::new(Mutex::new(Some(handler)));
+
+        mz_ore::task::spawn(
+            || "serve",
+            transport::serve(
+                "turmoil:0.0.0.0:7777".parse().unwrap(),
+                VERSION,
+                move || handler.lock().unwrap().take().unwrap(),
+            ),
+        );
+
+        // Wait for the client to connect, then shut down.
+        assert_eq!(in_rx.recv().await, Some(1));
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut client = connect_ctp::<i32, ()>("turmoil:server:7777", VERSION).await;
+
+        client.send(1).await?;
+
+        // Server has disconnected.
+        assert_eq!(
+            client.recv().await.map_err(|e| e.to_string()),
+            Err("unexpected end of file".into()),
+        );
+        // Trying to receive on a failed connection yields more errors.
+        assert_eq!(
+            client.recv().await.map_err(|e| e.to_string()),
+            Err("unexpected end of file".into()),
+        );
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+#[test] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+fn test_handshake_magic_mismatch() {
+    let mut sim = setup();
+
+    sim.host("server", move || async {
+        let listener = Listener::bind("turmoil:0.0.0.0:7777").await?;
+        let (mut stream, _) = listener.accept().await?;
+        stream.write_u64(0xbad).await?;
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        connect_ctp_error::<(), ()>(
+            "turmoil:server:7777",
+            VERSION,
+            "invalid protocol magic: 0xbad",
+        )
+        .await?;
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+#[test] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+fn test_handshake_version_mismatch() {
+    const SERVER_VERSION: Version = Version::new(1, 2, 3);
+    const CLIENT_VERSION: Version = Version::new(1, 2, 4);
+
+    let mut sim = setup();
+
+    sim.host("server", move || async {
+        let (in_tx, mut in_rx) = mpsc::unbounded_channel::<()>();
+        let (_out_tx, out_rx) = mpsc::unbounded_channel::<()>();
+        let handler = ChannelHandler::new(in_tx, out_rx);
+        let handler = Arc::new(Mutex::new(Some(handler)));
+
+        mz_ore::task::spawn(
+            || "serve",
+            transport::serve(
+                "turmoil:0.0.0.0:7777".parse().unwrap(),
+                SERVER_VERSION,
+                move || handler.lock().unwrap().take().unwrap(),
+            ),
+        );
+
+        // Handshake failed.
+        assert_none!(in_rx.recv().await);
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        connect_ctp_error::<(), ()>(
+            "turmoil:server:7777",
+            CLIENT_VERSION,
+            "version mismatch: 1.2.3 != 1.2.4",
+        )
+        .await?;
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+/// Configure tracing for turmoil tests.
+///
+/// Log events are written to stdout and include the logical time of the simulation.
+fn configure_tracing_for_turmoil() {
+    #[derive(Clone)]
+    struct SimElapsedTime;
+
+    impl FormatTime for SimElapsedTime {
+        fn format_time(
+            &self,
+            w: &mut tracing_subscriber::fmt::format::Writer<'_>,
+        ) -> std::fmt::Result {
+            tracing_subscriber::fmt::time().format_time(w)?;
+            if let Some(sim_elapsed) = turmoil::sim_elapsed() {
+                write!(w, " [{:?}]", sim_elapsed)?;
+            }
+            Ok(())
+        }
+    }
+
+    static INIT_TRACING: Once = Once::new();
+    INIT_TRACING.call_once(|| {
+        let env_filter = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .from_env_lossy();
+        let subscriber = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_env_filter(env_filter)
+            .with_timer(SimElapsedTime)
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}


### PR DESCRIPTION
This PR adds the implementation of a new cluster transport protocol (CTP) that's meant to replace gRPC as the message fabric for the compute and storage protocols (and perhaps others in the future). The protocol has all the features we need from it, but the keep the scope manageable actually wiring it up in Mz is left to [a future PR](https://github.com/MaterializeInc/materialize/pull/32897).

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/5038

### Tips for reviewer

The diff is quite large, but 50% of it consists of tests and there are plenty of code comments. Individual commits are meaningful and self-contained. If people prefer, I can split the PR into smaller ones that each only contain a subset of the commits, just lmk!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
