### PR TITLE
Don't panic when the same parameter is coerced twice

### DIFF
--- a/test/sqllogictest/prepare.slt
+++ b/test/sqllogictest/prepare.slt
@@ -60,3 +60,63 @@ SELECT * FROM t;
 4
 5
 6
+
+statement ok
+PREPARE p1 AS
+SELECT $1 + $1::bigint;
+
+query I
+EXECUTE p1(5);
+----
+10
+
+statement ok
+PREPARE p2 AS
+SELECT $1::bigint + $1::bigint;
+
+query I
+EXECUTE p2(7);
+----
+14
+
+statement ok
+PREPARE p3 AS
+SELECT $1 || $1;
+
+query T
+EXECUTE p3('abc');
+----
+abcabc
+
+statement ok
+PREPARE p4 AS
+SELECT $1::text || $1::bigint::text;
+
+query error db error: ERROR: invalid input syntax for type bigint: invalid digit found in string: "abc"
+EXECUTE p4('abc');
+
+query T
+EXECUTE p4('123');
+----
+123123
+
+statement ok
+PREPARE p5 AS
+SELECT $1, $1::bigint;
+
+query II
+EXECUTE p5(7);
+----
+0
+7
+
+query error db error: ERROR: operator does not exist: bigint \|\| bigint
+PREPARE p6 AS
+SELECT $1 + $1::bigint, $1 || $1;
+
+query error db error: ERROR: operator does not exist: text \+ bigint
+PREPARE p7 AS
+SELECT $1 || $1, $1 + $1::bigint;
+
+query error db error: ERROR: there are contradicting constraints for the type of parameter \$1: should be both text and integer
+PREPARE p AS SELECT repeat($1, $1);


### PR DESCRIPTION
Fixes a panic when `plan_coerce` is called twice on a parameter. This typically happens when there is a function call whose more than one argument involves the same prepared statement.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9268

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
