### PR TITLE
[persist] Postgres specific consensus queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8532,6 +8532,7 @@ dependencies = [
  "differential-dataflow",
  "futures",
  "humantime",
+ "mz-dyncfg",
  "mz-http-util",
  "mz-orchestrator-tracing",
  "mz-ore",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -824,6 +824,23 @@ steps:
               composition: platform-checks
               args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-parallel-restart-environmentd-clusterd-storage-postgres-consensus
+        label: "Checks parallel + restart of environmentd & storage clusterd with Postgres for consensus"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        parallelism: 2
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [
+                --scenario=RestartEnvironmentdClusterdStorage,
+                --execution-mode=parallel,
+                "--seed=$BUILDKITE_JOB_ID",
+                --features=postgres_consensus,
+              ]
+
       - id: checks-parallel-kill-clusterd-storage
         label: "Checks parallel + kill storage clusterd"
         depends_on: build-aarch64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -802,6 +802,7 @@ steps:
                   --scenario=DropCreateDefaultReplica,
                   --execution-mode=parallel,
                   --features=postgres_consensus,
+                  --system-param=persist_use_postgres_tuned_queries=true,
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
@@ -854,8 +855,9 @@ steps:
               args: [
                 --scenario=RestartEnvironmentdClusterdStorage,
                 --execution-mode=parallel,
-                "--seed=$BUILDKITE_JOB_ID",
                 --features=postgres_consensus,
+                --system-param=persist_use_postgres_tuned_queries=true,
+                "--seed=$BUILDKITE_JOB_ID",
               ]
 
       - id: checks-parallel-kill-clusterd-storage

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -842,7 +842,7 @@ steps:
               args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-environmentd-clusterd-storage-postgres-consensus
-        label: "Checks parallel + restart of environmentd & storage clusterd with Postgres for consensus"
+        label: "Checks parallel + restart of environmentd & storage clusterd (:postgres: Consensus)"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 2
@@ -1153,7 +1153,7 @@ steps:
               args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
       - id: persist-maelstrom-multi-node-postgres
-        label: "Long multi-node Maelstrom coverage of persist with :postgres: consensus"
+        label: "Long multi-node Maelstrom coverage of persist with :postgres: Consensus"
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1178,7 +1178,7 @@ steps:
               composition: persist
               args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --rate=500, --txn-wal]
 
-      - id: txn-wal-maelstrom
+      - id: txn-wal-maelstrom-postgres
         label: "Maelstrom coverage of txn-wal with :postgres: Consensus"
         depends_on: build-aarch64
         timeout_in_minutes: 40

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -787,6 +787,23 @@ steps:
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
+      - id: checks-parallel-drop-create-default-replica-postgres
+        label: "Checks parallel + DROP/CREATE replica (:postgres: Consensus)"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        parallelism: 2
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args:
+                [
+                  --scenario=DropCreateDefaultReplica,
+                  --execution-mode=parallel,
+                  --features=postgres_consensus,
+                  "--seed=$BUILDKITE_JOB_ID",
+                ]
 
       - id: checks-parallel-restart-clusterd-compute
         label: "Checks parallel + restart compute clusterd"
