### PR TITLE
compute,adapter: add peek response stash, for arbitrary sized peek responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4864,6 +4864,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "async-stream",
  "async-trait",
  "bytes",
  "bytesize",
@@ -4941,6 +4942,7 @@ dependencies = [
  "timely",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tracing",
  "tracing-core",
  "tracing-opentelemetry",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -72,6 +72,7 @@ def get_minimal_system_parameters(
         # -----
         # Others (ordered by name)
         "allow_real_time_recency": "true",
+        "enable_compute_peek_response_stash": "true",
         "enable_0dt_deployment": "true" if zero_downtime else "false",
         "enable_0dt_deployment_panic_after_timeout": "true",
         "enable_0dt_deployment_sources": (
@@ -165,6 +166,13 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "compute_apply_column_demands", "true", ["true", "false"]
+        ),
+        VariableSystemParameter(
+            "compute_peek_response_stash_threshold_bytes",
+            # 1 MiB, an in-between value
+            "1048576",
+            # force-enabled, the in-between, and the production value
+            ["0", "1048576", "314572800", "67108864"],
         ),
         VariableSystemParameter(
             "disk_cluster_replicas_default", "true", ["true", "false"]
@@ -510,6 +518,11 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "mz_metrics_lgalloc_map_refresh_interval",
     "mz_metrics_lgalloc_refresh_interval",
     "mz_metrics_rusage_refresh_interval",
+    "compute_peek_response_stash_batch_max_runs",
+    "compute_peek_response_stash_read_batch_size_bytes",
+    "compute_peek_response_stash_read_memory_budget_bytes",
+    "compute_peek_stash_num_batches",
+    "compute_peek_stash_batch_size",
 ]
 
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -55,6 +55,10 @@ ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS = {
     # This would increase the memory usage of many tests, making it harder to
     # tell small memory increase regressions
     "persist_blob_cache_scale_with_threads": "false",
+    # The peek response stash kicks in when results get larger, and it
+    # increases query latency. Which in turn makes benchmarking more
+    # unpredictable.
+    "enable_compute_peek_response_stash": "false",
 }
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1083,6 +1083,14 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_compute_active_dataflow_cancelation"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["enable_compute_peek_response_stash"] = (
+            BOOLEAN_FLAG_VALUES
+        )
+        self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
+            "0",  # "force enabled"
+            "1048576",  # 1 MiB, an in-between value
+            "314572800",  # 300 MiB, the production value
+        ]
 
         # If you are adding a new config flag in Materialize, consider using it
         # here instead of just marking it as uninteresting to silence the
@@ -1265,6 +1273,11 @@ class FlipFlagsAction(Action):
             "mz_metrics_lgalloc_map_refresh_interval",
             "mz_metrics_lgalloc_refresh_interval",
             "mz_metrics_rusage_refresh_interval",
+            "compute_peek_stash_num_batches",
+            "compute_peek_stash_batch_size",
+            "compute_peek_response_stash_batch_max_runs",
+            "compute_peek_response_stash_read_batch_size_bytes",
+            "compute_peek_response_stash_read_memory_budget_bytes",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.98"
 arrow = { version = "54.3.1", default-features = false }
+async-stream = "0.3.6"
 async-trait = "0.1.88"
 bytes = "1.10.1"
 bytesize = "1.3.0"
