### PR TITLE
Update pypi deployment to support pyproject.toml and mcp-materialize

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     gnupg2 \
     libxml2 \
     python3 \
+    python3.12-venv \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies. These are necessary to run some of our base tooling.

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -75,3 +75,4 @@ pyarrow-stubs==19.2
 pyarrow==20.0.0
 minio==7.2.15
 zstandard==0.23.0
+build==1.2.2.post1

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -76,3 +76,4 @@ pyarrow==20.0.0
 minio==7.2.15
 zstandard==0.23.0
 build==1.2.2.post1
+hatchling==1.27.0

--- a/ci/deploy/pypi.py
+++ b/ci/deploy/pypi.py
@@ -10,44 +10,85 @@
 import distutils.core  # pyright: ignore
 import os
 import sys
+import tarfile
+import tempfile
+from email.parser import Parser
 from pathlib import Path
+from typing import Literal
 
 import requests
 
 from materialize import spawn
 
-PACKAGE_PATHS = [
-    "misc/dbt-materialize",
-]
+PACKAGE_PATHS: dict[str, Literal["setup.py", "pyproject.toml"]] = {
+    "misc/dbt-materialize": "setup.py",
+    "misc/mcp-materialize": "pyproject.toml",
+}
 
 
 def main() -> None:
-    for path_str in PACKAGE_PATHS:
+    for path_str, build_type in PACKAGE_PATHS.items():
         path = Path(path_str)
-        distribution = distutils.core.run_setup(str(path / "setup.py"))
-        name = distribution.metadata.name
-        version = distribution.metadata.version
-        assert name
+
+        if build_type == "setup.py":
+            name, version = get_metadata_from_setup_py(path)
+            build_package_setup_py(path)
+        elif build_type == "pyproject.toml":
+            name, version = get_metadata_from_pyproject(path)
+            build_package_pyproject(path)
+        else:
+            raise ValueError(f"Unknown build type: {build_type}")
+
+        assert name and version
         released_versions = get_released_versions(name)
         if version in released_versions:
             print(f"{name} {version} already released, continuing...")
             continue
-        else:
-            print(f"Releasing {name} {version}")
-            spawn.runv(
-                [sys.executable, "setup.py", "build", "sdist"],
-                cwd=path,
-                env={**os.environ, "RELEASE_BUILD": "1"},
-            )
-            dist_files = (path / "dist").iterdir()
-            spawn.runv(
-                ["twine", "upload", *dist_files],
-                env={
-                    **os.environ,
-                    "TWINE_USERNAME": "__token__",
-                    "TWINE_PASSWORD": os.environ["PYPI_TOKEN"],
-                },
-            )
+
+        print(f"Releasing {name} {version}")
+        upload_to_pypi(path)
+
+
+def get_metadata_from_setup_py(path: Path) -> tuple[str, str]:
+    distribution = distutils.core.run_setup(str(path / "setup.py"))
+    return distribution.metadata.name, distribution.metadata.version
+
+
+def get_metadata_from_pyproject(path: Path) -> tuple[str, str]:
+    import build
+
+    with tempfile.TemporaryDirectory() as out_dir:
+        builder = build.ProjectBuilder(path)
+        sdist_path = Path(builder.build("sdist", out_dir))
+
+        with tarfile.open(sdist_path) as tar:
+            pkg_info = next(m for m in tar.getmembers() if m.name.endswith("PKG-INFO"))
+            f = tar.extractfile(pkg_info)
+            if not f:
+                raise RuntimeError("Failed to extract PKG-INFO")
+            metadata = Parser().parsestr(f.read().decode())
+
+        return metadata["Name"], metadata["Version"]
+
+
+def build_package_setup_py(path: Path) -> None:
+    spawn.runv([sys.executable, "setup.py", "build", "sdist"], cwd=path)
+
+
+def build_package_pyproject(path: Path) -> None:
+    spawn.runv([sys.executable, "-m", "build"], cwd=path)
+
+
+def upload_to_pypi(path: Path) -> None:
+    dist_files = list((path / "dist").iterdir())
+    spawn.runv(
+        ["twine", "upload", *dist_files],
+        env={
+            **os.environ,
+            "TWINE_USERNAME": "__token__",
+            "TWINE_PASSWORD": os.environ["PYPI_TOKEN"],
+        },
+    )
 
 
 def get_released_versions(name: str) -> set[str]:

--- a/ci/deploy/pypi.py
+++ b/ci/deploy/pypi.py
@@ -93,6 +93,9 @@ def upload_to_pypi(path: Path) -> None:
 
 def get_released_versions(name: str) -> set[str]:
     res = requests.get(f"https://pypi.org/pypi/{name}/json")
+    if res.status_code == 404:
+        # First release, no versions exist yet
+        return set()
     res.raise_for_status()
     return set(res.json()["releases"])
 


### PR DESCRIPTION

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
