### PR TITLE
Mark some azure HTTP errors as determinate

### DIFF
--- a/src/persist/src/azure.rs
+++ b/src/persist/src/azure.rs
@@ -234,7 +234,7 @@ impl Blob for AzureBlob {
         let path = self.get_path(key);
         let blob = self.client.blob_client(path);
 
-        /// Fetch a the body of a single [`GetBlobResponse`].
+        /// Fetch the body of a single [`GetBlobResponse`].
         async fn fetch_chunk(
             response: GetBlobResponse,
             metrics: S3BlobMetrics,


### PR DESCRIPTION
This means that we can retry past this error instead of bailing out early. We observe it when first starting an environmentd right as storage is being created...

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9253

There may be more errors that need the same treatment, but I think this is likely to solve this particular problem.

### Tips for reviewer

I'll kick off the same nightly test, but this seems a bit flaky... let me know if there's other testing you'd like to do.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
