### PR TITLE
Add some additional context to vpc endpoint errors

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2157,19 +2157,26 @@ impl Coordinator {
 
         if let Some(cloud_resource_controller) = &self.cloud_resource_controller {
             // Clean up any extraneous VpcEndpoints that shouldn't exist.
-            let existing_vpc_endpoints = cloud_resource_controller.list_vpc_endpoints().await?;
+            let existing_vpc_endpoints = cloud_resource_controller
+                .list_vpc_endpoints()
+                .await
+                .context("list vpc endpoints")?;
             let existing_vpc_endpoints = BTreeSet::from_iter(existing_vpc_endpoints.into_keys());
             let desired_vpc_endpoints = privatelink_connections.keys().cloned().collect();
             let vpc_endpoints_to_remove = existing_vpc_endpoints.difference(&desired_vpc_endpoints);
             for id in vpc_endpoints_to_remove {
-                cloud_resource_controller.delete_vpc_endpoint(*id).await?;
+                cloud_resource_controller
+                    .delete_vpc_endpoint(*id)
+                    .await
+                    .context("deleting extraneous vpc endpoint")?;
             }
 
             // Ensure desired VpcEndpoints are up to date.
             for (id, spec) in privatelink_connections {
                 cloud_resource_controller
                     .ensure_vpc_endpoint(id, spec)
-                    .await?;
+                    .await
+                    .context("ensuring vpc endpoint")?;
             }
         }
 


### PR DESCRIPTION
Add some additional logging to help diagnose a CI error.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9253

- In both examples of the linked logs, we get `startup: coordinator init: bootstrap: postamble beginning`, but never `postamble ending`, so we are highly likely to be hitting the error in this phase of bootstrap.
- The only operations that can return an err during the postamble are these VPC management APIs.
- The error log contains `ApiError`, which can be emitted by the kube client error handling; and `storage is (re)initializing`, which is a string found in the k8s source.

So I think it's pretty likely that the error is coming from around here. Hopefully the logs will help narrow it down.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