@@ -1124,7 +1141,7 @@ steps:
               args: [--node-count=1, --consensus=mem, --blob=mem, --time-limit=600, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
       - id: persist-maelstrom-multi-node
-        label: Long multi-node Maelstrom coverage of persist with postgres consensus
+        label: Long multi-node Maelstrom coverage of persist with CockroachDB consensus
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
@@ -1135,8 +1152,20 @@ steps:
               composition: persist
               args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
+      - id: persist-maelstrom-multi-node-postgres
+        label: "Long multi-node Maelstrom coverage of persist with :postgres: consensus"
+        depends_on: build-aarch64
+        timeout_in_minutes: 40
+        agents:
+          queue: hetzner-aarch64-4cpu-8gb
+        artifact_paths: [test/persist/maelstrom/**/*.log]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: persist
+              args: [--node-count=4, --consensus=postgres, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+
       - id: txn-wal-maelstrom
-        label: Maelstrom coverage of txn-wal
+        label: Maelstrom coverage of txn-wal with CockroachDB Consensus
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
@@ -1146,6 +1175,18 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: persist
               args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --rate=500, --txn-wal]
+
+      - id: txn-wal-maelstrom
+        label: "Maelstrom coverage of txn-wal with :postgres: Consensus"
+        depends_on: build-aarch64
+        timeout_in_minutes: 40
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        artifact_paths: [test/persist/maelstrom/**/*.log]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: persist
+              args: [--node-count=4, --consensus=postgres, --blob=maelstrom, --time-limit=300, --rate=500, --txn-wal]
 
       - id: persistence-failpoints
         label: Persistence failpoints

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -636,7 +636,7 @@ steps:
                 ]
 
       - id: checks-restart-environmentd-clusterd-storage-postgres-consensus
-        label: "Checks + restart of environmentd & storage clusterd (Postgres Consensus)"
+        label: "Checks + restart of environmentd & storage clusterd (:postgres: Consensus)"
         depends_on: build-aarch64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -635,25 +635,6 @@ steps:
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
-      - id: checks-restart-environmentd-clusterd-storage-postgres-consensus
-        label: "Checks + restart of environmentd & storage clusterd (:postgres: Consensus)"
-        depends_on: build-aarch64
-        inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 45
-        parallelism: 6
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args:
-                [
-                  --scenario=RestartEnvironmentdClusterdStorage,
-                  --features=postgres_consensus,
-                  --system-param=persist_use_postgres_tuned_queries=true,
-                  "--seed=$BUILDKITE_JOB_ID",
-                ]
-
       - id: checks-no-restart-no-upgrade
         label: "Checks without restart or upgrade"
         depends_on: build-aarch64

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -635,6 +635,25 @@ steps:
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
+      - id: checks-restart-environmentd-clusterd-storage-postgres-consensus
+        label: "Checks + restart of environmentd & storage clusterd (Postgres Consensus)"
+        depends_on: build-aarch64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 45
+        parallelism: 6
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args:
+                [
+                  --scenario=RestartEnvironmentdClusterdStorage,
+                  --features=postgres_consensus,
+                  --system-param=persist_use_postgres_tuned_queries=true,
+                  "--seed=$BUILDKITE_JOB_ID",
+                ]
+
       - id: checks-no-restart-no-upgrade
         label: "Checks without restart or upgrade"
         depends_on: build-aarch64

--- a/misc/python/materialize/checks/features.py
+++ b/misc/python/materialize/checks/features.py
@@ -15,6 +15,7 @@
 class Features:
     AZURITE = "azurite"
     SQL_SERVER = "sql_server"
+    POSTGRES_CONSENSUS = "postgres_consensus"
 
     def __init__(self, features):
         self.features = features
@@ -24,3 +25,6 @@ class Features:
 
     def sql_server_enabled(self) -> bool:
         return self.features and self.SQL_SERVER in self.features
+
+    def postgres_consensus_enabled(self) -> bool:
+        return self.features and self.POSTGRES_CONSENSUS in self.features

--- a/src/persist-cli/BUILD.bazel
+++ b/src/persist-cli/BUILD.bazel
@@ -36,6 +36,7 @@ rust_binary(
     }),
     version = "0.0.0",
     deps = [
+        "//src/dyncfg:mz_dyncfg",
         "//src/http-util:mz_http_util",
         "//src/orchestrator-tracing:mz_orchestrator_tracing",
         "//src/ore:mz_ore",

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "4.5.23", features = ["derive", "env"] }
 differential-dataflow = "0.14.2"
 futures = "0.3.31"
 humantime = "2.2.0"
