### PR TITLE
adapter: Support parameters in OFFSET clause

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -100,6 +100,21 @@ fn test_bind_params() {
         assert_eq!(vals, &[1, 2]);
     }
 
+    // Ensure that parameters in a `SELECT .. OFFSET` clause are supported.
+    // See also in `order_by.slt`.
+    {
+        let stmt = client
+            .prepare("SELECT generate_series(1, 5) OFFSET $1")
+            .unwrap();
+        let vals = client
+            .query(&stmt, &[&2_i64])
+            .unwrap()
+            .iter()
+            .map(|r| r.get(0))
+            .collect::<Vec<i32>>();
+        assert_eq!(vals, &[3, 4, 5]);
+    }
+
     // Ensure that parameters in a `VALUES .. LIMIT` clause are supported.
     {
         let stmt = client.prepare("VALUES (1), (2), (3) LIMIT $1").unwrap();

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3634,14 +3634,18 @@ impl JoinInputCharacteristicsV1 {
 /// keywords), whereas much of the rest of SQL is defined in terms of unordered
 /// multisets. But as it turns out, the same idea can be used to optimize
 /// trivial peeks.
+///
+/// The generic parameters are for accommodating prepared statement parameters in
+/// `limit` and `offset`: the planner can hold these fields as HirScalarExpr long enough to call
+/// `bind_parameters` on them.
 #[derive(Arbitrary, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RowSetFinishing<L = NonNeg<i64>> {
+pub struct RowSetFinishing<L = NonNeg<i64>, O = usize> {
     /// Order rows by the given columns.
     pub order_by: Vec<ColumnOrder>,
     /// Include only as many rows (after offset).
     pub limit: Option<L>,
     /// Omit as many rows.
-    pub offset: usize,
+    pub offset: O,
     /// Include only given columns.
     pub project: Vec<usize>,
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -285,6 +285,9 @@ pub enum PlanError {
     Replan(String),
     NetworkPolicyLockoutError,
     NetworkPolicyInUse,
+    // Expected a constant expression that evaluates without an error to a non-null value.
+    ConstantExpressionSimplificationFailed(String),
+    InvalidOffset(String),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -801,6 +804,8 @@ impl fmt::Display for PlanError {
             Self::UntilReadyTimeoutRequired => {
                 write!(f, "TIMEOUT=<duration> option is required for ALTER CLUSTER ... WITH (WAIT UNTIL READY ( ... ))")
             },
+            Self::ConstantExpressionSimplificationFailed(e) => write!(f, "{}", e),
+            Self::InvalidOffset(e) => write!(f, "Invalid OFFSET clause: {}", e),
         }
     }
 }

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -253,7 +253,7 @@ INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
 query error aggregate functions are not allowed in LIMIT \(function pg_catalog.sum\)
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
 
-query error OFFSET must be an integer constant
+query error db error: ERROR: aggregate functions are not allowed in OFFSET \(function pg_catalog\.sum\)
 SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v)
 
 query error aggregate functions are not allowed in VALUES

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1760,3 +1760,69 @@ Source materialize.public.t4
 Target cluster: no_replicas
 
 EOF
+
+# OFFSET clause in RowSetFinishing
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
+SELECT a+b
+FROM t4
+OFFSET 1;
+----
+Explained Query:
+  Finish offset=1 output=[#0]
+    Project (#3)
+      Map ((#0{a} + #1{b}))
+        ReadStorage materialize.public.t4
+
+Source materialize.public.t4
+
+Target cluster: no_replicas
+
+EOF
+
+# OFFSET clause in TopK
+query T multiline
+EXPLAIN
+SELECT a+b, (SELECT a*b FROM t4 OFFSET 1)
+FROM t4;
+----
+Explained Query:
+  With
+    cte l0 =
+      TopK offset=1
+        Project (#3)
+          Map ((#0{a} * #1{b}))
+            ReadStorage materialize.public.t4
+    cte l1 =
+      Union
+        Get l0
+        Map (error("more than one record produced in subquery"))
+          Project ()
+            Filter (#0 > 1)
+              Reduce aggregates=[count(*)]
+                Project ()
+                  Get l0
+  Return
+    Project (#3, #2)
+      Map ((#0{a} + #1{b}))
+        CrossJoin type=differential
+          ArrangeBy keys=[[]]
+            Project (#0, #1)
+              ReadStorage materialize.public.t4
+          ArrangeBy keys=[[]]
+            Union
+              Get l1
+              Map (null)
+                Union
+                  Negate
+                    Distinct project=[]
+                      Project ()
+                        Get l1
+                  Constant
+                    - ()
+
+Source materialize.public.t4
+
+Target cluster: no_replicas
+
+EOF

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -839,7 +839,20 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                     null
                   ]
                 },
-                "offset": 0,
+                "offset": {
+                  "Literal": [
+                    {
+                      "data": [
+                        49
+                      ]
+                    },
+                    {
+                      "scalar_type": "Int64",
+                      "nullable": false
+                    },
+                    null
+                  ]
+                },
                 "expected_group_size": null
               }
             },
@@ -925,7 +938,20 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                         null
                       ]
                     },
-                    "offset": 0,
+                    "offset": {
+                      "Literal": [
+                        {
+                          "data": [
+                            49
+                          ]
+                        },
+                        {
+                          "scalar_type": "Int64",
+                          "nullable": false
+                        },
+                        null
+                      ]
+                    },
                     "expected_group_size": null
                   }
                 },

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -742,3 +742,92 @@ Reduce aggregates=[count(distinct true)]
 Target cluster: quickstart
 
 EOF
+
+# OFFSET clause in RowSetFinishing
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b
+FROM t
+OFFSET 1;
+----
+Finish offset=1 output=[#0]
+  Project (#2)
+    Map ((#0{a} + #1{b}))
+      Get materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# OFFSET clause in TopK
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b, (SELECT a*b FROM t OFFSET 1)
+FROM t;
+----
+Project (#2, #3)
+  With
+    cte [l1 as subquery-1] =
+      Project (#2)
+        TopK offset=1
+          Map ((#0{a} * #1{b}))
+            Get materialize.public.t
+  Return
+    Map ((#0{a} + #1{b}), select(Get l1))
+      Get materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# OFFSET 0 makes the TopK disappear, even if it was an expression that comes out to 0.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b
+FROM t
+OFFSET 0;
+----
+Project (#2)
+  Map ((#0{a} + #1{b}))
+    Get materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b
+FROM t
+OFFSET 7-7;
+----
+Project (#2)
+  Map ((#0{a} + #1{b}))
+    Get materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# The OFFSET should _not_ be printed when it is 0.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b
+FROM t
+LIMIT 9
+OFFSET 7-7;
+----
+Finish limit=9 output=[#0]
+  Project (#2)
+    Map ((#0{a} + #1{b}))
+      Get materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+query error db error: ERROR: Invalid OFFSET clause: invalid input syntax for type bigint: invalid digit found in string: "aaa"
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a+b
+FROM t
+OFFSET 'aaa'::bigint;

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -1174,3 +1174,409 @@ Used Indexes:
 Target cluster: quickstart
 
 EOF
+
+########################################################################################################################
+# Tests for prepared statement parameters in OFFSET, and for non-trivial expressions in OFFSET.
+# (Non-trivial expressions in OFFSET clauses have to be simplifiable to a literal, possibly after parameter binding.)
+#
+# (LIMIT clauses with prepared statement parameters have tests in `test_bind_params` in `pgwire.rs`.
+# LIMIT clauses with non-trivial expressions, referring to the outer context, have tests in `limit_expr.slt`.)
+########################################################################################################################
+
+statement ok
+PREPARE p1 AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET $1;
+
+query IT
+EXECUTE p1(0::bigint);
+----
+0  zero
+1  one
+2  two
+
+query IT
+EXECUTE p1(1::bigint);
+----
+1  one
+2  two
+
+query IT
+EXECUTE p1((1+1)::bigint);
+----
+2  two
+
+query error db error: ERROR: Invalid OFFSET clause: Expected an expression that evaluates to a non\-null value, got null
+EXECUTE p1(null::bigint);
+
+query error db error: ERROR: Invalid OFFSET clause: Expected an expression that evaluates to a non\-null value, got null
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET null;
+
+# Prepared statement parameter in OFFSET inside a subquery
+statement ok
+PREPARE p2 AS
+SELECT
+  (SELECT sum(a) FROM (
+    SELECT a
+    FROM foo
+    ORDER BY a, b
+    OFFSET $1
+  ))
+FROM foo AS outer_foo
+OFFSET $2;
+
+query I
+EXECUTE p2(0::bigint, 0::bigint);
+----
+3
+3
+3
+
+query I
+EXECUTE p2(2::bigint, 0::bigint);
+----
+2
+2
+2
+
+query I
+EXECUTE p2(0::bigint, 1::bigint);
+----
+3
+3
+
+query I
+EXECUTE p2(2::bigint, 1::bigint);
+----
+2
+2
+
+statement ok
+PREPARE p3 AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET $1 - 2;
+
+query error db error: ERROR: Invalid OFFSET clause: must not be negative, got \-2
+EXECUTE p3(0);
+
+query II
+EXECUTE p3(2);
+----
+0  0
+1  0
+2  0
+
+query II
+EXECUTE p3(3);
+----
+1  0
+2  0
+
+query error db error: ERROR: mismatched parameter type: expected bigint, got integer
+EXECUTE p1(1);
+
+query error db error: ERROR: mismatched parameter type: expected bigint, got text
+EXECUTE p1('aaa');
+
+query error db error: ERROR: Invalid OFFSET clause: must not be negative, got \-7
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET -7;
+
+query error db error: ERROR: Invalid OFFSET clause: must not be negative, got \-2
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET 5-7;
+
+query error db error: ERROR: Invalid OFFSET clause: invalid input syntax for type bigint: invalid digit found in string: "aaa"
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET 'aaa';
+
+query error db error: ERROR: column "a" does not exist
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY a, b
+OFFSET a;
+
+# TODO: This error msg is incomplete: it's missing the `integer_to_bigint\(\#\^0\{a\}\)` from the end, which is present
+# in the actual error msg. If we include that, then sqllogictest panics due to a bug in sqllogictest and/or in
+# `regex::escape`.
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+PREPARE p_error AS
+SELECT
+  (
+    SELECT *
+    FROM foo
+    ORDER BY a, b
+    OFFSET outer_foo.a
+  )
+FROM foo AS outer_foo;
+
+query error db error: ERROR: Expected subselect to return 1 column, got 2 columns
+PREPARE p_error AS
+SELECT
+  (
+    SELECT *
+    FROM foo
+    ORDER BY a, b
+    OFFSET outer_foo.a + $1
+  )
+FROM foo AS outer_foo;
+
+# It would be nice to error this out already in the PREPARE, but we currently error out only when executing this.
+statement ok
+PREPARE p_error_1 AS
+SELECT
+  (
+    SELECT b
+    FROM foo
+    ORDER BY a, b
+    OFFSET outer_foo.a + $1
+  )
+FROM foo AS outer_foo;
+
+# This tests the `plan_select_inner`'s `try_visit_mut_pre` just after binding the parameters of `expr`.
+query error db error: ERROR: Invalid OFFSET clause: Expected a constant expression, got
+EXECUTE p_error_1(7);
+
+query error db error: ERROR: OFFSET does not allow subqueries
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET (SELECT 2);
+
+query error db error: ERROR: window functions are not allowed in OFFSET \(function pg_catalog\.lag\)
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET lag(5) OVER ();
+
+query error db error: ERROR: window functions are not allowed in OFFSET \(function pg_catalog\.lag\)
+PREPARE p_error AS
+SELECT
+  (
+    SELECT a
+    FROM foo
+    ORDER BY a, b
+    OFFSET lag(5) OVER ()
+  )
+FROM foo AS outer_foo;
+
+# Unmaterializable function calls are not allowed (not deemed a constant by `HirScalarExpr::is_constant`, and then
+# not simplified by `MirScalarExpr::reduce`).
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got text_to_bigint\(mz_timestamp_to_text\(mz_now\(\)\)\)
+PREPARE p_error AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET mz_now()::string::bigint;
+
+# OFFSET with CREATE VIEW
+
+statement ok
+CREATE VIEW v1 AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET 1;
+
+query T
+SELECT b || a
+FROM v1
+----
+two2
+zero0
+
+query T
+SELECT b || a
+FROM v1
+OFFSET 1
+----
+zero0
+
+query T
+SELECT b || a
+FROM v1
+OFFSET 2 - 1
+----
+zero0
+
+query error db error: ERROR: column "a" does not exist
+CREATE VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET a;
+
+query error db error: ERROR: Invalid OFFSET clause: invalid input syntax for type bigint: invalid digit found in string: "aaaaa"
+CREATE VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET 'aaaaa';
+
+query error db error: ERROR: Invalid OFFSET clause: Expected an expression that evaluates to a non\-null value, got null
+CREATE VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET null;
+
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+CREATE VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET mz_now()::string::bigint;
+
+statement ok
+CREATE VIEW v2 AS
+SELECT
+  (SELECT sum(a) FROM (
+    (SELECT a
+     FROM foo)
+    UNION
+    (SELECT a+1
+     FROM foo)
+    ORDER BY a, b
+    OFFSET 2
+  )) AS s
+FROM foo AS outer_foo
+OFFSET 1;
+
+query IIR
+SELECT sum(s), count(s), avg(s) FROM v2;
+----
+10  2  5
+
+# OFFSET with CREATE MATERIALIZED VIEW
+
+statement ok
+CREATE MATERIALIZED VIEW mv1 AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET 1;
+
+query T
+SELECT b || a
+FROM mv1
+----
+two2
+zero0
+
+query T
+SELECT b || a
+FROM mv1
+OFFSET 1
+----
+zero0
+
+query T
+SELECT b || a
+FROM mv1
+OFFSET 2 - 1
+----
+zero0
+
+query error db error: ERROR: column "a" does not exist
+CREATE MATERIALIZED VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET a;
+
+query error db error: ERROR: Invalid OFFSET clause: invalid input syntax for type bigint: invalid digit found in string: "aaaaa"
+CREATE MATERIALIZED VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET 'aaaaa';
+
+query error db error: ERROR: Invalid OFFSET clause: Expected an expression that evaluates to a non\-null value, got null
+CREATE MATERIALIZED VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET null;
+
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+CREATE MATERIALIZED VIEW err AS
+SELECT *
+FROM foo
+ORDER BY b, a
+OFFSET mz_now()::string::bigint;
+
+statement ok
+CREATE MATERIALIZED VIEW mv2 AS
+SELECT
+  (SELECT sum(a) FROM (
+    (SELECT a
+     FROM foo)
+    UNION
+    (SELECT a+1
+     FROM foo)
+    ORDER BY a, b
+    OFFSET 2
+  )) AS s
+FROM foo AS outer_foo
+OFFSET 1;
+
+query IIR
+SELECT sum(s), count(s), avg(s) FROM mv2;
+----
+10  2  5
+
+# VALUES statement -- OFFSET with parameter
+
+statement ok
+PREPARE p4 AS
+VALUES (0), (1), (2) OFFSET $1
+
+query I
+EXECUTE p4(1::bigint);
+----
+1
+2
+
+statement ok
+PREPARE p5 AS
+VALUES (10), (11), (12) OFFSET $1 - 1
+
+query I
+EXECUTE p5(2);
+----
+11
+12
+
+statement ok
+PREPARE p6 AS
+VALUES (10), (11), (12), ($2), ($3)
+ORDER BY 1 DESC
+OFFSET $1 - 1
+
+query I
+EXECUTE p6(2, 100, 200);
+----
+100
+12
+11
+10

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -437,7 +437,7 @@ INSERT INTO not_allowed_tests (k, v) VALUES (99, 100) RETURNING sum(v) OVER ();
 query error window functions are not allowed in LIMIT
 SELECT sum(v) FROM not_allowed_tests GROUP BY k LIMIT sum(v) OVER ();
 
-query error OFFSET must be an integer constant
+query error db error: ERROR: window functions are not allowed in OFFSET \(function pg_catalog\.sum\)
 SELECT sum(v) FROM not_allowed_tests GROUP BY k LIMIT 1 OFFSET sum(v) OVER ();
 
 query error window functions are not allowed in VALUES


### PR DESCRIPTION
This PR adds support for prepared statement parameters in `OFFSET` clauses. It follows a similar approach as https://github.com/MaterializeInc/materialize/pull/25221 did for `LIMIT` expressions: We make `RowSetFinishing` generic over the type of the offset, so that the planner can hold the finishing's offset as an `HirScalarExpr` long enough to call `bind_parameters` on it.

I suggest starting the review from `plan_query_inner` in `query.rs`, since that is the first thing that runs from among all the touched code. The other important thing is in `plan_select_inner`. And then all the other things are just in service of these two things.

For the type of the `OFFSET` clause's expression, I went with `ScalarType::Int64`, i.e., `bigint` for now, as [discussed on slack](https://materializeinc.slack.com/archives/C08A62E0751/p1746711669627839?thread_ts=1746563801.896649&cid=C08A62E0751).

I've also added various TODOs to existing code. I'm planning to do those in follow-up PRs.

There is also the issue that the type of the arguments given in `EXECUTE` calls have to exactly match the expected types, i.e., it's not enough to be castable to it. This seems to be a general limitation of our prepared statements, e.g., it also occurs for the `LIMIT` clause. I'm somewhat surprised that this hasn't caused problems so far, but we can work on this separately if it turns out to be a problem. (I'll at least open an issue shortly.)

Nightly: https://buildkite.com/materialize/nightly/builds/11986

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/database-issues/issues/9009

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
