### PR TITLE
add support for pod affinity and tolerations

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -107,13 +107,21 @@ The following table lists the configurable parameters of the Materialize operato
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `balancerd.affinity` | Affinity to use for balancerd pods spawned by the operator | ``nil`` |
 | `balancerd.enabled` | Flag to indicate whether to create balancerd pods for the environments | ``true`` |
-| `balancerd.nodeSelector` | Node selector to use for balancerd pods spawned by the operator | ``{}`` |
-| `clusterd.nodeSelector` | Node selector to use for clusterd pods spawned by the operator | ``{}`` |
+| `balancerd.nodeSelector` | Node selector to use for balancerd pods spawned by the operator | ``nil`` |
+| `balancerd.tolerations` | Tolerations to use for balancerd pods spawned by the operator | ``nil`` |
+| `clusterd.affinity` | Affinity to use for clusterd pods spawned by the operator | ``nil`` |
+| `clusterd.nodeSelector` | Node selector to use for clusterd pods spawned by the operator | ``nil`` |
+| `clusterd.tolerations` | Tolerations to use for clusterd pods spawned by the operator | ``nil`` |
+| `console.affinity` | Affinity to use for console pods spawned by the operator | ``nil`` |
 | `console.enabled` | Flag to indicate whether to create console pods for the environments | ``true`` |
 | `console.imageTagMapOverride` | Override the mapping of environmentd versions to console versions | ``{}`` |
-| `console.nodeSelector` | Node selector to use for console pods spawned by the operator | ``{}`` |
-| `environmentd.nodeSelector` | Node selector to use for environmentd pods spawned by the operator | ``{}`` |
+| `console.nodeSelector` | Node selector to use for console pods spawned by the operator | ``nil`` |
+| `console.tolerations` | Tolerations to use for console pods spawned by the operator | ``nil`` |
+| `environmentd.affinity` | Affinity to use for environmentd pods spawned by the operator | ``nil`` |
+| `environmentd.nodeSelector` | Node selector to use for environmentd pods spawned by the operator | ``nil`` |
+| `environmentd.tolerations` | Tolerations to use for environmentd pods spawned by the operator | ``nil`` |
 | `networkPolicies.egress` | egress from Materialize pods to sources and sinks | ``{"cidrs":["0.0.0.0/0"],"enabled":false}`` |
 | `networkPolicies.enabled` | Whether to enable network policies for securing communication between pods | ``false`` |
 | `networkPolicies.ingress` | Whether to enable ingress to the SQL and HTTP interfaces on environmentd or balancerd | ``{"cidrs":["0.0.0.0/0"],"enabled":false}`` |
@@ -121,6 +129,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `observability.enabled` | Whether to enable observability features | ``true`` |
 | `observability.podMetrics.enabled` | Whether to enable the pod metrics scraper which populates the Environment Overview Monitoring tab in the web console (requires metrics-server to be installed) | ``false`` |
 | `observability.prometheus.scrapeAnnotations.enabled` | Whether to annotate pods with common keys used for prometheus scraping. | ``true`` |
+| `operator.affinity` | Affinity to use for the operator pod | ``nil`` |
 | `operator.args.enableInternalStatementLogging` |  | ``true`` |
 | `operator.args.startupLogFilter` | Log filtering settings for startup logs | ``"INFO,mz_orchestratord=TRACE"`` |
 | `operator.cloudProvider.providers.aws.accountID` | When using AWS, accountID is required | ``""`` |
@@ -144,10 +153,11 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
 | `operator.image.tag` | The tag/version of the operator image to be used | ``"v0.143.0"`` |
-| `operator.nodeSelector` |  | ``{}`` |
+| `operator.nodeSelector` | Node selector to use for the operator pod | ``nil`` |
 | `operator.resources.limits` | Resource limits for the operator's CPU and memory | ``{"memory":"512Mi"}`` |
 | `operator.resources.requests` | Resources requested by the operator for CPU and memory | ``{"cpu":"100m","memory":"512Mi"}`` |
 | `operator.secretsController` | Which secrets controller to use for storing secrets. Valid values are 'kubernetes' and 'aws-secrets-manager'. Setting 'aws-secrets-manager' requires a configured AWS cloud provider and IAM role for the environment with Secrets Manager permissions. | ``"kubernetes"`` |