+mz-dyncfg = { path = "../dyncfg" }
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["bytes", "network", "panic", "tracing", "test"] }

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -417,6 +417,7 @@ impl Service for TransactorService {
                     consensus_uri,
                     Box::new(config.clone()),
                     metrics.postgres_consensus.clone(),
+                    Arc::clone(&config.configs),
                 )
                 .expect("consensus_uri should be valid");
                 loop {

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -640,6 +640,7 @@ impl Service for TransactorService {
                     consensus_uri,
                     Box::new(config.clone()),
                     metrics.postgres_consensus.clone(),
+                    Arc::clone(&config.configs),
                 )
                 .expect("consensus_uri should be valid");
                 loop {

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
+use mz_dyncfg::ConfigUpdates;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
@@ -596,6 +597,14 @@ impl Service for TransactorService {
 
         let mut config =
             PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
+        {
+            // We only use the Postgres tuned queries when connected to vanilla
+            // Postgres, so we always want to enable them for testing.
+            let mut updates = ConfigUpdates::default();
+            updates.add(&mz_persist::postgres::USE_POSTGRES_TUNED_QUERIES, true);
+            config.apply_from(&updates);
+        }
+
         let metrics = Arc::new(Metrics::new(&config, &MetricsRegistry::new()));
 
         // Construct requested Blob.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -173,6 +173,7 @@ impl PersistClientCache {
                     x.key(),
                     Box::new(self.cfg.clone()),
                     self.metrics.postgres_consensus.clone(),
+                    Arc::clone(&self.cfg().configs),
                 )?;
                 let consensus =
                     retry_external(&self.metrics.retries.external.consensus_open, || {

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -130,6 +130,7 @@ pub(super) async fn make_consensus(
         consensus_uri,
         Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
+        Arc::clone(&cfg.configs),
     )?;
     let consensus = consensus.clone().open().await?;
     let consensus = if commit {

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -36,6 +36,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
+        .add(&crate::postgres::USE_POSTGRES_TUNED_QUERIES)
 }
 
 /// Config for an implementation of [Blob].
@@ -233,10 +234,11 @@ impl ConsensusConfig {
         url: &SensitiveUrl,
         knobs: Box<dyn PostgresClientKnobs>,
         metrics: PostgresClientMetrics,
+        dyncfg: Arc<ConfigSet>,
     ) -> Result<Self, ExternalError> {
         let config = match url.scheme() {
             "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
-                PostgresConsensusConfig::new(url, knobs, metrics)?,
+                PostgresConsensusConfig::new(url, knobs, metrics, dyncfg)?,
             )),
             "mem" => {
                 if !cfg!(debug_assertions) {

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -35,7 +35,8 @@ use tracing::{info, warn};
 use crate::error::Error;
 use crate::location::{CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData};
 
-pub(crate) const USE_POSTGRES_TUNED_QUERIES: mz_dyncfg::Config<bool> = mz_dyncfg::Config::new(
+/// Flag to use concensus queries that are tuned for vanilla Postgres.
+pub const USE_POSTGRES_TUNED_QUERIES: mz_dyncfg::Config<bool> = mz_dyncfg::Config::new(
     "persist_use_postgres_tuned_queries",
     false,
     "Use a set of queries for consensus that have specifically been tuned against

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -399,14 +399,13 @@ impl Consensus for PostgresConsensus {
             /// minimizes possible serialization conflicts.
             static POSTGRES_CAS_QUERY: &str = "
             WITH last_seq AS (
-                SELECT sequence_number
-                FROM materialize1.consensus
+                SELECT sequence_number FROM consensus
                 WHERE shard = $1
                 ORDER BY sequence_number DESC
                 LIMIT 1
                 FOR UPDATE
             )
-            INSERT INTO materialize1.consensus (shard, sequence_number, data)
+            INSERT INTO consensus (shard, sequence_number, data)
             SELECT $1, $2, $3
             FROM last_seq
             WHERE last_seq.sequence_number = $4;

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -495,7 +495,12 @@ impl Consensus for PostgresConsensus {
         /// concurrently running compare and swap operations that are trying to
         /// evolve the shard.
         ///
-        /// It's performance has been benchmarked agaisnt Postgres 15.
+        /// It's performance has been benchmarked against Postgres 15.
+        ///
+        /// Note: The `ORDER BY` in the newer_exists CTE exists so we obtain a
+        /// row lock on the lowest possible sequence number. This ensures
+        /// minimal conflict between concurrently running truncate and append
+        /// operations.
         static POSTGRES_TRUNCATE_QUERY: &str = "
         WITH newer_exists AS (
             SELECT * FROM consensus

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -36,9 +36,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.persistcli import Persistcli
-from materialize.mzcompose.services.postgres import (
-    Postgres,
-)
+from materialize.mzcompose.services.postgres import Postgres, PostgresMetadata
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.ssh_bastion_host import SshBastionHost
@@ -52,6 +50,7 @@ TESTDRIVE_DEFAULT_TIMEOUT = os.environ.get("PLATFORM_CHECKS_TD_TIMEOUT", "300s")
 
 def create_mzs(
     azurite: bool,
+    postgres_consensus: bool,
     default_replication_factor: int,
     additional_system_parameter_defaults: dict[str, str] | None = None,
 ) -> list[TestdriveService | Materialized]:
@@ -63,7 +62,7 @@ def create_mzs(
             blob_store_is_azure=azurite,
             sanity_restart=False,
             volumes_extra=["secrets:/share/secrets"],
-            metadata_store="cockroach",
+            metadata_store="postgres-metadata" if postgres_consensus else "cockroach",
             additional_system_parameter_defaults=additional_system_parameter_defaults,
             default_replication_factor=default_replication_factor,
         )
@@ -89,9 +88,11 @@ def create_mzs(
 
 SERVICES = [
     TestCerts(),
-    # TODO(def-): Switch to CockroachOrPostgres after we have 4 versions
-    # support Postgres as metadata store
     Cockroach(
+        # Workaround for database-issues#5899
+        restart="on-failure:5",
+    ),
+    PostgresMetadata(
         # Workaround for database-issues#5899
         restart="on-failure:5",
     ),
@@ -142,7 +143,7 @@ SERVICES = [
     Clusterd(
         name="clusterd_compute_1"
     ),  # Started by some Scenarios, defined here only for the teardown
-    *create_mzs(azurite=False, default_replication_factor=1),
+    *create_mzs(azurite=False, postgres_consensus=False, default_replication_factor=1),
     Persistcli(),
     SshBastionHost(),
 ]
@@ -226,7 +227,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "--features",
         nargs="*",
-        help="A list of features (e.g. azurite, sql_server), to enable.",
+        help="A list of features (e.g. azurite, sql_server, postgres_consensus), to enable.",
     )
 
     parser.add_argument(
@@ -273,6 +274,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(
         *create_mzs(
             features.azurite_enabled(),
+            features.postgres_consensus_enabled(),
             args.default_replication_factor,
             additional_system_parameter_defaults,
         )


### PR DESCRIPTION
This PR adds some new queries to `PostgresConsensus` that are tuned against vanilla postgres to obtain row level locks as opposed to the table level locks that the current queries get. These new queries are only used if `persist_use_postgres_tuned_queries` is set to true, __and__ we detect we're running against vanilla Postgres. 

Locks acquired on `main`
```
  pid  |       mode       | granted
-------+------------------+---------
 21004 | AccessShareLock  | t
 21004 | RowExclusiveLock | t
```

Locks acquired with the new feature enabled
```
  pid  |       mode       | granted
-------+------------------+---------
 21004 | RowShareLock     | t
 21004 | RowExclusiveLock | t
```

It's not entirely clear that this improves performance, but some simulation testing seems to indicate that it does.

### Testing

Also included in this PR are new CI workflows that run platform-checks and maelstrom against Postgres consensus, using the new Postgres queries.


### Motivation

Improve performance of self-hosted which runs against vanilla postgres

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
