### PR TITLE
Convert more binary functions to sqlfunc macro

### DIFF
--- a/src/expr-derive/src/lib.rs
+++ b/src/expr-derive/src/lib.rs
@@ -30,9 +30,15 @@
 /// * `is_infix_op`: A boolean indicating whether the function is an infix operator. Applies to
 ///   binary functions only.
 /// * `output_type`: The output type of the function.
+/// * `output_type_expr`: An expression that evaluates to the output type. Applies to binary
+///   functions only. The expression has access to the `input_type_a` and `input_type_b` variables,
+///   and should evaluate to a `ColumnType` value. Requires `introduces_nulls`, and conflicts with
+///   `output_type`.
 /// * `could_error`: A boolean indicating whether the function could error.
 /// * `propagate_nulls`: A boolean indicating whether the function propagates nulls. Applies to
 ///   binary functions only.
+/// * `introduces_nulls`: A boolean indicating whether the function introduces nulls. Applies to
+///   all functions.
 ///
 /// # Limitations
 /// * The input and output types can contain lifetime parameters, as long as they are `'a`.

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -510,7 +510,6 @@ fn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 #[sqlfunc(
     is_monotone = "(true, false)",
     output_type = "Numeric",
-    is_infix_op = false,
     sqlname = "round",
     propagates_nulls = true
 )]
@@ -563,9 +562,7 @@ fn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, Eva
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "String",
-    is_infix_op = false,
     sqlname = "convert_from",
     propagates_nulls = true
 )]
@@ -595,13 +592,7 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "String",
-    is_infix_op = false,
-    sqlname = "encode",
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "String", sqlname = "encode", propagates_nulls = true)]
 fn encode<'a>(
     bytes: Datum<'a>,
     format: Datum<'a>,
@@ -622,13 +613,7 @@ fn decode<'a>(
     Ok(Datum::from(temp_storage.push_bytes(out)))
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "i32",
-    is_infix_op = false,
-    sqlname = "length",
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "i32", sqlname = "length", propagates_nulls = true)]
 fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     // Convert PostgreSQL-style encoding names[1] to WHATWG-style encoding names[2],
     // which the encoding library uses[3].
@@ -747,7 +732,6 @@ fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = "&",
@@ -758,7 +742,6 @@ fn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = "&",
@@ -769,7 +752,6 @@ fn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = "&",
@@ -780,7 +762,6 @@ fn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = "&",
@@ -791,7 +772,6 @@ fn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = "&",
@@ -802,7 +782,6 @@ fn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = "&",
@@ -813,7 +792,6 @@ fn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = "|",
@@ -824,7 +802,6 @@ fn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = "|",
@@ -835,7 +812,6 @@ fn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = "|",
@@ -846,7 +822,6 @@ fn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = "|",
@@ -857,7 +832,6 @@ fn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = "|",
@@ -868,7 +842,6 @@ fn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = "|",
@@ -879,7 +852,6 @@ fn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = "#",
@@ -890,7 +862,6 @@ fn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = "#",
@@ -901,7 +872,6 @@ fn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = "#",
@@ -912,7 +882,6 @@ fn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = "#",
@@ -923,7 +892,6 @@ fn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = "#",
@@ -934,7 +902,6 @@ fn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = "#",
@@ -945,7 +912,6 @@ fn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = "<<",
@@ -963,7 +929,6 @@ fn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = "<<",
@@ -978,7 +943,6 @@ fn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = "<<",
@@ -993,7 +957,6 @@ fn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = "<<",
@@ -1011,7 +974,6 @@ fn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = "<<",
@@ -1024,7 +986,6 @@ fn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = "<<",
@@ -1037,7 +998,6 @@ fn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = ">>",
@@ -1055,7 +1015,6 @@ fn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = ">>",
@@ -1070,7 +1029,6 @@ fn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = ">>",
@@ -1085,7 +1043,6 @@ fn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = ">>",
@@ -1103,7 +1060,6 @@ fn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = ">>",
@@ -1116,7 +1072,6 @@ fn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = ">>",
@@ -1269,7 +1224,6 @@ fn sub_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 #[sqlfunc(
     is_monotone = "(true, true)",
     output_type = "Interval",
-    is_infix_op = false,
     sqlname = "age",
     propagates_nulls = true
 )]
@@ -1284,7 +1238,6 @@ fn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
 #[sqlfunc(
     is_monotone = "(true, true)",
     output_type = "Interval",
-    is_infix_op = false,
     sqlname = "age",
     propagates_nulls = true
 )]
@@ -1754,7 +1707,6 @@ fn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i16",
     is_infix_op = true,
     sqlname = "%",
@@ -1770,7 +1722,6 @@ fn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i32",
     is_infix_op = true,
     sqlname = "%",
@@ -1786,7 +1737,6 @@ fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "i64",
     is_infix_op = true,
     sqlname = "%",
@@ -1802,7 +1752,6 @@ fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u16",
     is_infix_op = true,
     sqlname = "%",
@@ -1818,7 +1767,6 @@ fn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u32",
     is_infix_op = true,
     sqlname = "%",
@@ -1834,7 +1782,6 @@ fn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "u64",
     is_infix_op = true,
     sqlname = "%",
@@ -1850,7 +1797,6 @@ fn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "f32",
     is_infix_op = true,
     sqlname = "%",
@@ -1866,7 +1812,6 @@ fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "f64",
     is_infix_op = true,
     sqlname = "%",
@@ -1882,7 +1827,6 @@ fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Numeric",
     is_infix_op = true,
     sqlname = "%",
@@ -1917,13 +1861,7 @@ fn log_guard_numeric(val: &Numeric, function_name: &str) -> Result<(), EvalError
     Ok(())
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "Numeric",
-    is_infix_op = false,
-    sqlname = "log",
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "Numeric", sqlname = "log", propagates_nulls = true)]
 fn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     log_guard_numeric(&a, "log")?;
@@ -1962,12 +1900,7 @@ fn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalErr
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "f64",
-    is_infix_op = false,
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "f64", propagates_nulls = true)]
 fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let a = a.unwrap_float64();
     let b = b.unwrap_float64();
@@ -1991,12 +1924,7 @@ fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     Ok(Datum::from(res))
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "uuid::Uuid",
-    is_infix_op = false,
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "uuid::Uuid", propagates_nulls = true)]
 fn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let a = a.unwrap_uuid();
     let b = b.unwrap_str();
@@ -2004,12 +1932,7 @@ fn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::Uuid(res)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "Numeric",
-    is_infix_op = false,
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "Numeric", propagates_nulls = true)]
 fn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mut a = a.unwrap_numeric().0;
     let b = b.unwrap_numeric().0;
@@ -2041,12 +1964,7 @@ fn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "i32",
-    is_infix_op = false,
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "i32", propagates_nulls = true)]
 fn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let bytes = a.unwrap_bytes();
     let index = b.unwrap_int32();
@@ -2068,12 +1986,7 @@ fn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     Ok(Datum::from(i32::from(i)))
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "i32",
-    is_infix_op = false,
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "i32", propagates_nulls = true)]
 fn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let bytes = a.unwrap_bytes();
     let index = b.unwrap_int32();
@@ -2088,9 +2001,7 @@ fn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
-    is_infix_op = false,
     sqlname = "constant_time_compare_bytes",
     propagates_nulls = true
 )]
@@ -2101,9 +2012,7 @@ pub fn constant_time_eq_bytes<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
-    is_infix_op = false,
     sqlname = "constant_time_compare_strings",
     propagates_nulls = true
 )]
@@ -2122,52 +2031,27 @@ where
     Datum::from(range.contains_elem(&elem))
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_i32<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
     a.contains_elem(&b)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_i64<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_date<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_numeric<'a>(a: Range<Datum<'a>>, elem: OrderedDecimal<Numeric>) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_timestamp<'a>(
     a: Range<Datum<'a>>,
     elem: CheckedTimestamp<NaiveDateTime>,
@@ -2175,12 +2059,7 @@ fn range_contains_timestamp<'a>(
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "@>",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "@>", propagates_nulls = true)]
 fn range_contains_timestamp_tz<'a>(
     a: Range<Datum<'a>>,
     elem: CheckedTimestamp<DateTime<Utc>>,
@@ -2188,52 +2067,27 @@ fn range_contains_timestamp_tz<'a>(
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_i32_rev<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
     a.contains_elem(&b)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_i64_rev<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_date_rev<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_numeric_rev<'a>(a: Range<Datum<'a>>, elem: OrderedDecimal<Numeric>) -> bool {
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_timestamp_rev<'a>(
     a: Range<Datum<'a>>,
     elem: CheckedTimestamp<NaiveDateTime>,
@@ -2241,12 +2095,7 @@ fn range_contains_timestamp_rev<'a>(
     a.contains_elem(&elem)
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = true,
-    sqlname = "<@",
-    propagates_nulls = true
-)]
+#[sqlfunc(is_infix_op = true, sqlname = "<@", propagates_nulls = true)]
 fn range_contains_timestamp_tz_rev<'a>(
     a: Range<Datum<'a>>,
     elem: CheckedTimestamp<DateTime<Utc>>,
@@ -2264,7 +2113,6 @@ macro_rules! range_fn {
         paste::paste! {
 
             #[sqlfunc(
-                is_monotone = "(false, false)",
                 output_type = "bool",
                 is_infix_op = true,
                 sqlname = $sqlname,
@@ -2292,7 +2140,6 @@ range_fn!(overright, overright, "&>");
 range_fn!(adjacent, adjacent, "-|-");
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "+",
@@ -2310,7 +2157,6 @@ fn range_union<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "*",
@@ -2328,7 +2174,6 @@ fn range_intersection<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "-",
@@ -2346,7 +2191,6 @@ fn range_difference<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "=",
@@ -2357,7 +2201,6 @@ fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "!=",
@@ -2419,13 +2262,7 @@ where
     Datum::String(temp_storage.push_string(fmt.render(ts)))
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "String",
-    is_infix_op = false,
-    sqlname = "tocharts",
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "String", sqlname = "tocharts", propagates_nulls = true)]
 fn to_char_timestamp_format<'a>(a: Datum<'a>, format: &str) -> String {
     let ts = a.unwrap_timestamp();
     let fmt = DateTimeFormat::compile(format);
@@ -2433,9 +2270,7 @@ fn to_char_timestamp_format<'a>(a: Datum<'a>, format: &str) -> String {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "String",
-    is_infix_op = false,
     sqlname = "tochartstz",
     propagates_nulls = true
 )]
@@ -2546,7 +2381,6 @@ fn jsonb_get_path<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "?",
@@ -2564,7 +2398,6 @@ fn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "?",
@@ -2577,7 +2410,6 @@ fn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "?&",
@@ -2594,7 +2426,6 @@ fn map_contains_all_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "?|",
@@ -2611,7 +2442,6 @@ fn map_contains_any_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "@>",
@@ -2630,7 +2460,6 @@ fn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.unwrap_map_value_type().clone().nullable(true)",
     is_infix_op = true,
     sqlname = "->",
@@ -2646,7 +2475,6 @@ fn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "@>",
@@ -2668,7 +2496,6 @@ fn list_contains_list<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "<@",
@@ -2681,7 +2508,6 @@ fn list_contains_list_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 
 // TODO(jamii) nested loops are possibly not the fastest way to do this
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "@>",
@@ -2716,7 +2542,6 @@ fn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "ScalarType::Jsonb.nullable(true)",
     is_infix_op = true,
     sqlname = "||",
@@ -2749,7 +2574,6 @@ fn jsonb_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> D
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "ScalarType::Jsonb.nullable(true)",
     is_infix_op = true,
     sqlname = "-",
@@ -2779,7 +2603,6 @@ fn jsonb_delete_int64<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "ScalarType::Jsonb.nullable(true)",
     is_infix_op = true,
     sqlname = "-",
@@ -2813,9 +2636,7 @@ where
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Numeric",
-    is_infix_op = false,
     sqlname = "extractiv",
     propagates_nulls = true,
     introduces_nulls = false
@@ -2829,9 +2650,7 @@ fn date_part_interval_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "f64",
-    is_infix_op = false,
     sqlname = "date_partiv",
     propagates_nulls = true,
     introduces_nulls = false
@@ -2856,9 +2675,7 @@ where
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Numeric",
-    is_infix_op = false,
     sqlname = "extractt",
     propagates_nulls = true,
     introduces_nulls = false
@@ -2872,9 +2689,7 @@ fn date_part_time_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, E
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "f64",
-    is_infix_op = false,
     sqlname = "date_partt",
     propagates_nulls = true,
     introduces_nulls = false
@@ -2900,9 +2715,7 @@ where
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Numeric",
-    is_infix_op = false,
     sqlname = "extractts",
     propagates_nulls = true
 )]
