### PR TITLE
platform-checks : Fix AlterConnectionDependencyOrder

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -272,7 +272,7 @@ class AlterConnectionDependencyOrder(Check):
                 $ set-from-sql var=other_ssh_id
                 SELECT id FROM mz_connections WHERE name = 'other_ssh';
 
-                > SELECT name FROM mz_connections WHERE create_sql LIKE '%${other_ssh_id}%';
+                > SELECT name FROM mz_connections WHERE create_sql LIKE '%[${other_ssh_id} AS %';
                 my_kafka_alter_conn
                 """
             )


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/32438

Seen failing in https://buildkite.com/materialize/test/builds/103327#0196b25b-e03c-4e3e-b6d8-c9aad8cff273

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
