### PR TITLE
parallel-workload: Update error message for webhook source creation

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1774,7 +1774,7 @@ class CreateWebhookSourceAction(Action):
         result = super().errors_to_ignore(exe)
         if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
             result.extend(
-                ["cannot create source in cluster with more than one replica"]
+                ["cannot create webhook source in cluster with more than one replica"]
             )
         return result
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/11939#0196890a-0af4-46f5-bb66-08c054b6ed62

Green nightly run: https://buildkite.com/materialize/nightly/builds/11957#01969dc8-3d9a-40fe-bccd-f00824dee33d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
