### PR TITLE
refactor to more cpu efficient topological sort

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -17,7 +17,6 @@ use std::iter;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use differential_dataflow::trace::implementations::BatchContainer;
 use futures::future;
 use itertools::{Either, Itertools};
 use mz_adapter_types::connection::ConnectionId;

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -10,12 +10,14 @@
 //! Logic related to applying updates from a [`mz_catalog::durable::DurableCatalogState`] to a
 //! [`CatalogState`].
 
+use core::panic;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::iter;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use differential_dataflow::trace::implementations::BatchContainer;
 use futures::future;
 use itertools::{Either, Itertools};
 use mz_adapter_types::connection::ConnectionId;
@@ -1936,22 +1938,25 @@ fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
         }
     }
 
-    /// Sort `CONNECTION` items.
+    type ConnectionKey = (mz_catalog::durable::Item, Timestamp, StateDiff);
+
+    /// Topologically sort `CONNECTION` items by dependencies.
     ///
     /// `CONNECTION`s can depend on one another, e.g. a `KAFKA CONNECTION` contains
     /// a list of `BROKERS` and these broker definitions can themselves reference other
     /// connections. This `BROKERS` list can also be `ALTER`ed and thus it's possible
     /// for a connection to depend on another with an ID greater than its own.
-    fn sort_connections(connections: &mut Vec<(mz_catalog::durable::Item, Timestamp, StateDiff)>) {
-        let mut topo: BTreeMap<
-            (mz_catalog::durable::Item, Timestamp, StateDiff),
-            BTreeSet<CatalogItemId>,
-        > = BTreeMap::default();
+    fn sort_connections(connections: &mut Vec<ConnectionKey>) {
+        let mut topo: BTreeMap<CatalogItemId, BTreeSet<CatalogItemId>> = BTreeMap::default();
+        let mut connection_in_degree: BTreeMap<CatalogItemId, (ConnectionKey, usize)> = connections
+            .iter()
+            .map(|conn| (conn.0.id, (conn.clone(), 0)))
+            .collect();
         let existing_connections: BTreeSet<_> = connections.iter().map(|item| item.0.id).collect();
 
         // Initialize our set of topological sort.
         tracing::info!(?connections, "sorting connections");
-        for (connection, ts, diff) in connections.drain(..) {
+        for (connection, _, _) in connections.drain(..) {
             let statement = mz_sql::parse::parse(&connection.create_sql)
                 .expect("valid CONNECTION create_sql")
                 .into_element()
@@ -1964,41 +1969,41 @@ fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
             // dependency already exists and thus it's not in `connections`.
             dependencies.retain(|dep| existing_connections.contains(dep));
 
+            for dep in dependencies.iter() {
+                connection_in_degree
+                    .entry(*dep)
+                    .and_modify(|(_, in_degree)| *in_degree += 1);
+            }
+
             // Be defensive and ensure we're not clobbering any items.
-            assert_none!(topo.insert((connection, ts, diff), dependencies));
+            assert_none!(topo.insert(connection.id, dependencies));
         }
-        tracing::info!(?topo, ?existing_connections, "built topological sort");
+
+        let mut to_sort: VecDeque<ConnectionKey> = VecDeque::new();
+        for (conn, in_degree) in connection_in_degree.values().cloned() {
+            if in_degree == 0 {
+                to_sort.push_back(conn);
+            }
+        }
 
         // Do a topological sort, pushing back into the provided Vec.
-        while !topo.is_empty() {
-            // Get all of the connections with no dependencies.
-            let no_deps: Vec<_> = topo
-                .iter()
-                .filter_map(|(item, deps)| {
-                    if deps.is_empty() {
-                        Some(item.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+        while !to_sort.is_empty() {
+            let Some(current) = to_sort.pop_front() else {
+                panic!(
+                    "Programming error, impossible situation nothing in queue after checking it is not empty."
+                )
+            };
+            let Some(outgoing_conns) = topo.get(&current.0.id) else {
+                panic!("Programming error, could not find dependencies for connection.")
+            };
 
-            // Cycle in our graph!
-            if no_deps.is_empty() {
-                panic!("programming error, cycle in Connections");
+            for outgoing_conn in outgoing_conns.iter() {
+                connection_in_degree
+                    .entry(*outgoing_conn)
+                    .and_modify(|(_, in_degree)| *in_degree -= 1);
             }
 
-            // Process all of the items with no dependencies.
-            for item in no_deps {
-                // Remove the item from our topological sort.
-                topo.remove(&item);
-                // Remove this item from anything that depends on it.
-                topo.values_mut().for_each(|deps| {
-                    deps.remove(&item.0.id);
-                });
-                // Push it back into our list as "completed".
-                connections.push(item);
-            }
+            connections.push(current);
         }
     }
 


### PR DESCRIPTION
### Motivation

a request was made by @petrosagg to refactor to a more efficient algorithm in our connection topological sort.

cc: @frankmcsherry @ParkMyCar 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