+| `operator.tolerations` | Tolerations to use for the operator pod | ``nil`` |
 | `rbac.create` | Whether to create necessary RBAC roles and bindings | ``true`` |
 | `schedulerName` | Optionally use a non-default kubernetes scheduler. | ``nil`` |
 | `serviceAccount.create` | Whether to create a new service account for the operator | ``true`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -30,6 +30,14 @@ spec:
       nodeSelector:
         {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.operator.affinity }}
+      affinity:
+        {{- toYaml .Values.operator.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml .Values.operator.tolerations | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
@@ -118,17 +126,57 @@ spec:
         {{- end }}
         {{- end }}
         - "--image-pull-policy={{ kebabcase .Values.operator.image.pullPolicy }}"
+        {{- if .Values.environmentd.nodeSelector }}
         {{- range $key, $value := .Values.environmentd.nodeSelector }}
         - "--environmentd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
+        {{- end }}
+        {{- if .Values.environmentd.affinity }}
+        - '--environmentd-affinity={{ toJson .Values.environmentd.affinity }}'
+        {{- end }}
+        {{- if .Values.environmentd.tolerations }}
+        {{- range $toleration := .Values.environmentd.tolerations }}
+        - '--environmentd-toleration={{ toJson $toleration }}'
+        {{- end }}
+        {{- end }}
+        {{- if .Values.clusterd.nodeSelector }}
         {{- range $key, $value := .Values.clusterd.nodeSelector }}
         - "--clusterd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
+        {{- end }}
+        {{- if .Values.clusterd.affinity }}
+        - '--clusterd-affinity={{ toJson .Values.clusterd.affinity }}'
+        {{- end }}
+        {{- if .Values.clusterd.tolerations }}
+        {{- range $toleration := .Values.clusterd.tolerations }}
+        - '--clusterd-toleration={{ toJson $toleration }}'
+        {{- end }}
+        {{- end }}
+        {{- if .Values.balancerd.nodeSelector }}
         {{- range $key, $value := .Values.balancerd.nodeSelector }}
         - "--balancerd-node-selector={{ $key }}={{ $value }}"
         {{- end }}
+        {{- end }}
+        {{- if .Values.balancerd.affinity }}
+        - '--balancerd-affinity={{ toJson .Values.balancerd.affinity }}'
+        {{- end }}
+        {{- if .Values.balancerd.tolerations }}
+        {{- range $toleration := .Values.balancerd.tolerations }}
+        - '--balancerd-toleration={{ toJson $toleration }}'
+        {{- end }}
+        {{- end }}
+        {{- if .Values.console.nodeSelector }}
         {{- range $key, $value := .Values.console.nodeSelector }}
         - "--console-node-selector={{ $key }}={{ $value }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.console.affinity }}
+        - '--console-affinity={{ toJson .Values.console.affinity }}'
+        {{- end }}
+        {{- if .Values.console.tolerations }}
+        {{- range $toleration := .Values.console.tolerations }}
+        - '--console-toleration={{ toJson $toleration }}'
+        {{- end }}
         {{- end }}
         {{- if .Values.storage.storageClass.name }}
         - "--ephemeral-volume-class={{ .Values.storage.storageClass.name }}"

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -175,8 +175,12 @@ operator:
       support: 0
       analytics: 0
 
-  # Node selector to use for the operator pod
-  nodeSelector: {}
+  # -- Node selector to use for the operator pod
+  nodeSelector:
+  # -- Affinity to use for the operator pod
+  affinity:
+  # -- Tolerations to use for the operator pod
+  tolerations:
   resources:
     # -- Resources requested by the operator for CPU and memory
     requests:
@@ -194,17 +198,29 @@ operator:
 
 environmentd:
   # -- Node selector to use for environmentd pods spawned by the operator
-  nodeSelector: {}
+  nodeSelector:
+  # -- Affinity to use for environmentd pods spawned by the operator
+  affinity:
+  # -- Tolerations to use for environmentd pods spawned by the operator
+  tolerations:
 
 clusterd:
   # -- Node selector to use for clusterd pods spawned by the operator
-  nodeSelector: {}
+  nodeSelector:
+  # -- Affinity to use for clusterd pods spawned by the operator
+  affinity:
+  # -- Tolerations to use for clusterd pods spawned by the operator
+  tolerations:
 
 balancerd:
   # -- Flag to indicate whether to create balancerd pods for the environments
   enabled: true
   # -- Node selector to use for balancerd pods spawned by the operator
-  nodeSelector: {}
+  nodeSelector:
+  # -- Affinity to use for balancerd pods spawned by the operator
+  affinity:
+  # -- Tolerations to use for balancerd pods spawned by the operator
+  tolerations:
 
 console:
   # -- Flag to indicate whether to create console pods for the environments
@@ -212,7 +228,11 @@ console:
   # -- Override the mapping of environmentd versions to console versions
   imageTagMapOverride: {}
   # -- Node selector to use for console pods spawned by the operator
-  nodeSelector: {}
+  nodeSelector:
+  # -- Affinity to use for console pods spawned by the operator
+  affinity:
+  # -- Tolerations to use for console pods spawned by the operator
+  tolerations:
 
 # RBAC (Role-Based Access Control) settings
 rbac:

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -233,6 +233,14 @@ pub struct Args {
     /// orchestrator in the form `KEY=VALUE`.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_NODE_SELECTOR")]
     orchestrator_kubernetes_service_node_selector: Vec<KeyValueArg<String, String>>,
+    /// Affinity to apply to all services created by the Kubernetes
+    /// orchestrator as a JSON string.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_AFFINITY")]
+    orchestrator_kubernetes_service_affinity: Option<String>,
+    /// Tolerations to apply to all services created by the Kubernetes
+    /// orchestrator as a JSON string.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_TOLERATIONS")]
+    orchestrator_kubernetes_service_tolerations: Option<String>,
     /// The name of a service account to apply to all services created by the
     /// Kubernetes orchestrator.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_ACCOUNT")]
@@ -842,6 +850,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                             .into_iter()
                             .map(|l| (l.key, l.value))
                             .collect(),
+                        service_affinity: args.orchestrator_kubernetes_service_affinity,
+                        service_tolerations: args.orchestrator_kubernetes_service_tolerations,
                         service_account: args.orchestrator_kubernetes_service_account,
                         image_pull_policy: args.orchestrator_kubernetes_image_pull_policy,
                         aws_external_id_prefix: args.aws_external_id_prefix.clone(),

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -15,7 +15,10 @@ use std::{
 };
 
 use http::HeaderValue;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
+use k8s_openapi::{
+    api::core::v1::{Affinity, Toleration},
+    apimachinery::pkg::apis::meta::v1::{Condition, Time},
+};
 use kube::{Api, Client, Resource, ResourceExt, api::PostParams, runtime::controller::Action};
 use serde::Deserialize;
 use tracing::{debug, trace};
@@ -83,12 +86,28 @@ pub struct MaterializeControllerArgs {
     orchestratord_pod_selector_labels: Vec<KeyValueArg<String, String>>,
     #[clap(long)]
     environmentd_node_selector: Vec<KeyValueArg<String, String>>,
+    #[clap(long, value_parser = parse_affinity)]
+    environmentd_affinity: Option<Affinity>,
+    #[clap(long = "environmentd-toleration", value_parser = parse_tolerations)]
+    environmentd_tolerations: Option<Vec<Toleration>>,
     #[clap(long)]
     clusterd_node_selector: Vec<KeyValueArg<String, String>>,
+    #[clap(long, value_parser = parse_affinity)]
+    clusterd_affinity: Option<Affinity>,
+    #[clap(long = "clusterd-toleration", value_parser = parse_tolerations)]
+    clusterd_tolerations: Option<Vec<Toleration>>,
     #[clap(long)]
     balancerd_node_selector: Vec<KeyValueArg<String, String>>,
+    #[clap(long, value_parser = parse_affinity)]
+    balancerd_affinity: Option<Affinity>,
+    #[clap(long = "balancerd-toleration", value_parser = parse_tolerations)]
+    balancerd_tolerations: Option<Vec<Toleration>>,
     #[clap(long)]
     console_node_selector: Vec<KeyValueArg<String, String>>,
+    #[clap(long, value_parser = parse_affinity)]
+    console_affinity: Option<Affinity>,
+    #[clap(long = "console-toleration", value_parser = parse_tolerations)]
+    console_tolerations: Option<Vec<Toleration>>,
     #[clap(long, default_value = "always", value_enum)]
     image_pull_policy: KubernetesImagePullPolicy,
     #[clap(flatten)]
@@ -153,6 +172,14 @@ pub struct MaterializeControllerArgs {
 
     #[clap(long, hide = true)]
     disable_license_key_checks: bool,
+}
+
+fn parse_affinity(s: &str) -> anyhow::Result<Affinity> {
+    Ok(serde_json::from_str(s)?)
+}
+
+fn parse_tolerations(s: &str) -> anyhow::Result<Toleration> {
+    Ok(serde_json::from_str(s)?)
 }
 
 #[derive(Clone, Deserialize, Default)]

--- a/src/orchestratord/src/controller/materialize/balancer.rs
+++ b/src/orchestratord/src/controller/materialize/balancer.rs
@@ -324,6 +324,8 @@ fn create_balancerd_deployment_object(
                         .map(|selector| (selector.key.clone(), selector.value.clone()))
                         .collect(),
                 ),
+                affinity: config.balancerd_affinity.clone(),
+                tolerations: config.balancerd_tolerations.clone(),
                 security_context: Some(PodSecurityContext {
                     fs_group: Some(999),
                     run_as_user: Some(999),

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -315,6 +315,8 @@ ssl_certificate_key /nginx/tls/tls.key;",
                         .map(|selector| (selector.key.clone(), selector.value.clone()))
                         .collect(),
                 ),
+                affinity: config.console_affinity.clone(),
+                tolerations: config.console_tolerations.clone(),
                 scheduler_name: config.scheduler_name.clone(),
                 service_account_name: Some(mz.service_account_name()),
                 volumes,


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9161

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
