### PR TITLE
Convert more binary funcs to the sqlfunc macro

### DIFF
--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -718,7 +718,9 @@ mod relation {
 
 /// Support for parsing [mz_expr::MirScalarExpr].
 mod scalar {
-    use mz_expr::{BinaryFunc, ColumnOrder, MirScalarExpr};
+    use mz_expr::{
+        BinaryFunc, ColumnOrder, MirScalarExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc,
+    };
     use mz_repr::{AsColumnType, Datum, Row, RowArena, ScalarType};
 
     use super::*;
@@ -1102,8 +1104,6 @@ mod scalar {
     }
 
     fn parse_apply(input: ParseStream) -> Result {
-        use mz_expr::func::{BinaryFunc::*, UnmaterializableFunc::*, VariadicFunc::*, *};
-
         let ident = input.parse::<syn::Ident>()?;
 
         // parse parentheses
@@ -1135,14 +1135,14 @@ mod scalar {
         // name resolution in the parser.
         match ident.to_string().to_lowercase().as_str() {
             // Supported unmaterializable (a.k.a. nullary) functions:
-            "mz_environment_id" => parse_nullary(MzEnvironmentId),
+            "mz_environment_id" => parse_nullary(UnmaterializableFunc::MzEnvironmentId),
             // Supported unary functions:
-            "abs" => parse_unary(AbsInt64.into()),
-            "not" => parse_unary(Not.into()),
+            "abs" => parse_unary(mz_expr::func::AbsInt64.into()),
+            "not" => parse_unary(mz_expr::func::Not.into()),
             // Supported binary functions:
-            "ltrim" => parse_binary(TrimLeading),
+            "ltrim" => parse_binary(BinaryFunc::TrimLeading),
             // Supported variadic functions:
-            "greatest" => parse_variadic(Greatest),
+            "greatest" => parse_variadic(VariadicFunc::Greatest),
             _ => Err(Error::new(ident.span(), "unsupported function name")),
         }
     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -592,7 +592,7 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     }
 }
 
-#[sqlfunc(output_type = "String", sqlname = "encode", propagates_nulls = true)]
+#[sqlfunc(output_type = "String", propagates_nulls = true)]
 fn encode<'a>(
     bytes: Datum<'a>,
     format: Datum<'a>,
@@ -603,6 +603,7 @@ fn encode<'a>(
     Ok(Datum::from(temp_storage.push_string(out)))
 }
 
+#[sqlfunc(output_type = "Vec<u8>", propagates_nulls = true)]
 fn decode<'a>(
     string: Datum<'a>,
     format: Datum<'a>,
@@ -3027,6 +3028,18 @@ fn timezone_interval_timestamptz(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'st
     }
 }
 
+#[sqlfunc(
+    output_type_expr = "ScalarType::Record {
+                fields: [
+                    (\"abbrev\".into(), ScalarType::String.nullable(false)),
+                    (\"base_utc_offset\".into(), ScalarType::Interval.nullable(false)),
+                    (\"dst_offset\".into(), ScalarType::Interval.nullable(false)),
+                ].into(),
+                custom_id: None,
+            }.nullable(true)",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn timezone_offset<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -3049,7 +3062,12 @@ fn timezone_offset<'a>(
 
 /// Determines if an mz_aclitem contains one of the specified privileges. This will return true if
 /// any of the listed privileges are contained in the mz_aclitem.
-fn mz_acl_item_contains_privilege(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'static>, EvalError> {
+#[sqlfunc(
+    sqlname = "mz_aclitem_contains_privilege",
+    output_type = "bool",
+    propagates_nulls = true
+)]
+fn mz_acl_item_contains_privilege<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let mz_acl_item = a.unwrap_mz_acl_item();
     let privileges = b.unwrap_str();
     let acl_mode = AclMode::parse_multiple_privileges(privileges)
@@ -3058,6 +3076,10 @@ fn mz_acl_item_contains_privilege(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'s
     Ok(contains.into())
 }
 
+#[sqlfunc(
+    output_type = "mz_repr::ArrayRustType<String>",
+    propagates_nulls = true
+)]
 // transliterated from postgres/src/backend/utils/adt/misc.c
 fn parse_ident<'a>(
     a: Datum<'a>,
@@ -3267,6 +3289,7 @@ fn regexp_split_to_array_re<'a>(
     Ok(temp_storage.push_unary_row(row))
 }
 
+#[sqlfunc(output_type = "String", propagates_nulls = true)]
 fn pretty_sql<'a>(
     sql: Datum<'a>,
     width: Datum<'a>,
