### PR TITLE
ore: report panics to Sentry before aborting

### DIFF
--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -95,6 +95,9 @@ pub fn install_enhanced_handler() {
             return;
         }
 
+        // Report the panic to Sentry.
+        sentry_panic::panic_handler(panic_info);
+
         // can't use if cfg!() here because that will require chrono::Utc import
         #[cfg(feature = "chrono")]
         let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ  ").to_string();
@@ -196,9 +199,6 @@ pub fn install_enhanced_handler() {
             let mut stderr = unsafe { File::from_raw_fd(2) };
             let _ = stderr.write_all(buf.as_bytes());
         }
-
-        // Report the panic to Sentry.
-        sentry_panic::panic_handler(panic_info);
 
         process::abort();
     }))


### PR DESCRIPTION
The enhanced panic handler had a bug where it would report the panic to Sentry only after spawning a thread that could abort the process before the Sentry call had a chance to run, causing panics to be missing from Sentry. The fix is to do the Sentry reporting earlier.

### Motivation

  * This PR fixes a previously unreported bug.

Panics sometimes don't show up in Sentry. See [thread](https://materializeinc.slack.com/archives/C04DJT084KA/p1745592445518599).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
