### PR TITLE
platform-checks: Switch to CockroachOrPostgresMetadata

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -787,25 +787,6 @@ steps:
                   "--seed=$BUILDKITE_JOB_ID",
                 ]
 
-      - id: checks-parallel-drop-create-default-replica-postgres
-        label: "Checks parallel + DROP/CREATE replica (:postgres: Consensus)"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        parallelism: 2
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args:
-                [
-                  --scenario=DropCreateDefaultReplica,
-                  --execution-mode=parallel,
-                  --features=postgres_consensus,
-                  --system-param=persist_use_postgres_tuned_queries=true,
-                  "--seed=$BUILDKITE_JOB_ID",
-                ]
-
       - id: checks-parallel-restart-clusterd-compute
         label: "Checks parallel + restart compute clusterd"
         depends_on: build-aarch64
@@ -841,24 +822,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
-
-      - id: checks-parallel-restart-environmentd-clusterd-storage-postgres-consensus
-        label: "Checks parallel + restart of environmentd & storage clusterd (:postgres: Consensus)"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        parallelism: 2
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [
-                --scenario=RestartEnvironmentdClusterdStorage,
-                --execution-mode=parallel,
-                --features=postgres_consensus,
-                --system-param=persist_use_postgres_tuned_queries=true,
-                "--seed=$BUILDKITE_JOB_ID",
-              ]
 
       - id: checks-parallel-kill-clusterd-storage
         label: "Checks parallel + kill storage clusterd"

--- a/misc/python/materialize/checks/features.py
+++ b/misc/python/materialize/checks/features.py
@@ -15,7 +15,6 @@
 class Features:
     AZURITE = "azurite"
     SQL_SERVER = "sql_server"
-    POSTGRES_CONSENSUS = "postgres_consensus"
 
     def __init__(self, features):
         self.features = features
@@ -25,6 +24,3 @@ class Features:
 
     def sql_server_enabled(self) -> bool:
         return self.features and self.SQL_SERVER in self.features
-
-    def postgres_consensus_enabled(self) -> bool:
-        return self.features and self.POSTGRES_CONSENSUS in self.features

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -86,7 +86,6 @@ class StartMz(MzcomposeAction):
             restart=self.restart,
             force_migrations=self.force_migrations,
             publish=self.publish,
-            metadata_store="cockroach",
             default_replication_factor=2,
         )
 


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/32389

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
