### PR TITLE
Remove `bind_parameter` calls from statement types that don't support `PREPARE`

### DIFF
--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2120,6 +2120,18 @@ impl HirRelationExpr {
         })
     }
 
+    pub fn contains_parameters(&self) -> Result<bool, PlanError> {
+        let mut contains_parameters = false;
+        #[allow(deprecated)]
+        self.visit_scalar_expressions(0, &mut |e: &HirScalarExpr, _: usize| {
+            if e.contains_parameters() {
+                contains_parameters = true;
+            }
+            Ok::<(), PlanError>(())
+        })?;
+        Ok(contains_parameters)
+    }
+
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
         #[allow(deprecated)]
@@ -3774,12 +3786,6 @@ impl AbstractExpr for HirScalarExpr {
 }
 
 impl AggregateExpr {
-    /// Replaces any parameter references in the expression with the
-    /// corresponding datum from `parameters`.
-    pub fn bind_parameters(&mut self, params: &Params) -> Result<(), PlanError> {
-        self.expr.bind_parameters(params)
-    }
-
     pub fn typ(
         &self,
         outers: &[RelationType],

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -341,11 +341,9 @@ pub fn plan(
         Statement::CreateTable(stmt) => ddl::plan_create_table(scx, stmt),
         Statement::CreateTableFromSource(stmt) => ddl::plan_create_table_from_source(scx, stmt),
         Statement::CreateType(stmt) => ddl::plan_create_type(scx, stmt),
-        Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt, params),
-        Statement::CreateMaterializedView(stmt) => {
-            ddl::plan_create_materialized_view(scx, stmt, params)
-        }
-        Statement::CreateContinualTask(stmt) => ddl::plan_create_continual_task(scx, stmt, params),
+        Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt),
+        Statement::CreateMaterializedView(stmt) => ddl::plan_create_materialized_view(scx, stmt),
+        Statement::CreateContinualTask(stmt) => ddl::plan_create_continual_task(scx, stmt),
         Statement::CreateNetworkPolicy(stmt) => ddl::plan_create_network_policy(scx, stmt),
         Statement::DropObjects(stmt) => ddl::plan_drop_objects(scx, stmt),
         Statement::DropOwned(stmt) => ddl::plan_drop_owned(scx, stmt),
@@ -364,7 +362,7 @@ pub fn plan(
         Statement::Delete(stmt) => dml::plan_delete(scx, stmt, params),
         Statement::ExplainPlan(stmt) => dml::plan_explain_plan(scx, stmt, params),
         Statement::ExplainPushdown(stmt) => dml::plan_explain_pushdown(scx, stmt, params),
-        Statement::ExplainTimestamp(stmt) => dml::plan_explain_timestamp(scx, stmt, params),
+        Statement::ExplainTimestamp(stmt) => dml::plan_explain_timestamp(scx, stmt),
         Statement::ExplainSinkSchema(stmt) => dml::plan_explain_schema(scx, stmt),
         Statement::Insert(stmt) => dml::plan_insert(scx, stmt, params),
         Statement::Select(stmt) => dml::plan_select(scx, stmt, params, None),


### PR DESCRIPTION
This PR is a little bit of spring cleaning: It removes `bind_parameter` calls and related wiring from the planning of statement types that can't be made into prepared statements (DDL and EXPLAIN TIMESTAMP). Note that Postgres also doesn't support preparing DDL.

However, even for these statements, we still need to check that there are no parameters in them. E.g., if the user writes
```
CREATE VIEW v AS SELECT $1
```
then we need to do _something_ about that `$1`. That something used to be `bind_parameters` complaining that `there is no parameter $1`. After the PR we print a more specific error msg: `views cannot have parameters`.

Additionally, the PR removes the `bind_parameters` fn from `AggregateExpr`, because it was unused, and I can't imagine a use for it.

### Motivation

   * Spring cleaning, but I also have a more specific motivation: I'm planning to tackle https://github.com/MaterializeInc/database-issues/issues/9266, where I'll need to pass more things into `bind_parameter`, so I didn't want to have more calls to it than necessary.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
