### PR TITLE
remove rc wrapper from SharedRow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "compact_bytes"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b08f6a0d5ec37167557a0434307dcfbd7e6808b860492a5a626568a5522550e"
+checksum = "4b8688f4a138f72f4dc214e7cafcd80c629363415c26db3040842acd26cb37eb"
 dependencies = [
  "serde",
  "static_assertions",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4.39", default-features = false, features = [
 clap = { version = "4.5.23", features = ["env", "string"], optional = true }
 columnation = { version = "0.1.0", optional = true }
 columnar = { version = "0.4.1", optional = true }
-compact_bytes = { version = "0.1.3", optional = true }
+compact_bytes = { version = "0.1.4", optional = true }
 ctor = { version = "0.4.2", optional = true }
 differential-dataflow = { version = "0.14.2", optional = true }
 derivative = { version = "2.2.0", optional = true }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1.0.0"
 columnar = "0.4.1"
 columnation = "0.1.0"
 chrono = { version = "0.4.39", default-features = false, features = ["serde", "std"] }
-compact_bytes = "0.1.3"
+compact_bytes = "0.1.4"
 dec = "0.4.8"
 differential-dataflow = "0.14.2"
 enum-kinds = "0.5.1"


### PR DESCRIPTION
I wasn't totally sure if the goal was to have the memory allocation be defined by the code initializing SharedRow and thereby the safety of this be up to the consumer or if we still wanted to use thread_local but with a const initialization which appears to be possible.

```rust
thread_local! {
  static SHARED_ROW: RefCell<Row> = const { RefCell::new(Row::empty()) }
}
```

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9232

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
