### PR TITLE
[optimizer] typechecking errors should panic in CI

### DIFF
--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1201,8 +1201,7 @@ impl Typecheck {
 macro_rules! type_error {
     ($severity:expr, $($arg:tt)+) => {{
         if $severity {
-          ::tracing::warn!($($arg)+);
-          soft_panic_or_log!("type error in MIR optimization (details in warning; see 'Type error omnibus' issue database-issues#5663 <https://github.com/MaterializeInc/database-issues/issues/5663>)");
+          soft_panic_or_log!($($arg)+);
         } else {
           ::tracing::debug!($($arg)+);
         }
@@ -1233,7 +1232,7 @@ impl crate::Transform for Typecheck {
             {
                 type_error!(
                     false, // not severe
-                    "TYPE WARNING: NEW NON-TRANSIENT GLOBAL ID {id}\n{}",
+                    "type warning: new non-transient global id {id}\n{}",
                     relation.pretty()
                 );
             }
@@ -1265,7 +1264,7 @@ impl crate::Transform for Typecheck {
                         ),
                     };
 
-                    type_error!(severity, "TYPE ERROR IN KNOWN GLOBAL ID {id}:\n{err}");
+                    type_error!(severity, "type error in known global id {id}:\n{err}");
                 }
             }
             (Ok(got), None) => {
@@ -1279,15 +1278,15 @@ impl crate::Transform for Typecheck {
                         let id = transform_ctx.global_id.unwrap();
                         (
                             format!("expected type {}\n", columns_pretty(expected, &humanizer)),
-                            format!("KNOWN GLOBAL ID {id}"),
+                            format!("known global id {id}"),
                         )
                     }
-                    None => ("".to_string(), "TRANSIENT QUERY".to_string()),
+                    None => ("".to_string(), "transient query".to_string()),
                 };
 
                 type_error!(
                     true, // SEVERE: the transformed code is inconsistent
-                    "TYPE ERROR IN {binding}:\n{err}\n{expected}{}",
+                    "type error in {binding}:\n{err}\n{expected}{}",
                     relation.pretty()
                 );
             }

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -19,6 +19,7 @@ use mz_expr::{
     AggregateExpr, ColumnOrder, Id, JoinImplementation, LocalId, MirRelationExpr, MirScalarExpr,
     RECURSION_LIMIT, non_nullable_columns,
 };
+use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::explain::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{ColumnName, ColumnType, RelationType, Row, ScalarBaseType, ScalarType};
@@ -1194,14 +1195,14 @@ impl Typecheck {
     }
 }
 
-/// Detailed type error logging as a warning, with failures in CI (SOFT_ASSERTIONS) and a logged error in production
+/// Detailed type error logging as a warning, with failures in CI and a logged error in production
 ///
 /// type_error(severity, ...) logs a type warning; if `severity` is `true`, it will also log an error (visible in Sentry)
 macro_rules! type_error {
     ($severity:expr, $($arg:tt)+) => {{
         if $severity {
           ::tracing::warn!($($arg)+);
-          ::tracing::error!("type error in MIR optimization (details in warning; see 'Type error omnibus' issue database-issues#5663 <https://github.com/MaterializeInc/database-issues/issues/5663>)");
+          soft_panic_or_log!("type error in MIR optimization (details in warning; see 'Type error omnibus' issue database-issues#5663 <https://github.com/MaterializeInc/database-issues/issues/5663>)");
         } else {
           ::tracing::debug!($($arg)+);
         }


### PR DESCRIPTION
We were invoking `tracing::error!` rathe than `soft_panic_or_log!`. @ggevay and I couldn't reconstruct why that is: the penultimate commit of #18666 turned a soft panic into an error message under the auspices of simplifying error messages.

### Motivation

  * This PR fixes a previously unreported bug.
  The fix for #32486 somehow didn't fail in CI, leading us to discover this oversight. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
