### PR TITLE
fix prepared statements should get different ids

### DIFF
--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -306,7 +306,7 @@ impl Coordinator {
         let mut out = None;
 
         let uuid = match logging {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => uuid.clone(),
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => *uuid,
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -306,9 +306,7 @@ impl Coordinator {
         let mut out = None;
 
         let uuid = match logging {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid: _ } => {
-                epoch_to_uuid_v7(&(self.now()))
-            }
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => uuid.clone(),
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,
@@ -721,14 +719,14 @@ impl Coordinator {
         }
         let (ps_record, ps_uuid) = self.log_prepared_statement(session, logging)?;
 
+        let now = self.now();
         let uuid = match session.qcell_rw(logging) {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => *uuid,
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid: _ } => epoch_to_uuid_v7(&now),
             PreparedStatementLoggingInfo::StillToLog { prepared_at, .. } => {
                 epoch_to_uuid_v7(prepared_at)
             }
         };
 
-        let now = self.now();
         self.record_statement_lifecycle_event(
             &StatementLoggingId(uuid),
             &StatementLifecycleEvent::ExecutionBegan,

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -306,7 +306,9 @@ impl Coordinator {
         let mut out = None;
 
         let uuid = match logging {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => *uuid,
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid: _ } => {
+                epoch_to_uuid_v7(&(self.now()))
+            }
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 redacted_sql,

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -720,13 +720,7 @@ impl Coordinator {
         let (ps_record, ps_uuid) = self.log_prepared_statement(session, logging)?;
 
         let now = self.now();
-        let uuid = match session.qcell_rw(logging) {
-            PreparedStatementLoggingInfo::AlreadyLogged { uuid: _ } => epoch_to_uuid_v7(&now),
-            PreparedStatementLoggingInfo::StillToLog { prepared_at, .. } => {
-                epoch_to_uuid_v7(prepared_at)
-            }
-        };
-
+        let uuid = epoch_to_uuid_v7(&now);
         self.record_statement_lifecycle_event(
             &StatementLoggingId(uuid),
             &StatementLifecycleEvent::ExecutionBegan,


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9242

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
