### PR TITLE
repr: store thread-local shared row inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "compact_bytes"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b08f6a0d5ec37167557a0434307dcfbd7e6808b860492a5a626568a5522550e"
+checksum = "4b8688f4a138f72f4dc214e7cafcd80c629363415c26db3040842acd26cb37eb"
 dependencies = [
  "serde",
  "static_assertions",

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -555,10 +555,7 @@ impl ColReader {
                 // First read a binary value into a temp row, and later parse that as UUID into our
                 // actual Row Packer.
                 let mut temp_row = SharedRow::get();
-                temp_row
-                    .pack_with(|temp_packer| reader.read(idx, temp_packer))
-                    .context("uuid")?;
-                let temp_row = temp_row.borrow();
+                reader.read(idx, &mut temp_row.packer()).context("uuid")?;
                 let slice = match temp_row.unpack_first() {
                     Datum::Bytes(slice) => slice,
                     Datum::Null => {
@@ -587,10 +584,7 @@ impl ColReader {
                 // First read a string value into a temp row, and later parse that as JSON into our
                 // actual Row Packer.
                 let mut temp_row = SharedRow::get();
-                temp_row
-                    .pack_with(|temp_packer| reader.read(idx, temp_packer))
-                    .context("jsonb")?;
-                let temp_row = temp_row.borrow();
+                reader.read(idx, &mut temp_row.packer()).context("jsonb")?;
                 let value = match temp_row.unpack_first() {
                     Datum::String(value) => value,
                     Datum::Null => {

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -308,7 +308,7 @@ impl WorkerMetrics {
     pub fn record_shared_row_metrics(&self) {
         let binding = SharedRow::get();
         self.shared_row_heap_capacity_bytes
-            .set(u64::cast_from(binding.borrow().byte_capacity()));
+            .set(u64::cast_from(binding.byte_capacity()));
     }
 
     /// Increase the count of maintained collections.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1773,8 +1773,7 @@ impl Pairer {
     /// Splits a datum iterator into a pair of `Row` instances.
     fn split<'a>(&self, datum_iter: impl IntoIterator<Item = Datum<'a>>) -> (Row, Row) {
         let mut datum_iter = datum_iter.into_iter();
-        let binding = SharedRow::get();
-        let mut row_builder = binding.borrow_mut();
+        let mut row_builder = SharedRow::get();
         let first = row_builder.pack_using(datum_iter.by_ref().take(self.split_arity));
         let second = row_builder.pack_using(datum_iter);
         (first, second)

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -791,8 +791,7 @@ where
         let until = std::rc::Rc::new(until);
 
         let (stream, errors) = self.flat_map(key_val, max_demand, move |row_datums, time, diff| {
-            let binding = SharedRow::get();
-            let mut row_builder = binding.borrow_mut();
+            let mut row_builder = SharedRow::get();
             let until = std::rc::Rc::clone(&until);
             let temp_storage = RowArena::new();
             let row_iter = row_datums.iter();

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -136,8 +136,7 @@ fn drain_through_mfp<T>(
     <T as Columnar>::Container: Clone + Send,
 {
     let temp_storage = RowArena::new();
-    let binding = SharedRow::get();
-    let mut row_builder = binding.borrow_mut();
+    let mut row_builder = SharedRow::get();
 
     // This is not cheap, and is meant to be amortized across many `extensions`.
     let mut datums_local = datum_vec.borrow_with(input_row);

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -276,8 +276,7 @@ where
                                 // Reuseable allocation for unpacking.
                                 let mut datums = DatumVec::new();
                                 move |row| {
-                                    let binding = SharedRow::get();
-                                    let mut row_builder = binding.borrow_mut();
+                                    let mut row_builder = SharedRow::get();
                                     let temp_storage = RowArena::new();
                                     let mut datums_local = datums.borrow_with(&row);
                                     // TODO(mcsherry): re-use `row` allocation.
@@ -353,8 +352,7 @@ where
         move |(row, time)| {
             let temp_storage = RowArena::new();
             let datums_local = datums.borrow_with(&row);
-            let binding = SharedRow::get();
-            let mut row_builder = binding.borrow_mut();
+            let mut row_builder = SharedRow::get();
             row_builder.packer().try_extend(
                 prev_key
                     .iter()
@@ -388,8 +386,7 @@ where
                 // shutting down.
                 shutdown_token.probe()?;
 
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
+                let mut row_builder = SharedRow::get();
                 let temp_storage = RowArena::new();
 
                 let mut datums_local = datums.borrow();
@@ -435,8 +432,7 @@ where
                 // shutting down.
                 shutdown_token.probe()?;
 
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
+                let mut row_builder = SharedRow::get();
                 let temp_storage = RowArena::new();
 
                 let mut datums_local = datums.borrow();
@@ -490,8 +486,7 @@ where
                 let mut datums = DatumVec::new();
                 Box::new(move |input, ok_output, err_output| {
                     input.for_each(|time, data| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
+                        let mut row_builder = SharedRow::get();
                         let mut ok_session = ok_output.session(&time);
                         let mut err_session = err_output.session(&time);
 

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -267,8 +267,7 @@ where
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         move |row| {
-                            let binding = SharedRow::get();
-                            let mut row_builder = binding.borrow_mut();
+                            let mut row_builder = SharedRow::get();
                             let temp_storage = RowArena::new();
                             let mut datums_local = datums.borrow_with(&row);
                             // TODO(mcsherry): re-use `row` allocation.
@@ -312,8 +311,7 @@ where
                     // Reuseable allocation for unpacking.
                     let mut datums = DatumVec::new();
                     move |row| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
+                        let mut row_builder = SharedRow::get();
                         let temp_storage = RowArena::new();
                         let mut datums_local = datums.borrow_with(&row);
                         // TODO(mcsherry): re-use `row` allocation.
@@ -500,8 +498,7 @@ where
                     &next_input,
                     self.shutdown_token.clone(),
                     move |key, old, new| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
+                        let mut row_builder = SharedRow::get();
                         let temp_storage = RowArena::new();
 
                         let mut datums_local = datums.borrow();
@@ -532,8 +529,7 @@ where
                 &next_input,
                 self.shutdown_token.clone(),
                 move |key, old, new| {
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
+                    let mut row_builder = SharedRow::get();
                     let temp_storage = RowArena::new();
 
                     let mut datums_local = datums.borrow();

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -113,8 +113,7 @@ where
                 input_key.map(|k| (k, None)),
                 max_demand,
                 move |row_datums, time, diff| {
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
+                    let mut row_builder = SharedRow::get();
                     let temp_storage = RowArena::new();
 
                     let mut row_iter = row_datums.drain(..);
@@ -711,8 +710,7 @@ where
 
         // Extract the value we were asked to aggregate over.
         let mut partial = input.map(move |(key, row)| {
-            let binding = SharedRow::get();
-            let mut row_builder = binding.borrow_mut();
+            let mut row_builder = SharedRow::get();
             let value = row.iter().nth(index).unwrap();
             row_builder.packer().push(value);
             (key, row_builder.clone())
@@ -1026,8 +1024,7 @@ where
 
             // Gather the relevant keys with their hashes along with values ordered by aggregation_index.
             let mut stage = input.map(move |(key, row)| {
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
+                let mut row_builder = SharedRow::get();
                 let mut row_packer = row_builder.packer();
                 let mut row_iter = row.iter();
                 for skip in skips.iter() {
@@ -1303,8 +1300,7 @@ where
                     }
                 }
 
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
+                let mut row_builder = SharedRow::get();
                 let mut row_packer = row_builder.packer();
 
                 let mut source_iters = source
@@ -1351,8 +1347,7 @@ where
         // Gather the relevant values into a vec of rows ordered by aggregation_index
         let collection = collection
             .map(move |(key, row)| {
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
+                let mut row_builder = SharedRow::get();
                 let mut values = Vec::with_capacity(skips.len());
                 let mut row_iter = row.iter();
                 for skip in skips.iter() {
@@ -1677,8 +1672,7 @@ fn evaluate_mfp_after<'a, 'b>(
     temp_storage: &'a RowArena,
     key_len: usize,
 ) -> Option<Row> {
-    let binding = SharedRow::get();
-    let mut row_builder = binding.borrow_mut();
+    let mut row_builder = SharedRow::get();
     // Apply MFP if it exists and pack a Row of
     // aggregate values from `datums_local`.
     if let Some(mfp) = mfp_after {

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3167,8 +3167,7 @@ fn regexp_matches<'a, 'r: 'a>(
             .map(|m| Datum::from(m.map(|m| m.as_str())))
             .collect::<Vec<_>>();
 
-        let row = SharedRow::get();
-        let mut binding = row.borrow_mut();
+        let mut binding = SharedRow::get();
         let mut packer = binding.packer();
 
         let dimension = ArrayDimension {

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -821,8 +821,7 @@ pub fn decode_copy_format_csv(
             std::cmp::Ordering::Equal => Ok(()),
         }?;
 
-        let binding = SharedRow::get();
-        let mut row_builder = binding.borrow_mut();
+        let mut row_builder = SharedRow::get();
         let mut row_packer = row_builder.packer();
 
         for (typ, raw_value) in column_types.iter().zip(record.iter()) {

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1.0.0"
 columnar = "0.4.1"
 columnation = "0.1.0"
 chrono = { version = "0.4.39", default-features = false, features = ["serde", "std"] }
-compact_bytes = "0.1.3"
+compact_bytes = "0.1.4"
 dec = "0.4.8"
 differential-dataflow = "0.14.2"
 enum-kinds = "0.5.1"

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -111,8 +111,7 @@ impl Jsonb {
     ///
     /// Errors if the slice is not valid JSON.
     pub fn from_slice(buf: &[u8]) -> Result<Jsonb, anyhow::Error> {
-        let binding = SharedRow::get();
-        let mut row_builder = binding.borrow_mut();
+        let mut row_builder = SharedRow::get();
         let mut packer = row_builder.packer();
         JsonbPacker::new(&mut packer).pack_slice(buf)?;
         Ok(Jsonb {


### PR DESCRIPTION
This PR removes the Rc indirection for the shared row and simplifies the API by not requiring the caller to explicitly mutably borrow the RefCell.

The constructor of the `SharedRow` is documented to panic if more than one instance is constructed. This allows us to use a single `Cell<Option<Row>>` as the contents of the thread local that gets replaced with `None` when someone gets the shared row and is put back when the `SharedRow` value is dropped.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9232

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
