### PR TITLE
[persist] Lease cleanup

### DIFF
--- a/src/persist-client/src/batch.proto
+++ b/src/persist-client/src/batch.proto
@@ -25,37 +25,3 @@ message ProtoBatch {
 
   reserved 4;
 }
-
-// This is only to impl ExchangeData, and so used between processes running the
-// same version of code. It's not durably written down anywhere.
-message ProtoLeasedBatchPart {
-  string shard_id = 1;
-  ProtoFetchBatchFilter filter = 2;
-  mz_persist_client.internal.state.ProtoU64Description desc = 3;
-  mz_persist_client.internal.state.ProtoHollowBatchPart part = 4;
-  ProtoLease lease = 5;
-  bool filter_pushdown_audit = 6;
-}
-
-message ProtoFetchBatchFilter {
-  oneof kind {
-    // Apply snapshot-style semantics to the fetched batch part.
-    //
-    // Return all values with time leq `as_of`.
-    mz_persist_client.internal.state.ProtoU64Antichain snapshot = 1;
-    // Apply listen-style semantics to the fetched batch part.
-    ProtoFetchBatchFilterListen listen = 2;
-  }
-}
-
-message ProtoFetchBatchFilterListen {
-  // Return all values with time in advance of `as_of`.
-  mz_persist_client.internal.state.ProtoU64Antichain as_of = 1;
-  // Return all values with `lower` leq time.
-  mz_persist_client.internal.state.ProtoU64Antichain lower = 2;
-}
-
-message ProtoLease {
-  string reader_id = 1;
-  optional uint64 seqno = 2;
-}

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -481,7 +481,7 @@ pub struct LeasedBatchPart<T> {
     pub(crate) part: BatchPart<T>,
     /// The lease that prevents this part from being GCed. Code should ensure that this lease
     /// lives as long as the part is needed.
-    pub(crate) lease: Option<Lease>,
+    pub(crate) lease: Lease,
     pub(crate) filter_pushdown_audit: bool,
 }
 
@@ -498,9 +498,9 @@ where
     /// that can't travel across process boundaries. The caller is responsible for
     /// ensuring that the lease is held for as long as the batch part may be in use:
     /// dropping it too early may cause a fetch to fail.
