### PR TITLE
[cloud-resources] soft assert we can parse image references

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -376,7 +376,13 @@ pub mod v1alpha1 {
                 // version checks. Usually these are custom images that have
                 // been by a developer on a branch forked from a recent copy
                 // of main, and so this works out reasonably well in practice.
-                None => true,
+                None => {
+                    mz_ore::soft_panic_or_log!(
+                        "failed to parse image ref: {}",
+                        self.spec.environmentd_image_ref
+                    );
+                    true
+                }
             }
         }
 

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -377,9 +377,9 @@ pub mod v1alpha1 {
                 // been by a developer on a branch forked from a recent copy
                 // of main, and so this works out reasonably well in practice.
                 None => {
-                    mz_ore::soft_panic_or_log!(
-                        "failed to parse image ref: {}",
-                        self.spec.environmentd_image_ref
+                    tracing::warn!(
+                        image_ref = %self.spec.environmentd_image_ref,
+                        "failed to parse image ref",
                     );
                     true
                 }


### PR DESCRIPTION
In the rare case that we can't parse a version from the image ref, log an error so we can debug the issue better.

I'm also happy to make this just a `tracing::warn!` if folks prefer, the `soft_assert` seemed nice though since this should(?) be rare.

### Motivation

Some minimum version checks are failing open and it would be nice to know if it's because the image ref can't be parsed.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
