### PR TITLE
compute: more logging on dataflow reconciliation failures

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -574,6 +574,17 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                                     new_as_of = ?as_of,
                                     "dataflow reconciliation failed",
                                 );
+
+                                // Dump the full dataflow plans if they are incompatible, to
+                                // simplify debugging hard-to-reproduce reconciliation failures.
+                                if !compatible {
+                                    warn!(
+                                        old = ?old_dataflow,
+                                        new = ?dataflow,
+                                        "incompatible dataflows in reconciliation",
+                                    );
+                                }
+
                                 todo_commands
                                     .push(ComputeCommand::CreateDataflow(dataflow.clone()));
                             }


### PR DESCRIPTION
Reconciliation failures due to incompatible dataflow plans are sometimes hard to debug, so this PR adds a new log that dumps the full plans.

The specific motivation is debugging https://github.com/MaterializeInc/database-issues/issues/9273. If it turns out that the log is too noisy, e.g. because incompatible plans happen a lot in the wild for non-bug reasons, we may decide to remove it again.

### Motivation

  * This PR helps investigating a recognized bug.

Advances https://github.com/MaterializeInc/database-issues/issues/9273

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