@@ -86,6 +87,7 @@ static_assertions = "1.1"
 timely = "0.21.0"
 tokio = { version = "1.44.1", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
+tokio-stream = "0.1.17"
 tracing = "0.1.37"
 tracing-core = "0.1.34"
 tracing-opentelemetry = { version = "0.25.0" }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -186,7 +186,7 @@ pub struct Response<T> {
     pub otel_ctx: OpenTelemetryContext,
 }
 
-pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send>>;
+pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send + Sync>>;
 
 /// The response to [`Client::startup`](crate::Client::startup).
 #[derive(Derivative)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -127,6 +127,7 @@ use mz_ore::vec::VecExt;
 use mz_ore::{
     assert_none, instrument, soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log, stack,
 };
+use mz_persist_client::PersistClient;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
@@ -1636,6 +1637,10 @@ pub struct Coordinator {
     /// read their catalog as long as needed. In the future we would like this
     /// to be a pTVC, but for now this is sufficient.
     catalog: Arc<Catalog>,
+
+    /// A client for persist. Initially, this is only used for reading stashed
+    /// peek responses out of batches.
+    persist_client: PersistClient,
 
     /// Channel to manage internal commands from the coordinator to itself.
     internal_cmd_tx: mpsc::UnboundedSender<Message>,
@@ -4297,6 +4302,7 @@ pub fn serve(
                     read_only_controllers,
                     buffered_builtin_table_updates: Some(Vec::new()),
                     license_key,
+                    persist_client,
                 };
                 let bootstrap = handle.block_on(async {
                     coord

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -16,9 +16,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use differential_dataflow::consolidation::consolidate;
-use futures::TryFutureExt;
+use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_cluster_client::ReplicaId;
@@ -32,16 +33,21 @@ use mz_expr::explain::{HumanizedExplain, HumanizerMode, fmt_text_constant_rows};
 use mz_expr::row::RowCollection;
 use mz_expr::{
     EvalError, Id, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing,
-    permutation_for_arrangement,
+    RowSetFinishingIncremental, permutation_for_arrangement,
 };
 use mz_ore::cast::CastFrom;
 use mz_ore::str::{StrExt, separated};
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_persist_client::Schemas;
+use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{CompactScalars, IndexUsageType, PlanRenderingContext, UsedIndexes};
-use mz_repr::{Diff, GlobalId, IntoRowIterator, RelationType, Row, RowIterator, preserves_order};
+use mz_repr::{
+    Diff, GlobalId, IntoRowIterator, RelationDesc, RelationType, Row, RowIterator, preserves_order,
+};
+use mz_storage_types::sources::SourceData;
 use serde::{Deserialize, Serialize};
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use uuid::Uuid;
 
 use crate::coord::timestamp_selection::TimestampDetermination;
@@ -368,6 +374,13 @@ pub struct PlannedPeek {
     pub plan: PeekPlan,
     pub determination: TimestampDetermination<mz_repr::Timestamp>,
     pub conn_id: ConnectionId,
+    /// The result type _after_ reading out of the "source" and applying any
+    /// [MapFilterProject](mz_expr::MapFilterProject), but _before_ applying a
+    /// [RowSetFinishing].
+    ///
+    /// This is _the_ `result_type` as far as compute is concerned and futher
+    /// changes through projections happen purely in the adapter.
+    pub intermediate_result_type: RelationType,
     pub source_arity: usize,
     pub source_ids: BTreeSet<GlobalId>,
 }
@@ -622,6 +635,7 @@ impl crate::coord::Coordinator {
             plan: fast_path,
             determination,
             conn_id,
+            intermediate_result_type,
             source_arity,
             source_ids,
         } = plan;
@@ -766,6 +780,7 @@ impl crate::coord::Coordinator {
                     index_key.len() + index_thinned_arity,
                 );
                 let map_filter_project = mfp_to_safe_plan(map_filter_project)?;
+
                 (
                     (None, timestamp, map_filter_project),
                     Some(index_id),
@@ -807,6 +822,13 @@ impl crate::coord::Coordinator {
             .insert(uuid, compute_instance);
         let (literal_constraints, timestamp, map_filter_project) = peek_command;
 
+        // At this stage we don't know column names for the result because we
+        // only know the peek's result type as a bare ResultType.
+        let peek_result_column_names =
+            (0..intermediate_result_type.arity()).map(|i| format!("peek_{i}"));
+        let peek_result_desc =
+            RelationDesc::new(intermediate_result_type, peek_result_column_names);
+
         self.controller
             .compute
             .peek(
@@ -815,18 +837,72 @@ impl crate::coord::Coordinator {
                 literal_constraints,
                 uuid,
                 timestamp,
+                peek_result_desc,
                 finishing.clone(),
                 map_filter_project,
                 target_replica,
                 rows_tx,
             )
             .unwrap_or_terminate("cannot fail to peek");
+
         let duration_histogram = self.metrics.row_set_finishing_seconds();
 
-        // Prepare the receiver to return as a response.
-        let rows_rx = rows_rx.map_ok_or_else(
-            |e| PeekResponseUnary::Error(e.to_string()),
-            move |resp| match resp {
+        // If a dataflow was created, drop it once the peek command is sent.
+        if let Some(index_id) = drop_dataflow {
+            self.remove_compute_ids_from_timeline(vec![(compute_instance, index_id)]);
+            self.drop_indexes(vec![(compute_instance, index_id)]);
+        }
+
+        let persist_client = self.persist_client.clone();
+        let peek_stash_read_batch_size_bytes =
+            mz_compute_types::dyncfgs::PEEK_RESPONSE_STASH_READ_BATCH_SIZE_BYTES
+                .get(self.catalog().system_config().dyncfgs());
+        let peek_stash_read_memory_budget_bytes =
+            mz_compute_types::dyncfgs::PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES
+                .get(self.catalog().system_config().dyncfgs());
+
+        let peek_response_stream = Self::create_peek_response_stream(
+            rows_rx,
+            finishing,
+            max_result_size,
+            max_returned_query_size,
+            duration_histogram,
+            persist_client,
+            peek_stash_read_batch_size_bytes,
+            peek_stash_read_memory_budget_bytes,
+        );
+
+        Ok(crate::ExecuteResponse::SendingRowsStreaming {
+            rows: Box::pin(peek_response_stream),
+            instance_id: compute_instance,
+            strategy,
+        })
+    }
+
+    /// Creates an async stream that processes peek responses and yields rows.
+    #[mz_ore::instrument(level = "debug")]
+    fn create_peek_response_stream(
+        rows_rx: tokio::sync::oneshot::Receiver<PeekResponse>,
+        finishing: RowSetFinishing,
+        max_result_size: u64,
+        max_returned_query_size: Option<u64>,
+        duration_histogram: prometheus::Histogram,
+        mut persist_client: mz_persist_client::PersistClient,
+        peek_stash_read_batch_size_bytes: usize,
+        peek_stash_read_memory_budget_bytes: usize,
+    ) -> impl futures::Stream<Item = PeekResponseUnary> {
+        async_stream::stream!({
+            let result = rows_rx.await;
+
+            let rows = match result {
+                Ok(rows) => rows,
+                Err(e) => {
+                    yield PeekResponseUnary::Error(e.to_string());
+                    return;
+                }
+            };
+
+            match rows {
                 PeekResponse::Rows(rows) => {
                     match finishing.finish(
                         rows,
@@ -834,25 +910,182 @@ impl crate::coord::Coordinator {
                         max_returned_query_size,
                         &duration_histogram,
                     ) {
-                        Ok((rows, _size_bytes)) => PeekResponseUnary::Rows(Box::new(rows)),
-                        Err(e) => PeekResponseUnary::Error(e),
+                        Ok((rows, _size_bytes)) => yield PeekResponseUnary::Rows(Box::new(rows)),
+                        Err(e) => yield PeekResponseUnary::Error(e),
                     }
                 }
-                PeekResponse::Canceled => PeekResponseUnary::Canceled,
-                PeekResponse::Error(e) => PeekResponseUnary::Error(e),
-            },
-        );
+                PeekResponse::Stashed(response) => {
+                    let response = *response;
 
-        // If it was created, drop the dataflow once the peek command is sent.
-        if let Some(index_id) = drop_dataflow {
-            self.remove_compute_ids_from_timeline(vec![(compute_instance, index_id)]);
-            self.drop_indexes(vec![(compute_instance, index_id)]);
-        }
+                    let shard_id = response.shard_id;
 
-        Ok(crate::ExecuteResponse::SendingRows {
-            future: Box::pin(rows_rx),
-            instance_id: compute_instance,
-            strategy,
+                    let mut batches = Vec::new();
+                    for proto_batch in response.batches.into_iter() {
+                        let batch =
+                            persist_client.batch_from_transmittable_batch(&shard_id, proto_batch);
+
+                        batches.push(batch);
+                    }
+                    tracing::trace!(?batches, "stashed peek response");
+
+                    let as_of = Antichain::from_elem(mz_repr::Timestamp::default());
+                    let read_schemas: Schemas<SourceData, ()> = Schemas {
+                        id: None,
+                        key: Arc::new(response.relation_desc.clone()),
+                        val: Arc::new(UnitSchema),
+                    };
+
+                    let mut row_cursor = persist_client
+                        .read_batches_consolidated::<_, _, _, i64>(
+                            response.shard_id,
+                            as_of,
+                            read_schemas,
+                            batches,
+                            |_stats| true,
+                            peek_stash_read_memory_budget_bytes,
+                        )
+                        .await
+                        .expect("invalid usage");
+
+                    // NOTE: Using the cursor creates Futures that are not Sync,
+                    // so we can't drive them on the main Coordinator loop.
+                    // Spawning a task has the additional benefit that we get to
+                    // delete batches once we're done.
+                    //
+                    // Batch deletion is best-effort, though, and there are
+                    // multiple known ways in which they can leak, among them:
+                    //
+                    // - ProtoBatch is lost in flight
+                    // - ProtoBatch is lost because when combining PeekResponse
+                    // from workers a cancellation or error "overrides" other
+                    // results, meaning we drop them
+                    // - This task here is not run to completion before it can
+                    // delete all batches
+                    //
+                    // This is semi-ok, because persist needs a reaper of leaked
+                    // batches already, and so we piggy-back on that, even if it
+                    // might not exist as of today.
+                    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+                    mz_ore::task::spawn(|| "read_peek_batches", async move {
+                        // We always send our inline rows first. Ordering
+                        // doesn't matter because we can only be in this case
+                        // when there is no ORDER BY.
+                        //
+                        // We _could_ write these out as a Batch, and include it
+                        // in the batches we read via the Consolidator. If we
+                        // wanted to get a consistent ordering. That's not
+                        // needed for correctness! But might be nice for more
+                        // aesthetic reasons.
+                        let result = tx.send(response.inline_rows).await;
+                        if result.is_err() {
+                            tracing::error!("receiver went away");
+                        }
+
+                        let mut current_batch = Vec::new();
+                        let mut current_batch_size: usize = 0;
+
+                        'outer: while let Some(rows) = row_cursor.next().await {
+                            for ((key, _val), _ts, diff) in rows {
+                                let source_data = key.expect("decoding error");
+
+                                let row = source_data
+                                    .0
+                                    .expect("we are not sending errors on this code path");
+
+                                let diff = usize::try_from(diff)
+                                    .expect("peek responses cannot have negative diffs");
+
+                                if diff > 0 {
+                                    let diff =
+                                        NonZeroUsize::new(diff).expect("checked to be non-zero");
+                                    current_batch_size =
+                                        current_batch_size.saturating_add(row.byte_len());
+                                    current_batch.push((row, diff));
+                                }
+
+                                if current_batch_size > peek_stash_read_batch_size_bytes {
+                                    // We're re-encoding the rows as a RowCollection
+                                    // here, for which we pay in CPU time. We're in a
+                                    // slow path already, since we're returning a big
+                                    // stashed result so this is worth the convenience
+                                    // of that for now.
+                                    let result = tx
+                                        .send(RowCollection::new(
+                                            current_batch.drain(..).collect_vec(),
+                                            &[],
+                                        ))
+                                        .await;
+                                    if result.is_err() {
+                                        tracing::error!("receiver went away");
+                                        // Don't return but break so we fall out to the
+                                        // batch delete logic below.
+                                        break 'outer;
+                                    }
+
+                                    current_batch_size = 0;
+                                }
+                            }
+                        }
+
+                        if current_batch.len() > 0 {
+                            let result = tx.send(RowCollection::new(current_batch, &[])).await;
+                            if result.is_err() {
+                                tracing::error!("receiver went away");
+                            }
+                        }
+
+                        let batches = row_cursor.into_lease();
+                        tracing::trace!(?response.shard_id, "cleaning up batches of peek result");
+                        for batch in batches {
+                            batch.delete().await;
+                        }
+                    });
+
+                    assert!(
+                        finishing.is_streamable(response.relation_desc.arity()),
+                        "can only get stashed responses when the finishing is streamable"
+                    );
+
+                    tracing::trace!("query result is streamable!");
+
+                    assert!(finishing.is_streamable(response.relation_desc.arity()));
+                    let mut incremental_finishing = RowSetFinishingIncremental::new(
+                        finishing.offset,
+                        finishing.limit,
+                        finishing.project,
+                        max_returned_query_size,
+                    );
+
+                    let mut got_zero_rows = true;
+                    while let Some(rows) = rx.recv().await {
+                        got_zero_rows = false;
+
+                        let result_rows = incremental_finishing.finish_incremental(
+                            rows,
+                            max_result_size,
+                            &duration_histogram,
+                        );
+
+                        match result_rows {
+                            Ok(result_rows) => yield PeekResponseUnary::Rows(Box::new(result_rows)),
+                            Err(e) => yield PeekResponseUnary::Error(e),
+                        }
+                    }
+
+                    // Even when there's zero rows, clients still expect an
+                    // empty PeekResponse.
+                    if got_zero_rows {
+                        let row_iter = vec![].into_row_iter();
+                        yield PeekResponseUnary::Rows(Box::new(row_iter));
+                    }
+                }
+                PeekResponse::Canceled => {
+                    yield PeekResponseUnary::Canceled;
+                }
+                PeekResponse::Error(e) => {
+                    yield PeekResponseUnary::Error(e);
+                }
+            }
         })
     }
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -862,6 +862,7 @@ impl Coordinator {
             plan: peek_plan,
             determination: determination.clone(),
             conn_id: conn_id.clone(),
+            intermediate_result_type: typ,
             source_arity,
             source_ids,
         };

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -59,7 +59,7 @@ pub mod telemetry;
 pub mod webhook;
 
 pub use crate::client::{Client, Handle, SessionClient};
-pub use crate::command::{ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse};
+pub use crate::command::{ExecuteResponse, ExecuteResponseKind, StartupResponse};
 pub use crate::coord::ExecuteContext;
 pub use crate::coord::ExecuteContextExtra;
 pub use crate::coord::id_bundle::CollectionIdBundle;

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -163,7 +163,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
                         execution_strategy: Some(StatementExecutionStrategy::Constant),
                     }
                 }
-                ExecuteResponse::SendingRows { .. } => {
+                ExecuteResponse::SendingRowsStreaming { .. } => {
                     panic!("SELECTs terminate on peek finalization, not here.")
                 }
                 ExecuteResponse::Subscribing { .. } => {
@@ -177,7 +177,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
             ExecuteResponse::Fetch { .. } => {
                 panic!("FETCHes terminate after a follow-up message is sent.")
             }
-            ExecuteResponse::SendingRows { .. } => {
+            ExecuteResponse::SendingRowsStreaming { .. } => {
                 panic!("SELECTs terminate on peek finalization, not here.")
             }
             ExecuteResponse::Subscribing { .. } => {

--- a/src/compute-client/BUILD.bazel
+++ b/src/compute-client/BUILD.bazel
@@ -144,6 +144,7 @@ filegroup(
         "//src/compute-types:all_protos",
         "//src/dyncfg:all_protos",
         "//src/expr:all_protos",
+        "//src/persist-client:all_protos",
         "//src/proto:all_protos",
         "//src/repr:all_protos",
         "//src/service:all_protos",

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -54,7 +54,8 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{Datum, GlobalId, Row, TimestampManipulation};
+use mz_persist_types::PersistLocation;
+use mz_repr::{Datum, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_storage_client::controller::StorageController;
 use mz_storage_types::dyncfgs::ORE_OVERFLOWING_BEHAVIOR;
 use mz_storage_types::read_holds::ReadHold;
@@ -151,10 +152,28 @@ impl PeekNotification {
     /// parameters are used to calculate the number of rows in the peek result.
     fn new(peek_response: &PeekResponse, offset: usize, limit: Option<usize>) -> Self {
         match peek_response {
-            PeekResponse::Rows(rows) => Self::Success {
-                rows: u64::cast_from(rows.count(offset, limit)),
-                result_size: u64::cast_from(rows.byte_len()),
-            },
+            PeekResponse::Rows(rows) => {
+                let num_rows = u64::cast_from(rows.count(offset, limit));
+                let result_size = u64::cast_from(rows.byte_len());
+
+                tracing::trace!(?num_rows, ?result_size, "inline peek result");
+
+                Self::Success {
+                    rows: num_rows,
+                    result_size,
+                }
+            }
+            PeekResponse::Stashed(stashed_response) => {
+                let rows = stashed_response.num_rows(offset, limit);
+                let result_size = stashed_response.size_bytes();
+
+                tracing::trace!(?rows, ?result_size, "stashed peek result");
+
+                Self::Success {
+                    rows: u64::cast_from(rows),
+                    result_size: u64::cast_from(result_size),
+                }
+            }
             PeekResponse::Error(err) => Self::Error(err.clone()),
             PeekResponse::Canceled => Self::Canceled,
         }
@@ -181,6 +200,8 @@ pub struct ComputeController<T: ComputeControllerTimestamp> {
     read_only: bool,
     /// Compute configuration to apply to new instances.
     config: ComputeParameters,
+    /// The persist location where we can stash large peek results.
+    peek_stash_persist_location: PersistLocation,
     /// A controller response to be returned on the next call to [`ComputeController::process`].
     stashed_response: Option<ComputeControllerResponse<T>>,
     /// A number that increases on every `environmentd` restart.
@@ -223,6 +244,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         envd_epoch: NonZeroI64,
         read_only: bool,
         metrics_registry: &MetricsRegistry,
+        peek_stash_persist_location: PersistLocation,
         controller_metrics: ControllerMetrics,
         now: NowFn,
         wallclock_lag: WallclockLagFn<T>,
@@ -285,6 +307,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             initialized: false,
             read_only,
             config: Default::default(),
+            peek_stash_persist_location,
             stashed_response: None,
             envd_epoch,
             metrics,
@@ -474,6 +497,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             initialized,
             read_only,
             config: _,
+            peek_stash_persist_location: _,
             stashed_response,
             envd_epoch,
             metrics: _,
@@ -551,6 +575,7 @@ where
             id,
             self.build_info,
             Arc::clone(&self.storage_collections),
+            self.peek_stash_persist_location.clone(),
             logs,
             self.envd_epoch,
             self.metrics.for_instance(id),
@@ -888,6 +913,7 @@ where
         literal_constraints: Option<Vec<Row>>,
         uuid: Uuid,
         timestamp: T,
+        result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
         target_replica: Option<ReplicaId>,
@@ -922,6 +948,7 @@ where
                 literal_constraints,
                 uuid,
                 timestamp,
+                result_desc,
                 finishing,
                 map_filter_project,
                 read_hold,

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -632,6 +632,7 @@ where
 #[derive(Debug)]
 pub struct PeekMetrics<M> {
     rows: M,
+    rows_stashed: M,
     error: M,
     canceled: M,
 }
@@ -643,6 +644,7 @@ impl<M> PeekMetrics<M> {
     {
         Self {
             rows: build_metric("rows"),
+            rows_stashed: build_metric("rows_stashed"),
             error: build_metric("error"),
             canceled: build_metric("canceled"),
         }
@@ -653,6 +655,7 @@ impl<M> PeekMetrics<M> {
 
         match response {
             Rows(_) => &self.rows,
+            Stashed(_) => &self.rows_stashed,
             Error(_) => &self.error,
             Canceled => &self.canceled,
         }

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -22,6 +22,7 @@ import "expr/src/relation.proto";
 import "google/protobuf/empty.proto";
 import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
+import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 import "service/src/params.proto";
 import "storage-client/src/client.proto";
@@ -51,6 +52,8 @@ message ProtoComputeCommand {
 message ProtoInstanceConfig {
   logging.ProtoLoggingConfig logging = 1;
   optional mz_proto.ProtoDuration expiration_offset = 2;
+  string peek_stash_blob_uri = 3;
+  string peek_stash_consensus_uri = 4;
 }
 
 message ProtoIndexTarget {
@@ -69,6 +72,7 @@ message ProtoPeek {
   mz_expr.relation.ProtoRowSetFinishing finishing = 5;
   mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
   map<string, string> otel_ctx = 7;
+  mz_repr.relation_and_scalar.ProtoRelationDesc result_desc = 10;
   oneof target {
     ProtoIndexTarget index = 8;
     ProtoPersistTarget persist = 9;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -9,6 +9,7 @@
 
 //! Compute protocol commands.
 
+use std::str::FromStr;
 use std::time::Duration;
 
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig, TryIntoTimelyConfig};
@@ -17,8 +18,10 @@ use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::ConfigUpdates;
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_ore::url::SensitiveUrl;
+use mz_persist_types::PersistLocation;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError, any_uuid};
-use mz_repr::{GlobalId, Row};
+use mz_repr::{GlobalId, RelationDesc, Row};
 use mz_service::params::GrpcClientParameters;
 use mz_storage_client::client::ProtoCompaction;
 use mz_storage_types::controller::CollectionMetadata;
@@ -183,7 +186,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     Schedule(GlobalId),
 
     /// `AllowCompaction` informs the replica about the relaxation of external read capabilities on
-    /// a compute collection exported by one of the replica’s dataflow.
+    /// a compute collection exported by one of the replica's dataflows.
     ///
     /// The command names a collection and provides a frontier after which accumulations must be
     /// correct. The replica gains the liberty of compacting the corresponding maintained trace up
@@ -233,7 +236,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// A [`Peek`] description that violates any of the above properties can cause the replica to
     /// exhibit undefined behavior.
     ///
-    /// Specifying a [`Peek::timestamp`] that is less than the target index’s `since` frontier does
+    /// Specifying a [`Peek::timestamp`] that is less than the target index's `since` frontier does
     /// not provoke undefined behavior. Instead, the replica must produce a [`PeekResponse::Error`]
     /// in response.
     ///
@@ -381,12 +384,14 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
 /// Configuration for a replica, passed with the `CreateInstance`. Replicas should halt
 /// if the controller attempt to reconcile them with different values
 /// for anything in this struct.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Arbitrary)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct InstanceConfig {
     /// Specification of introspection logging.
     pub logging: LoggingConfig,
     /// The offset relative to the replica startup at which it should expire. None disables feature.
     pub expiration_offset: Option<Duration>,
+    /// The persist location where we can stash large peek results.
+    pub peek_stash_persist_location: PersistLocation,
 }
 
 impl InstanceConfig {
@@ -402,10 +407,12 @@ impl InstanceConfig {
         let InstanceConfig {
             logging: self_logging,
             expiration_offset: self_offset,
+            peek_stash_persist_location: self_peek_stash_persist_location,
         } = self;
         let InstanceConfig {
             logging: other_logging,
             expiration_offset: other_offset,
+            peek_stash_persist_location: other_peek_stash_persist_location,
         } = other;
 
         // Logging is compatible if exactly the same.
@@ -417,7 +424,10 @@ impl InstanceConfig {
         let other_offset = Antichain::from_iter(*other_offset);
         let offset_compatible = timely::PartialOrder::less_equal(&other_offset, &self_offset);
 
-        logging_compatible && offset_compatible
+        let persist_location_compatible =
+            self_peek_stash_persist_location == other_peek_stash_persist_location;
+
+        logging_compatible && offset_compatible && persist_location_compatible
     }
 }
 
@@ -426,6 +436,14 @@ impl RustType<ProtoInstanceConfig> for InstanceConfig {
         ProtoInstanceConfig {
             logging: Some(self.logging.into_proto()),
             expiration_offset: self.expiration_offset.into_proto(),
+            peek_stash_blob_uri: self
+                .peek_stash_persist_location
+                .blob_uri
+                .to_string_unredacted(),
+            peek_stash_consensus_uri: self
+                .peek_stash_persist_location
+                .consensus_uri
+                .to_string_unredacted(),
         }
     }
 
@@ -435,6 +453,10 @@ impl RustType<ProtoInstanceConfig> for InstanceConfig {
                 .logging
                 .into_rust_if_some("ProtoCreateInstance::logging")?,
             expiration_offset: proto.expiration_offset.into_rust()?,
+            peek_stash_persist_location: PersistLocation {
+                blob_uri: SensitiveUrl::from_str(&proto.peek_stash_blob_uri)?,
+                consensus_uri: SensitiveUrl::from_str(&proto.peek_stash_consensus_uri)?,
+            },
         })
     }
 }
@@ -585,6 +607,10 @@ impl PeekTarget {
 pub struct Peek<T = mz_repr::Timestamp> {
     /// Target-specific metadata.
     pub target: PeekTarget,
+    /// The relation description for the rows returned by this peek, before
+    /// applying the [RowSetFinishing] but _after_ applying the given
+    /// `map_filter_project`.
+    pub result_desc: RelationDesc,
     /// If `Some`, then look up only the given keys from the collection (instead of a full scan).
     /// The vector is never empty.
     #[proptest(strategy = "proptest::option::of(proptest::collection::vec(any::<Row>(), 1..5))")]
@@ -624,6 +650,7 @@ impl RustType<ProtoPeek> for Peek {
             finishing: Some(self.finishing.into_proto()),
             map_filter_project: Some(self.map_filter_project.into_proto()),
             otel_ctx: self.otel_ctx.clone().into(),
+            result_desc: Some(self.result_desc.into_proto()),
             target: Some(match &self.target {
                 PeekTarget::Index { id } => proto_peek::Target::Index(ProtoIndexTarget {
                     id: Some(id.into_proto()),
@@ -652,6 +679,7 @@ impl RustType<ProtoPeek> for Peek {
                 .map_filter_project
                 .into_rust_if_some("ProtoPeek::map_filter_project")?,
             otel_ctx: x.otel_ctx.into(),
+            result_desc: x.result_desc.into_rust_if_some("ProtoPeek::result_desc")?,
             target: match x.target {
                 Some(proto_peek::Target::Index(target)) => PeekTarget::Index {
                     id: target.id.into_rust_if_some("ProtoIndexTarget::id")?,

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -15,9 +15,11 @@ package mz_compute_client.protocol.response;
 
 import "expr/src/row/collection.proto";
 import "google/protobuf/empty.proto";
+import "persist-client/src/batch.proto";
 import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
+import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 
 message ProtoComputeResponse {
@@ -57,9 +59,19 @@ message ProtoFrontiersResponse {
   mz_repr.antichain.ProtoU64Antichain output_frontier = 3;
 }
 
+message ProtoStashedPeekResponse {
+  mz_repr.relation_and_scalar.ProtoRelationDesc relation_desc = 1;
+  string shard_id = 2;
+  repeated mz_persist_client.batch.ProtoBatch batches = 3;
+  uint64 num_rows = 4;
+  uint64 encoded_size_bytes = 5;
+  mz_expr.row.collection.ProtoRowCollection inline_rows = 6;
+}
+
 message ProtoPeekResponse {
   oneof kind {
     mz_expr.row.collection.ProtoRowCollection rows = 1;
+    ProtoStashedPeekResponse stashed = 4;
     string error = 2;
     google.protobuf.Empty canceled = 3;
   }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -15,8 +15,10 @@ use mz_compute_types::plan::LirId;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_persist_client::batch::ProtoBatch;
+use mz_persist_types::ShardId;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError, any_uuid};
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_timely_util::progress::any_antichain;
 use proptest::prelude::{Arbitrary, any};
 use proptest::strategy::{BoxedStrategy, Just, Strategy, Union};
@@ -324,6 +326,8 @@ impl Arbitrary for FrontiersResponse {
 pub enum PeekResponse {
     /// Returned rows of a successful peek.
     Rows(RowCollection),
+    /// Results of the peek were stashed in persist batches.
+    Stashed(Box<StashedPeekResponse>),
     /// Error of an unsuccessful peek.
     Error(String),
     /// The peek was canceled.
@@ -336,6 +340,7 @@ impl RustType<ProtoPeekResponse> for PeekResponse {
         ProtoPeekResponse {
             kind: Some(match self {
                 PeekResponse::Rows(rows) => Rows(rows.into_proto()),
+                PeekResponse::Stashed(stashed) => Stashed(stashed.as_ref().into_proto()),
                 PeekResponse::Error(err) => proto_peek_response::Kind::Error(err.clone()),
                 PeekResponse::Canceled => Canceled(()),
             }),
@@ -346,6 +351,7 @@ impl RustType<ProtoPeekResponse> for PeekResponse {
         use proto_peek_response::Kind::*;
         match proto.kind {
             Some(Rows(rows)) => Ok(PeekResponse::Rows(rows.into_rust()?)),
+            Some(Stashed(stashed)) => Ok(PeekResponse::Stashed(Box::new(stashed.into_rust()?))),
             Some(proto_peek_response::Kind::Error(err)) => Ok(PeekResponse::Error(err)),
             Some(Canceled(())) => Ok(PeekResponse::Canceled),
             None => Err(TryFromProtoError::missing_field("ProtoPeekResponse::kind")),
@@ -371,6 +377,90 @@ impl Arbitrary for PeekResponse {
             ".*".prop_map(PeekResponse::Error).boxed(),
             Just(PeekResponse::Canceled).boxed(),
         ])
+    }
+}
+
+/// Response from a peek whose results have been stashed into persist.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StashedPeekResponse {
+    /// The number of rows stored in response batches. This is the sum of the
+    /// diff values of the contained rows.
+    ///
+    /// This does _NOT_ include rows in `inline_rows`.
+    pub num_rows_batches: u64,
+    /// The sum of the encoded sizes of all batches in this response.
+    pub encoded_size_bytes: usize,
+    /// [RelationDesc] for the rows in these stashed batches of results.
+    pub relation_desc: RelationDesc,
+    /// The [ShardId] under which result batches have been stashed.
+    pub shard_id: ShardId,
+    /// Batches of Rows, must be combined with reponses from other workers and
+    /// consolidated before sending back via a client.
+    pub batches: Vec<ProtoBatch>,
+    /// Rows that have not been uploaded to the stash, because their total size
+    /// did not go above the threshold for using the peek stash.
+    ///
+    /// We will have a mix of stashed responses and inline responses because the
+    /// result sizes across different workers can and will vary.
+    pub inline_rows: RowCollection,
+}
+
+impl StashedPeekResponse {
+    /// Total count of [`Row`]s represented by this collection, considering a
+    /// possible `OFFSET` and `LIMIT`.
+    pub fn num_rows(&self, offset: usize, limit: Option<usize>) -> usize {
+        let num_stashed_rows: usize = usize::cast_from(self.num_rows_batches);
+        let num_inline_rows = self.inline_rows.count(offset, limit);
+        let mut num_rows = num_stashed_rows + num_inline_rows;
+
+        // Consider a possible OFFSET.
+        num_rows = num_rows.saturating_sub(offset);
+
+        // Consider a possible LIMIT.
+        if let Some(limit) = limit {
+            num_rows = std::cmp::min(limit, num_rows);
+        }
+
+        num_rows
+    }
+
+    /// The size in bytes of the encoded rows in this result.
+    pub fn size_bytes(&self) -> usize {
+        let inline_size = self.inline_rows.byte_len();
+
+        self.encoded_size_bytes + inline_size
+    }
+}
+
+impl RustType<ProtoStashedPeekResponse> for StashedPeekResponse {
+    fn into_proto(&self) -> ProtoStashedPeekResponse {
+        ProtoStashedPeekResponse {
+            relation_desc: Some(self.relation_desc.into_proto()),
+            shard_id: self.shard_id.into_proto(),
+            batches: self.batches.clone(),
+            num_rows: self.num_rows_batches.into_proto(),
+            encoded_size_bytes: self.encoded_size_bytes.into_proto(),
+            inline_rows: Some(self.inline_rows.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoStashedPeekResponse) -> Result<Self, TryFromProtoError> {
+        let shard_id: ShardId = proto
+            .shard_id
+            .into_rust()
+            .expect("valid transmittable shard_id");
+        Ok(StashedPeekResponse {
+            relation_desc: proto
+                .relation_desc
+                .into_rust_if_some("ProtoStashedPeekResponse::relation_desc")?,
+            shard_id,
+            batches: proto.batches,
+            num_rows_batches: proto.num_rows,
+            encoded_size_bytes: usize::cast_from(proto.encoded_size_bytes),
+            inline_rows: proto
+                .inline_rows
+                .into_rust_if_some("ProtoStashedPeekResponse::inline_rows")?,
+        })
     }
 }
 

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -20,8 +20,8 @@ use bytesize::ByteSize;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
 use mz_expr::row::RowCollection;
-use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
+use mz_ore::{assert_none, soft_assert_eq_or_log};
 use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{GrpcClient, GrpcServer, ProtoServiceTypes, ResponseStream};
@@ -35,7 +35,7 @@ use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::{ComputeCommand, ProtoComputeCommand};
 use crate::protocol::response::{
     ComputeResponse, CopyToResponse, FrontiersResponse, PeekResponse, ProtoComputeResponse,
-    SubscribeBatch, SubscribeResponse,
+    StashedPeekResponse, SubscribeBatch, SubscribeResponse,
 };
 use crate::service::proto_compute_server::ProtoCompute;
 
@@ -316,6 +316,26 @@ where
                             (PeekResponse::Canceled, _) => PeekResponse::Canceled,
                             (_, PeekResponse::Error(e)) => PeekResponse::Error(e),
                             (PeekResponse::Error(e), _) => PeekResponse::Error(e),
+                            (PeekResponse::Rows(rows), PeekResponse::Stashed(mut stashed))
+                            | (PeekResponse::Stashed(mut stashed), PeekResponse::Rows(rows)) => {
+                                let total_inlined_size = rows
+                                    .byte_len()
+                                    .saturating_add(stashed.inline_rows.byte_len());
+
+                                if total_inlined_size > usize::cast_from(self.max_result_size) {
+                                    // Note: We match on this specific error message in tests
+                                    // so it's important that nothing else returns the same
+                                    // string.
+                                    let err = format!(
+                                        "total result exceeds max size of {}",
+                                        ByteSize::b(self.max_result_size)
+                                    );
+                                    PeekResponse::Error(err)
+                                } else {
+                                    stashed.inline_rows.merge(&rows);
+                                    PeekResponse::Stashed(stashed)
+                                }
+                            }
                             (PeekResponse::Rows(mut rows), PeekResponse::Rows(other)) => {
                                 let total_byte_size =
                                     rows.byte_len().saturating_add(other.byte_len());
@@ -332,6 +352,75 @@ where
                                 } else {
                                     rows.merge(&other);
                                     PeekResponse::Rows(rows)
+                                }
+                            }
+                            (PeekResponse::Stashed(stashed), PeekResponse::Stashed(other)) => {
+                                // Deconstruct so we don't miss adding new
+                                // fields. We need to be careful about merging
+                                // everything!
+                                let StashedPeekResponse {
+                                    num_rows_batches: self_num_rows_batches,
+                                    encoded_size_bytes: self_encoded_size_bytes,
+                                    relation_desc: self_relation_desc,
+                                    shard_id: self_shard_id,
+                                    batches: mut self_batches,
+                                    inline_rows: mut self_inline_rows,
+                                } = *stashed;
+                                let StashedPeekResponse {
+                                    num_rows_batches: other_num_rows_batches,
+                                    encoded_size_bytes: other_encoded_size_bytes,
+                                    relation_desc: other_relation_desc,
+                                    shard_id: other_shard_id,
+                                    batches: mut other_batches,
+                                    inline_rows: other_inline_rows,
+                                } = *other;
+
+                                soft_assert_eq_or_log!(self_shard_id, other_shard_id);
+                                soft_assert_eq_or_log!(self_relation_desc, other_relation_desc);
+
+                                let total_inlined_size = self_inline_rows
+                                    .byte_len()
+                                    .saturating_add(other_inline_rows.byte_len());
+
+                                if self_shard_id != other_shard_id {
+                                    let err = format!(
+                                        "internal error: shard IDs of stashed response do not match, got {self_shard_id} and {other_shard_id}",
+                                    );
+                                    PeekResponse::Error(err)
+                                } else if self_relation_desc != other_relation_desc {
+                                    let err = format!(
+                                        "internal error: RelationDesc of stashed response do not match, got {:?} and {:?}",
+                                        self_relation_desc, other_relation_desc,
+                                    );
+                                    PeekResponse::Error(err)
+                                } else if total_inlined_size
+                                    > usize::cast_from(self.max_result_size)
+                                {
+                                    // Note: We match on this specific error message in tests
+                                    // so it's important that nothing else returns the same
+                                    // string.
+                                    let err = format!(
+                                        "total result exceeds max size of {}",
+                                        ByteSize::b(self.max_result_size)
+                                    );
+                                    PeekResponse::Error(err)
+                                } else {
+                                    self_inline_rows.merge(&other_inline_rows);
+
+                                    self_batches.append(&mut other_batches);
+
+                                    let merged_response = StashedPeekResponse {
+                                        num_rows_batches: self_num_rows_batches
+                                            + other_num_rows_batches,
+                                        encoded_size_bytes: self_encoded_size_bytes
+                                            + other_encoded_size_bytes,
+                                        relation_desc: self_relation_desc,
+                                        shard_id: self_shard_id,
+                                        batches: self_batches,
+                                        inline_rows: self_inline_rows,
+                                    };
+
+                                    PeekResponse::Stashed(Box::new(merged_response))
                                 }
                             }
                         };

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -1,0 +1,245 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! For eligible peeks, we send the result back via the peek stash (aka persist
+//! blob), instead of inline in `ComputeResponse`.
+
+use std::num::{NonZeroI64, NonZeroU64};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use mz_compute_client::protocol::command::Peek;
+use mz_compute_client::protocol::response::{PeekResponse, StashedPeekResponse};
+use mz_expr::row::RowCollection;
+use mz_ore::cast::CastFrom;
+use mz_ore::task::AbortOnDropHandle;
+use mz_persist_client::Schemas;
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::{PersistLocation, ShardId};
+use mz_repr::{Diff, RelationDesc, Row, Timestamp};
+use mz_storage_types::sources::SourceData;
+use timely::progress::Antichain;
+
+use tokio::sync::oneshot;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::arrangement::manager::{PaddedTrace, TraceBundle};
+use crate::compute_state::peek_result_iterator;
+use crate::compute_state::peek_result_iterator::PeekResultIterator;
+use crate::typedefs::RowRowAgent;
+
+/// An async task that stashes a peek response in persist and yields a handle to
+/// the batch in a [PeekResponse::Stashed].
+///
+/// Note that `PeekResponseTask` intentionally does not implement or derive
+/// `Clone`, as each `PeekResponseTask` is meant to be dropped after it's
+/// done or no longer needed.
+pub struct StashingPeek {
+    pub peek: Peek,
+    /// Iterator for the results. The worker thread has to continually pump
+    /// results from this to the `rows_tx` channel.
+    peek_iterator: Option<PeekResultIterator<PaddedTrace<RowRowAgent<Timestamp, Diff>>>>,
+    /// We can't give a PeekResultIterator to our async upload task because the
+    /// underlying trace reader is not Send/Sync. So we need to use a channel to
+    /// send result rows from the worker thread to the async background task.
+    rows_tx: Option<tokio::sync::mpsc::Sender<Result<Vec<(Row, NonZeroI64)>, String>>>,
+    /// The result of the background task, eventually.
+    pub result: oneshot::Receiver<(PeekResponse, Duration)>,
+    /// The `tracing::Span` tracking this peek's operation
+    pub span: tracing::Span,
+    /// A background task that's responsible for producing the peek results.
+    /// If we're no longer interested in the results, we abort the task.
+    _abort_handle: AbortOnDropHandle<()>,
+}
+
+impl StashingPeek {
+    pub fn start_upload(
+        persist_clients: Arc<PersistClientCache>,
+        persist_location: &PersistLocation,
+        peek: Peek,
+        mut trace_bundle: TraceBundle,
+        batch_max_runs: usize,
+    ) -> Self {
+        let (rows_tx, rows_rx) = tokio::sync::mpsc::channel(10);
+        let (result_tx, result_rx) = oneshot::channel::<(PeekResponse, Duration)>();
+
+        let persist_clients = Arc::clone(&persist_clients);
+        let persist_location = persist_location.clone();
+
+        let peek_uuid = peek.uuid;
+        let relation_desc = peek.result_desc.clone();
+
+        let oks_handle = trace_bundle.oks_mut();
+
+        let peek_iterator = peek_result_iterator::PeekResultIterator::new(
+            peek.target.id().clone(),
+            peek.map_filter_project.clone(),
+            peek.timestamp,
+            peek.literal_constraints.clone(),
+            oks_handle,
+        );
+
+        let task_handle = mz_ore::task::spawn(
+            || format!("peek_stash::stash_peek_response({peek_uuid})"),
+            async move {
+                let start = Instant::now();
+
+                let result = Self::do_upload(
+                    &persist_clients,
+                    persist_location,
+                    batch_max_runs,
+                    peek.uuid,
+                    relation_desc,
+                    rows_rx,
+                )
+                .await;
+
+                let result = match result {
+                    Ok(peek_response) => peek_response,
+                    Err(e) => PeekResponse::Error(e.to_string()),
+                };
+                match result_tx.send((result, start.elapsed())) {
+                    Ok(()) => {}
+                    Err((_result, elapsed)) => {
+                        debug!(duration = ?elapsed, "dropping result for cancelled peek {}", peek_uuid)
+                    }
+                }
+            },
+        );
+
+        Self {
+            peek,
+            peek_iterator: Some(peek_iterator),
+            rows_tx: Some(rows_tx),
+            result: result_rx,
+            span: tracing::Span::current(),
+            _abort_handle: task_handle.abort_on_drop(),
+        }
+    }
+
+    async fn do_upload(
+        persist_clients: &PersistClientCache,
+        persist_location: PersistLocation,
+        batch_max_runs: usize,
+        peek_uuid: Uuid,
+        relation_desc: RelationDesc,
+        mut rows_rx: tokio::sync::mpsc::Receiver<Result<Vec<(Row, NonZeroI64)>, String>>,
+    ) -> Result<PeekResponse, String> {
+        let client = persist_clients
+            .open(persist_location)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let shard_id = format!("s{}", peek_uuid);
+        let shard_id = ShardId::try_from(shard_id).expect("can parse");
+        let write_schemas: Schemas<SourceData, ()> = Schemas {
+            id: None,
+            key: Arc::new(relation_desc.clone()),
+            val: Arc::new(UnitSchema),
+        };
+
+        let result_ts = Timestamp::default();
+        let lower = Antichain::from_elem(result_ts);
+        let upper = Antichain::from_elem(result_ts.step_forward());
+
+        // We have to use SourceData, which is a wrapper around a Result<Row,
+        // DataflowError>, because the bare columnar Row encoder doesn't support
+        // encoding rows with zero columns.
+        //
+        // TODO: We _could_ work around the above by teaching the bare columnar
+        // Row encoder about zero-column rows.
+        let mut batch_builder = client
+            .batch_builder::<SourceData, (), Timestamp, i64>(
+                shard_id,
+                write_schemas,
+                lower,
+                Some(batch_max_runs),
+            )
+            .await;
+
+        let mut num_rows: u64 = 0;
+
+        loop {
+            let row = rows_rx.recv().await;
+            match row {
+                Some(Ok(rows)) => {
+                    for (row, diff) in rows {
+                        num_rows +=
+                            u64::from(NonZeroU64::try_from(diff).expect("diff fits into u64"));
+                        let diff: i64 = diff.into();
+
+                        batch_builder
+                            .add(&SourceData(Ok(row)), &(), &Timestamp::default(), &diff)
+                            .await
+                            .expect("invalid usage");
+                    }
+                }
+                Some(Err(err)) => return Ok(PeekResponse::Error(err)),
+                None => {
+                    break;
+                }
+            }
+        }
+
+        let batch = batch_builder.finish(upper).await.expect("invalid usage");
+
+        let stashed_response = StashedPeekResponse {
+            num_rows_batches: u64::cast_from(num_rows),
+            encoded_size_bytes: batch.encoded_size_bytes(),
+            relation_desc,
+            shard_id,
+            batches: vec![batch.into_transmittable_batch()],
+            inline_rows: RowCollection::new(vec![], &[]),
+        };
+        let result = PeekResponse::Stashed(Box::new(stashed_response));
+        Ok(result)
+    }
+
+    /// Pumps rows from the [PeekResultIterator] to the async task, via our
+    /// `rows_tx`. Will pump at most `batch_size` rows in one batch, and at most
+    /// the given `num_batches` batches.
+    pub fn pump_rows(&mut self, mut num_batches: usize, batch_size: usize) {
+        while let Some(row_iter) = self.peek_iterator.as_mut() {
+            // Try to reserve space in the channel before pulling rows from the
+            // iterator.
+            let permit = match self
+                .rows_tx
+                .as_mut()
+                .expect("missing rows_tx")
+                .try_reserve()
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    // Channel is full, can't send more rows right now.
+                    break;
+                }
+            };
+
+            let rows: Result<Vec<_>, _> = row_iter.take(batch_size).collect();
+            match rows {
+                Ok(rows) if rows.is_empty() => {
+                    // Iterator is exhausted, we're done
+                    drop(permit);
+                    self.peek_iterator.take();
+                    self.rows_tx.take();
+                    break;
+                }
+                Ok(rows) => {
+                    permit.send(Ok(rows));
+                }
+                Err(e) => {
+                    permit.send(Err(e));
+                }
+            }
+
+            num_batches -= 1;
+            if num_batches == 0 {
+                break;
+            }
+        }
+    }
+}

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -670,7 +670,7 @@ where
 
         let storage_controller = mz_storage_controller::Controller::new(
             config.build_info,
-            config.persist_location,
+            config.persist_location.clone(),
             config.persist_clients,
             config.now.clone(),
             wallclock_lag_fn.clone(),
@@ -692,6 +692,7 @@ where
             envd_epoch,
             read_only,
             &config.metrics_registry,
+            config.persist_location,
             controller_metrics,
             config.now.clone(),
             wallclock_lag_fn,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -46,8 +46,8 @@ pub use relation::{
     AccessStrategy, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
     JoinInputCharacteristics, LetRecLimit, MirRelationExpr, ProtoAggregateExpr, ProtoAggregateFunc,
     ProtoColumnOrder, ProtoRowSetFinishing, ProtoTableFunc, RECURSION_LIMIT, RowSetFinishing,
-    WindowFrame, WindowFrameBound, WindowFrameUnits, canonicalize, compare_columns,
-    non_nullable_columns,
+    RowSetFinishingIncremental, WindowFrame, WindowFrameBound, WindowFrameUnits, canonicalize,
+    compare_columns, non_nullable_columns,
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3687,6 +3687,15 @@ impl<L> RowSetFinishing<L> {
             && self.offset == 0
             && self.project.iter().copied().eq(0..arity)
     }
+    /// True if the finishing does not require an ORDER BY.
+    ///
+    /// LIMIT and OFFSET without an ORDER BY _are_ streamable: without an
+    /// explicit ordering we will skip an arbitrary bag of elements and return
+    /// the first arbitrary elements in the remaining bag. The result semantics
+    /// are still correct but maybe surprising for some users.
+    pub fn is_streamable(&self, arity: usize) -> bool {
+        self.order_by.is_empty() && self.project.iter().copied().eq(0..arity)
+    }
 }
 
 impl RowSetFinishing {
@@ -3757,6 +3766,124 @@ impl RowSetFinishing {
         }
 
         Ok((iter, response_size))
+    }
+}
+
+/// A [RowSetFinishing] that can be repeatedly applied to batches of updates (in
+/// a [RowCollection]) and keeps track of the remaining limit, offset, and cap
+/// on query result size.
+#[derive(Debug)]
+pub struct RowSetFinishingIncremental {
+    /// Include only as many rows (after offset).
+    pub remaining_limit: Option<usize>,
+    /// Omit as many rows.
+    pub remaining_offset: usize,
+    /// The maximum allowed result size, as requested by the client.
+    pub max_returned_query_size: Option<u64>,
+    /// Tracks our remaining allowed budget for result size.
+    pub remaining_max_returned_query_size: Option<u64>,
+    /// Include only given columns.
+    pub project: Vec<usize>,
+}
+
+impl RowSetFinishingIncremental {
+    /// Turns the given [RowSetFinishing] into a [RowSetFinishingIncremental].
+    /// Can only be used when [is_streamable](RowSetFinishing::is_streamable) is
+    /// `true`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the result is not streamable, that is it has an ORDER BY.
+    pub fn new(
+        offset: usize,
+        limit: Option<NonNeg<i64>>,
+        project: Vec<usize>,
+        max_returned_query_size: Option<u64>,
+    ) -> Self {
+        let limit = limit.map(|l| {
+            let l = u64::from(l);
+            let l = usize::cast_from(l);
+            l
+        });
+
+        RowSetFinishingIncremental {
+            remaining_limit: limit,
+            remaining_offset: offset,
+            max_returned_query_size,
+            remaining_max_returned_query_size: max_returned_query_size,
+            project,
+        }
+    }
+
+    /// Applies finishing actions to the given [`RowCollection`], and reports
+    /// the total time it took to run.
+    ///
+    /// Returns a [`SortedRowCollectionIter`] that contains all of the response
+    /// data.
+    pub fn finish_incremental(
+        &mut self,
+        rows: RowCollection,
+        max_result_size: u64,
+        duration_histogram: &Histogram,
+    ) -> Result<SortedRowCollectionIter, String> {
+        let now = Instant::now();
+        let result = self.finish_incremental_inner(rows, max_result_size);
+        let duration = now.elapsed();
+        duration_histogram.observe(duration.as_secs_f64());
+
+        result
+    }
+
+    fn finish_incremental_inner(
+        &mut self,
+        rows: RowCollection,
+        max_result_size: u64,
+    ) -> Result<SortedRowCollectionIter, String> {
+        // How much additional memory is required to make a sorted view.
+        let sorted_view_mem = rows.entries().saturating_mul(std::mem::size_of::<usize>());
+        let required_memory = rows.byte_len().saturating_add(sorted_view_mem);
+
+        // Bail if creating the sorted view would require us to use too much memory.
+        if required_memory > usize::cast_from(max_result_size) {
+            let max_bytes = ByteSize::b(max_result_size);
+            return Err(format!("total result exceeds max size of {max_bytes}",));
+        }
+
+        let batch_num_rows = rows.count(0, None);
+
+        let sorted_view = rows.sorted_view(&[]);
+        let mut iter = sorted_view
+            .into_row_iter()
+            .apply_offset(self.remaining_offset)
+            .with_projection(self.project.clone());
+
+        if let Some(limit) = self.remaining_limit {
+            iter = iter.with_limit(limit);
+        };
+
+        self.remaining_offset = self.remaining_offset.saturating_sub(batch_num_rows);
+        if let Some(remaining_limit) = self.remaining_limit.as_mut() {
+            *remaining_limit -= iter.count();
+        }
+
+        // TODO(parkmycar): Re-think how we can calculate the total response size without
+        // having to iterate through the entire collection of Rows, while still
+        // respecting the LIMIT, OFFSET, and projections.
+        //
+        // Note: It feels a bit bad always calculating the response size, but we almost
+        // always need it to either check the `max_returned_query_size`, or for reporting
+        // in the query history.
+        let response_size: usize = iter.clone().map(|row| row.data().len()).sum();
+
+        // Bail if we would end up returning more data to the client than they can support.
+        if let Some(max) = self.remaining_max_returned_query_size {
+            if response_size > usize::cast_from(max) {
+                let max_bytes = ByteSize::b(self.max_returned_query_size.expect("known to exist"));
+                return Err(format!("total result exceeds max size of {max_bytes}"));
+            }
+        }
+
+        Ok(iter)
     }
 }
 

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -272,6 +272,11 @@ where
         }
         self.batch.parts = parts;
     }
+
+    /// The sum of the encoded sizes of all parts in the batch.
+    pub fn encoded_size_bytes(&self) -> usize {
+        self.batch.encoded_size_bytes()
+    }
 }
 
 impl<K, V, T, D> Batch<K, V, T, D>

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1000,6 +1000,7 @@ where
             &batches,
             lease,
             should_fetch_part,
+            COMPACTION_MEMORY_BOUND_BYTES.get(&self.cfg),
         )
     }
 
@@ -1015,6 +1016,7 @@ where
         batches: &[HollowBatch<T>],
         lease: L,
         should_fetch_part: impl for<'a> Fn(Option<&'a LazyPartStats>) -> bool,
+        memory_budget_bytes: usize,
     ) -> Result<Cursor<K, V, T, D, L>, Since<T>> {
         let context = format!("{}[as_of={:?}]", shard_id, as_of.elements());
         let filter = FetchBatchFilter::Snapshot {
@@ -1030,7 +1032,7 @@ where
             shard_metrics,
             read_metrics,
             filter,
-            COMPACTION_MEMORY_BOUND_BYTES.get(persist_cfg),
+            memory_budget_bytes,
         );
         for batch in batches {
             for (meta, run) in batch.runs() {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2815,7 +2815,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count >= 2, f"got {count}"
 
     # mz_compute_peeks_total
-    count = metrics.get_peeks_total("rows")
+    count = metrics.get_peeks_total("rows") + metrics.get_peeks_total("rows_stashed")
     assert count == 2, f"got {count}"
     count = metrics.get_peeks_total("error")
     assert count == 0, f"got {count}"

--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -37,6 +37,10 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="1s"
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_rbac_checks = false
 
+# No peek result stash for large results, so that result sizes match the expectations below.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_peek_response_stash = false
+
 # Now the real test begins
 
 # This will be executed on `mz_catalog_server`, due to auto-routing of "simple" queries.

--- a/test/sqllogictest/max_result_size.slt
+++ b/test/sqllogictest/max_result_size.slt
@@ -19,6 +19,11 @@ ALTER SYSTEM SET max_result_size TO '1MB';
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_peek_response_stash TO 'false';
+----
+COMPLETE 0
+
 statement ok
 CREATE CLUSTER c1 SIZE 'mem-2';
 

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -225,11 +225,22 @@ COMPLETE 0
 statement ok
 SELECT * FROM large_rows LIMIT 1;
 
+# Need to disable the result stash, so that we actually exceed max result size
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_peek_response_stash = false
+----
+COMPLETE 0
+
 query error db error: ERROR: result exceeds max size of 1048.6 KB
 SELECT * FROM large_rows LIMIT 99;
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET max_result_size
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_peek_response_stash
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -177,6 +177,12 @@ db error: ERROR: INSERT INTO t1 VALUES ((SELECT 1 ORDER BY (SELECT x FROM t1 LIM
 statement ok
 ROLLBACK
 
+# Need to disable the result stash, so that we actually exceed max result size
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_peek_response_stash = false
+----
+COMPLETE 0
+
 # Verify that max_query_result_size doesn't affect read part of RTW queries.
 # See database-issues#8099
 statement ok
@@ -206,6 +212,12 @@ COMPLETE 0
 
 statement error db error: ERROR: result exceeds max size of 1048.6 KB
 INSERT INTO t SELECT * FROM t_big
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_peek_response_stash
+----
+COMPLETE 0
+
 
 # Test unmat fns in the SET clause.
 statement ok

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -422,6 +422,12 @@ public
 query error db error: ERROR: SHOW variable in subqueries not yet supported
 SELECT * FROM (show client_encoding)
 
+# Need to disable the result stash, so that we actually exceed max result size
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_peek_response_stash = false
+----
+COMPLETE 0
+
 statement ok
 SET max_query_result_size = 100
 
@@ -449,6 +455,11 @@ select 1 from (select array_agg(generate_series) x from generate_series(1, 10000
 
 statement ok
 RESET max_query_result_size
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_peek_response_stash
+----
+COMPLETE 0
 
 statement ok
 CREATE ROLE parker;


### PR DESCRIPTION
Currently, results of SELECT queries (aka. peeks) are sent back from the
cluster to environmentd via the compute protocol and these results are
fully materialized (stored in memory) in environmentd before sending
them out to the client.

This has several implications:

- Sending large results "clogs up" the cluster/controller communication
- The amount of memory we want to give to environmentd limits the size
  of results we can return

In practice the above make it so we limit the size of results using a
`max_result_size` parameter, and some larger customers are chafing
against that.

Specifically, peek responses are sent inline, in the response stream
from `clusterd` to `environmentd`/Controller. As a
`ComputeResponse::PeekResponse`.

With this change, we can "stash" large peek responses and only send a
handle to them back via the response stream. Large peek responses are
stored using the new persist API for "free-standing" batches (batches
that are never intended for appending to a shard) and read out using the
also new `read_batches_consolidated`.

One current limitation is that we can only stash results when the SELECT
does _NOT_ have an ORDER BY. This is left as a follow up.

We introduces a bunch of dyncfgs for controlling when and how the result
stash is used:

- Enable/disable: for staged rollout.
- Peek stash threshold: above what result size we use the stash. This is
  deliberately separate from the existing `max_result_size`
  configuration and in practice I think we want a low-ish stash
  threshold and keep the current `max_result_size`.
- Batching while writing: we don't want to block the timely worker
  thread by writing out the whole result in one go. Instead we have
  configurable batching and batch size.
- Batching while reading: we read consolidated "chunks" out of the
  batches, when serving the result to the client. Here we also make the
  batch size configurable.

Implements https://github.com/MaterializeInc/database-issues/issues/9180