### PR TITLE
tests: Fix escaping in slt error messages

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -201,10 +201,15 @@ impl<'a> Outcome<'a> {
                 // This value gets fed back into regex to check that it matches
                 // `self`, so escape its meta characters.
                 regex::escape(
-                    // Take only first string in error message, which should be
-                    // sufficient for meaningfully matching error.
+                    // Take only the first string in the error message, which should be
+                    // sufficient for meaningfully matching the error.
                     error.to_string().split('\n').next().unwrap(),
-                ),
+                )
+                // We need to undo the escaping of #. `regex::escape` escapes this because it
+                // expects that we use the `x` flag when building a regex, but this is not the case,
+                // so \# would end up being an invalid escape sequence, which would choke the
+                // parsing of the slt file the next time around.
+                .replace(r"\#", "#"),
             ),
             _ => None,
         }

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -1314,10 +1314,7 @@ FROM foo
 ORDER BY a, b
 OFFSET a;
 
-# TODO: This error msg is incomplete: it's missing the `integer_to_bigint\(\#\^0\{a\}\)` from the end, which is present
-# in the actual error msg. If we include that, then sqllogictest panics due to a bug in sqllogictest and/or in
-# `regex::escape`.
-query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got integer_to_bigint\(#\^0\{a\}\)
 PREPARE p_error AS
 SELECT
   (
@@ -1352,7 +1349,7 @@ SELECT
 FROM foo AS outer_foo;
 
 # This tests the `plan_select_inner`'s `try_visit_mut_pre` just after binding the parameters of `expr`.
-query error db error: ERROR: Invalid OFFSET clause: Expected a constant expression, got
+query error db error: ERROR: Invalid OFFSET clause: Expected a constant expression, got integer_to_bigint\(\(#\^0\{a\} \+ 7\)\)
 EXECUTE p_error_1(7);
 
 query error db error: ERROR: OFFSET does not allow subqueries
@@ -1440,7 +1437,7 @@ FROM foo
 ORDER BY b, a
 OFFSET null;
 
-query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got text_to_bigint\(mz_timestamp_to_text\(mz_now\(\)\)\)
 CREATE VIEW err AS
 SELECT *
 FROM foo
@@ -1518,7 +1515,7 @@ FROM foo
 ORDER BY b, a
 OFFSET null;
 
-query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got
+query error db error: ERROR: Invalid OFFSET clause: must be simplifiable to a constant, possibly after parameter binding, got text_to_bigint\(mz_timestamp_to_text\(mz_now\(\)\)\)
 CREATE MATERIALIZED VIEW err AS
 SELECT *
 FROM foo


### PR DESCRIPTION
Slt escapes regex special characters when it auto-rewrites error msgs, because the error msg is used in a regex when parsing the file. It does the escaping with `regex::escape`, but this seems to have a bug (or at least a surprising behavior): It unconditionally escapes `#`. This is a problem because `\#` is valid only when the `x` flag is used when building a regex, which we don't use. So, this PR simply undoes the escaping of `#`.

### Motivation

This PR fixes a minor bug in sqllogictest. Ran into this in https://github.com/MaterializeInc/materialize/pull/32443

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
