### PR TITLE
[bazel] cross language LTO

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -170,6 +170,7 @@ build:release --compilation_mode=opt
 build:release-lto --copt=-flto=thin
 build:release-lto --linkopt=-flto=thin
 build:release-lto --@rules_rust//rust/settings:lto=thin
+build:release-lto --@//misc/bazel/platforms:xlang_lto=True
 
 # Builds from `main` or tagged builds.
 #

--- a/misc/bazel/cargo-gazelle/BUILD.bazel
+++ b/misc/bazel/cargo-gazelle/BUILD.bazel
@@ -90,7 +90,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = ["-Copt-level=3"],
+    rustc_flags = ["-Copt-level=3"] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [":cargo_gazelle"] + all_crate_deps(normal = True),
 )

--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 use guppy::graph::PackageMetadata;
 use std::sync::LazyLock;
 
+use crate::ToBazelDefinition;
 use crate::targets::{AdditiveContent, RustTestSize};
 
 const KEY_NAME: &str = "cargo-gazelle";
@@ -313,5 +314,23 @@ impl CommonConfig {
 
     pub fn rustc_env(&self) -> &BTreeMap<String, String> {
         &self.rustc_env
+    }
+}
+
+/// Values that are mirrored in `/misc/bazel/platforms/BUILD.bazel`.
+#[derive(Debug, Copy, Clone)]
+pub enum ConfigSettingGroup {
+    XlangLtoEnabled,
+}
+
+impl ToBazelDefinition for ConfigSettingGroup {
+    fn format(&self, w: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
+        match self {
+            ConfigSettingGroup::XlangLtoEnabled => {
+                write!(w, "@//misc/bazel/platforms:xlang_lto_enabled")?
+            }
+        }
+
+        Ok(())
     }
 }

