### PR TITLE
Use `SqlState::UNDEFINED_PARAMETER` for certain parameter errors

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -489,6 +489,12 @@ impl AdapterError {
             AdapterError::PlanError(PlanError::ColumnAlreadyExists { .. }) => {
                 SqlState::DUPLICATE_COLUMN
             }
+            AdapterError::PlanError(PlanError::UnknownParameter(_)) => {
+                SqlState::UNDEFINED_PARAMETER
+            }
+            AdapterError::PlanError(PlanError::ParameterNotAllowed(_)) => {
+                SqlState::UNDEFINED_PARAMETER
+            }
             AdapterError::PlanError(_) => SqlState::INTERNAL_ERROR,
             AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -130,8 +130,6 @@ fn test_bind_params() {
 
     // Some statement types can't have parameters at all.
     //
-    // TODO: these should be `SqlState::UNDEFINED_PARAMETER`.
-    //
     // TODO: We should harmonize whether `describe` returns parameters for statement types that
     // can't have parameters. For example, currently it does return parameters for
     // EXPLAIN TIMESTAMP,
@@ -144,14 +142,14 @@ fn test_bind_params() {
             .query_one("CREATE VIEW v AS SELECT $3", &[])
             .unwrap_db_error();
         assert_eq!(err.message(), "views cannot have parameters");
-        assert_eq!(err.code(), &SqlState::INTERNAL_ERROR);
+        assert_eq!(err.code(), &SqlState::UNDEFINED_PARAMETER);
     }
     {
         let err = client
             .query_one("CREATE MATERIALIZED VIEW mv AS SELECT $3", &[])
             .unwrap_db_error();
         assert_eq!(err.message(), "materialized views cannot have parameters");
-        assert_eq!(err.code(), &SqlState::INTERNAL_ERROR);
+        assert_eq!(err.code(), &SqlState::UNDEFINED_PARAMETER);
     }
     {
         let err = client
@@ -161,14 +159,14 @@ fn test_bind_params() {
             .query_one("EXPLAIN TIMESTAMP FOR SELECT $1::int", &[&42_i32])
             .unwrap_db_error();
         assert_eq!(err.message(), "EXPLAIN TIMESTAMP cannot have parameters");
-        assert_eq!(err.code(), &SqlState::INTERNAL_ERROR);
+        assert_eq!(err.code(), &SqlState::UNDEFINED_PARAMETER);
     }
     {
         let err = client
             .query_one("EXPLAIN CREATE MATERIALIZED VIEW mv AS SELECT $3", &[])
             .unwrap_db_error();
         assert_eq!(err.message(), "materialized views cannot have parameters");
-        assert_eq!(err.code(), &SqlState::INTERNAL_ERROR);
+        assert_eq!(err.code(), &SqlState::UNDEFINED_PARAMETER);
     }
 
     // Surprisingly, the following are allowed. The weirdness is that it is only allowed through a

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -100,6 +100,7 @@ pub enum PlanError {
         context: String,
     },
     UnknownParameter(usize),
+    ParameterNotAllowed(String),
     RecursionLimit(RecursionLimitError),
     StrconvParse(strconv::ParseError),
     Catalog(CatalogError),
@@ -575,6 +576,7 @@ impl fmt::Display for PlanError {
                 write!(f, "{} does not allow subqueries", context)
             }
             Self::UnknownParameter(n) => write!(f, "there is no parameter ${}", n),
+            Self::ParameterNotAllowed(object_type) => write!(f, "{} cannot have parameters", object_type),
             Self::RecursionLimit(e) => write!(f, "{}", e),
             Self::StrconvParse(e) => write!(f, "{}", e),
             Self::Catalog(e) => write!(f, "{}", e),

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2989,7 +2989,7 @@ impl HirScalarExpr {
         self.visit_recursively_mut(0, &mut |_: usize, e: &mut HirScalarExpr| {
             if let HirScalarExpr::Parameter(n, name) = e {
                 let datum = match params.datums.iter().nth(*n - 1) {
-                    None => sql_bail!("there is no parameter ${}", n),
+                    None => return Err(PlanError::UnknownParameter(*n)),
                     Some(datum) => datum,
                 };
                 let scalar_type = &params.types[*n - 1];

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2516,7 +2516,7 @@ pub fn plan_view(
         expr.arity()
     ));
     if expr.contains_parameters()? {
-        sql_bail!("views cannot have parameters")
+        return Err(PlanError::ParameterNotAllowed("views".to_string()));
     }
 
     let dependencies = expr
@@ -2694,7 +2694,9 @@ pub fn plan_create_materialized_view(
         expr.arity()
     ));
     if expr.contains_parameters()? {
-        sql_bail!("materialized views cannot have parameters")
+        return Err(PlanError::ParameterNotAllowed(
+            "materialized views".to_string(),
+        ));
     }
 
     plan_utils::maybe_rename_columns(
@@ -3072,7 +3074,11 @@ pub fn plan_create_continual_task(
             expr.arity()
         ));
         if expr.contains_parameters()? {
-            sql_bail!("continual tasks cannot have parameters")
+            if expr.contains_parameters()? {
+                return Err(PlanError::ParameterNotAllowed(
+                    "continual tasks".to_string(),
+                ));
+            }
         }
         let expr = match desc.as_mut() {
             None => {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -712,7 +712,9 @@ pub fn plan_explain_timestamp(
             scope: _,
         } = query::plan_root_query(scx, explain.select.query, QueryLifetime::OneShot)?;
         if raw_plan.contains_parameters()? {
-            sql_bail!("EXPLAIN TIMESTAMP cannot have parameters")
+            return Err(PlanError::ParameterNotAllowed(
+                "EXPLAIN TIMESTAMP".to_string(),
+            ));
         }
 
         raw_plan


### PR DESCRIPTION
As it says on the tin.

### Motivation

  * This PR fixes a recognized bug: an old TODO in a code comment, see diff. Also, part of https://github.com/MaterializeInc/database-issues/issues/4468

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