@@ -3288,6 +3311,7 @@ fn pretty_sql<'a>(
     Ok(Datum::String(pretty))
 }
 
+#[sqlfunc(output_type = "bool", propagates_nulls = true)]
 fn starts_with<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let a = a.unwrap_str();
     let b = b.unwrap_str();
@@ -4470,7 +4494,12 @@ impl BinaryFunc {
             | BinaryFunc::ListRemove
             | BinaryFunc::ToCharTimestamp
             | BinaryFunc::ToCharTimestampTz
-            | BinaryFunc::ListContainsList { rev: _ } => false,
+            | BinaryFunc::ListContainsList { rev: _ }
+            | BinaryFunc::Trim
+            | BinaryFunc::TrimLeading
+            | BinaryFunc::TrimTrailing
+            | BinaryFunc::TextConcat
+            | BinaryFunc::StartsWith => false,
 
             _ => true,
         }
@@ -7439,6 +7468,13 @@ fn error_if_null<'a>(
     }
 }
 
+#[sqlfunc(
+    sqlname = "||",
+    is_infix_op = true,
+    output_type = "String",
+    propagates_nulls = true,
+    is_monotone = (false, true),
+)]
 fn text_concat_binary<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     let mut buf = String::new();
     buf.push_str(a.unwrap_str());
@@ -7597,6 +7633,11 @@ fn split_part<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     ))
 }
 
+#[sqlfunc(
+    output_type = "String",
+    propagates_nulls = true,
+    introduces_nulls = false
+)]
 fn like_escape<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
@@ -8307,6 +8348,7 @@ fn make_timestamp<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
     Ok(timestamp.try_into()?)
 }
 
+#[sqlfunc(output_type = "i32", propagates_nulls = true)]
 fn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let substring: &'a str = a.unwrap_str();
     let string = b.unwrap_str();
@@ -8326,6 +8368,7 @@ fn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
+#[sqlfunc(output_type = "String", propagates_nulls = true)]
 fn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let string: &'a str = a.unwrap_str();
     let n = i64::from(b.unwrap_int32());
@@ -8352,6 +8395,7 @@ fn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     Ok(Datum::String(&string[..end_in_bytes]))
 }
 
+#[sqlfunc(output_type = "String", propagates_nulls = true)]
 fn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let string: &'a str = a.unwrap_str();
     let n = b.unwrap_int32();
@@ -8380,12 +8424,14 @@ fn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     Ok(Datum::String(&string[start_in_bytes..]))
 }
 
+#[sqlfunc(sqlname = "btrim", output_type = "String", propagates_nulls = true)]
 fn trim<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let trim_chars = b.unwrap_str();
 
     Datum::from(a.unwrap_str().trim_matches(|c| trim_chars.contains(c)))
 }
 
+#[sqlfunc(sqlname = "ltrim", output_type = "String", propagates_nulls = true)]
 fn trim_leading<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let trim_chars = b.unwrap_str();
 
@@ -8395,6 +8441,7 @@ fn trim_leading<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     )
 }
 
+#[sqlfunc(sqlname = "rtrim", output_type = "String", propagates_nulls = true)]
 fn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     let trim_chars = b.unwrap_str();
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3029,14 +3029,14 @@ fn timezone_interval_timestamptz(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'st
 }
 
 #[sqlfunc(
-    output_type_expr = "ScalarType::Record {
+    output_type_expr = r#"ScalarType::Record {
                 fields: [
-                    (\"abbrev\".into(), ScalarType::String.nullable(false)),
-                    (\"base_utc_offset\".into(), ScalarType::Interval.nullable(false)),
-                    (\"dst_offset\".into(), ScalarType::Interval.nullable(false)),
+                    ("abbrev".into(), ScalarType::String.nullable(false)),
+                    ("base_utc_offset".into(), ScalarType::Interval.nullable(false)),
+                    ("dst_offset".into(), ScalarType::Interval.nullable(false)),
                 ].into(),
                 custom_id: None,
-            }.nullable(true)",
+            }.nullable(true)"#,
     propagates_nulls = true,
     introduces_nulls = false
 )]

--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -513,7 +513,13 @@ mod test {
         );
         check(func::RoundNumericBinary, BF::RoundNumeric, &i32_ty, &i32_ty);
         check(func::ConvertFrom, BF::ConvertFrom, &i32_ty, &i32_ty);