--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -327,7 +327,7 @@ impl ToBazelDefinition for ConfigSettingGroup {
     fn format(&self, w: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
         match self {
             ConfigSettingGroup::XlangLtoEnabled => {
-                write!(w, "@//misc/bazel/platforms:xlang_lto_enabled")?
+                write!(w, "\"@//misc/bazel/platforms:xlang_lto_enabled\"")?
             }
         }
 

--- a/misc/bazel/cargo-gazelle/src/lib.rs
+++ b/misc/bazel/cargo-gazelle/src/lib.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt::{self, Debug, Write};
 use std::rc::Rc;
 
-use crate::platforms::PlatformVariant;
 use crate::targets::RustTarget;
 
 pub mod args;
@@ -510,20 +509,21 @@ impl ToBazelDefinition for Glob {
 /// ```
 #[derive(Debug)]
 pub struct Select<T> {
-    entries: BTreeMap<PlatformVariant, T>,
+    entries: BTreeMap<String, T>,
     default: T,
 }
 
 impl<T> Select<T> {
-    pub fn new<E, I>(entires: I, default: E) -> Select<T>
+    pub fn new<E, I, J>(entires: I, default: E) -> Select<T>
     where
         E: Into<T>,
-        I: IntoIterator<Item = (PlatformVariant, E)>,
+        J: ToBazelDefinition,
+        I: IntoIterator<Item = (J, E)>,
     {
         Select {
             entries: entires
                 .into_iter()
-                .map(|(variant, entry)| (variant, entry.into()))
+                .map(|(variant, entry)| (variant.to_bazel_definition(), entry.into()))
                 .collect(),
             default: default.into(),
         }
@@ -538,7 +538,7 @@ impl<T: ToBazelDefinition> ToBazelDefinition for Select<T> {
         {
             let mut w = w.indent();
             for (variant, entry) in &self.entries {
-                variant.format(&mut w)?;
+                write!(w, "{variant}")?;
                 write!(w, ": ")?;
                 entry.format(&mut w)?;
                 writeln!(w, ",")?;

--- a/misc/bazel/cargo-gazelle/src/targets.rs
+++ b/misc/bazel/cargo-gazelle/src/targets.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write};
 use std::str::FromStr;
 
-use crate::config::{CrateConfig, GlobalConfig};
+use crate::config::{ConfigSettingGroup, CrateConfig, GlobalConfig};
 use crate::context::CrateContext;
 use crate::platforms::PlatformVariant;
 use crate::rules::Rule;
@@ -382,8 +382,17 @@ impl RustBinary {
         let (paths, globs) = bin_config.common().compile_data();
         let compile_data = List::new(paths).concat_other(globs.map(Glob::new));
 
+        let xlang_lto_select: Select<List<QuotedString>> = Select::new(
+            [(
+                ConfigSettingGroup::XlangLtoEnabled,
+                vec![QuotedString::new("-Clinker-plugin-lto")],
+            )],
+            vec![],
+        );
+
         let env = Dict::new(bin_config.env());
-        let rustc_flags = List::new(bin_config.common().rustc_flags());
+        let rustc_flags =
+            List::new(bin_config.common().rustc_flags()).concat_other(xlang_lto_select);
         let rustc_env = Dict::new(bin_config.common().rustc_env());
 
         Ok(Some(RustBinary {

--- a/misc/bazel/platforms/BUILD.bazel
+++ b/misc/bazel/platforms/BUILD.bazel
@@ -16,7 +16,7 @@ support building Materialize for.
 """
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 # A flag that we can specify on the command line to configure whether or not we
 # build with a sanitizer.
@@ -43,6 +43,28 @@ config_setting(
 config_setting(
     name = "sanitizer_hwaddress",
     flag_values = {":sanitizer": "hwaddress"},
+)
+
+bool_flag(
+    name = "xlang_lto",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_xlang_lto",
+    flag_values = {":xlang_lto": "True"},
+)
+
+# With our current toolchain setup, cross language LTO is only supported when building for Linux.
+#
+# See <https://github.com/rust-lang/rust/issues/60059> for macOS support.
+selects.config_setting_group(
+    name = "xlang_lto_enabled",
+    match_all = [
+        "@platforms//os:linux",
+        ":use_xlang_lto",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 # We only want to use jemalloc if we're building for Linux and we're not using sanitizers.

--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -179,7 +179,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         ":mz_balancerd",

--- a/src/catalog-debug/BUILD.bazel
+++ b/src/catalog-debug/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         "//src/adapter:mz_adapter",

--- a/src/clusterd/BUILD.bazel
+++ b/src/clusterd/BUILD.bazel
@@ -156,7 +156,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         ":mz_clusterd",

--- a/src/environmentd/BUILD.bazel
+++ b/src/environmentd/BUILD.bazel
@@ -793,7 +793,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         ":mz_environmentd",

--- a/src/fivetran-destination/BUILD.bazel
+++ b/src/fivetran-destination/BUILD.bazel
@@ -116,7 +116,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         ":mz_fivetran_destination",

--- a/src/frontegg-mock/BUILD.bazel
+++ b/src/frontegg-mock/BUILD.bazel
@@ -132,7 +132,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         ":mz_frontegg_mock",

--- a/src/interchange/BUILD.bazel
+++ b/src/interchange/BUILD.bazel
@@ -126,7 +126,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         ":mz_interchange",

--- a/src/kafka-util/BUILD.bazel
+++ b/src/kafka-util/BUILD.bazel
@@ -105,7 +105,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         ":mz_kafka_util",

--- a/src/lsp-server/BUILD.bazel
+++ b/src/lsp-server/BUILD.bazel
@@ -144,7 +144,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.3.0",
     deps = [
         ":mz_lsp_server",

--- a/src/materialized/BUILD.bazel
+++ b/src/materialized/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         "//src/clusterd:mz_clusterd",

--- a/src/mz-debug/BUILD.bazel
+++ b/src/mz-debug/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.1.0",
     deps = [
         "//src/build-info:mz_build_info",

--- a/src/mz/BUILD.bazel
+++ b/src/mz/BUILD.bazel
@@ -139,7 +139,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.3.0",
     deps = [
         ":mz",

--- a/src/orchestratord/BUILD.bazel
+++ b/src/orchestratord/BUILD.bazel
@@ -123,7 +123,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         ":mz_orchestratord",

--- a/src/persist-cli/BUILD.bazel
+++ b/src/persist-cli/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         "//src/http-util:mz_http_util",

--- a/src/pgtest/BUILD.bazel
+++ b/src/pgtest/BUILD.bazel
@@ -90,7 +90,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         ":mz_pgtest",

--- a/src/s3-datagen/BUILD.bazel
+++ b/src/s3-datagen/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         "//src/aws-util:mz_aws_util",

--- a/src/sqllogictest/BUILD.bazel
+++ b/src/sqllogictest/BUILD.bazel
@@ -203,7 +203,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.1",
     deps = [
         ":mz_sqllogictest",

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -165,7 +165,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.144.0-dev.0",
     deps = [
         ":mz_testdrive",

--- a/test/metabase/smoketest/BUILD.bazel
+++ b/test/metabase/smoketest/BUILD.bazel
@@ -30,7 +30,10 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [],
+    rustc_flags = [] + select({
+        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
+        "//conditions:default": [],
+    }),
     version = "0.0.0",
     deps = [
         "//src/metabase:mz_metabase",


### PR DESCRIPTION
This PR enables cross language LTO for our release builds, meaning function calls from external C dependencies like `libdecimal` can potentially get inlined into Rust code.

The way this works is when building our final binaries, e.g. `environmentd` and `clusterd`, we specify the `-Clinker-plugin-lto` flag to `rustc` which has our linker (`lld`) run the LTO passes instead of `rustc`. At which point all of our Rust and C code has been compiled to LLVM bitcode so to `lld` is free to optimize across languages.

This only works when building for Linux. Arguments that `rustc` passes to the linker when targetting macOS don't seem to be supported by `ld64.lld`? See https://github.com/rust-lang/rust/issues/60059 for some more investigation.

### Motivation

Faster runtime performance. 

### Tips for reviewer

The commits are broken down as follows:

1. Some Bazel configuration so we can detect when the cross language LTO is requested _and_ when we're building on a Linux machine.
2. Updates to cargo-gazelle so we specify the right `rustc` flags. Theoretically something like this could be upstreamed into `rules_rust` which I started working on in https://github.com/bazelbuild/rules_rust/pull/3162. But for now updating cargo-gazelle is a lot easier.
3. Running `bin/bazel gen`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
