### PR TITLE
doc: add materialize emulator debugging document

### DIFF
--- a/doc/developer/emulator.md
+++ b/doc/developer/emulator.md
@@ -7,9 +7,8 @@ The emulator is a version of materialize used primarily for local testing. User 
 Run the emulator using the following command to allow for local access to the heap dump endpoints for usage with the [debug tool](https://materialize.com/docs/self-managed/v25.1/integrations/mz-debug/).
 
 ```bash
-  docker run \
+  docker run -d \
         --name materialized \
-        --network host \
         -p 6874:6874 \
         -p 6875:6875 \
         -p 6877:6877 \

--- a/doc/developer/emulator.md
+++ b/doc/developer/emulator.md
@@ -1,6 +1,6 @@
 # Emulator
 
-The emulator is a version of materialize used primarily for local testing. User documentation can be found [here](https://materialize.com/docs/get-started/install-materialize-emulator/)
+The emulator is a version of materialize used primarily for local testing. User documentation can be found [here](https://materialize.com/docs/get-started/install-materialize-emulator/).
 
 ## How to profile the emulator
 

--- a/doc/developer/emulator.md
+++ b/doc/developer/emulator.md
@@ -1,0 +1,57 @@
+# Emulator
+
+The emulator is a version of materialize used primarily for local testing. User documentation can be found [here](https://materialize.com/docs/get-started/install-materialize-emulator/)
+
+## How to profile the emulator
+
+Run the emulator using the following command to allow for local access to the heap dump endpoints for usage with the [debug tool](https://materialize.com/docs/self-managed/v25.1/integrations/mz-debug/).
+
+```bash
+  docker run \
+        --name materialized \
+        --network host \
+        -p 6874:6874 \
+        -p 6875:6875 \
+        -p 6877:6877 \
+        -p 6878:6878 \
+        -e "MZ_NO_TELEMETRY=0" \
+        materialize/materialized:latest \
+        --cluster-replica-sizes='{"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "12G"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "12G"}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "24G"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "48G"}}' \
+        --bootstrap-default-cluster-replica-size=3xsmall \
+        --bootstrap-builtin-system-cluster-replica-size=3xsmall \
+        --bootstrap-builtin-catalog-server-cluster-replica-size=3xsmall \
+        --bootstrap-builtin-support-cluster-replica-size=3xsmall \
+        --bootstrap-builtin-probe-cluster-replica-size=3xsmall \
+        --availability-zone=test1 \
+        --availability-zone=test2 \
+        --aws-account-id=123456789000 \
+        --aws-external-id-prefix=00000000-00000000-00000000-00000000 \
+        --aws-connection-role-arn=arn:aws:iam::123456789000:role/MaterializeConnection \
+        --system-parameter-default=max_clusters=100 \
+        --system-parameter-default=max_sources=10000 \
+        --system-parameter-default=max_objects_per_schema=10000 \
+        --orchestrator-process-tcp-proxy-listen-addr=0.0.0.0
+```
+
+Navigate to `http://localhost:6878` to view debug information for environtmentd.
+
+**Linux Only**
+
+To profile using the [parka agent](https://github.com/parca-dev/parca-agent) you must be running on Linux as it requires sharing a variety of directories with the emulator container.
+
+```bash
+  docker run -d \
+      -p 7071:7071 \
+      --privileged \
+      --pid host \
+      -v /sys/fs/bpf:/sys/fs/bpf \
+      -v /run:/run \
+      -v /boot:/boot \
+      -v /lib/modules:/lib/modules \
+      -v /sys/kernel/debug:/sys/kernel/debug \
+      -v /sys/fs/cgroup:/sys/fs/cgroup \
+      -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+      ghcr.io/parca-dev/parca-agent:v0.36.0 \
+      --remote-store-address=grpc.polarsignals.com:443 \
+      --remote-store-bearer-token=<redacted>
+```


### PR DESCRIPTION
### Motivation

missing documentation for how to debug emulator locally whilst running in docker.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