-    pub(crate) fn into_exchangeable_part(mut self) -> (ExchangeableBatchPart<T>, Option<Lease>) {
+    pub(crate) fn into_exchangeable_part(self) -> (ExchangeableBatchPart<T>, Lease) {
         // If `x` has a lease, we've effectively transferred it to `r`.
-        let lease = self.lease.take();
+        let lease = self.lease.clone();
         let part = ExchangeableBatchPart {
             shard_id: self.shard_id,
             encoded_size_bytes: self.part.encoded_size_bytes(),

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -169,6 +169,10 @@ impl<T: Message + Default> LazyProto<T> {
     pub fn decode(&self) -> Result<T, prost::DecodeError> {
         T::decode(&*self.buf)
     }
+
+    pub fn decode_to<R: RustType<T>>(&self) -> anyhow::Result<R> {
+        Ok(T::decode(&*self.buf)?.into_rust()?)
+    }
 }
 
 impl<T: Message + Default> RustType<Bytes> for LazyProto<T> {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1106,8 +1106,9 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            for batch in snap {
-                let res = fetcher1.fetch_leased_part(&batch).await;
+            for part in snap {
+                let (part, _lease) = part.into_exchangeable_part();
+                let res = fetcher1.fetch_leased_part(part).await;
                 assert_eq!(
                     res.unwrap_err(),
                     InvalidUsage::BatchNotFromThisShard {

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -696,6 +696,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use mz_persist::location::SeqNo;
     use timely::dataflow::Scope;
     use timely::dataflow::operators::Leave;
     use timely::dataflow::operators::Probe;
@@ -706,7 +707,7 @@ mod tests {
 
     #[mz_ore::test]
     fn test_lease_manager() {
-        let lease = Lease::default();
+        let lease = Lease::new(SeqNo::minimum());
         let mut manager = LeaseManager::new();
         for t in 0u64..10 {
             manager.push_at(t, lease.clone());

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -572,9 +572,7 @@ where
                 // seemed to work okay so far. Continue to revisit as necessary.
                 let worker_idx = usize::cast_from(Instant::now().hashed()) % num_workers;
                 let (part, lease) = part_desc.into_exchangeable_part();
-                if let Some(lease) = lease {
-                    leases.borrow_mut().push_at(current_ts.clone(), lease);
-                }
+                leases.borrow_mut().push_at(current_ts.clone(), lease);
                 descs_output.give(&session_cap, (worker_idx, part));
             }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -723,7 +723,6 @@ where
         LeasedBatchPart {
             metrics: Arc::clone(&self.metrics),
             shard_id: self.machine.shard_id(),
-            reader_id: self.reader_id.clone(),
             filter,
             desc,
             part,
@@ -1454,8 +1453,9 @@ mod tests {
             this_seqno = part_seqno;
             assert!(this_seqno >= last_seqno);
 
-            let _ = fetcher.fetch_leased_part(&part).await;
-            drop(part);
+            let (part, lease) = part.into_exchangeable_part();
+            let _ = fetcher.fetch_leased_part(part).await;
+            drop(lease);
 
             // Simulates an exchange
             for event in subscribe.next(None).await {

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -726,7 +726,7 @@ where
             filter,
             desc,
             part,
-            lease: Some(self.lease_seqno()),
+            lease: self.lease_seqno(),
             filter_pushdown_audit: false,
         }
     }
@@ -1450,7 +1450,7 @@ mod tests {
 
         // Repeat the same process as above, more or less, while fetching + returning parts
         for (mut i, part) in parts.into_iter().enumerate() {
-            let part_seqno = part.lease.as_ref().unwrap().seqno();
+            let part_seqno = part.lease.seqno();
             let last_seqno = this_seqno;
             this_seqno = part_seqno;
             assert!(this_seqno >= last_seqno);
@@ -1463,9 +1463,8 @@ mod tests {
             for event in subscribe.next(None).await {
                 if let ListenEvent::Updates(parts) = event {
                     for part in parts {
-                        if let (_, Some(lease)) = part.into_exchangeable_part() {
-                            subsequent_parts.push(lease);
-                        }
+                        let (_, lease) = part.into_exchangeable_part();
+                        subsequent_parts.push(lease);
                     }
                 }
             }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -26,8 +26,8 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::{PersistConfig, RetryParameters};
+use mz_persist_client::fetch::{ExchangeableBatchPart, ShardSourcePart};
 use mz_persist_client::fetch::{FetchedBlob, FetchedPart};
-use mz_persist_client::fetch::{SerdeLeasedBatchPart, ShardSourcePart};
 use mz_persist_client::operators::shard_source::{
     ErrorHandler, FilterResult, SnapshotMode, shard_source,
 };
@@ -690,7 +690,7 @@ pub trait Backpressureable: Clone + 'static {
     fn byte_size(&self) -> usize;
 }
 
-impl Backpressureable for (usize, SerdeLeasedBatchPart) {
+impl<T: Clone + 'static> Backpressureable for (usize, ExchangeableBatchPart<T>) {
     fn byte_size(&self) -> usize {
         self.1.encoded_size_bytes()
     }


### PR DESCRIPTION
This bundles together a few related cleanups for the leased part:
- We had a few proto types that were only useful for short-lived exchanges in the source. We encode those with serde now. (While continuing to encode long-lived data like the hollow batch as proto.)
- As part of the batch fetching, we created leased parts that didn't actually have leases attached, then consumed them immediately. This switches the fetching code to use the exchangeable part instead and makes leases required in all other cases.

### Motivation

Previously-unspecified cleanup.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
