### PR TITLE
fix failing to parse timezones correctly

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1874,15 +1874,6 @@ pub enum CalendarEra {
     AD,
 }
 
-impl CalendarEra {
-    fn as_str(&self) -> &'static str {
-        match self {
-            CalendarEra::BC => "BC",
-            CalendarEra::AD => "AD",
-        }
-    }
-}
-
 /// Takes a 'date timezone' 'date time timezone' string and splits it into 'date
 /// {time}' and 'timezone' components then checks for a 'CalenderEra' defaulting
 /// to 'AD'.
@@ -1938,14 +1929,33 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
     }
 }
 
+/// We support three era formats:
+///  1. "<timestamp><separator><timezone> <era>"
+///  2. "<timestamp> <era>"
+///  3. "<timestamp><era>"
+///
+/// NB(ptravers): pg supports more formats than noted above.
 fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
     use CalendarEra::{AD, BC};
     let timezone = timezone.trim();
     let timezone_upper = timezone.to_uppercase();
 
+    if timezone.len() < 3 {
+        return match (
+            timezone_upper.strip_suffix("BC"),
+            timezone_upper.strip_suffix("AD"),
+        ) {
+            (Some(_), None) => ("", BC),
+            (None, Some(_)) => ("", AD),
+            // NB(ptravers): we expect this to fail when we go to check
+            // the timezone is valid in the next step.
+            _ => (timezone, AD),
+        };
+    }
+
     match (
-        timezone_upper.strip_suffix(BC.as_str()),
-        timezone_upper.strip_suffix(AD.as_str()),
+        timezone_upper.strip_suffix(" BC"),
+        timezone_upper.strip_suffix(" AD"),
     ) {
         (Some(remainder), None) => (&timezone[..remainder.len()], BC),
         (None, Some(remainder)) => (&timezone[..remainder.len()], AD),

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1955,12 +1955,15 @@ fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
     }
 
     // Covers case 3.
+    //
+    // Safety: upper case and lower case chars for a, b, c, d, and \s
+    // are all 1 byte so suffix is always of length 3 bytes.
     match (
         timezone_upper.strip_suffix(" BC"),
         timezone_upper.strip_suffix(" AD"),
     ) {
-        (Some(remainder), None) => (&timezone[..remainder.len()], BC),
-        (None, Some(remainder)) => (&timezone[..remainder.len()], AD),
+        (Some(_), None) => (&timezone[..timezone.len() - 3], BC),
+        (None, Some(_)) => (&timezone[..timezone.len() - 3], AD),
         _ => (timezone, AD),
     }
 }

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1929,12 +1929,12 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str, CalendarEra) {
     }
 }
 
-/// We support three era formats:
-///  1. "<timestamp><separator><timezone> <era>"
-///  2. "<timestamp> <era>"
-///  3. "<timestamp><era>"
-///
-/// NB(ptravers): pg supports more formats than noted above.
+// We support three era formats:
+//  1. "<timestamp><separator><timezone> <era>"
+//  2. "<timestamp> <era>"
+//  3. "<timestamp><era>"
+//
+// NB(ptravers): pg supports more formats than noted above.
 fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
     use CalendarEra::{AD, BC};
     let timezone = timezone.trim();

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1940,6 +1940,7 @@ fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
     let timezone = timezone.trim();
     let timezone_upper = timezone.to_uppercase();
 
+    // Covers cases 1 and 2.
     if timezone.len() < 3 {
         return match (
             timezone_upper.strip_suffix("BC"),
@@ -1953,6 +1954,7 @@ fn strip_era_from_timezone(timezone: &str) -> (&str, CalendarEra) {
         };
     }
 
+    // Covers case 3.
     match (
         timezone_upper.strip_suffix(" BC"),
         timezone_upper.strip_suffix(" AD"),

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -494,3 +494,10 @@ query T
 SELECT '0001-12-31 19:03:58AD '::timestamp;
 ----
 0001-12-31 19:03:58
+
+# Regression test for #9236 which mis-parsed timezones ending with 'AD' or 'BC'
+query T
+SELECT '2020-12-21 18:53:49 Asia/Baghdad'::timestamp
+----
+2020-12-21 15:53:49+00
+

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -495,8 +495,12 @@ SELECT '0001-12-31 19:03:58AD '::timestamp;
 ----
 0001-12-31 19:03:58
 
-# Regression test for #9236 which mis-parsed timezones ending with 'AD' or 'BC'
+# Regression test for #9236 which mis-parsed timezones ending with 'AD' or 'BC'.
 query T
-SELECT '2020-12-21 18:53:49 Asia/Baghdad'::timestamp
+SELECT '2020-12-21 18:53:49 Asia/Baghdad'::timestamp;
 ----
 2020-12-21 18:53:49
+
+# Regression test covering case where a characters lower is 1 byte and upper is 2 bytes.
+query error ERROR: invalid input syntax for type timestamp: Invalid character at offset 19 in 2025-01-01 00:00:00ı: 'ı': "2025-01-01 00:00:00ı AD"
+SELECT '2025-01-01 00:00:00ı AD'::timestamp;

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -502,5 +502,6 @@ SELECT '2020-12-21 18:53:49 Asia/Baghdad'::timestamp;
 2020-12-21 18:53:49
 
 # Regression test covering case where a characters lower is 1 byte and upper is 2 bytes.
+# Incorrect failing case is a panic due to splitting a string in the middle of a char.
 query error ERROR: invalid input syntax for type timestamp: Invalid character at offset 19 in 2025-01-01 00:00:00ı: 'ı': "2025-01-01 00:00:00ı AD"
 SELECT '2025-01-01 00:00:00ı AD'::timestamp;

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -499,5 +499,4 @@ SELECT '0001-12-31 19:03:58AD '::timestamp;
 query T
 SELECT '2020-12-21 18:53:49 Asia/Baghdad'::timestamp
 ----
-2020-12-21 15:53:49+00
-
+2020-12-21 18:53:49


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9236

see pg docs for full spec: https://www.postgresql.org/docs/12/datetime-input-rules.html

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
