### PR TITLE
[persist] Decode structured data in inspection CLI

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -1302,6 +1302,10 @@ where
         self.part.desc.since().borrow() == AntichainRef::new(&[T::minimum()])
     }
 
+    pub(crate) fn updates(&self) -> &BlobTraceUpdates {
+        &self.part.updates
+    }
+
     /// Returns the updates with all truncation / timestamp rewriting applied.
     pub(crate) fn normalize(&self, metrics: &ColumnarMetrics) -> BlobTraceUpdates {
         let updates = self.part.updates.clone();

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -383,6 +383,17 @@ impl BlobTraceUpdates {
         structured
     }
 
+    /// If we have structured data, cast this data as a structured part.
+    pub fn as_part(&self) -> Option<Part> {
+        let ext = self.structured()?.clone();
+        Some(Part {
+            key: ext.key,
+            val: ext.val,
+            time: self.timestamps().clone(),
+            diff: self.diffs().clone(),
+        })
+    }
+
     /// Convert this blob into a structured part, transforming the codec data if necessary.
     pub fn into_part<K: Codec, V: Codec>(
         &mut self,


### PR DESCRIPTION
Instead of threading around byte arrays, we need to thread around ArrayIdx.

### Motivation

This would panic on any recent part. We also want to reduce our dependence on some of these old records-only APIs...

### Tips for reviewer

There's more to do in this vein, but it may have to wait for the next skunkwork...

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
