### PR TITLE
Add the `mz-pgwire` part of statement lifecycle

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -551,6 +551,7 @@ impl Coordinator {
             let params = portal.parameters.clone();
             let stmt = portal.stmt.clone();
             let logging = Arc::clone(&portal.logging);
+            let lifecycle_timestamps = portal.lifecycle_timestamps.clone();
 
             let extra = if let Some(extra) = outer_context {
                 // We are executing in the context of another SQL statement, so we don't
@@ -559,7 +560,12 @@ impl Coordinator {
                 extra
             } else {
                 // This is a new statement, log it and return the context
-                let maybe_uuid = self.begin_statement_execution(&mut session, &params, &logging);
+                let maybe_uuid = self.begin_statement_execution(
+                    &mut session,
+                    &params,
+                    &logging,
+                    lifecycle_timestamps,
+                );
 
                 ExecuteContextExtra::new(maybe_uuid)
             };

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -720,9 +720,9 @@ impl Coordinator {
         let (ps_record, ps_uuid) = self.log_prepared_statement(session, logging)?;
 
         let now = self.now();
-        let uuid = epoch_to_uuid_v7(&now);
+        let execution_uuid = epoch_to_uuid_v7(&now);
         self.record_statement_lifecycle_event(
-            &StatementLoggingId(uuid),
+            &StatementLoggingId(execution_uuid),
             &StatementLifecycleEvent::ExecutionBegan,
             now,
         );
@@ -738,7 +738,7 @@ impl Coordinator {
             })
             .collect();
         let record = StatementBeganExecutionRecord {
-            id: uuid,
+            id: execution_uuid,
             prepared_statement_id: ps_uuid,
             sample_rate,
             params,
@@ -773,7 +773,9 @@ impl Coordinator {
         self.statement_logging
             .pending_statement_execution_events
             .push((mseh_update, Diff::ONE));
-        self.statement_logging.executions_begun.insert(uuid, record);
+        self.statement_logging
+            .executions_begun
+            .insert(execution_uuid, record);
         if let Some((ps_record, ps_update)) = ps_record {
             self.statement_logging
                 .pending_prepared_statement_events
@@ -789,7 +791,7 @@ impl Coordinator {
                     .push(sh_update);
             }
         }
-        Some(StatementLoggingId(uuid))
+        Some(StatementLoggingId(execution_uuid))
     }
 
     /// Record a new connection event

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -723,6 +723,7 @@ impl<T: TimestampManipulation> Session<T> {
                 result_formats,
                 state: PortalState::NotStarted,
                 logging,
+                lifecycle_timestamps: None,
             },
         );
         Ok(())
@@ -774,6 +775,7 @@ impl<T: TimestampManipulation> Session<T> {
                         result_formats,
                         state: PortalState::NotStarted,
                         logging,
+                        lifecycle_timestamps: None,
                     });
                     return Ok(name);
                 }
@@ -952,6 +954,9 @@ pub struct Portal {
     /// The execution state of the portal.
     #[derivative(Debug = "ignore")]
     pub state: PortalState,
+    /// Statement lifecycle timestamps coming from `mz-pgwire`. This is set only for
+    /// "Simple Query"s.
+    pub lifecycle_timestamps: Option<LifecycleTimestamps>,
 }
 
 /// Execution states of a portal.
@@ -987,6 +992,17 @@ impl InProgressRows {
 
 /// A channel of batched rows.
 pub type RowBatchStream = UnboundedReceiver<PeekResponseUnary>;
+
+/// Part of statement lifecycle. These are timestamps that come from the `mz-pgwire` part of the
+/// lifecycle.
+#[derive(Debug, Clone)]
+pub struct LifecycleTimestamps {
+    /// When the query was received. More specifically, when the tokio recv returned with a
+    /// complete query.
+    pub received: EpochMillis,
+    /// When the parsing of a "Simple Query" finished.
+    pub parsing_finished: EpochMillis,
+}
 
 /// The transaction status of a session.
 ///

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -19,6 +19,8 @@ use crate::{AdapterError, ExecuteResponse};
 
 #[derive(Clone, Debug)]
 pub enum StatementLifecycleEvent {
+    Received,
+    ParsingFinished,
     ExecutionBegan,
     OptimizationFinished,
     StorageDependenciesFinished,
@@ -29,6 +31,8 @@ pub enum StatementLifecycleEvent {
 impl StatementLifecycleEvent {
     pub fn as_str(&self) -> &str {
         match self {
+            Self::Received => "received",
+            Self::ParsingFinished => "parsing-finished",
             Self::ExecutionBegan => "execution-began",
             Self::OptimizationFinished => "optimization-finished",
             Self::StorageDependenciesFinished => "storage-dependencies-finished",


### PR DESCRIPTION
**Edit:**
Closing, because this is unfortunately not enough in its current form, because we need these new events also for prepared statements. I'll start a discussion on how to do that.

### Motivation

  * This PR adds a known-desirable feature: Part of https://github.com/MaterializeInc/database-issues/issues/9140

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
