### PR TITLE
ci: Remove feature benchmark from test pipeline

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -663,23 +663,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
 
-  - id: feature-benchmark-kafka-only
-    label: "Feature benchmark (Kafka only)"
-    depends_on: build-x86_64
-    timeout_in_minutes: 60
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            [
-              --scenario=KafkaUpsertUnique,
-              --other-tag=common-ancestor,
-              --ignore-other-tag-missing,
-            ]
-    coverage: skip
-    agents:
-      queue: hetzner-x86-64-dedi-4cpu-16gb
-
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent
   - id: persistence


### PR DESCRIPTION
It is often the slowest test, and also runs in Nightly. Let's see how often it falls over.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
