### PR TITLE
ci: Introduce a CI_UPLOAD_DEBUG_SYMBOLS env variable

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -52,9 +52,9 @@ steps:
         depends_on: [build-x86_64]
         timeout_in_minutes: 20
         priority: 50
-        if: build.tag != null
+        if: build.tag != null || (build.env("CI_UPLOAD_DEBUG_SYMBOLS") != null && build.env("CI_UPLOAD_DEBUG_SYMBOLS") != "0")
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: rust-build-aarch64
@@ -80,9 +80,9 @@ steps:
         depends_on: [build-aarch64]
         priority: 50
         timeout_in_minutes: 20
-        if: build.tag != null
+        if: build.tag != null || (build.env("CI_UPLOAD_DEBUG_SYMBOLS") != null && build.env("CI_UPLOAD_DEBUG_SYMBOLS") != "0")
         agents:
-          queue: builder-linux-aarch64-mem
+          queue: linux-aarch64-small
         coverage: skip
 
       - id: build-x86_64


### PR DESCRIPTION
So that we can upload debuginfo to Polar Signals without having to tag
Also reduced the agent size, this shouldn't require many CPU/memory resources.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
