### PR TITLE
ci: Bump agent size for debug symbol upload

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -54,7 +54,7 @@ steps:
         priority: 50
         if: build.tag != null || (build.env("CI_UPLOAD_DEBUG_SYMBOLS") != null && build.env("CI_UPLOAD_DEBUG_SYMBOLS") != "0")
         agents:
-          queue: linux-x86_64-small
+          queue: linux-x86_64
         coverage: skip
 
       - id: rust-build-aarch64
@@ -82,7 +82,7 @@ steps:
         timeout_in_minutes: 20
         if: build.tag != null || (build.env("CI_UPLOAD_DEBUG_SYMBOLS") != null && build.env("CI_UPLOAD_DEBUG_SYMBOLS") != "0")
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         coverage: skip
 
       - id: build-x86_64


### PR DESCRIPTION
Uses llvm-dwarfdump which requires a lot of memory

Seen in https://buildkite.com/materialize/test/builds/103333#0196b647-0dfc-4130-958f-286040d2036f

Regression introduced in https://github.com/MaterializeInc/materialize/pull/32433

Verified that we have enough memory now: https://buildkite.com/materialize/test/builds/103379

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