+        check(func::Left, BF::Left, &i32_ty, &i32_ty);
+        check(func::Right, BF::Right, &i32_ty, &i32_ty);
+        check(func::Trim, BF::Trim, &i32_ty, &i32_ty);
+        check(func::TrimLeading, BF::TrimLeading, &i32_ty, &i32_ty);
+        check(func::TrimTrailing, BF::TrimTrailing, &i32_ty, &i32_ty);
         check(func::Encode, BF::Encode, &i32_ty, &i32_ty);
+        check(func::Decode, BF::Decode, &i32_ty, &i32_ty);
         check(
             func::EncodedBytesCharLength,
             BF::EncodedBytesCharLength,
@@ -839,6 +845,10 @@ mod test {
         check(func::Gt, BF::Gt, &i32_ty, &i32_ty);
         check(func::Gte, BF::Gte, &i32_ty, &i32_ty);
 
+        check(func::LikeEscape, BF::LikeEscape, &i32_ty, &i32_ty);
+        check(func::TimezoneOffset, BF::TimezoneOffset, &i32_ty, &i32_ty);
+        check(func::TextConcatBinary, BF::TextConcat, &i32_ty, &i32_ty);
+
         check(
             func::ToCharTimestampFormat,
             BF::ToCharTimestamp,
@@ -1022,5 +1032,14 @@ mod test {
         check(func::DigestString, BF::DigestString, &i32_ty, &i32_ty);
         check(func::DigestBytes, BF::DigestBytes, &i32_ty, &i32_ty);
         check(func::MzRenderTypmod, BF::MzRenderTypmod, &i32_ty, &i32_ty);
+        check(
+            func::MzAclItemContainsPrivilege,
+            BF::MzAclItemContainsPrivilege,
+            &i32_ty,
+            &i32_ty,
+        );
+        check(func::ParseIdent, BF::ParseIdent, &i32_ty, &i32_ty);
+        check(func::StartsWith, BF::StartsWith, &i32_ty, &i32_ty);
+        check(func::PrettySql, BF::PrettySql, &i32_ty, &i32_ty);
     }
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__decode.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__decode.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(output_type = \"Vec<u8>\", propagates_nulls = true)]\nfn decode<'a>(\n    string: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.decode(string.unwrap_str())?;\n    Ok(Datum::from(temp_storage.push_bytes(out)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,8 +15,8 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct Decode;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Decode {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
     type Output = Result<Datum<'a>, EvalError>;
@@ -26,7 +26,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        decode(a, b, temp_storage)
     }
     fn output_type(
         &self,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         input_type_b: mz_repr::ColumnType,
     ) -> mz_repr::ColumnType {
         use mz_repr::AsColumnType;
-        let output = <String>::as_column_type();
+        let output = <Vec<u8>>::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -47,23 +47,23 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
             )
     }
     fn introduces_nulls(&self) -> bool {
-        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+        <Vec<u8> as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn propagates_nulls(&self) -> bool {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for Decode {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str(stringify!(decode))
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
+fn decode<'a>(
+    string: Datum<'a>,
     format: Datum<'a>,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
     let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+    let out = format.decode(string.unwrap_str())?;
+    Ok(Datum::from(temp_storage.push_bytes(out)))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__left.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__left.snap
@@ -1,0 +1,87 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let string: &'a str = a.unwrap_str();\n    let n = i64::from(b.unwrap_int32());\n    let mut byte_indices = string.char_indices().map(|(i, _)| i);\n    let end_in_bytes = match n.cmp(&0) {\n        Ordering::Equal => 0,\n        Ordering::Greater => {\n            let n = usize::try_from(n)\n                .map_err(|_| {\n                    EvalError::InvalidParameterValue(\n                        format!(\"invalid parameter n: {:?}\", n).into(),\n                    )\n                })?;\n            byte_indices.nth(n).unwrap_or(string.len())\n        }\n        Ordering::Less => {\n            let n = usize::try_from(n.abs() - 1)\n                .map_err(|_| {\n                    EvalError::InvalidParameterValue(\n                        format!(\"invalid parameter n: {:?}\", n).into(),\n                    )\n                })?;\n            byte_indices.rev().nth(n).unwrap_or(0)\n        }\n    };\n    Ok(Datum::String(&string[..end_in_bytes]))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Left;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Left {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        left(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Left {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(left))
+    }
+}
+fn left<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let string: &'a str = a.unwrap_str();
+    let n = i64::from(b.unwrap_int32());
+    let mut byte_indices = string.char_indices().map(|(i, _)| i);
+    let end_in_bytes = match n.cmp(&0) {
+        Ordering::Equal => 0,
+        Ordering::Greater => {
+            let n = usize::try_from(n)
+                .map_err(|_| {
+                    EvalError::InvalidParameterValue(
+                        format!("invalid parameter n: {:?}", n).into(),
+                    )
+                })?;
+            byte_indices.nth(n).unwrap_or(string.len())
+        }
+        Ordering::Less => {
+            let n = usize::try_from(n.abs() - 1)
+                .map_err(|_| {
+                    EvalError::InvalidParameterValue(
+                        format!("invalid parameter n: {:?}", n).into(),
+                    )
+                })?;
+            byte_indices.rev().nth(n).unwrap_or(0)
+        }
+    };
+    Ok(Datum::String(&string[..end_in_bytes]))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__like_escape.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__like_escape.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true, introduces_nulls = false)]\nfn like_escape<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let pattern = a.unwrap_str();\n    let escape = like_pattern::EscapeBehavior::from_str(b.unwrap_str())?;\n    let normalized = like_pattern::normalize_pattern(pattern, escape)?;\n    Ok(Datum::String(temp_storage.push_string(normalized)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,8 +15,8 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct LikeEscape;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for LikeEscape {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
     type Output = Result<Datum<'a>, EvalError>;
@@ -26,7 +26,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        like_escape(a, b, temp_storage)
     }
     fn output_type(
         &self,
@@ -47,23 +47,24 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
             )
     }
     fn introduces_nulls(&self) -> bool {
-        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+        false
     }
     fn propagates_nulls(&self) -> bool {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for LikeEscape {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str(stringify!(like_escape))
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
+fn like_escape<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+    let pattern = a.unwrap_str();
+    let escape = like_pattern::EscapeBehavior::from_str(b.unwrap_str())?;
+    let normalized = like_pattern::normalize_pattern(pattern, escape)?;
+    Ok(Datum::String(temp_storage.push_string(normalized)))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mz_acl_item_contains_privilege.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mz_acl_item_contains_privilege.snap
@@ -1,0 +1,73 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    sqlname = \"mz_aclitem_contains_privilege\",\n    output_type = \"bool\",\n    propagates_nulls = true\n)]\n/// Determines if an mz_aclitem contains one of the specified privileges. This will return true if\n/// any of the listed privileges are contained in the mz_aclitem.\nfn mz_acl_item_contains_privilege<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let mz_acl_item = a.unwrap_mz_acl_item();\n    let privileges = b.unwrap_str();\n    let acl_mode = AclMode::parse_multiple_privileges(privileges)\n        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;\n    let contains = !mz_acl_item.acl_mode.intersection(acl_mode).is_empty();\n    Ok(contains.into())\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct MzAclItemContainsPrivilege;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MzAclItemContainsPrivilege {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        mz_acl_item_contains_privilege(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <bool>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for MzAclItemContainsPrivilege {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("mz_aclitem_contains_privilege")
+    }
+}
+/// Determines if an mz_aclitem contains one of the specified privileges. This will return true if
+/// any of the listed privileges are contained in the mz_aclitem.
+fn mz_acl_item_contains_privilege<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+) -> Result<Datum<'a>, EvalError> {
+    let mz_acl_item = a.unwrap_mz_acl_item();
+    let privileges = b.unwrap_str();
+    let acl_mode = AclMode::parse_multiple_privileges(privileges)
+        .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;
+    let contains = !mz_acl_item.acl_mode.intersection(acl_mode).is_empty();
+    Ok(contains.into())
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__parse_ident.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__parse_ident.snap
@@ -1,0 +1,146 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"mz_repr::ArrayRustType<String>\", propagates_nulls = true)]\nfn parse_ident<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    fn is_ident_start(c: char) -> bool {\n        matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '\\u{80}'..= char::MAX)\n    }\n    fn is_ident_cont(c: char) -> bool {\n        matches!(c, '0'..='9' | '$') || is_ident_start(c)\n    }\n    let ident = a.unwrap_str();\n    let strict = b.unwrap_bool();\n    let mut elems = vec![];\n    let buf = &mut LexBuf::new(ident);\n    let mut after_dot = false;\n    buf.take_while(|ch| ch.is_ascii_whitespace());\n    loop {\n        let mut missing_ident = true;\n        let c = buf.next();\n        if c == Some('\"') {\n            let s = buf.take_while(|ch| !matches!(ch, '\"'));\n            if buf.next() != Some('\"') {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"String has unclosed double quotes.\".into()),\n                });\n            }\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        } else if c.map(is_ident_start).unwrap_or(false) {\n            buf.prev();\n            let s = buf.take_while(is_ident_cont);\n            let s = temp_storage.push_string(s.to_ascii_lowercase());\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        }\n        if missing_ident {\n            if c == Some('.') {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"No valid identifier before \\\".\\\".\".into()),\n                });\n            } else if after_dot {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"No valid identifier after \\\".\\\".\".into()),\n                });\n            } else {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: None,\n                });\n            }\n        }\n        buf.take_while(|ch| ch.is_ascii_whitespace());\n        match buf.next() {\n            Some('.') => {\n                after_dot = true;\n                buf.take_while(|ch| ch.is_ascii_whitespace());\n            }\n            Some(_) if strict => {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: None,\n                });\n            }\n            _ => break,\n        }\n    }\n    Ok(\n        temp_storage\n            .try_make_datum(|packer| {\n                packer\n                    .try_push_array(\n                        &[\n                            ArrayDimension {\n                                lower_bound: 1,\n                                length: elems.len(),\n                            },\n                        ],\n                        elems,\n                    )\n            })?,\n    )\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct ParseIdent;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for ParseIdent {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        parse_ident(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <mz_repr::ArrayRustType<String>>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <mz_repr::ArrayRustType<String> as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for ParseIdent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(parse_ident))
+    }
+}
+fn parse_ident<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    fn is_ident_start(c: char) -> bool {
+        matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '\u{80}'..= char::MAX)
+    }
+    fn is_ident_cont(c: char) -> bool {
+        matches!(c, '0'..='9' | '$') || is_ident_start(c)
+    }
+    let ident = a.unwrap_str();
+    let strict = b.unwrap_bool();
+    let mut elems = vec![];
+    let buf = &mut LexBuf::new(ident);
+    let mut after_dot = false;
+    buf.take_while(|ch| ch.is_ascii_whitespace());
+    loop {
+        let mut missing_ident = true;
+        let c = buf.next();
+        if c == Some('"') {
+            let s = buf.take_while(|ch| !matches!(ch, '"'));
+            if buf.next() != Some('"') {
+                return Err(EvalError::InvalidIdentifier {
+                    ident: ident.into(),
+                    detail: Some("String has unclosed double quotes.".into()),
+                });
+            }
+            elems.push(Datum::String(s));
+            missing_ident = false;
+        } else if c.map(is_ident_start).unwrap_or(false) {
+            buf.prev();
+            let s = buf.take_while(is_ident_cont);
+            let s = temp_storage.push_string(s.to_ascii_lowercase());
+            elems.push(Datum::String(s));
+            missing_ident = false;
+        }
+        if missing_ident {
+            if c == Some('.') {
+                return Err(EvalError::InvalidIdentifier {
+                    ident: ident.into(),
+                    detail: Some("No valid identifier before \".\".".into()),
+                });
+            } else if after_dot {
+                return Err(EvalError::InvalidIdentifier {
+                    ident: ident.into(),
+                    detail: Some("No valid identifier after \".\".".into()),
+                });
+            } else {
+                return Err(EvalError::InvalidIdentifier {
+                    ident: ident.into(),
+                    detail: None,
+                });
+            }
+        }
+        buf.take_while(|ch| ch.is_ascii_whitespace());
+        match buf.next() {
+            Some('.') => {
+                after_dot = true;
+                buf.take_while(|ch| ch.is_ascii_whitespace());
+            }
+            Some(_) if strict => {
+                return Err(EvalError::InvalidIdentifier {
+                    ident: ident.into(),
+                    detail: None,
+                });
+            }
+            _ => break,
+        }
+    }
+    Ok(
+        temp_storage
+            .try_make_datum(|packer| {
+                packer
+                    .try_push_array(
+                        &[
+                            ArrayDimension {
+                                lower_bound: 1,
+                                length: elems.len(),
+                            },
+                        ],
+                        elems,
+                    )
+            })?,
+    )
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__position.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__position.snap
@@ -1,0 +1,76 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let substring: &'a str = a.unwrap_str();\n    let string = b.unwrap_str();\n    let char_index = string.find(substring);\n    if let Some(char_index) = char_index {\n        let string_prefix = &string[0..char_index];\n        let num_prefix_chars = string_prefix.chars().count();\n        let num_prefix_chars = i32::try_from(num_prefix_chars)\n            .map_err(|_| EvalError::Int32OutOfRange(\n                num_prefix_chars.to_string().into(),\n            ))?;\n        Ok(Datum::Int32(num_prefix_chars + 1))\n    } else {\n        Ok(Datum::Int32(0))\n    }\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Position;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Position {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        position(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <i32>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Position {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(position))
+    }
+}
+fn position<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let substring: &'a str = a.unwrap_str();
+    let string = b.unwrap_str();
+    let char_index = string.find(substring);
+    if let Some(char_index) = char_index {
+        let string_prefix = &string[0..char_index];
+        let num_prefix_chars = string_prefix.chars().count();
+        let num_prefix_chars = i32::try_from(num_prefix_chars)
+            .map_err(|_| EvalError::Int32OutOfRange(
+                num_prefix_chars.to_string().into(),
+            ))?;
+        Ok(Datum::Int32(num_prefix_chars + 1))
+    } else {
+        Ok(Datum::Int32(0))
+    }
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__pretty_sql.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__pretty_sql.snap
@@ -1,0 +1,80 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn pretty_sql<'a>(\n    sql: Datum<'a>,\n    width: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let sql = sql.unwrap_str();\n    let width = width.unwrap_int32();\n    let width = usize::try_from(width)\n        .map_err(|_| EvalError::PrettyError(\"invalid width\".into()))?;\n    let pretty = pretty_str(\n            sql,\n            PrettyConfig {\n                width,\n                format_mode: FormatMode::Simple,\n            },\n        )\n        .map_err(|e| EvalError::PrettyError(e.to_string().into()))?;\n    let pretty = temp_storage.push_string(pretty);\n    Ok(Datum::String(pretty))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct PrettySql;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for PrettySql {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        pretty_sql(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for PrettySql {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(pretty_sql))
+    }
+}
+fn pretty_sql<'a>(
+    sql: Datum<'a>,
+    width: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let sql = sql.unwrap_str();
+    let width = width.unwrap_int32();
+    let width = usize::try_from(width)
+        .map_err(|_| EvalError::PrettyError("invalid width".into()))?;
+    let pretty = pretty_str(
+            sql,
+            PrettyConfig {
+                width,
+                format_mode: FormatMode::Simple,
+            },
+        )
+        .map_err(|e| EvalError::PrettyError(e.to_string().into()))?;
+    let pretty = temp_storage.push_string(pretty);
+    Ok(Datum::String(pretty))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__right.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__right.snap
@@ -1,0 +1,88 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let string: &'a str = a.unwrap_str();\n    let n = b.unwrap_int32();\n    let mut byte_indices = string.char_indices().map(|(i, _)| i);\n    let start_in_bytes = if n == 0 {\n        string.len()\n    } else if n > 0 {\n        let n = usize::try_from(n - 1)\n            .map_err(|_| {\n                EvalError::InvalidParameterValue(\n                    format!(\"invalid parameter n: {:?}\", n).into(),\n                )\n            })?;\n        byte_indices.rev().nth(n).unwrap_or(0)\n    } else if n == i32::MIN {\n        0\n    } else {\n        let n = n.abs();\n        let n = usize::try_from(n)\n            .map_err(|_| {\n                EvalError::InvalidParameterValue(\n                    format!(\"invalid parameter n: {:?}\", n).into(),\n                )\n            })?;\n        byte_indices.nth(n).unwrap_or(string.len())\n    };\n    Ok(Datum::String(&string[start_in_bytes..]))\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct Right;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Right {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        right(a, b)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = <String>::as_column_type();
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for Right {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(right))
+    }
+}
+fn right<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let string: &'a str = a.unwrap_str();
+    let n = b.unwrap_int32();
+    let mut byte_indices = string.char_indices().map(|(i, _)| i);
+    let start_in_bytes = if n == 0 {
+        string.len()
+    } else if n > 0 {
+        let n = usize::try_from(n - 1)
+            .map_err(|_| {
+                EvalError::InvalidParameterValue(
+                    format!("invalid parameter n: {:?}", n).into(),
+                )
+            })?;
+        byte_indices.rev().nth(n).unwrap_or(0)
+    } else if n == i32::MIN {
+        0
+    } else {
+        let n = n.abs();
+        let n = usize::try_from(n)
+            .map_err(|_| {
+                EvalError::InvalidParameterValue(
+                    format!("invalid parameter n: {:?}", n).into(),
+                )
+            })?;
+        byte_indices.nth(n).unwrap_or(string.len())
+    };
+    Ok(Datum::String(&string[start_in_bytes..]))
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__starts_with.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__starts_with.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(output_type = \"bool\", propagates_nulls = true)]\nfn starts_with<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let a = a.unwrap_str();\n    let b = b.unwrap_str();\n    Datum::from(a.starts_with(b))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,18 +15,18 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct StartsWith;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for StartsWith {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Datum<'a>;
     fn call(
         &self,
         a: Self::Input1,
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        starts_with(a, b)
     }
     fn output_type(
         &self,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         input_type_b: mz_repr::ColumnType,
     ) -> mz_repr::ColumnType {
         use mz_repr::AsColumnType;
-        let output = <String>::as_column_type();
+        let output = <bool>::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -47,23 +47,19 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
             )
     }
     fn introduces_nulls(&self) -> bool {
-        <String as ::mz_repr::DatumType<'_, ()>>::nullable()
+        <bool as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn propagates_nulls(&self) -> bool {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for StartsWith {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str(stringify!(starts_with))
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+fn starts_with<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let a = a.unwrap_str();
+    let b = b.unwrap_str();
+    Datum::from(a.starts_with(b))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__text_concat_binary.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__text_concat_binary.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"||\",\n    is_infix_op = true,\n    output_type = \"String\",\n    propagates_nulls = true,\n    is_monotone = (false, true),\n)]\nfn text_concat_binary<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Datum<'a> {\n    let mut buf = String::new();\n    buf.push_str(a.unwrap_str());\n    buf.push_str(b.unwrap_str());\n    Datum::String(temp_storage.push_string(buf))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,18 +15,18 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct TextConcatBinary;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for TextConcatBinary {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Datum<'a>;
     fn call(
         &self,
         a: Self::Input1,
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        text_concat_binary(a, b, temp_storage)
     }
     fn output_type(
         &self,
@@ -49,21 +49,28 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
     fn introduces_nulls(&self) -> bool {
         <String as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn is_monotone(&self) -> (bool, bool) {
+        (false, true)
+    }
     fn propagates_nulls(&self) -> bool {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for TextConcatBinary {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str("||")
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
+fn text_concat_binary<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
     temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+) -> Datum<'a> {
+    let mut buf = String::new();
+    buf.push_str(a.unwrap_str());
+    buf.push_str(b.unwrap_str());
+    Datum::String(temp_storage.push_string(buf))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__timezone_offset.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__timezone_offset.snap
@@ -1,0 +1,92 @@
+---
+source: src/expr/src/scalar/func.rs
+expression: "#[sqlfunc(\n    output_type_expr = \"ScalarType::Record {\n                fields: [\n                    (\\\"abbrev\\\".into(), ScalarType::String.nullable(false)),\n                    (\\\"base_utc_offset\\\".into(), ScalarType::Interval.nullable(false)),\n                    (\\\"dst_offset\\\".into(), ScalarType::Interval.nullable(false)),\n                ].into(),\n                custom_id: None,\n            }.nullable(true)\",\n    propagates_nulls = true,\n    introduces_nulls = false\n)]\nfn timezone_offset<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let tz_str = a.unwrap_str();\n    let tz = match Tz::from_str_insensitive(tz_str) {\n        Ok(tz) => tz,\n        Err(_) => return Err(EvalError::InvalidIanaTimezoneId(tz_str.into())),\n    };\n    let offset = tz.offset_from_utc_datetime(&b.unwrap_timestamptz().naive_utc());\n    Ok(\n        temp_storage\n            .make_datum(|packer| {\n                packer\n                    .push_list_with(|packer| {\n                        packer.push(Datum::from(offset.abbreviation()));\n                        packer.push(Datum::from(offset.base_utc_offset()));\n                        packer.push(Datum::from(offset.dst_offset()));\n                    });\n            }),\n    )\n}\n"
+---
+#[derive(
+    proptest_derive::Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    mz_lowertest::MzReflect
+)]
+pub struct TimezoneOffset;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for TimezoneOffset {
+    type Input1 = Datum<'a>;
+    type Input2 = Datum<'a>;
+    type Output = Result<Datum<'a>, EvalError>;
+    fn call(
+        &self,
+        a: Self::Input1,
+        b: Self::Input2,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output {
+        timezone_offset(a, b, temp_storage)
+    }
+    fn output_type(
+        &self,
+        input_type_a: mz_repr::ColumnType,
+        input_type_b: mz_repr::ColumnType,
+    ) -> mz_repr::ColumnType {
+        use mz_repr::AsColumnType;
+        let output = ScalarType::Record {
+            fields: [
+                ("abbrev".into(), ScalarType::String.nullable(false)),
+                ("base_utc_offset".into(), ScalarType::Interval.nullable(false)),
+                ("dst_offset".into(), ScalarType::Interval.nullable(false)),
+            ]
+                .into(),
+            custom_id: None,
+        }
+            .nullable(true);
+        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
+            self,
+        );
+        let nullable = output.nullable;
+        output
+            .nullable(
+                nullable
+                    || (propagates_nulls
+                        && (input_type_a.nullable || input_type_b.nullable)),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl std::fmt::Display for TimezoneOffset {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(stringify!(timezone_offset))
+    }
+}
+fn timezone_offset<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let tz_str = a.unwrap_str();
+    let tz = match Tz::from_str_insensitive(tz_str) {
+        Ok(tz) => tz,
+        Err(_) => return Err(EvalError::InvalidIanaTimezoneId(tz_str.into())),
+    };
+    let offset = tz.offset_from_utc_datetime(&b.unwrap_timestamptz().naive_utc());
+    Ok(
+        temp_storage
+            .make_datum(|packer| {
+                packer
+                    .push_list_with(|packer| {
+                        packer.push(Datum::from(offset.abbreviation()));
+                        packer.push(Datum::from(offset.base_utc_offset()));
+                        packer.push(Datum::from(offset.dst_offset()));
+                    });
+            }),
+    )
+}

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(sqlname = \"btrim\", output_type = \"String\", propagates_nulls = true)]\nfn trim<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let trim_chars = b.unwrap_str();\n    Datum::from(a.unwrap_str().trim_matches(|c| trim_chars.contains(c)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,18 +15,18 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct Trim;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Trim {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Datum<'a>;
     fn call(
         &self,
         a: Self::Input1,
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        trim(a, b)
     }
     fn output_type(
         &self,
@@ -53,17 +53,12 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for Trim {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str("btrim")
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+fn trim<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let trim_chars = b.unwrap_str();
+    Datum::from(a.unwrap_str().trim_matches(|c| trim_chars.contains(c)))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim_leading.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim_leading.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(sqlname = \"ltrim\", output_type = \"String\", propagates_nulls = true)]\nfn trim_leading<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let trim_chars = b.unwrap_str();\n    Datum::from(a.unwrap_str().trim_start_matches(|c| trim_chars.contains(c)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,18 +15,18 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct TrimLeading;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for TrimLeading {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Datum<'a>;
     fn call(
         &self,
         a: Self::Input1,
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        trim_leading(a, b)
     }
     fn output_type(
         &self,
@@ -53,17 +53,12 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for TrimLeading {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str("ltrim")
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+fn trim_leading<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let trim_chars = b.unwrap_str();
+    Datum::from(a.unwrap_str().trim_start_matches(|c| trim_chars.contains(c)))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim_trailing.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__trim_trailing.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn encode<'a>(\n    bytes: Datum<'a>,\n    format: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    let format = encoding::lookup_format(format.unwrap_str())?;\n    let out = format.encode(bytes.unwrap_bytes());\n    Ok(Datum::from(temp_storage.push_string(out)))\n}\n"
+expression: "#[sqlfunc(sqlname = \"rtrim\", output_type = \"String\", propagates_nulls = true)]\nfn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let trim_chars = b.unwrap_str();\n    Datum::from(a.unwrap_str().trim_end_matches(|c| trim_chars.contains(c)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -15,18 +15,18 @@ expression: "#[sqlfunc(output_type = \"String\", propagates_nulls = true)]\nfn e
     Hash,
     mz_lowertest::MzReflect
 )]
-pub struct Encode;
-impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
+pub struct TrimTrailing;
+impl<'a> crate::func::binary::EagerBinaryFunc<'a> for TrimTrailing {
     type Input1 = Datum<'a>;
     type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Datum<'a>;
     fn call(
         &self,
         a: Self::Input1,
         b: Self::Input2,
         temp_storage: &'a mz_repr::RowArena,
     ) -> Self::Output {
-        encode(a, b, temp_storage)
+        trim_trailing(a, b)
     }
     fn output_type(
         &self,
@@ -53,17 +53,12 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Encode {
         true
     }
 }
-impl std::fmt::Display for Encode {
+impl std::fmt::Display for TrimTrailing {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(stringify!(encode))
+        f.write_str("rtrim")
     }
 }
-fn encode<'a>(
-    bytes: Datum<'a>,
-    format: Datum<'a>,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let format = encoding::lookup_format(format.unwrap_str())?;
-    let out = format.encode(bytes.unwrap_bytes());
-    Ok(Datum::from(temp_storage.push_string(out)))
+fn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let trim_chars = b.unwrap_str();
+    Datum::from(a.unwrap_str().trim_end_matches(|c| trim_chars.contains(c)))
 }


### PR DESCRIPTION
Includes:
* Decode
* Left
* LikeEscape
* MzAclItemContainsPrivilege
* ParseIdent
* PrettySql
* Right
* StartsWith
* TextConcat
* TimezoneOffset
* Trim{Leading, Trailing, }

As usual, the new functionality is tested, but not yet used.