@@ -2917,9 +2730,7 @@ fn date_part_timestamp_timestamp_numeric<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Numeric",
-    is_infix_op = false,
     sqlname = "extracttstz",
     propagates_nulls = true
 )]
@@ -2933,45 +2744,29 @@ fn date_part_timestamp_timestamp_tz_numeric<'a>(
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = false,
-    sqlname = "date_partts",
-    propagates_nulls = true
-)]
-fn date_part_timestamp_timestamp_f64<'a>(
+#[sqlfunc(sqlname = "date_partts", propagates_nulls = true)]
+fn date_part_timestamp_timestamp_f64(
     units: &str,
     ts: CheckedTimestamp<NaiveDateTime>,
 ) -> Result<f64, EvalError> {
     match units.parse() {
-        Ok(units) => Ok(date_part_timestamp_inner::<_, f64>(units, &*ts)?.into()),
+        Ok(units) => date_part_timestamp_inner(units, &*ts),
         Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = false,
-    sqlname = "date_parttstz",
-    propagates_nulls = true
-)]
-fn date_part_timestamp_timestamp_tz_f64<'a>(
+#[sqlfunc(sqlname = "date_parttstz", propagates_nulls = true)]
+fn date_part_timestamp_timestamp_tz_f64(
     units: &str,
     ts: CheckedTimestamp<DateTime<Utc>>,
 ) -> Result<f64, EvalError> {
     match units.parse() {
-        Ok(units) => Ok(date_part_timestamp_inner::<_, f64>(units, &*ts)?.into()),
+        Ok(units) => date_part_timestamp_inner(units, &*ts),
         Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    output_type = "Numeric",
-    is_infix_op = false,
-    sqlname = "extractd",
-    propagates_nulls = true
-)]
+#[sqlfunc(output_type = "Numeric", sqlname = "extractd", propagates_nulls = true)]
 fn extract_date_units<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let units = a.unwrap_str();
     match units.parse() {
@@ -3030,7 +2825,6 @@ where
 #[sqlfunc(
     is_monotone = "(true, true)",
     output_type = "CheckedTimestamp<NaiveDateTime>",
-    is_infix_op = false,
     sqlname = "bin_unix_epoch_timestamp",
     propagates_nulls = true
 )]
@@ -3047,7 +2841,6 @@ fn date_bin_timestamp<'a>(
 #[sqlfunc(
     is_monotone = "(true, true)",
     output_type = "CheckedTimestamp<DateTime<Utc>>",
-    is_infix_op = false,
     sqlname = "bin_unix_epoch_timestamptz",
     propagates_nulls = true
 )]
@@ -3071,13 +2864,8 @@ where
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = false,
-    sqlname = "date_truncts",
-    propagates_nulls = true
-)]
-fn date_trunc_units_timestamp<'a>(
+#[sqlfunc(sqlname = "date_truncts", propagates_nulls = true)]
+fn date_trunc_units_timestamp(
     units: &str,
     ts: CheckedTimestamp<NaiveDateTime>,
 ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
@@ -3087,13 +2875,8 @@ fn date_trunc_units_timestamp<'a>(
     }
 }
 
-#[sqlfunc(
-    is_monotone = "(false, false)",
-    is_infix_op = false,
-    sqlname = "date_trunctstz",
-    propagates_nulls = true
-)]
-fn date_trunc_units_timestamp_tz<'a>(
+#[sqlfunc(sqlname = "date_trunctstz", propagates_nulls = true)]
+fn date_trunc_units_timestamp_tz(
     units: &str,
     ts: CheckedTimestamp<DateTime<Utc>>,
 ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -3104,9 +2887,7 @@ fn date_trunc_units_timestamp_tz<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Interval",
-    is_infix_op = false,
     sqlname = "date_trunciv",
     propagates_nulls = true
 )]
@@ -8621,7 +8402,6 @@ fn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Option<i32>",
     is_infix_op = true,
     sqlname = "array_length",
@@ -8644,7 +8424,6 @@ fn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Option<i32>",
     is_infix_op = true,
     sqlname = "array_lower",
@@ -8665,9 +8444,7 @@ fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
-    is_infix_op = false,
     sqlname = "array_remove",
     propagates_nulls = false,
     introduces_nulls = false
@@ -8705,7 +8482,6 @@ fn array_remove<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Option<i32>",
     is_infix_op = true,
     sqlname = "array_upper",
@@ -8774,7 +8550,6 @@ fn list_length_max<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "array_contains",
@@ -8787,7 +8562,6 @@ fn array_contains<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "@>",
@@ -8809,7 +8583,6 @@ fn array_contains_array<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "bool",
     is_infix_op = true,
     sqlname = "<@",
@@ -8821,7 +8594,6 @@ fn array_contains_array_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "||",
@@ -8933,7 +8705,6 @@ fn array_array_concat<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "||",
@@ -8954,7 +8725,6 @@ fn list_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) 
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "||",
@@ -8975,7 +8745,6 @@ fn list_element_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowAren
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
     is_infix_op = true,
     sqlname = "||",
@@ -8996,9 +8765,7 @@ fn element_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowAren
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
-    is_infix_op = false,
     sqlname = "list_remove",
     propagates_nulls = false,
     introduces_nulls = false
@@ -9020,9 +8787,7 @@ fn list_remove<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Da
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Vec<u8>",
-    is_infix_op = false,
     sqlname = "digest",
     propagates_nulls = true,
     introduces_nulls = false
@@ -9037,9 +8802,7 @@ fn digest_string<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "Vec<u8>",
-    is_infix_op = false,
     sqlname = "digest",
     propagates_nulls = true,
     introduces_nulls = false
@@ -9071,9 +8834,7 @@ fn digest_inner<'a>(
 }
 
 #[sqlfunc(
-    is_monotone = "(false, false)",
     output_type = "String",
-    is_infix_op = false,
     sqlname = "mz_render_typmod",
     propagates_nulls = true,
     introduces_nulls = false

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2122,6 +2122,138 @@ where
     Datum::from(range.contains_elem(&elem))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_i32<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
+    a.contains_elem(&b)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_i64<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_date<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_numeric<'a>(a: Range<Datum<'a>>, elem: OrderedDecimal<Numeric>) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_timestamp<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<NaiveDateTime>,
+) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true
+)]
+fn range_contains_timestamp_tz<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<DateTime<Utc>>,
+) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_i32_rev<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
+    a.contains_elem(&b)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_i64_rev<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_date_rev<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_numeric_rev<'a>(a: Range<Datum<'a>>, elem: OrderedDecimal<Numeric>) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_timestamp_rev<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<NaiveDateTime>,
+) -> bool {
+    a.contains_elem(&elem)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true
+)]
+fn range_contains_timestamp_tz_rev<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<DateTime<Utc>>,
+) -> bool {
+    a.contains_elem(&elem)
+}
+
 /// Macro to define binary function for various range operations.
 /// Parameters:
 /// 1. Unique binary function symbol.
@@ -2159,6 +2291,14 @@ range_fn!(overleft, overleft, "&<");
 range_fn!(overright, overright, "&>");
 range_fn!(adjacent, adjacent, "-|-");
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "+",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn range_union<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -2169,6 +2309,14 @@ fn range_union<'a>(
     l.union(&r)?.into_result(temp_storage)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "*",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn range_intersection<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -2179,6 +2327,14 @@ fn range_intersection<'a>(
     l.intersection(&r).into_result(temp_storage)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn range_difference<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -2261,6 +2417,32 @@ where
 {
     let fmt = DateTimeFormat::compile(format);
     Datum::String(temp_storage.push_string(fmt.render(ts)))
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "String",
+    is_infix_op = false,
+    sqlname = "tocharts",
+    propagates_nulls = true
+)]
+fn to_char_timestamp_format<'a>(a: Datum<'a>, format: &str) -> String {
+    let ts = a.unwrap_timestamp();
+    let fmt = DateTimeFormat::compile(format);
+    fmt.render(&*ts)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "String",
+    is_infix_op = false,
+    sqlname = "tochartstz",
+    propagates_nulls = true
+)]
+fn to_char_timestamp_tz_format<'a>(a: Datum<'a>, format: &str) -> String {
+    let ts = a.unwrap_timestamptz();
+    let fmt = DateTimeFormat::compile(format);
+    fmt.render(&*ts)
 }
 
 fn jsonb_get_int64<'a>(
@@ -2447,6 +2629,14 @@ fn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
         .into()
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.unwrap_map_value_type().clone().nullable(true)",
+    is_infix_op = true,
+    sqlname = "->",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 fn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let target_key = b.unwrap_str();
     match a.unwrap_map().iter().find(|(key, _v)| target_key == *key) {
@@ -2455,6 +2645,14 @@ fn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "bool",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn list_contains_list<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let a = a.unwrap_list();
     let b = b.unwrap_list();
@@ -2467,6 +2665,18 @@ fn list_contains_list<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
             .all(|item_b| a.iter().any(|item_a| item_a == item_b))
             .into()
     }
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "bool",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn list_contains_list_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    list_contains_list(b, a)
 }
 
 // TODO(jamii) nested loops are possibly not the fastest way to do this
@@ -2505,6 +2715,14 @@ fn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     contains(a, b, true).into()
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "ScalarType::Jsonb.nullable(true)",
+    is_infix_op = true,
+    sqlname = "||",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 fn jsonb_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     match (a, b) {
         (Datum::Map(dict_a), Datum::Map(dict_b)) => {
@@ -2530,6 +2748,14 @@ fn jsonb_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> D
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "ScalarType::Jsonb.nullable(true)",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 fn jsonb_delete_int64<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     let i = b.unwrap_int64();
     match a {
@@ -2552,6 +2778,14 @@ fn jsonb_delete_int64<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "ScalarType::Jsonb.nullable(true)",
+    is_infix_op = true,
+    sqlname = "-",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 fn jsonb_delete_string<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     match a {
         Datum::List(list) => {
@@ -2578,6 +2812,38 @@ where
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Numeric",
+    is_infix_op = false,
+    sqlname = "extractiv",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn date_part_interval_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_interval_inner::<Numeric>(units, b.unwrap_interval())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "f64",
+    is_infix_op = false,
+    sqlname = "date_partiv",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn date_part_interval_f64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_interval_inner::<f64>(units, b.unwrap_interval())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}
+
 fn date_part_time<'a, D>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError>
 where
     D: DecimalLike + Into<Datum<'a>>,
@@ -2585,6 +2851,38 @@ where
     let units = a.unwrap_str();
     match units.parse() {
         Ok(units) => Ok(date_part_time_inner::<D>(units, b.unwrap_time())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Numeric",
+    is_infix_op = false,
+    sqlname = "extractt",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn date_part_time_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_time_inner::<Numeric>(units, b.unwrap_time())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "f64",
+    is_infix_op = false,
+    sqlname = "date_partt",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn date_part_time_f64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_time_inner::<f64>(units, b.unwrap_time())?.into()),
         Err(_) => Err(EvalError::UnknownUnits(units.into())),
     }
 }
@@ -3643,7 +3941,7 @@ impl BinaryFunc {
             }
 
             DatePartInterval | DatePartTime | DatePartTimestamp | DatePartTimestampTz => {
-                ScalarType::Float64.nullable(true)
+                ScalarType::Float64.nullable(in_nullable)
             }
 
             DateBinTimestampTz | DateTruncTimestampTz => ScalarType::TimestampTz { precision: None }.nullable(true),
@@ -4244,12 +4542,23 @@ impl BinaryFunc {
             | BinaryFunc::SubTimeInterval
             | BinaryFunc::UuidGenerateV5
             | BinaryFunc::RangeContainsRange { .. }
+            | BinaryFunc::RangeContainsElem { .. }
             | BinaryFunc::RangeOverlaps
             | BinaryFunc::RangeAfter
             | BinaryFunc::RangeBefore
             | BinaryFunc::RangeOverleft
             | BinaryFunc::RangeOverright
-            | BinaryFunc::RangeAdjacent => false,
+            | BinaryFunc::RangeAdjacent
+            | BinaryFunc::ArrayLower
+            | BinaryFunc::ArrayContains
+            | BinaryFunc::ArrayContainsArray { rev: _ }
+            | BinaryFunc::ListListConcat
+            | BinaryFunc::ListElementConcat
+            | BinaryFunc::ElementListConcat
+            | BinaryFunc::ListRemove
+            | BinaryFunc::ToCharTimestamp
+            | BinaryFunc::ToCharTimestampTz
+            | BinaryFunc::ListContainsList { rev: _ } => false,
 
             _ => true,
         }
@@ -4633,9 +4942,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::EncodedBytesCharLength => f.write_str("length"),
             BinaryFunc::ListLengthMax { .. } => f.write_str("list_length_max"),
             BinaryFunc::ArrayContains => f.write_str("array_contains"),
-            BinaryFunc::ArrayContainsArray { rev, .. } => {
-                f.write_str(if *rev { "<@" } else { "@>" })
-            }
+            BinaryFunc::ArrayContainsArray { rev } => f.write_str(if *rev { "<@" } else { "@>" }),
             BinaryFunc::ArrayLength => f.write_str("array_length"),
             BinaryFunc::ArrayLower => f.write_str("array_lower"),
             BinaryFunc::ArrayRemove => f.write_str("array_remove"),
@@ -4645,7 +4952,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ListElementConcat => f.write_str("||"),
             BinaryFunc::ElementListConcat => f.write_str("||"),
             BinaryFunc::ListRemove => f.write_str("list_remove"),
-            BinaryFunc::ListContainsList { rev, .. } => f.write_str(if *rev { "<@" } else { "@>" }),
+            BinaryFunc::ListContainsList { rev } => f.write_str(if *rev { "<@" } else { "@>" }),
             BinaryFunc::DigestString | BinaryFunc::DigestBytes => f.write_str("digest"),
             BinaryFunc::MzRenderTypmod => f.write_str("mz_render_typmod"),
             BinaryFunc::Encode => f.write_str("encode"),
@@ -8205,6 +8512,14 @@ fn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     })
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Option<i32>",
+    is_infix_op = true,
+    sqlname = "array_lower",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -8218,6 +8533,14 @@ fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = false,
+    sqlname = "array_remove",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn array_remove<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -8250,6 +8573,14 @@ fn array_remove<'a>(
     Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Option<i32>",
+    is_infix_op = true,
+    sqlname = "array_upper",
+    propagates_nulls = true,
+    introduces_nulls = true
+)]
 // TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn array_upper<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
