### PR TITLE
Mention the supported Kafka version in the docs

### DIFF
--- a/doc/user/content/ingest-data/kafka/_index.md
+++ b/doc/user/content/ingest-data/kafka/_index.md
@@ -15,6 +15,10 @@ from Kafka, you need to
 1. Create a connection that specifies access and authentication parameters.
 2. Create a source that specifies the format of the data you want to ingest.
 
+## Supported versions
+
+The Kafka source supports **Kafka 3.2+** and is compatible with most common Kafka hosted services, including all supported versions of the [Confluent Platform](https://docs.confluent.io/platform/current/installation/versions-interoperability.html).
+
 ## Integration guides
 
 - [Amazon MSK](/ingest-data/kafka/amazon-msk/)

--- a/doc/user/content/ingest-data/kafka/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka/kafka-self-hosted.md
@@ -27,7 +27,7 @@ self-hosted Kafka cluster.
 
 Before you begin, you must have:
 
-- A Kafka cluster running.
+- A Kafka cluster running Kafka 3.2 or later.
 - A client machine that can interact with your cluster.
 
 ## Configure network security

--- a/doc/user/content/ingest-data/redpanda/_index.md
+++ b/doc/user/content/ingest-data/redpanda/_index.md
@@ -36,6 +36,10 @@ enabled explicitly in Redpanda:
 For more information on general Redpanda configuration, see the
 [Redpanda documentation](https://docs.redpanda.com/home/).
 
+## Supported versions
+
+Materialize supports **Redpanda 24.1+** and is compatible with most common Redpanda hosted services. This includes [all officially supported versions of Redpanda](https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions).
+
 ## Related pages
 
 - [`CREATE SOURCE`](/sql/create-source/kafka/)


### PR DESCRIPTION
Running older versions than this may work, but we don't test for it, and we may have to break compat in the future. Write a policy down!

### Motivation

In recent Kafka sink work, we lost some time to figuring out whether we needed to maintain support for very old Kafka versions. Having an explicit policy here should help us move faster and give users more confidence that their deployment is expected to work.

### Tips for reviewer

All our hosted service guides are for services that keep users on fairly recent versions, so I've only added the explicit version requirement on the self-hosted guide.

As usual, feel free to edit the prose if it doesn't match the overall style!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
