### PR TITLE
adapter: Allow parameters in `RETURNING`

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -439,7 +439,7 @@ pub fn plan_insert_query(
             relation_type: &typ,
             allow_aggregates: false,
             allow_subqueries: false,
-            allow_parameters: false,
+            allow_parameters: true,
             allow_windows: false,
         };
         let table_func_names = BTreeMap::new();

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -103,7 +103,10 @@ pub fn plan_insert(
     let returning = returning
         .expr
         .into_iter()
-        .map(|expr| expr.lower_uncorrelated())
+        .map(|mut expr| {
+            expr.bind_parameters(params)?;
+            expr.lower_uncorrelated()
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(Plan::Insert(InsertPlan {

--- a/test/sqllogictest/prepare.slt
+++ b/test/sqllogictest/prepare.slt
@@ -1,0 +1,62 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# For more prepared statement tests, see `order_by.slt` and `test_bind_params`.
+
+statement ok
+CREATE TABLE t (a int);
+
+# INSERT
+statement ok
+PREPARE i1 AS
+INSERT INTO t(a) VALUES($1);
+
+statement ok
+EXECUTE i1(5);
+
+query I
+SELECT * FROM t;
+----
+5
+
+# INSERT ... RETURNING
+statement ok
+PREPARE i2 AS
+INSERT INTO t(a) VALUES($1 - 1) RETURNING $1 + 1;
+
+query I
+EXECUTE i2(7);
+----
+8
+
+query I
+SELECT * FROM t;
+----
+5
+6
+
+query error db error: ERROR: operator is not unique: unknown \+ unknown
+PREPARE i3 AS
+INSERT INTO t(a) VALUES(4) RETURNING $1 + $1;
+
+statement ok
+PREPARE i3 AS
+INSERT INTO t(a) VALUES(4) RETURNING $1;
+
+query T
+EXECUTE i3('x');
+----
+x
+
+query I
+SELECT * FROM t;
+----
+4
+5
+6


### PR DESCRIPTION
This PR makes us support prepared statement parameters in `RETURNING`.

There is a `prepare.slt` that we inherited from Cockroach, but the whole test file is currently turned off, because there are too many things there that we don't support. I've been trying to see what it would take to turn it on, and parameters in `RETURNING` is one of the unsupported things, and it seemed easy enough to add support for, so I did it quickly. 

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
