### PR TITLE
optimizer: Typecheck also in local optimization

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -169,6 +169,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
             &self.typecheck_ctx,
             &mut df_meta,
             Some(&self.metrics),
+            Some(self.select_id),
         );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -199,6 +199,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
             &self.typecheck_ctx,
             &mut df_meta,
             Some(&self.metrics),
+            Some(self.view_id),
         );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -183,6 +183,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
             &self.typecheck_ctx,
             &mut df_meta,
             Some(&self.metrics),
+            Some(self.select_id),
         );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -231,6 +231,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
                     &self.typecheck_ctx,
                     &mut df_meta,
                     Some(&self.metrics),
+                    Some(self.view_id),
                 );
                 let expr = optimize_mir_local(expr, &mut transform_ctx)?;
 

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -69,6 +69,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
             &self.typecheck_ctx,
             &mut df_meta,
             self.metrics.as_ref(),
+            None,
         );
 
         // First, we run a very simple optimizer pipeline, which only folds constants. This takes

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -37,7 +37,7 @@
 //! let features = OptimizerFeatures::default();
 //! let typecheck_ctx = typecheck::empty_context();
 //! let mut df_meta = DataflowMetainfo::default();
-//! let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+//! let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None, None);
 //!
 //! // Filter.transform() will deduplicate any predicates
 //! Filter.transform(&mut expr, &mut transform_ctx);

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -144,11 +144,12 @@ impl<'a> TransformCtx<'a> {
         typecheck_ctx: &'a SharedContext,
         df_meta: &'a mut DataflowMetainfo,
         metrics: Option<&'a OptimizerMetrics>,
+        global_id: Option<GlobalId>,
     ) -> Self {
         Self {
             indexes: &EmptyIndexOracle,
             stats: &EmptyStatisticsOracle,
-            global_id: None,
+            global_id,
             features,
             typecheck_ctx,
             df_meta,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -186,7 +186,8 @@ impl<'a> TransformCtx<'a> {
         Arc::clone(self.typecheck_ctx)
     }
 
-    fn set_global_id(&mut self, global_id: GlobalId) {
+    /// Lets self know the id of the object that is being optimized.
+    pub fn set_global_id(&mut self, global_id: GlobalId) {
         self.global_id = Some(global_id);
     }
 

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -66,7 +66,7 @@
 //! let features = OptimizerFeatures::default();
 //! let typecheck_ctx = typecheck::empty_context();
 //! let mut df_meta = DataflowMetainfo::default();
-//! let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+//! let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None, None);
 //!
 //! PredicatePushdown::default().transform(&mut expr, &mut transform_ctx);
 //!

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -46,12 +46,14 @@ mod tests {
     const JSON: &str = "json";
     const TEST: &str = "test";
 
+    const TEST_GLOBAL_ID: GlobalId = GlobalId::Transient(1234567);
+
     thread_local! {
         static FULL_TRANSFORM_LIST: Vec<Box<dyn Transform>> = {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+            let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None, Some(TEST_GLOBAL_ID));
 
             #[allow(deprecated)]
             Optimizer::logical_optimizer(&mut transform_ctx)
@@ -179,7 +181,13 @@ mod tests {
         let features = OptimizerFeatures::default();
         let typecheck_ctx = typecheck::empty_context();
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+        let mut transform_ctx = TransformCtx::local(
+            &features,
+            &typecheck_ctx,
+            &mut df_meta,
+            None,
+            Some(TEST_GLOBAL_ID),
+        );
         let mut rel = parse_relation(s, cat, args)?;
         for t in args.get("apply").cloned().unwrap_or_else(Vec::new).iter() {
             get_transform(t)?.transform(&mut rel, &mut transform_ctx)?;
@@ -356,8 +364,13 @@ mod tests {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx =
-                TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+            let mut transform_ctx = TransformCtx::local(
+                &features,
+                &typecheck_ctx,
+                &mut df_meta,
+                None,
+                Some(TEST_GLOBAL_ID),
+            );
 
             #[allow(deprecated)]
             let optimizer = Optimizer::logical_optimizer(&mut transform_ctx);
@@ -391,8 +404,13 @@ mod tests {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx =
-                TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+            let mut transform_ctx = TransformCtx::local(
+                &features,
+                &typecheck_ctx,
+                &mut df_meta,
+                None,
+                Some(TEST_GLOBAL_ID),
+            );
 
             let log_optimizer = Optimizer::logical_cleanup_pass(&mut transform_ctx, true);
             let phys_optimizer = Optimizer::physical_optimizer(&mut transform_ctx);

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -12,12 +12,15 @@ use std::collections::BTreeSet;
 use mz_expr::explain::{ExplainContext, enforce_linear_chains};
 use mz_expr_parser::{TestCatalog, handle_define, try_parse_mir};
 use mz_ore::str::Indent;
+use mz_repr::GlobalId;
 use mz_repr::explain::text::text_string_at;
 use mz_repr::explain::{ExplainConfig, PlanRenderingContext};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
 use mz_transform::analysis::annotate_plan;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::TypeErrorHumanizer;
+
+const TEST_GLOBAL_ID: GlobalId = GlobalId::Transient(1234567);
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // can't call foreign function `rust_psm_stack_pointer` on OS `linux`
@@ -263,8 +266,13 @@ fn apply_transform<T: mz_transform::Transform>(
     features.enable_dequadratic_eqprop_map = true;
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
-    let mut transform_ctx =
-        mz_transform::TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None);
+    let mut transform_ctx = mz_transform::TransformCtx::local(
+        &features,
+        &typecheck_ctx,
+        &mut df_meta,
+        None,
+        Some(TEST_GLOBAL_ID),
+    );
 
     // Apply the transformation, returning early on TransformError.
     transform


### PR DESCRIPTION
This PR makes us do typechecking also in local optimization. Not doing this earlier was the reason that we did not catch https://github.com/MaterializeInc/materialize/pull/32486.

(Normally, `optimize_dataflow_relations` sets the `GlobalId` in the `TransformCtx`, but `optimize_dataflow_relations` is not involved in the local optimization.)

This should now produce errors in `list.slt` (because https://github.com/MaterializeInc/materialize/pull/32486 is not fixed on this branch), but I'm not sure if this will fail CI. Running CI with the PR in draft to find out. I'm also running all slts locally with an explicit panic instead of the error, and with https://github.com/MaterializeInc/materialize/pull/32486 cherry-picked, to see if any other type errors show up due to doing typechecking in more places now.

Edit: There are also type errors in `src/transform/tests/test_runner.rs`! Need to investigate! Edit 2: Found it, will fix it up after the meeting.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