@@ -8311,11 +8642,27 @@ fn list_length_max<'a>(
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "bool",
+    is_infix_op = true,
+    sqlname = "array_contains",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn array_contains<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let array = Datum::unwrap_array(&b);
     Datum::from(array.elements().iter().any(|e| e == a))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "bool",
+    is_infix_op = true,
+    sqlname = "@>",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn array_contains_array<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let a = a.unwrap_array().elements();
     let b = b.unwrap_array().elements();
@@ -8330,6 +8677,26 @@ fn array_contains_array<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     }
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "bool",
+    is_infix_op = true,
+    sqlname = "<@",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
+fn array_contains_array_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    array_contains_array(a, b)
+}
+
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "||",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn array_array_concat<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -8434,6 +8801,14 @@ fn array_array_concat<'a>(
     Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "||",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn list_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     if a.is_null() {
         return b;
@@ -8447,6 +8822,14 @@ fn list_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) 
     temp_storage.make_datum(|packer| packer.push_list(a.chain(b)))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "||",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn list_element_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     temp_storage.make_datum(|packer| {
         packer.push_list_with(|packer| {
@@ -8460,6 +8843,14 @@ fn list_element_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowAren
     })
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = true,
+    sqlname = "||",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn element_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     temp_storage.make_datum(|packer| {
         packer.push_list_with(|packer| {
@@ -8473,6 +8864,14 @@ fn element_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowAren
     })
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type_expr = "input_type_a.scalar_type.without_modifiers().nullable(true)",
+    is_infix_op = false,
+    sqlname = "list_remove",
+    propagates_nulls = false,
+    introduces_nulls = false
+)]
 fn list_remove<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     if a.is_null() {
         return a;
@@ -8489,6 +8888,14 @@ fn list_remove<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Da
     })
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Vec<u8>",
+    is_infix_op = false,
+    sqlname = "digest",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn digest_string<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -8498,6 +8905,14 @@ fn digest_string<'a>(
     digest_inner(to_digest, b, temp_storage)
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "Vec<u8>",
+    is_infix_op = false,
+    sqlname = "digest",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn digest_bytes<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -8524,6 +8939,14 @@ fn digest_inner<'a>(
     Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
 }
 
+#[sqlfunc(
+    is_monotone = "(false, false)",
+    output_type = "String",
+    is_infix_op = false,
+    sqlname = "mz_render_typmod",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn mz_render_typmod<'a>(
     oid: Datum<'a>,
     typmod: Datum<'a>,

