### PR TITLE
Strip AD/BC only with a leading space

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1874,15 +1874,6 @@ pub enum CalendarEra {
     AD,
 }
 
-impl CalendarEra {
-    fn as_str(&self) -> &'static str {
-        match self {
-            CalendarEra::BC => "BC",
-            CalendarEra::AD => "AD",
-        }
-    }
-}
-
 /// Takes a 'date timezone' 'date time timezone' string and splits it into 'date
 /// {time}' and 'timezone' components then checks for a 'CalenderEra' defaulting
 /// to 'AD'.
@@ -1944,8 +1935,8 @@ fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
     let timezone_upper = timezone.to_uppercase();
 
     match (
-        timezone_upper.strip_suffix(BC.as_str()),
-        timezone_upper.strip_suffix(AD.as_str()),
+        timezone_upper.strip_suffix(" BC"), // Space is important to avoid matching timezones.
+        timezone_upper.strip_suffix(" AD"), // Space is important to avoid matching timezones.
     ) {
         (Some(remainder), None) => (&timezone[..remainder.len()], BC),
         (None, Some(remainder)) => (&timezone[..remainder.len()], AD),

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -50,6 +50,12 @@ SHOW TIME ZONE
 ----
 +00:00
 
+# Regression test for #9236 which mis-parsed timezones ending with 'AD' or 'BC'
+query T
+SELECT TIMESTAMP '2020-12-21 18:53:49' AT TIME ZONE 'Asia/Baghdad'
+----
+2020-12-21 15:53:49+00
+
 query T
 SELECT TIMESTAMP '2020-12-21 18:53:49' AT TIME ZONE 'America/New_York'
 ----


### PR DESCRIPTION
Timezones like `Asia/Baghdad` were misparsed as ending with `AD`, which was stripped resulting in `Asia/Baghd` (https://github.com/MaterializeInc/database-issues/issues/9236). This PR changes this to match only on ` AD` and ` BC`, with leading spaces.

No idea if this is within spec, but what we were doing seemed equally wrong.

For reference: postgres's docs about how they parse things: https://www.postgresql.org/docs/12/datetime-input-rules.html. We skip actual tokenization, and do a bit of ad-hoc string matching. Tokenization (and access to their "internal tables") would have treated AD/BC correctly (they would not have been tokens extracted from `Asia/Baghdad`).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
