### PR TITLE
controller: initialize workload class for new storage clusters

### DIFF
--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -352,7 +352,8 @@ where
         id: ClusterId,
         config: ClusterConfig,
     ) -> Result<(), anyhow::Error> {
-        self.storage.create_instance(id);
+        self.storage
+            .create_instance(id, config.workload_class.clone());
         self.compute
             .create_instance(id, config.arranged_logs, config.workload_class)?;
         Ok(())

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -373,7 +373,7 @@ pub trait StorageController: Debug {
     /// created with zero replicas.
     ///
     /// Panics if a storage instance with the given ID already exists.
-    fn create_instance(&mut self, id: StorageInstanceId);
+    fn create_instance(&mut self, id: StorageInstanceId, workload_class: Option<String>);
 
     /// Drops the storage instance with the given ID.
     ///

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -119,6 +119,7 @@ where
 {
     /// Creates a new [`Instance`].
     pub fn new(
+        workload_class: Option<String>,
         envd_epoch: NonZeroI64,
         metrics: InstanceMetrics,
         dyncfg: Arc<ConfigSet>,
@@ -130,7 +131,7 @@ where
         let epoch = ClusterStartupEpoch::new(envd_epoch, 0);
 
         let mut instance = Self {
-            workload_class: None,
+            workload_class,
             replicas: Default::default(),
             active_ingestions: Default::default(),
             ingestion_exports: Default::default(),

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -508,9 +508,10 @@ where
         self.storage_collections.check_exists(id)
     }
 
-    fn create_instance(&mut self, id: StorageInstanceId) {
+    fn create_instance(&mut self, id: StorageInstanceId, workload_class: Option<String>) {
         let metrics = self.metrics.for_instance(id);
         let mut instance = Instance::new(
+            workload_class,
             self.envd_epoch,
             metrics,
             Arc::clone(self.config().config_set()),


### PR DESCRIPTION
Due to an oversight the controller would initialize the state tracked for new compute clusters with the known workload class, but omit doing the same for storage clusters. As a result, metrics and wallclock lag measurements would sometimes miss their `workload_class` annotations after an envd restart.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