--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -911,6 +911,18 @@ mod test {
         );
 
         check(
+            func::DateBinTimestamp,
+            BF::DateBinTimestamp,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::DateBinTimestampTz,
+            BF::DateBinTimestampTz,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
             func::DatePartIntervalNumeric,
             BF::ExtractInterval,
             &i32_ty,
@@ -918,14 +930,50 @@ mod test {
         );
         check(func::DatePartTimeNumeric, BF::ExtractTime, &i32_ty, &i32_ty);
         check(
+            func::DatePartTimestampTimestampNumeric,
+            BF::ExtractTimestamp,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::DatePartTimestampTimestampTzNumeric,
+            BF::ExtractTimestampTz,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
             func::DatePartIntervalF64,
             BF::DatePartInterval,
             &i32_ty,
             &i32_ty,
         );
         check(func::DatePartTimeF64, BF::DatePartTime, &i32_ty, &i32_ty);
+        check(
+            func::DatePartTimestampTimestampF64,
+            BF::DatePartTimestamp,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::DatePartTimestampTimestampTzF64,
+            BF::DatePartTimestampTz,
+            &i32_ty,
+            &i32_ty,
+        );
 
         check(func::ExtractDateUnits, BF::ExtractDate, &i32_ty, &i32_ty);
+        check(
+            func::DateTruncUnitsTimestamp,
+            BF::DateTruncTimestamp,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::DateTruncUnitsTimestampTz,
+            BF::DateTruncTimestampTz,
+            &i32_ty,
+            &i32_ty,
+        );
         check(
             func::DateTruncInterval,
             BF::DateTruncInterval,

--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -481,6 +481,13 @@ mod test {
             nullable: input_nullable,
             scalar_type: ScalarType::Interval,
         };
+        let i32_map_ty = ColumnType {
+            nullable: input_nullable,
+            scalar_type: ScalarType::Map {
+                value_type: Box::new(ScalarType::Int32),
+                custom_id: None,
+            },
+        };
 
         use BinaryFunc as BF;
 
@@ -689,6 +696,115 @@ mod test {
         );
 
         check(
+            func::RangeContainsI32,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Int32,
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsI64,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Int64,
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsDate,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Date,
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsNumeric,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Numeric { max_scale: None },
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsTimestamp,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Timestamp { precision: None },
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsTimestampTz,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::TimestampTz { precision: None },
+                rev: false,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsI32Rev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Int32,
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsI64Rev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Int64,
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsDateRev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Date,
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsNumericRev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Numeric { max_scale: None },
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsTimestampRev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::Timestamp { precision: None },
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::RangeContainsTimestampTzRev,
+            BF::RangeContainsElem {
+                elem_type: ScalarType::TimestampTz { precision: None },
+                rev: true,
+            },
+            &i32_ty,
+            &i32_ty,
+        );
+
+        check(
             func::RangeContainsRange,
             BF::RangeContainsRange { rev: false },
             &i32_ty,
@@ -707,6 +823,15 @@ mod test {
         check(func::RangeOverright, BF::RangeOverright, &i32_ty, &i32_ty);
         check(func::RangeAdjacent, BF::RangeAdjacent, &i32_ty, &i32_ty);
 
+        check(func::RangeUnion, BF::RangeUnion, &i32_ty, &i32_ty);
+        check(
+            func::RangeIntersection,
+            BF::RangeIntersection,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::RangeDifference, BF::RangeDifference, &i32_ty, &i32_ty);
+
         check(func::Eq, BF::Eq, &i32_ty, &i32_ty);
         check(func::NotEq, BF::NotEq, &i32_ty, &i32_ty);
         check(func::Lt, BF::Lt, &i32_ty, &i32_ty);
@@ -714,6 +839,23 @@ mod test {
         check(func::Gt, BF::Gt, &i32_ty, &i32_ty);
         check(func::Gte, BF::Gte, &i32_ty, &i32_ty);
 
+        check(
+            func::ToCharTimestampFormat,
+            BF::ToCharTimestamp,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ToCharTimestampTzFormat,
+            BF::ToCharTimestampTz,
+            &i32_ty,
+            &i32_ty,
+        );
+
+        // JsonbGet* have a `stringify` parameter that doesn't work with the sqlfunc macro.
+        // check(func::JsonbGetInt64, BF::JsonbGetInt64, &i32_ty, &i32_ty);
+        // check(func::JsonbGetString, BF::JsonbGetString, &i32_ty, &i32_ty);
+        // check(func::JsonbGetPath, BF::JsonbGetPath, &i32_ty, &i32_ty);
         check(
             func::JsonbContainsString,
             BF::JsonbContainsString,
@@ -734,6 +876,19 @@ mod test {
             &i32_ty,
         );
         check(func::MapContainsMap, BF::MapContainsMap, &i32_ty, &i32_ty);
+        check(func::MapGetValue, BF::MapGetValue, &i32_map_ty, &i32_ty);
+        check(
+            func::ListContainsList,
+            BF::ListContainsList { rev: false },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ListContainsListRev,
+            BF::ListContainsList { rev: true },
+            &i32_ty,
+            &i32_ty,
+        );
 
         check(
             func::JsonbContainsJsonb,
@@ -741,6 +896,34 @@ mod test {
             &i32_ty,
             &i32_ty,
         );
+        check(func::JsonbConcat, BF::JsonbConcat, &i32_ty, &i32_ty);
+        check(
+            func::JsonbDeleteInt64,
+            BF::JsonbDeleteInt64,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::JsonbDeleteString,
+            BF::JsonbDeleteString,
+            &i32_ty,
+            &i32_ty,
+        );
+
+        check(
+            func::DatePartIntervalNumeric,
+            BF::ExtractInterval,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::DatePartTimeNumeric, BF::ExtractTime, &i32_ty, &i32_ty);
+        check(
+            func::DatePartIntervalF64,
+            BF::DatePartInterval,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::DatePartTimeF64, BF::DatePartTime, &i32_ty, &i32_ty);
 
         check(func::ExtractDateUnits, BF::ExtractDate, &i32_ty, &i32_ty);
         check(
@@ -751,5 +934,45 @@ mod test {
         );
 
         check(func::ArrayLength, BF::ArrayLength, &i32_ty, &i32_ty);
+        check(func::ArrayLower, BF::ArrayLower, &i32_ty, &i32_ty);
+        check(func::ArrayRemove, BF::ArrayRemove, &i32_ty, &i32_ty);
+        check(func::ArrayUpper, BF::ArrayUpper, &i32_ty, &i32_ty);
+        // check(func::ListLength, BF::ListLength, &i32_ty, &i32_ty);
+        check(func::ArrayContains, BF::ArrayContains, &i32_ty, &i32_ty);
+        check(
+            func::ArrayContainsArray,
+            BF::ArrayContainsArray { rev: false },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ArrayContainsArrayRev,
+            BF::ArrayContainsArray { rev: true },
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ArrayArrayConcat,
+            BF::ArrayArrayConcat,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::ListListConcat, BF::ListListConcat, &i32_ty, &i32_ty);
+        check(
+            func::ListElementConcat,
+            BF::ListElementConcat,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::ElementListConcat,
+            BF::ElementListConcat,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::ListRemove, BF::ListRemove, &i32_ty, &i32_ty);
+        check(func::DigestString, BF::DigestString, &i32_ty, &i32_ty);
+        check(func::DigestBytes, BF::DigestBytes, &i32_ty, &i32_ty);
+        check(func::MzRenderTypmod, BF::MzRenderTypmod, &i32_ty, &i32_ty);
     }
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamp.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = false,\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamp();\n    let b_ts = b.unwrap_timestamp();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"Interval\",\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamp();\n    let b_ts = b.unwrap_timestamp();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,9 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AgeTimestamp {
     }
     fn introduces_nulls(&self) -> bool {
         <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamptz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__age_timestamptz.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = Interval,\n    is_infix_op = false,\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamptz();\n    let b_ts = b.unwrap_timestamptz();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"Interval\",\n    sqlname = \"age\",\n    propagates_nulls = true\n)]\nfn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a_ts = a.unwrap_timestamptz();\n    let b_ts = b.unwrap_timestamptz();\n    let age = a_ts.age(&b_ts)?;\n    Ok(Datum::from(age))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,9 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AgeTimestamptz {
     }
     fn introduces_nulls(&self) -> bool {
         <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_array_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_array_concat.snap
@@ -1,0 +1,132 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn array_array_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    if a.is_null() {\n        return Ok(b);\n    } else if b.is_null() {\n        return Ok(a);\n    }\n    let a_array = a.unwrap_array();\n    let b_array = b.unwrap_array();\n    let a_dims: Vec<ArrayDimension> = a_array.dims().into_iter().collect();\n    let b_dims: Vec<ArrayDimension> = b_array.dims().into_iter().collect();\n    let a_ndims = a_dims.len();\n    let b_ndims = b_dims.len();\n    if a_ndims == 0 {\n        return Ok(b);\n    } else if b_ndims == 0 {\n        return Ok(a);\n    }\n    #[allow(clippy::as_conversions)]\n    if (a_ndims as isize - b_ndims as isize).abs() > 1 {\n        return Err(EvalError::IncompatibleArrayDimensions {\n            dims: Some((a_ndims, b_ndims)),\n        });\n    }\n    let mut dims;\n    match a_ndims.cmp(&b_ndims) {\n        Ordering::Equal => {\n            if &a_dims[1..] != &b_dims[1..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + b_dims[0].length, }\n            ];\n            dims.extend(&a_dims[1..]);\n        }\n        Ordering::Less => {\n            if &a_dims[..] != &b_dims[1..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : b_dims[0].lower_bound, length : b_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(a_dims);\n        }\n        Ordering::Greater => {\n            if &a_dims[1..] != &b_dims[..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(b_dims);\n        }\n    }\n    let elems = a_array.elements().iter().chain(b_array.elements().iter());\n    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayArrayConcat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayArrayConcat {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_array_concat(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ArrayArrayConcat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("||")
+    }
+}
+fn array_array_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if a.is_null() {
+        return Ok(b);
+    } else if b.is_null() {
+        return Ok(a);
+    }
+    let a_array = a.unwrap_array();
+    let b_array = b.unwrap_array();
+    let a_dims: Vec<ArrayDimension> = a_array.dims().into_iter().collect();
+    let b_dims: Vec<ArrayDimension> = b_array.dims().into_iter().collect();
+    let a_ndims = a_dims.len();
+    let b_ndims = b_dims.len();
+    if a_ndims == 0 {
+        return Ok(b);
+    } else if b_ndims == 0 {
+        return Ok(a);
+    }
+    #[allow(clippy::as_conversions)]
+    if (a_ndims as isize - b_ndims as isize).abs() > 1 {
+        return Err(EvalError::IncompatibleArrayDimensions {
+            dims: Some((a_ndims, b_ndims)),
+        });
+    }
+    let mut dims;
+    match a_ndims.cmp(&b_ndims) {
+        Ordering::Equal => {
+            if &a_dims[1..] != &b_dims[1..] {
+                return Err(EvalError::IncompatibleArrayDimensions {
+                    dims: None,
+                });
+            }
+            dims = vec![
+                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]
+                .length + b_dims[0].length, }
+            ];
+            dims.extend(&a_dims[1..]);
+        }
+        Ordering::Less => {
+            if &a_dims[..] != &b_dims[1..] {
+                return Err(EvalError::IncompatibleArrayDimensions {
+                    dims: None,
+                });
+            }
+            dims = vec![
+                ArrayDimension { lower_bound : b_dims[0].lower_bound, length : b_dims[0]
+                .length + 1, }
+            ];
+            dims.extend(a_dims);
+        }
+        Ordering::Greater => {
+            if &a_dims[1..] != &b_dims[..] {
+                return Err(EvalError::IncompatibleArrayDimensions {
+                    dims: None,
+                });
+            }
+            dims = vec![
+                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]
+                .length + 1, }
+            ];
+            dims.extend(b_dims);
+        }
+    }
+    let elems = a_array.elements().iter().chain(b_array.elements().iter());
+    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains.snap
@@ -1,0 +1,67 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"array_contains\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn array_contains<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let array = Datum::unwrap_array(&b);\n    Datum::from(array.elements().iter().any(|e| e == a))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayContains;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayContains {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_contains(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayContains {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("array_contains")
+    }
+}
+fn array_contains<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let array = Datum::unwrap_array(&b);
+    Datum::from(array.elements().iter().any(|e| e == a))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains_array.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains_array.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn array_contains_array<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_array().elements();\n    let b = b.unwrap_array().elements();\n    if b.iter().contains(&Datum::Null) {\n        Datum::False\n    } else {\n        b.iter().all(|item_b| a.iter().any(|item_a| item_a == item_b)).into()\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayContainsArray;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayContainsArray {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_contains_array(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayContainsArray {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn array_contains_array<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let a = a.unwrap_array().elements();
+    let b = b.unwrap_array().elements();
+    if b.iter().contains(&Datum::Null) {
+        Datum::False
+    } else {
+        b.iter().all(|item_b| a.iter().any(|item_a| item_a == item_b)).into()
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains_array_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_contains_array_rev.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<@\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn array_contains_array_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    array_contains_array(a, b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayContainsArrayRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayContainsArrayRev {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_contains_array_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayContainsArrayRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn array_contains_array_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    array_contains_array(a, b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_length.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_length.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Option<i32>\",\n    is_infix_op = true,\n    sqlname = \"array_length\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let i = match usize::try_from(b.unwrap_int64()) {\n        Ok(0) | Err(_) => return Ok(Datum::Null),\n        Ok(n) => n - 1,\n    };\n    Ok(\n        match a.unwrap_array().dims().into_iter().nth(i) {\n            None => Datum::Null,\n            Some(dim) => {\n                Datum::Int32(\n                    dim\n                        .length\n                        .try_into()\n                        .map_err(|_| EvalError::Int32OutOfRange(\n                            dim.length.to_string().into(),\n                        ))?,\n                )\n            }\n        },\n    )\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"Option<i32>\",\n    is_infix_op = true,\n    sqlname = \"array_length\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn array_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let i = match usize::try_from(b.unwrap_int64()) {\n        Ok(0) | Err(_) => return Ok(Datum::Null),\n        Ok(n) => n - 1,\n    };\n    Ok(\n        match a.unwrap_array().dims().into_iter().nth(i) {\n            None => Datum::Null,\n            Some(dim) => {\n                Datum::Int32(\n                    dim\n                        .length\n                        .try_into()\n                        .map_err(|_| EvalError::Int32OutOfRange(\n                            dim.length.to_string().into(),\n                        ))?,\n                )\n            }\n        },\n    )\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayLength {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_lower.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_lower.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Option<i32>\",\n    is_infix_op = true,\n    sqlname = \"array_lower\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let i = b.unwrap_int64();\n    if i < 1 {\n        return Datum::Null;\n    }\n    match a.unwrap_array().dims().into_iter().nth(i as usize - 1) {\n        Some(_) => Datum::Int32(1),\n        None => Datum::Null,\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayLower;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayLower {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_lower(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Option<i32>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayLower {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("array_lower")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let i = b.unwrap_int64();
+    if i < 1 {
+        return Datum::Null;
+    }
+    match a.unwrap_array().dims().into_iter().nth(i as usize - 1) {
+        Some(_) => Datum::Int32(1),
+        None => Datum::Null,
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_remove.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_remove.snap
@@ -1,0 +1,83 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    sqlname = \"array_remove\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn array_remove<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    if a.is_null() {\n        return Ok(a);\n    }\n    let arr = a.unwrap_array();\n    if arr.dims().len() == 0 {\n        return Ok(a);\n    }\n    if arr.dims().len() > 1 {\n        return Err(EvalError::MultidimensionalArrayRemovalNotSupported);\n    }\n    let elems: Vec<_> = arr.elements().iter().filter(|v| v != &b).collect();\n    let mut dims = arr.dims().into_iter().collect::<Vec<_>>();\n    dims[0] = ArrayDimension {\n        lower_bound: 1,\n        length: elems.len(),\n    };\n    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayRemove;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayRemove {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_remove(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ArrayRemove {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("array_remove")
+    }
+}
+fn array_remove<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if a.is_null() {
+        return Ok(a);
+    }
+    let arr = a.unwrap_array();
+    if arr.dims().len() == 0 {
+        return Ok(a);
+    }
+    if arr.dims().len() > 1 {
+        return Err(EvalError::MultidimensionalArrayRemovalNotSupported);
+    }
+    let elems: Vec<_> = arr.elements().iter().filter(|v| v != &b).collect();
+    let mut dims = arr.dims().into_iter().collect::<Vec<_>>();
+    dims[0] = ArrayDimension {
+        lower_bound: 1,
+        length: elems.len(),
+    };
+    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_upper.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_upper.snap
@@ -1,0 +1,85 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Option<i32>\",\n    is_infix_op = true,\n    sqlname = \"array_upper\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn array_upper<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let i = b.unwrap_int64();\n    if i < 1 {\n        return Ok(Datum::Null);\n    }\n    Ok(\n        match a.unwrap_array().dims().into_iter().nth(i as usize - 1) {\n            Some(dim) => {\n                Datum::Int32(\n                    dim\n                        .length\n                        .try_into()\n                        .map_err(|_| EvalError::Int32OutOfRange(\n                            dim.length.to_string().into(),\n                        ))?,\n                )\n            }\n            None => Datum::Null,\n        },\n    )\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ArrayUpper;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ArrayUpper {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        array_upper(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Option<i32>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ArrayUpper {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("array_upper")
+    }
+}
+#[allow(clippy::as_conversions)]
+fn array_upper<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let i = b.unwrap_int64();
+    if i < 1 {
+        return Ok(Datum::Null);
+    }
+    Ok(
+        match a.unwrap_array().dims().into_iter().nth(i as usize - 1) {
+            Some(dim) => {
+                Datum::Int32(
+                    dim
+                        .length
+                        .try_into()
+                        .map_err(|_| EvalError::Int32OutOfRange(
+                            dim.length.to_string().into(),
+                        ))?,
+                )
+            }
+            None => Datum::Null,
+        },
+    )
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() & b.unwrap_int16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() & b.unwrap_int16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() & b.unwrap_int32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() & b.unwrap_int32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() & b.unwrap_int64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() & b.unwrap_int64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() & b.unwrap_uint16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() & b.unwrap_uint16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() & b.unwrap_uint32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() & b.unwrap_uint32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_and_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() & b.unwrap_uint64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"&\",\n    propagates_nulls = true\n)]\nfn bit_and_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() & b.unwrap_uint64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitAndUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() | b.unwrap_int16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() | b.unwrap_int16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() | b.unwrap_int32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() | b.unwrap_int32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() | b.unwrap_int64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() | b.unwrap_int64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() | b.unwrap_uint16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() | b.unwrap_uint16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() | b.unwrap_uint32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() | b.unwrap_uint32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_or_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() | b.unwrap_uint64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"|\",\n    propagates_nulls = true\n)]\nfn bit_or_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() | b.unwrap_uint64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitOrUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: i32 = a.unwrap_int16() as i32;\n    let rhs: u32 = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs) as i16)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: i32 = a.unwrap_int16() as i32;\n    let rhs: u32 = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs) as i16)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: u32 = a.unwrap_uint16() as u32;\n    let rhs: u32 = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs) as u16)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_left_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs: u32 = a.unwrap_uint16() as u32;\n    let rhs: u32 = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs) as u16)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_left_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn bit_shift_left_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shl(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftLeftUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int16() as i32;\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs) as i16)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int16() as i32;\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs) as i16)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int32();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_int64();\n    let rhs = b.unwrap_int32() as u32;\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint16() as u32;\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs) as u16)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\n#[allow(clippy::as_conversions)]\nfn bit_shift_right_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint16() as u32;\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs) as u16)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint32();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_shift_right_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn bit_shift_right_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let lhs = a.unwrap_uint64();\n    let rhs = b.unwrap_uint32();\n    Datum::from(lhs.wrapping_shr(rhs))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitShiftRightUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() ^ b.unwrap_int16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int16() ^ b.unwrap_int16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() ^ b.unwrap_int32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int32() ^ b.unwrap_int32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() ^ b.unwrap_int64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_int64() ^ b.unwrap_int64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() ^ b.unwrap_uint16())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint16() ^ b.unwrap_uint16())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() ^ b.unwrap_uint32())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint32() ^ b.unwrap_uint32())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__bit_xor_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() ^ b.unwrap_uint64())\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"#\",\n    propagates_nulls = true\n)]\nfn bit_xor_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a.unwrap_uint64() ^ b.unwrap_uint64())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for BitXorUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_bytes.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_bytes.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = false,\n    sqlname = \"constant_time_compare_bytes\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_bytes<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a_bytes = a.unwrap_bytes();\n    let b_bytes = b.unwrap_bytes();\n    Ok(Datum::from(bool::from(a_bytes.ct_eq(b_bytes))))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    sqlname = \"constant_time_compare_bytes\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_bytes<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a_bytes = a.unwrap_bytes();\n    let b_bytes = b.unwrap_bytes();\n    Ok(Datum::from(bool::from(a_bytes.ct_eq(b_bytes))))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConstantTimeEqBytes {
     }
     fn introduces_nulls(&self) -> bool {
         <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__constant_time_eq_string.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = false,\n    sqlname = \"constant_time_compare_strings\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_string<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_str();\n    let b = b.unwrap_str();\n    Ok(Datum::from(bool::from(a.as_bytes().ct_eq(b.as_bytes()))))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    sqlname = \"constant_time_compare_strings\",\n    propagates_nulls = true\n)]\npub fn constant_time_eq_string<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_str();\n    let b = b.unwrap_str();\n    Ok(Datum::from(bool::from(a.as_bytes().ct_eq(b.as_bytes()))))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConstantTimeEqString {
     }
     fn introduces_nulls(&self) -> bool {
         <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = String,\n    is_infix_op = false,\n    sqlname = \"convert_from\",\n    propagates_nulls = true\n)]\nfn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some(\"utf-8\") {\n        return Err(EvalError::InvalidEncodingName(encoding_name));\n    }\n    match str::from_utf8(a.unwrap_bytes()) {\n        Ok(from) => Ok(Datum::String(from)),\n        Err(e) => {\n            Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.to_string().into(),\n                encoding_name,\n            })\n        }\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"String\", sqlname = \"convert_from\", propagates_nulls = true)]\nfn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some(\"utf-8\") {\n        return Err(EvalError::InvalidEncodingName(encoding_name));\n    }\n    match str::from_utf8(a.unwrap_bytes()) {\n        Ok(from) => Ok(Datum::String(from)),\n        Err(e) => {\n            Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.to_string().into(),\n                encoding_name,\n            })\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ConvertFrom {
     }
     fn introduces_nulls(&self) -> bool {
         <String as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_bin_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_bin_timestamp.snap
@@ -1,0 +1,73 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"CheckedTimestamp<NaiveDateTime>\",\n    sqlname = \"bin_unix_epoch_timestamp\",\n    propagates_nulls = true\n)]\nfn date_bin_timestamp<'a>(\n    stride: Interval,\n    source: CheckedTimestamp<NaiveDateTime>,\n) -> Result<Datum<'a>, EvalError> {\n    let origin = CheckedTimestamp::from_timestamplike(\n            DateTime::from_timestamp(0, 0).unwrap().naive_utc(),\n        )\n        .expect(\"must fit\");\n    date_bin(stride, source, origin)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DateBinTimestamp;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateBinTimestamp {
+    type Input1 = Interval;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_bin_timestamp(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <CheckedTimestamp<NaiveDateTime>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <CheckedTimestamp<NaiveDateTime> as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DateBinTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bin_unix_epoch_timestamp")
+    }
+}
+fn date_bin_timestamp<'a>(
+    stride: Interval,
+    source: CheckedTimestamp<NaiveDateTime>,
+) -> Result<Datum<'a>, EvalError> {
+    let origin = CheckedTimestamp::from_timestamplike(
+            DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+        )
+        .expect("must fit");
+    date_bin(stride, source, origin)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_bin_timestamp_tz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_bin_timestamp_tz.snap
@@ -1,0 +1,73 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"CheckedTimestamp<DateTime<Utc>>\",\n    sqlname = \"bin_unix_epoch_timestamptz\",\n    propagates_nulls = true\n)]\nfn date_bin_timestamp_tz<'a>(\n    stride: Interval,\n    source: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<Datum<'a>, EvalError> {\n    let origin = CheckedTimestamp::from_timestamplike(\n            DateTime::from_timestamp(0, 0).unwrap(),\n        )\n        .expect(\"must fit\");\n    date_bin(stride, source, origin)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DateBinTimestampTz;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateBinTimestampTz {
+    type Input1 = Interval;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_bin_timestamp_tz(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <CheckedTimestamp<DateTime<Utc>>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <CheckedTimestamp<DateTime<Utc>> as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (true, true)
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DateBinTimestampTz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("bin_unix_epoch_timestamptz")
+    }
+}
+fn date_bin_timestamp_tz<'a>(
+    stride: Interval,
+    source: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<Datum<'a>, EvalError> {
+    let origin = CheckedTimestamp::from_timestamplike(
+            DateTime::from_timestamp(0, 0).unwrap(),
+        )
+        .expect("must fit");
+    date_bin(stride, source, origin)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_interval_f64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_interval_f64.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"f64\",\n    sqlname = \"date_partiv\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn date_part_interval_f64<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => {\n            Ok(date_part_interval_inner::<f64>(units, b.unwrap_interval())?.into())\n        }\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartIntervalF64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartIntervalF64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_interval_f64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartIntervalF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_partiv")
+    }
+}
+fn date_part_interval_f64<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => {
+            Ok(date_part_interval_inner::<f64>(units, b.unwrap_interval())?.into())
+        }
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_interval_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_interval_numeric.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Numeric\",\n    sqlname = \"extractiv\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn date_part_interval_numeric<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => {\n            Ok(date_part_interval_inner::<Numeric>(units, b.unwrap_interval())?.into())\n        }\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartIntervalNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartIntervalNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_interval_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartIntervalNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("extractiv")
+    }
+}
+fn date_part_interval_numeric<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => {
+            Ok(date_part_interval_inner::<Numeric>(units, b.unwrap_interval())?.into())
+        }
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_time_f64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_time_f64.snap
@@ -1,0 +1,67 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"f64\",\n    sqlname = \"date_partt\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn date_part_time_f64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => Ok(date_part_time_inner::<f64>(units, b.unwrap_time())?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimeF64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartTimeF64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_time_f64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <f64>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimeF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_partt")
+    }
+}
+fn date_part_time_f64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_time_inner::<f64>(units, b.unwrap_time())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_time_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_time_numeric.snap
@@ -1,0 +1,70 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Numeric\",\n    sqlname = \"extractt\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn date_part_time_numeric<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => Ok(date_part_time_inner::<Numeric>(units, b.unwrap_time())?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimeNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartTimeNumeric {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_time_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimeNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("extractt")
+    }
+}
+fn date_part_time_numeric<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => Ok(date_part_time_inner::<Numeric>(units, b.unwrap_time())?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_f64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_f64.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(sqlname = \"date_partts\", propagates_nulls = true)]\nfn date_part_timestamp_timestamp_f64(\n    units: &str,\n    ts: CheckedTimestamp<NaiveDateTime>,\n) -> Result<f64, EvalError> {\n    match units.parse() {\n        Ok(units) => date_part_timestamp_inner(units, &*ts),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimestampTimestampF64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartTimestampTimestampF64 {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<f64, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_timestamp_timestamp_f64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimestampTimestampF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_partts")
+    }
+}
+fn date_part_timestamp_timestamp_f64(
+    units: &str,
+    ts: CheckedTimestamp<NaiveDateTime>,
+) -> Result<f64, EvalError> {
+    match units.parse() {
+        Ok(units) => date_part_timestamp_inner(units, &*ts),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_numeric.snap
@@ -1,0 +1,69 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"Numeric\", sqlname = \"extractts\", propagates_nulls = true)]\nfn date_part_timestamp_timestamp_numeric<'a>(\n    units: &str,\n    ts: CheckedTimestamp<NaiveDateTime>,\n) -> Result<Datum<'a>, EvalError> {\n    match units.parse() {\n        Ok(units) => Ok(date_part_timestamp_inner::<_, Numeric>(units, &*ts)?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimestampTimestampNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartTimestampTimestampNumeric {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_timestamp_timestamp_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimestampTimestampNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("extractts")
+    }
+}
+fn date_part_timestamp_timestamp_numeric<'a>(
+    units: &str,
+    ts: CheckedTimestamp<NaiveDateTime>,
+) -> Result<Datum<'a>, EvalError> {
+    match units.parse() {
+        Ok(units) => Ok(date_part_timestamp_inner::<_, Numeric>(units, &*ts)?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_tz_f64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_tz_f64.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(sqlname = \"date_parttstz\", propagates_nulls = true)]\nfn date_part_timestamp_timestamp_tz_f64(\n    units: &str,\n    ts: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<f64, EvalError> {\n    match units.parse() {\n        Ok(units) => date_part_timestamp_inner(units, &*ts),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimestampTimestampTzF64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DatePartTimestampTimestampTzF64 {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<f64, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_timestamp_timestamp_tz_f64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimestampTimestampTzF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_parttstz")
+    }
+}
+fn date_part_timestamp_timestamp_tz_f64(
+    units: &str,
+    ts: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<f64, EvalError> {
+    match units.parse() {
+        Ok(units) => date_part_timestamp_inner(units, &*ts),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_tz_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_part_timestamp_timestamp_tz_numeric.snap
@@ -1,0 +1,70 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"Numeric\", sqlname = \"extracttstz\", propagates_nulls = true)]\nfn date_part_timestamp_timestamp_tz_numeric<'a>(\n    units: &str,\n    ts: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<Datum<'a>, EvalError> {\n    match units.parse() {\n        Ok(units) => Ok(date_part_timestamp_inner::<_, Numeric>(units, &*ts)?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DatePartTimestampTimestampTzNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a>
+for DatePartTimestampTimestampTzNumeric {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_part_timestamp_timestamp_tz_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Numeric>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DatePartTimestampTimestampTzNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("extracttstz")
+    }
+}
+fn date_part_timestamp_timestamp_tz_numeric<'a>(
+    units: &str,
+    ts: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<Datum<'a>, EvalError> {
+    match units.parse() {
+        Ok(units) => Ok(date_part_timestamp_inner::<_, Numeric>(units, &*ts)?.into()),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_interval.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Interval\",\n    is_infix_op = false,\n    sqlname = \"date_trunciv\",\n    propagates_nulls = true\n)]\nfn date_trunc_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut interval = b.unwrap_interval();\n    let units = a.unwrap_str();\n    let dtf = units.parse().map_err(|_| EvalError::UnknownUnits(units.into()))?;\n    interval\n        .truncate_low_fields(dtf, Some(0), RoundBehavior::Truncate)\n        .expect(\n            \"truncate_low_fields should not fail with max_precision 0 and RoundBehavior::Truncate\",\n        );\n    Ok(interval.into())\n}\n"
+expression: "#[sqlfunc(output_type = \"Interval\", sqlname = \"date_trunciv\", propagates_nulls = true)]\nfn date_trunc_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut interval = b.unwrap_interval();\n    let units = a.unwrap_str();\n    let dtf = units.parse().map_err(|_| EvalError::UnknownUnits(units.into()))?;\n    interval\n        .truncate_low_fields(dtf, Some(0), RoundBehavior::Truncate)\n        .expect(\n            \"truncate_low_fields should not fail with max_precision 0 and RoundBehavior::Truncate\",\n        );\n    Ok(interval.into())\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateTruncInterval {
     }
     fn introduces_nulls(&self) -> bool {
         <Interval as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_units_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_units_timestamp.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(sqlname = \"date_truncts\", propagates_nulls = true)]\nfn date_trunc_units_timestamp(\n    units: &str,\n    ts: CheckedTimestamp<NaiveDateTime>,\n) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {\n    match units.parse() {\n        Ok(units) => Ok(date_trunc_inner(units, &*ts)?.try_into()?),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DateTruncUnitsTimestamp;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateTruncUnitsTimestamp {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_trunc_units_timestamp(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DateTruncUnitsTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_truncts")
+    }
+}
+fn date_trunc_units_timestamp(
+    units: &str,
+    ts: CheckedTimestamp<NaiveDateTime>,
+) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
+    match units.parse() {
+        Ok(units) => Ok(date_trunc_inner(units, &*ts)?.try_into()?),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_units_timestamp_tz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__date_trunc_units_timestamp_tz.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(sqlname = \"date_trunctstz\", propagates_nulls = true)]\nfn date_trunc_units_timestamp_tz(\n    units: &str,\n    ts: CheckedTimestamp<DateTime<Utc>>,\n) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {\n    match units.parse() {\n        Ok(units) => Ok(date_trunc_inner(units, &*ts)?.try_into()?),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DateTruncUnitsTimestampTz;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DateTruncUnitsTimestampTz {
+    type Input1 = &'a str;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        date_trunc_units_timestamp_tz(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DateTruncUnitsTimestampTz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("date_trunctstz")
+    }
+}
+fn date_trunc_units_timestamp_tz(
+    units: &str,
+    ts: CheckedTimestamp<DateTime<Utc>>,
+) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
+    match units.parse() {
+        Ok(units) => Ok(date_trunc_inner(units, &*ts)?.try_into()?),
+        Err(_) => Err(EvalError::UnknownUnits(units.into())),
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__digest_bytes.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__digest_bytes.snap
@@ -1,0 +1,68 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Vec<u8>\",\n    sqlname = \"digest\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn digest_bytes<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let to_digest = a.unwrap_bytes();\n    digest_inner(to_digest, b, temp_storage)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DigestBytes;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DigestBytes {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        digest_bytes(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Vec<u8>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DigestBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("digest")
+    }
+}
+fn digest_bytes<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let to_digest = a.unwrap_bytes();
+    digest_inner(to_digest, b, temp_storage)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__digest_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__digest_string.snap
@@ -1,0 +1,68 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"Vec<u8>\",\n    sqlname = \"digest\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn digest_string<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let to_digest = a.unwrap_str().as_bytes();\n    digest_inner(to_digest, b, temp_storage)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct DigestString;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DigestString {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        digest_string(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <Vec<u8>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for DigestString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("digest")
+    }
+}
+fn digest_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let to_digest = a.unwrap_str().as_bytes();
+    digest_inner(to_digest, b, temp_storage)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__element_list_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__element_list_concat.snap
@@ -1,0 +1,81 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn element_list_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    temp_storage\n        .make_datum(|packer| {\n            packer\n                .push_list_with(|packer| {\n                    packer.push(a);\n                    if !b.is_null() {\n                        for elem in b.unwrap_list().iter() {\n                            packer.push(elem);\n                        }\n                    }\n                })\n        })\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ElementListConcat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ElementListConcat {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        element_list_concat(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ElementListConcat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("||")
+    }
+}
+fn element_list_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    temp_storage
+        .make_datum(|packer| {
+            packer
+                .push_list_with(|packer| {
+                    packer.push(a);
+                    if !b.is_null() {
+                        for elem in b.unwrap_list().iter() {
+                            packer.push(elem);
+                        }
+                    }
+                })
+        })
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encode.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encode.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = String,\n    is_infix_op = false,\n    sqlname = \"encode\",\n    propagates_nulls = true\n)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(output_type = \"String\", sqlname = \"encode\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
     }
     fn introduces_nulls(&self) -> bool {
         <String as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = false,\n    sqlname = \"length\",\n    propagates_nulls = true\n)]\nfn encoded_bytes_char_length<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    let enc = match encoding_from_whatwg_label(&encoding_name) {\n        Some(enc) => enc,\n        None => return Err(EvalError::InvalidEncodingName(encoding_name)),\n    };\n    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {\n        Ok(s) => s,\n        Err(e) => {\n            return Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.into(),\n                encoding_name,\n            });\n        }\n    };\n    let count = decoded_string.chars().count();\n    match i32::try_from(count) {\n        Ok(l) => Ok(Datum::from(l)),\n        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", sqlname = \"length\", propagates_nulls = true)]\nfn encoded_bytes_char_length<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    let enc = match encoding_from_whatwg_label(&encoding_name) {\n        Some(enc) => enc,\n        None => return Err(EvalError::InvalidEncodingName(encoding_name)),\n    };\n    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {\n        Ok(s) => s,\n        Err(e) => {\n            return Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.into(),\n                encoding_name,\n            });\n        }\n    };\n    let count = decoded_string.chars().count();\n    match i32::try_from(count) {\n        Ok(l) => Ok(Datum::from(l)),\n        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for EncodedBytesCharLength {
     }
     fn introduces_nulls(&self) -> bool {
         <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"=\",\n    propagates_nulls = true\n)]\nfn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a == b)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"=\",\n    propagates_nulls = true\n)]\nfn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a == b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Eq {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__extract_date_units.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__extract_date_units.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    sqlname = \"extractd\",\n    propagates_nulls = true\n)]\nfn extract_date_units<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => Ok(extract_date_inner(units, b.unwrap_date().into())?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"Numeric\", sqlname = \"extractd\", propagates_nulls = true)]\nfn extract_date_units<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let units = a.unwrap_str();\n    match units.parse() {\n        Ok(units) => Ok(extract_date_inner(units, b.unwrap_date().into())?.into()),\n        Err(_) => Err(EvalError::UnknownUnits(units.into())),\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ExtractDateUnits {
     }
     fn introduces_nulls(&self) -> bool {
         <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"i32\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,\n    };\n    let index = usize::try_from(index).map_err(|_| err.clone())?;\n    let byte_index = index / 8;\n    let bit_index = index % 8;\n    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;\n    assert!(i == 0 || i == 1);\n    Ok(Datum::from(i32::from(i)))\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,\n    };\n    let index = usize::try_from(index).map_err(|_| err.clone())?;\n    let byte_index = index / 8;\n    let bit_index = index % 8;\n    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;\n    assert!(i == 0 || i == 1);\n    Ok(Datum::from(i32::from(i)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for GetBit {
     }
     fn introduces_nulls(&self) -> bool {
         <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"i32\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len()).unwrap() - 1,\n    };\n    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;\n    Ok(Datum::from(i32::from(*i)))\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len()).unwrap() - 1,\n    };\n    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;\n    Ok(Datum::from(i32::from(*i)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for GetByte {
     }
     fn introduces_nulls(&self) -> bool {
         <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_concat.snap
@@ -1,0 +1,90 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"ScalarType::Jsonb.nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn jsonb_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    match (a, b) {\n        (Datum::Map(dict_a), Datum::Map(dict_b)) => {\n            let mut pairs = dict_b.iter().chain(dict_a.iter()).collect::<Vec<_>>();\n            pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));\n            pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);\n            temp_storage.make_datum(|packer| packer.push_dict(pairs))\n        }\n        (Datum::List(list_a), Datum::List(list_b)) => {\n            let elems = list_a.iter().chain(list_b.iter());\n            temp_storage.make_datum(|packer| packer.push_list(elems))\n        }\n        (Datum::List(list_a), b) => {\n            let elems = list_a.iter().chain(Some(b));\n            temp_storage.make_datum(|packer| packer.push_list(elems))\n        }\n        (a, Datum::List(list_b)) => {\n            let elems = Some(a).into_iter().chain(list_b.iter());\n            temp_storage.make_datum(|packer| packer.push_list(elems))\n        }\n        _ => Datum::Null,\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbConcat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbConcat {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        jsonb_concat(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = ScalarType::Jsonb.nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for JsonbConcat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("||")
+    }
+}
+fn jsonb_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    match (a, b) {
+        (Datum::Map(dict_a), Datum::Map(dict_b)) => {
+            let mut pairs = dict_b.iter().chain(dict_a.iter()).collect::<Vec<_>>();
+            pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
+            pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
+            temp_storage.make_datum(|packer| packer.push_dict(pairs))
+        }
+        (Datum::List(list_a), Datum::List(list_b)) => {
+            let elems = list_a.iter().chain(list_b.iter());
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        (Datum::List(list_a), b) => {
+            let elems = list_a.iter().chain(Some(b));
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        (a, Datum::List(list_b)) => {
+            let elems = Some(a).into_iter().chain(list_b.iter());
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        _ => Datum::Null,
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_jsonb.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_jsonb.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {\n        match (a, b) {\n            (Datum::JsonNull, Datum::JsonNull) => true,\n            (Datum::False, Datum::False) => true,\n            (Datum::True, Datum::True) => true,\n            (Datum::Numeric(a), Datum::Numeric(b)) => a == b,\n            (Datum::String(a), Datum::String(b)) => a == b,\n            (Datum::List(a), Datum::List(b)) => {\n                b.iter()\n                    .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false)))\n            }\n            (Datum::Map(a), Datum::Map(b)) => {\n                b.iter()\n                    .all(|(b_key, b_val)| {\n                        a.iter()\n                            .any(|(a_key, a_val)| {\n                                (a_key == b_key) && contains(a_val, b_val, false)\n                            })\n                    })\n            }\n            (Datum::List(a), b) => {\n                at_top_level && a.iter().any(|a_elem| contains(a_elem, b, false))\n            }\n            _ => false,\n        }\n    }\n    contains(a, b, true).into()\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {\n        match (a, b) {\n            (Datum::JsonNull, Datum::JsonNull) => true,\n            (Datum::False, Datum::False) => true,\n            (Datum::True, Datum::True) => true,\n            (Datum::Numeric(a), Datum::Numeric(b)) => a == b,\n            (Datum::String(a), Datum::String(b)) => a == b,\n            (Datum::List(a), Datum::List(b)) => {\n                b.iter()\n                    .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false)))\n            }\n            (Datum::Map(a), Datum::Map(b)) => {\n                b.iter()\n                    .all(|(b_key, b_val)| {\n                        a.iter()\n                            .any(|(a_key, a_val)| {\n                                (a_key == b_key) && contains(a_val, b_val, false)\n                            })\n                    })\n            }\n            (Datum::List(a), b) => {\n                at_top_level && a.iter().any(|a_elem| contains(a_elem, b, false))\n            }\n            _ => false,\n        }\n    }\n    contains(a, b, true).into()\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbContainsJsonb {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_contains_string.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let k = b.unwrap_str();\n    match a {\n        Datum::List(list) => list.iter().any(|k2| b == k2).into(),\n        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),\n        Datum::String(string) => (string == k).into(),\n        _ => false.into(),\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let k = b.unwrap_str();\n    match a {\n        Datum::List(list) => list.iter().any(|k2| b == k2).into(),\n        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),\n        Datum::String(string) => (string == k).into(),\n        _ => false.into(),\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbContainsString {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_delete_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_delete_int64.snap
@@ -1,0 +1,87 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"ScalarType::Jsonb.nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn jsonb_delete_int64<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    let i = b.unwrap_int64();\n    match a {\n        Datum::List(list) => {\n            let i = if i >= 0 {\n                usize::cast_from(i.unsigned_abs())\n            } else {\n                let i = usize::cast_from(i.unsigned_abs());\n                (list.iter().count()).wrapping_sub(i)\n            };\n            let elems = list\n                .iter()\n                .enumerate()\n                .filter(|(i2, _e)| i != *i2)\n                .map(|(_, e)| e);\n            temp_storage.make_datum(|packer| packer.push_list(elems))\n        }\n        _ => Datum::Null,\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbDeleteInt64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbDeleteInt64 {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        jsonb_delete_int64(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = ScalarType::Jsonb.nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for JsonbDeleteInt64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn jsonb_delete_int64<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    let i = b.unwrap_int64();
+    match a {
+        Datum::List(list) => {
+            let i = if i >= 0 {
+                usize::cast_from(i.unsigned_abs())
+            } else {
+                let i = usize::cast_from(i.unsigned_abs());
+                (list.iter().count()).wrapping_sub(i)
+            };
+            let elems = list
+                .iter()
+                .enumerate()
+                .filter(|(i2, _e)| i != *i2)
+                .map(|(_, e)| e);
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        _ => Datum::Null,
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_delete_string.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__jsonb_delete_string.snap
@@ -1,0 +1,81 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"ScalarType::Jsonb.nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn jsonb_delete_string<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    match a {\n        Datum::List(list) => {\n            let elems = list.iter().filter(|e| b != *e);\n            temp_storage.make_datum(|packer| packer.push_list(elems))\n        }\n        Datum::Map(dict) => {\n            let k = b.unwrap_str();\n            let pairs = dict.iter().filter(|(k2, _v)| k != *k2);\n            temp_storage.make_datum(|packer| packer.push_dict(pairs))\n        }\n        _ => Datum::Null,\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct JsonbDeleteString;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for JsonbDeleteString {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        jsonb_delete_string(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = ScalarType::Jsonb.nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for JsonbDeleteString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn jsonb_delete_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    match a {
+        Datum::List(list) => {
+            let elems = list.iter().filter(|e| b != *e);
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        Datum::Map(dict) => {
+            let k = b.unwrap_str();
+            let pairs = dict.iter().filter(|(k2, _v)| k != *k2);
+            temp_storage.make_datum(|packer| packer.push_dict(pairs))
+        }
+        _ => Datum::Null,
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_contains_list.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_contains_list.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn list_contains_list<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_list();\n    let b = b.unwrap_list();\n    if b.iter().contains(&Datum::Null) {\n        Datum::False\n    } else {\n        b.iter().all(|item_b| a.iter().any(|item_a| item_a == item_b)).into()\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ListContainsList;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ListContainsList {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        list_contains_list(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ListContainsList {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn list_contains_list<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let a = a.unwrap_list();
+    let b = b.unwrap_list();
+    if b.iter().contains(&Datum::Null) {
+        Datum::False
+    } else {
+        b.iter().all(|item_b| a.iter().any(|item_a| item_a == item_b)).into()
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_contains_list_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_contains_list_rev.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<@\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn list_contains_list_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    list_contains_list(b, a)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ListContainsListRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ListContainsListRev {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        list_contains_list_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ListContainsListRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn list_contains_list_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    list_contains_list(b, a)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_element_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_element_concat.snap
@@ -1,0 +1,81 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn list_element_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    temp_storage\n        .make_datum(|packer| {\n            packer\n                .push_list_with(|packer| {\n                    if !a.is_null() {\n                        for elem in a.unwrap_list().iter() {\n                            packer.push(elem);\n                        }\n                    }\n                    packer.push(b);\n                })\n        })\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ListElementConcat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ListElementConcat {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        list_element_concat(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ListElementConcat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("||")
+    }
+}
+fn list_element_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    temp_storage
+        .make_datum(|packer| {
+            packer
+                .push_list_with(|packer| {
+                    if !a.is_null() {
+                        for elem in a.unwrap_list().iter() {
+                            packer.push(elem);
+                        }
+                    }
+                    packer.push(b);
+                })
+        })
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_list_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_list_concat.snap
@@ -1,0 +1,77 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn list_list_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    if a.is_null() {\n        return b;\n    } else if b.is_null() {\n        return a;\n    }\n    let a = a.unwrap_list().iter();\n    let b = b.unwrap_list().iter();\n    temp_storage.make_datum(|packer| packer.push_list(a.chain(b)))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ListListConcat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ListListConcat {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        list_list_concat(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ListListConcat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("||")
+    }
+}
+fn list_list_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Datum<'a> {
+    if a.is_null() {
+        return b;
+    } else if b.is_null() {
+        return a;
+    }
+    let a = a.unwrap_list().iter();
+    let b = b.unwrap_list().iter();
+    temp_storage.make_datum(|packer| packer.push_list(a.chain(b)))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_remove.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__list_remove.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    sqlname = \"list_remove\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn list_remove<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {\n    if a.is_null() {\n        return a;\n    }\n    temp_storage\n        .make_datum(|packer| {\n            packer\n                .push_list_with(|packer| {\n                    for elem in a.unwrap_list().iter() {\n                        if elem != b {\n                            packer.push(elem);\n                        }\n                    }\n                })\n        })\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ListRemove;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ListRemove {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        list_remove(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        false
+    }
+}
+impl std::fmt::Display for ListRemove {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("list_remove")
+    }
+}
+fn list_remove<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
+    if a.is_null() {
+        return a;
+    }
+    temp_storage
+        .make_datum(|packer| {
+            packer
+                .push_list_with(|packer| {
+                    for elem in a.unwrap_list().iter() {
+                        if elem != b {
+                            packer.push(elem);
+                        }
+                    }
+                })
+        })
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__log_base_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__log_base_numeric.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    sqlname = \"log\",\n    propagates_nulls = true\n)]\nfn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    log_guard_numeric(&a, \"log\")?;\n    let mut b = b.unwrap_numeric().0;\n    log_guard_numeric(&b, \"log\")?;\n    let mut cx = numeric::cx_datum();\n    cx.ln(&mut a);\n    cx.ln(&mut b);\n    cx.div(&mut b, &a);\n    if a.is_zero() {\n        Err(EvalError::DivisionByZero)\n    } else {\n        cx.set_precision(usize::from(numeric::NUMERIC_DATUM_MAX_PRECISION - 1))\n            .expect(\"reducing precision below max always succeeds\");\n        let mut integral_check = b.clone();\n        cx.reduce(&mut integral_check);\n        let mut b = if integral_check.exponent() >= 0 { integral_check } else { b };\n        numeric::munge_numeric(&mut b).unwrap();\n        Ok(Datum::from(b))\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"Numeric\", sqlname = \"log\", propagates_nulls = true)]\nfn log_base_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    log_guard_numeric(&a, \"log\")?;\n    let mut b = b.unwrap_numeric().0;\n    log_guard_numeric(&b, \"log\")?;\n    let mut cx = numeric::cx_datum();\n    cx.ln(&mut a);\n    cx.ln(&mut b);\n    cx.div(&mut b, &a);\n    if a.is_zero() {\n        Err(EvalError::DivisionByZero)\n    } else {\n        cx.set_precision(usize::from(numeric::NUMERIC_DATUM_MAX_PRECISION - 1))\n            .expect(\"reducing precision below max always succeeds\");\n        let mut integral_check = b.clone();\n        cx.reduce(&mut integral_check);\n        let mut b = if integral_check.exponent() >= 0 { integral_check } else { b };\n        numeric::munge_numeric(&mut b).unwrap();\n        Ok(Datum::from(b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for LogBaseNumeric {
     }
     fn introduces_nulls(&self) -> bool {
         <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_all_keys.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_all_keys.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?&\",\n    propagates_nulls = true\n)]\nfn map_contains_all_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .all(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?&\",\n    propagates_nulls = true\n)]\nfn map_contains_all_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .all(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsAllKeys {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_any_keys.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_any_keys.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?|\",\n    propagates_nulls = true\n)]\nfn map_contains_any_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .any(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?|\",\n    propagates_nulls = true\n)]\nfn map_contains_any_keys<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let keys = b.unwrap_array();\n    keys.elements()\n        .iter()\n        .any(|key| !key.is_null() && map.iter().any(|(k, _v)| k == key.unwrap_str()))\n        .into()\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsAnyKeys {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_key.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_key.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let k = b.unwrap_str();\n    map.iter().any(|(k2, _v)| k == k2).into()\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"?\",\n    propagates_nulls = true\n)]\nfn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map = a.unwrap_map();\n    let k = b.unwrap_str();\n    map.iter().any(|(k2, _v)| k == k2).into()\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsKey {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_map.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_contains_map.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map_a = a.unwrap_map();\n    b.unwrap_map()\n        .iter()\n        .all(|(b_key, b_val)| {\n            map_a.iter().any(|(a_key, a_val)| (a_key == b_key) && (a_val == b_val))\n        })\n        .into()\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn map_contains_map<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let map_a = a.unwrap_map();\n    b.unwrap_map()\n        .iter()\n        .all(|(b_key, b_val)| {\n            map_a.iter().any(|(a_key, a_val)| (a_key == b_key) && (a_val == b_val))\n        })\n        .into()\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapContainsMap {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_get_value.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__map_get_value.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.unwrap_map_value_type().clone().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"->\",\n    propagates_nulls = true,\n    introduces_nulls = true\n)]\nfn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let target_key = b.unwrap_str();\n    match a.unwrap_map().iter().find(|(key, _v)| target_key == *key) {\n        Some((_k, v)) => v,\n        None => Datum::Null,\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MapGetValue;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MapGetValue {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Datum<'a>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        map_get_value(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a
+            .scalar_type
+            .unwrap_map_value_type()
+            .clone()
+            .nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MapGetValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("->")
+    }
+}
+fn map_get_value<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let target_key = b.unwrap_str();
+    match a.unwrap_map().iter().find(|(key, _v)| target_key == *key) {
+        Some((_k, v)) => v,
+        None => Datum::Null,
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float32();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float32() % b))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"f32\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float32();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float32() % b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModFloat32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_float64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float64() % b))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"f64\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_float64() % b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModFloat64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int16().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int16().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int32().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int32().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int64().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_int64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_int64().checked_rem(b).unwrap_or(0)))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModInt64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_numeric.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = Numeric,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric();\n    let b = b.unwrap_numeric();\n    if b.0.is_zero() {\n        return Err(EvalError::DivisionByZero);\n    }\n    let mut cx = numeric::cx_datum();\n    cx.rem(&mut a.0, &b.0);\n    numeric::munge_numeric(&mut a.0).unwrap();\n    Ok(Datum::Numeric(a))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"Numeric\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric();\n    let b = b.unwrap_numeric();\n    if b.0.is_zero() {\n        return Err(EvalError::DivisionByZero);\n    }\n    let mut cx = numeric::cx_datum();\n    cx.rem(&mut a.0, &b.0);\n    numeric::munge_numeric(&mut a.0).unwrap();\n    Ok(Datum::Numeric(a))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModNumeric {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u16,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint16() % b))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint16();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint16() % b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint16 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u32,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint32() % b))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint32();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint32() % b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint32 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mod_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (false, false),\n    output_type = u64,\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint64() % b))\n    }\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"%\",\n    propagates_nulls = true\n)]\nfn mod_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_uint64();\n    if b == 0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        Ok(Datum::from(a.unwrap_uint64() % b))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ModUint64 {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mz_render_typmod.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mz_render_typmod.snap
@@ -1,0 +1,74 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type = \"String\",\n    sqlname = \"mz_render_typmod\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn mz_render_typmod<'a>(\n    oid: Datum<'a>,\n    typmod: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let oid = oid.unwrap_uint32();\n    let typmod = typmod.unwrap_int32();\n    let s = match Type::from_oid_and_typmod(oid, typmod) {\n        Ok(typ) => typ.constraint().display_or(\"\").to_string(),\n        Err(_) if typmod >= 0 => format!(\"({typmod})\"),\n        Err(_) => \"\".into(),\n    };\n    Ok(Datum::String(temp_storage.push_string(s)))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzRenderTypmod;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MzRenderTypmod {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mz_render_typmod(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MzRenderTypmod {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_render_typmod")
+    }
+}
+fn mz_render_typmod<'a>(
+    oid: Datum<'a>,
+    typmod: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let oid = oid.unwrap_uint32();
+    let typmod = typmod.unwrap_int32();
+    let s = match Type::from_oid_and_typmod(oid, typmod) {
+        Ok(typ) => typ.constraint().display_or("").to_string(),
+        Err(_) if typmod >= 0 => format!("({typmod})"),
+        Err(_) => "".into(),
+    };
+    Ok(Datum::String(temp_storage.push_string(s)))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"!=\",\n    propagates_nulls = true\n)]\nfn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a != b)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"!=\",\n    propagates_nulls = true\n)]\nfn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a != b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for NotEq {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"f64\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    if a == 0.0 && b.is_sign_negative() {\n        return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n    }\n    if a.is_sign_negative() && b.fract() != 0.0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let res = a.powf(b);\n    if res.is_infinite() {\n        return Err(EvalError::FloatOverflow);\n    }\n    if res == 0.0 && a != 0.0 {\n        return Err(EvalError::FloatUnderflow);\n    }\n    Ok(Datum::from(res))\n}\n"
+expression: "#[sqlfunc(output_type = \"f64\", propagates_nulls = true)]\nfn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    if a == 0.0 && b.is_sign_negative() {\n        return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n    }\n    if a.is_sign_negative() && b.fract() != 0.0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let res = a.powf(b);\n    if res.is_infinite() {\n        return Err(EvalError::FloatOverflow);\n    }\n    if res == 0.0 && a != 0.0 {\n        return Err(EvalError::FloatUnderflow);\n    }\n    Ok(Datum::from(res))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Power {
     }
     fn introduces_nulls(&self) -> bool {
         <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__power_numeric.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    let b = b.unwrap_numeric().0;\n    if a.is_zero() {\n        if b.is_zero() {\n            return Ok(Datum::from(Numeric::from(1)));\n        }\n        if b.is_negative() {\n            return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n        }\n    }\n    if a.is_negative() && b.exponent() < 0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let mut cx = numeric::cx_datum();\n    cx.pow(&mut a, &b);\n    let cx_status = cx.status();\n    if cx_status.overflow() || (cx_status.invalid_operation() && !b.is_negative()) {\n        Err(EvalError::FloatOverflow)\n    } else if cx_status.subnormal() || cx_status.invalid_operation() {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"Numeric\", propagates_nulls = true)]\nfn power_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    let b = b.unwrap_numeric().0;\n    if a.is_zero() {\n        if b.is_zero() {\n            return Ok(Datum::from(Numeric::from(1)));\n        }\n        if b.is_negative() {\n            return Err(EvalError::Undefined(\"zero raised to a negative power\".into()));\n        }\n    }\n    if a.is_negative() && b.exponent() < 0 {\n        return Err(EvalError::ComplexOutOfRange(\"pow\".into()));\n    }\n    let mut cx = numeric::cx_datum();\n    cx.pow(&mut a, &b);\n    let cx_status = cx.status();\n    if cx_status.overflow() || (cx_status.invalid_operation() && !b.is_negative()) {\n        Err(EvalError::FloatOverflow)\n    } else if cx_status.subnormal() || cx_status.invalid_operation() {\n        Err(EvalError::FloatUnderflow)\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for PowerNumeric {
     }
     fn introduces_nulls(&self) -> bool {
         <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_adjacent.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_adjacent.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"-|-\",\n    propagates_nulls = true\n)]\nfn range_adjacent<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::adjacent(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"-|-\",\n    propagates_nulls = true\n)]\nfn range_adjacent<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::adjacent(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeAdjacent {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_after.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_after.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn range_after<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::after(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">>\",\n    propagates_nulls = true\n)]\nfn range_after<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::after(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeAfter {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_before.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_before.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn range_before<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::before(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<<\",\n    propagates_nulls = true\n)]\nfn range_before<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::before(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeBefore {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_date.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_date.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_date<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsDate;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsDate {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = Date;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_date(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_date<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_date_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_date_rev.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_date_rev<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsDateRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsDateRev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = Date;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_date_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsDateRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_date_rev<'a>(a: Range<Datum<'a>>, elem: Date) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i32.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_i32<'a>(a: Range<Datum<'a>>, b: i32) -> bool {\n    a.contains_elem(&b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsI32;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsI32 {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = i32;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_i32(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsI32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_i32<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
+    a.contains_elem(&b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i32_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i32_rev.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_i32_rev<'a>(a: Range<Datum<'a>>, b: i32) -> bool {\n    a.contains_elem(&b)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsI32Rev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsI32Rev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = i32;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_i32_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsI32Rev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_i32_rev<'a>(a: Range<Datum<'a>>, b: i32) -> bool {
+    a.contains_elem(&b)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i64.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_i64<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsI64;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsI64 {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = i64;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_i64(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsI64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_i64<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i64_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_i64_rev.snap
@@ -1,0 +1,63 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_i64_rev<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsI64Rev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsI64Rev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = i64;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_i64_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsI64Rev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_i64_rev<'a>(a: Range<Datum<'a>>, elem: i64) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_numeric.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_numeric.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_numeric<'a>(\n    a: Range<Datum<'a>>,\n    elem: OrderedDecimal<Numeric>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsNumeric;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsNumeric {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = OrderedDecimal<Numeric>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_numeric(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_numeric<'a>(
+    a: Range<Datum<'a>>,
+    elem: OrderedDecimal<Numeric>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_numeric_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_numeric_rev.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_numeric_rev<'a>(\n    a: Range<Datum<'a>>,\n    elem: OrderedDecimal<Numeric>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsNumericRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsNumericRev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = OrderedDecimal<Numeric>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_numeric_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsNumericRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_numeric_rev<'a>(
+    a: Range<Datum<'a>>,
+    elem: OrderedDecimal<Numeric>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn range_contains_range<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"@>\",\n    propagates_nulls = true\n)]\nfn range_contains_range<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsRange {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_range_rev.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<@\",\n    propagates_nulls = true\n)]\nfn range_contains_range_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<@\",\n    propagates_nulls = true\n)]\nfn range_contains_range_rev<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::contains_range(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsRangeRev {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_timestamp<'a>(\n    a: Range<Datum<'a>>,\n    elem: CheckedTimestamp<NaiveDateTime>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsTimestamp;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsTimestamp {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_timestamp(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_timestamp<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<NaiveDateTime>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_rev.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_timestamp_rev<'a>(\n    a: Range<Datum<'a>>,\n    elem: CheckedTimestamp<NaiveDateTime>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsTimestampRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsTimestampRev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = CheckedTimestamp<NaiveDateTime>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_timestamp_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsTimestampRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_timestamp_rev<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<NaiveDateTime>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_tz.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_tz.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"@>\", propagates_nulls = true)]\nfn range_contains_timestamp_tz<'a>(\n    a: Range<Datum<'a>>,\n    elem: CheckedTimestamp<DateTime<Utc>>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsTimestampTz;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsTimestampTz {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_timestamp_tz(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsTimestampTz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("@>")
+    }
+}
+fn range_contains_timestamp_tz<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<DateTime<Utc>>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_tz_rev.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_contains_timestamp_tz_rev.snap
@@ -1,0 +1,66 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(is_infix_op = true, sqlname = \"<@\", propagates_nulls = true)]\nfn range_contains_timestamp_tz_rev<'a>(\n    a: Range<Datum<'a>>,\n    elem: CheckedTimestamp<DateTime<Utc>>,\n) -> bool {\n    a.contains_elem(&elem)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeContainsTimestampTzRev;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeContainsTimestampTzRev {
+    type Input1 = Range<Datum<'a>>;
+    type Input2 = CheckedTimestamp<DateTime<Utc>>;
+    type Output = bool;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_contains_timestamp_tz_rev(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeContainsTimestampTzRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("<@")
+    }
+}
+fn range_contains_timestamp_tz_rev<'a>(
+    a: Range<Datum<'a>>,
+    elem: CheckedTimestamp<DateTime<Utc>>,
+) -> bool {
+    a.contains_elem(&elem)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_difference.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_difference.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn range_difference<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    l.difference(&r)?.into_result(temp_storage)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeDifference;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeDifference {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_difference(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeDifference {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("-")
+    }
+}
+fn range_difference<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    l.difference(&r)?.into_result(temp_storage)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_intersection.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_intersection.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn range_intersection<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    l.intersection(&r).into_result(temp_storage)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeIntersection;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeIntersection {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_intersection(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeIntersection {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("*")
+    }
+}
+fn range_intersection<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    l.intersection(&r).into_result(temp_storage)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overlaps.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overlaps.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&&\",\n    propagates_nulls = true\n)]\nfn range_overlaps<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overlaps(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&&\",\n    propagates_nulls = true\n)]\nfn range_overlaps<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overlaps(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverlaps {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overleft.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overleft.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&<\",\n    propagates_nulls = true\n)]\nfn range_overleft<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overleft(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&<\",\n    propagates_nulls = true\n)]\nfn range_overleft<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overleft(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverleft {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overright.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_overright.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&>\",\n    propagates_nulls = true\n)]\nfn range_overright<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overright(&l, &r))\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"&>\",\n    propagates_nulls = true\n)]\nfn range_overright<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    Datum::from(Range::<Datum<'a>>::overright(&l, &r))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,9 +51,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeOverright {
     }
     fn is_infix_op(&self) -> bool {
         true
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_union.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__range_union.snap
@@ -1,0 +1,72 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn range_union<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let l = a.unwrap_range();\n    let r = b.unwrap_range();\n    l.union(&r)?.into_result(temp_storage)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct RangeUnion;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RangeUnion {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        range_union(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = input_type_a.scalar_type.without_modifiers().nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for RangeUnion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("+")
+    }
+}
+fn range_union<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let l = a.unwrap_range();
+    let r = b.unwrap_range();
+    l.union(&r)?.into_result(temp_storage)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__round_numeric_binary.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__round_numeric_binary.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, false),\n    output_type = \"Numeric\",\n    is_infix_op = false,\n    sqlname = \"round\",\n    propagates_nulls = true\n)]\nfn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    let mut b = b.unwrap_int32();\n    let mut cx = numeric::cx_datum();\n    let a_exp = a.exponent();\n    if a_exp > 0 && b > 0 || a_exp < 0 && -a_exp < b {\n        let max_remaining_scale = u32::from(numeric::NUMERIC_DATUM_MAX_PRECISION)\n            - (numeric::get_precision(&a) - numeric::get_scale(&a));\n        b = match i32::try_from(max_remaining_scale) {\n            Ok(max_remaining_scale) => std::cmp::min(b, max_remaining_scale),\n            Err(_) => b,\n        };\n        cx.rescale(&mut a, &numeric::Numeric::from(-b));\n    } else {\n        const MAX_P_LIMIT: i32 = 1\n            + cast::u8_to_i32(numeric::NUMERIC_DATUM_MAX_PRECISION);\n        b = std::cmp::min(MAX_P_LIMIT, b);\n        b = std::cmp::max(-MAX_P_LIMIT, b);\n        let mut b = numeric::Numeric::from(b);\n        cx.scaleb(&mut a, &b);\n        cx.round(&mut a);\n        cx.neg(&mut b);\n        cx.scaleb(&mut a, &b);\n    }\n    if cx.status().overflow() {\n        Err(EvalError::FloatOverflow)\n    } else if a.is_zero() {\n        Ok(Datum::from(numeric::Numeric::zero()))\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, false)\",\n    output_type = \"Numeric\",\n    sqlname = \"round\",\n    propagates_nulls = true\n)]\nfn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let mut a = a.unwrap_numeric().0;\n    let mut b = b.unwrap_int32();\n    let mut cx = numeric::cx_datum();\n    let a_exp = a.exponent();\n    if a_exp > 0 && b > 0 || a_exp < 0 && -a_exp < b {\n        let max_remaining_scale = u32::from(numeric::NUMERIC_DATUM_MAX_PRECISION)\n            - (numeric::get_precision(&a) - numeric::get_scale(&a));\n        b = match i32::try_from(max_remaining_scale) {\n            Ok(max_remaining_scale) => std::cmp::min(b, max_remaining_scale),\n            Err(_) => b,\n        };\n        cx.rescale(&mut a, &numeric::Numeric::from(-b));\n    } else {\n        const MAX_P_LIMIT: i32 = 1\n            + cast::u8_to_i32(numeric::NUMERIC_DATUM_MAX_PRECISION);\n        b = std::cmp::min(MAX_P_LIMIT, b);\n        b = std::cmp::max(-MAX_P_LIMIT, b);\n        let mut b = numeric::Numeric::from(b);\n        cx.scaleb(&mut a, &b);\n        cx.round(&mut a);\n        cx.neg(&mut b);\n        cx.scaleb(&mut a, &b);\n    }\n    if cx.status().overflow() {\n        Err(EvalError::FloatOverflow)\n    } else if a.is_zero() {\n        Ok(Datum::from(numeric::Numeric::zero()))\n    } else {\n        numeric::munge_numeric(&mut a).unwrap();\n        Ok(Datum::from(a))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,9 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for RoundNumericBinary {
     }
     fn introduces_nulls(&self) -> bool {
         <Numeric as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, false)

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__to_char_timestamp_format.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__to_char_timestamp_format.snap
@@ -1,0 +1,65 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"String\", sqlname = \"tocharts\", propagates_nulls = true)]\nfn to_char_timestamp_format<'a>(a: Datum<'a>, format: &str) -> String {\n    let ts = a.unwrap_timestamp();\n    let fmt = DateTimeFormat::compile(format);\n    fmt.render(&*ts)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ToCharTimestampFormat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ToCharTimestampFormat {
+    type Input1 = Datum<'a>;
+    type Input2 = &'a str;
+    type Output = String;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        to_char_timestamp_format(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ToCharTimestampFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("tocharts")
+    }
+}
+fn to_char_timestamp_format<'a>(a: Datum<'a>, format: &str) -> String {
+    let ts = a.unwrap_timestamp();
+    let fmt = DateTimeFormat::compile(format);
+    fmt.render(&*ts)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__to_char_timestamp_tz_format.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__to_char_timestamp_tz_format.snap
@@ -1,0 +1,65 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"String\", sqlname = \"tochartstz\", propagates_nulls = true)]\nfn to_char_timestamp_tz_format<'a>(a: Datum<'a>, format: &str) -> String {\n    let ts = a.unwrap_timestamptz();\n    let fmt = DateTimeFormat::compile(format);\n    fmt.render(&*ts)\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ToCharTimestampTzFormat;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ToCharTimestampTzFormat {
+    type Input1 = Datum<'a>;
+    type Input2 = &'a str;
+    type Output = String;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        to_char_timestamp_tz_format(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ToCharTimestampTzFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("tochartstz")
+    }
+}
+fn to_char_timestamp_tz_format<'a>(a: Datum<'a>, format: &str) -> String {
+    let ts = a.unwrap_timestamptz();
+    let fmt = DateTimeFormat::compile(format);
+    fmt.render(&*ts)
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__uuid_generate_v5.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__uuid_generate_v5.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"uuid::Uuid\",\n    is_infix_op = false,\n    propagates_nulls = true\n)]\nfn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_uuid();\n    let b = b.unwrap_str();\n    let res = uuid::Uuid::new_v5(&a, b.as_bytes());\n    Datum::Uuid(res)\n}\n"
+expression: "#[sqlfunc(output_type = \"uuid::Uuid\", propagates_nulls = true)]\nfn uuid_generate_v5<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_uuid();\n    let b = b.unwrap_str();\n    let res = uuid::Uuid::new_v5(&a, b.as_bytes());\n    Datum::Uuid(res)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -48,12 +48,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for UuidGenerateV5 {
     }
     fn introduces_nulls(&self) -> bool {
         <uuid::Uuid as ::mz_repr::DatumType<'_, ()>>::nullable()
-    }
-    fn is_infix_op(&self) -> bool {
-        false
-    }
-    fn is_monotone(&self) -> (bool, bool) {
-        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2114,6 +2114,27 @@ impl<'a, E> DatumType<'a, E> for Numeric {
     }
 }
 
+impl<'a, E> DatumType<'a, E> for OrderedDecimal<Numeric> {
+    fn nullable() -> bool {
+        false
+    }
+
+    fn fallible() -> bool {
+        false
+    }
+
+    fn try_from_result(res: Result<Datum<'a>, E>) -> Result<Self, Result<Datum<'a>, E>> {
+        match res {
+            Ok(Datum::Numeric(n)) => Ok(n),
+            _ => Err(res),
+        }
+    }
+
+    fn into_result(self, _temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
+        Ok(Datum::from(self))
+    }
+}
+
 impl AsColumnType for PgLegacyChar {
     fn as_column_type() -> ColumnType {
         ScalarType::PgLegacyChar.nullable(false)


### PR DESCRIPTION
As it says on the box, convert more binary functions to the sqlfunc macro. As before, this doesn't yet use any of the new code, but it's there once we can switch over to the new implementation.

Add a `output_type_expr` parameter to the proc macro that allows the caller to specify an expression over the input types to compute the output type. We need this because the output type for some functions cannot be described as a type, for example for jsonb.

As before, there are tests validating meta information.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
