### PR TITLE
helm-chart: Bump version of orchestratord better

### DIFF
--- a/misc/python/materialize/cli/helm_chart_version_bump.py
+++ b/misc/python/materialize/cli/helm_chart_version_bump.py
@@ -56,7 +56,14 @@ def main() -> int:
     ]
 
     if args.bump_orchestratord_version:
-        orchestratord_version = str(get_all_mz_versions()[0])
+        # There are two cases that bump the version:
+        # 1. Bump to new unreleased dev version: Use the latest released orchestratord version
+        # 2. Bump when releasing a new version: Use the version we are currently releasing
+        orchestratord_version = (
+            str(get_all_mz_versions()[0])
+            if "dev" in args.environmentd_version
+            else args.environmentd_version
+        )
         mods += [
             (
                 MZ_ROOT / "misc" / "helm-charts" / "operator" / "values.yaml",


### PR DESCRIPTION
Noticed by Kay in https://github.com/MaterializeInc/materialize/commit/14c73a6f8e175b2b64214f02b665cc79458dc48b#r156529641

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
