### PR TITLE
docs: fix rendering issue

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -169,9 +169,8 @@ cause a rollback — no size change will take effect in that case.
 The `REPLICATION FACTOR` option determines the number of replicas provisioned
 for the cluster. Each replica of the cluster provisions a new pool of compute
 resources to perform exactly the same computations on exactly the same data.
-Each replica incurs cost, calculated as `cluster
-[size](#resizing) * replication factor` per second. See [Usage &
-billing](/administration/billing/) for more details.
+Each replica incurs cost, calculated as `cluster size * replication factor` per
+second. See [Usage & billing](/administration/billing/) for more details.
 
 #### Replication factor and fault tolerance
 
@@ -182,9 +181,9 @@ available, the cluster can continue to maintain dataflows and serve queries.
 
 {{< note >}}
 
-- Each replica incurs cost, calculated as `cluster [size](#resizing)
-  * replication factor` per second. See [Usage & billing](/administration/billing/)
-  for more details.
+- Each replica incurs cost, calculated as `cluster size *
+  replication factor` per second. See [Usage &
+  billing](/administration/billing/) for more details.
 
 - Increasing the replication factor does **not** increase the cluster's work
   capacity. Replicas are exact copies of one another: each replica must do


### PR DESCRIPTION
Fix cost calculation rendering issue where it currently renders as shown in image below:
<img width="509" alt="Screenshot 2025-04-28 at 3 19 24 PM" src="https://github.com/user-attachments/assets/bce7ac80-764e-4550-84d2-ba62d2e4e500" />
instead of `cluster size * replication factor`