### PR TITLE
Ore does not have feature derivative

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -173,7 +173,7 @@ harness = false
 [[bench]]
 name = "bytes"
 harness = false
-required-features = ["bytes", "region", "tracing", "derivative"]
+required-features = ["bytes", "region", "tracing"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
Fix a warning caused by requiring a non-existent feature.
