### PR TITLE
catalog: fix the ordering of `CONNECTION` objects when bootstrapping

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -15,6 +15,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.checks.executors import Executor
 from materialize.checks.features import Features
 from materialize.mz_version import MzVersion
 
@@ -223,3 +224,53 @@ class AlterConnectionHost(AlterConnectionSshChangeBase):
         self, base_version: MzVersion, rng: Random | None, features: Features | None
     ):
         super().__init__(SshChange.CHANGE_SSH_HOST, 3, base_version, rng, features)
+
+
+class AlterConnectionDependencyOrder(Check):
+    """
+    Ensure that ALTER-ing a CONNECTION to reference one with a greater ID, does not panic.
+    """
+
+    def __init__(
+        self,
+        base_version: MzVersion,
+        rng: Random | None,
+        features: Features | None,
+    ):
+        super().__init__(base_version, rng, features)
+
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse_mz("v0.144.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE CONNECTION my_kafka_alter_conn TO KAFKA (BROKER 'localhost:32816') WITH (VALIDATE = false);
+                > CREATE CONNECTION other_ssh TO SSH TUNNEL (host 'foo', user 'bar', port 42) WITH (VALIDATE = false);
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                ALTER CONNECTION my_kafka_alter_conn SET (BROKER 'localhost:32816' USING SSH TUNNEL other_ssh) WITH (VALIDATE = false);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $ set-from-sql var=other_ssh_id
+                SELECT id FROM mz_connections WHERE name = 'other_ssh';
+
+                > SELECT name FROM mz_connections WHERE create_sql LIKE '%${other_ssh_id}%';
+                my_kafka_alter_conn
+                """
+            )
+        )

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -259,6 +259,8 @@ class AlterConnectionDependencyOrder(Check):
                 """
                 ALTER CONNECTION my_kafka_alter_conn SET (BROKER 'localhost:32816' USING SSH TUNNEL other_ssh) WITH (VALIDATE = false);
                 """,
+                """
+                """,
             ]
         ]
 

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -260,6 +260,7 @@ class AlterConnectionDependencyOrder(Check):
                 > ALTER CONNECTION my_kafka_alter_conn SET (BROKER 'localhost:32816' USING SSH TUNNEL other_ssh) WITH (VALIDATE = false);
                 """,
                 """
+                > CREATE CONNECTION another_kafka_conn TO KAFKA (BROKER 'localhost:32816') WITH (VALIDATE = false);
                 """,
             ]
         ]

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -257,7 +257,7 @@ class AlterConnectionDependencyOrder(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                ALTER CONNECTION my_kafka_alter_conn SET (BROKER 'localhost:32816' USING SSH TUNNEL other_ssh) WITH (VALIDATE = false);
+                > ALTER CONNECTION my_kafka_alter_conn SET (BROKER 'localhost:32816' USING SSH TUNNEL other_ssh) WITH (VALIDATE = false);
                 """,
                 """
                 """,

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1950,6 +1950,7 @@ fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
         let existing_connections: BTreeSet<_> = connections.iter().map(|item| item.0.id).collect();
 
         // Initialize our set of topological sort.
+        tracing::info!(?connections, "sorting connections");
         for (connection, ts, diff) in connections.drain(..) {
             let statement = mz_sql::parse::parse(&connection.create_sql)
                 .expect("valid CONNECTION create_sql")
@@ -1966,7 +1967,7 @@ fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
             // Be defensive and ensure we're not clobbering any items.
             assert_none!(topo.insert((connection, ts, diff), dependencies));
         }
-        tracing::info!(?topo, ?existing_connections, "sorting connections");
+        tracing::info!(?topo, ?existing_connections, "built topological sort");
 
         // Do a topological sort, pushing back into the provided Vec.
         while !topo.is_empty() {

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -3405,7 +3405,7 @@ pub enum StateUpdateKind {
 }
 
 /// Valid diffs for catalog state updates.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum StateDiff {
     Retraction,
     Addition,


### PR DESCRIPTION
This PR fixes an issue with our `CONNECTION` objects. `CONNECTION`s can depend on one another and be `ALTER`-ed. This means that a connection can depend on another object with an ID greater than its own which breaks some of our assumptions

The fix here is to do a topological sort of `CONNECTION` objects when applying updates.

### Motivation

Fix a known panic.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
