### PR TITLE
test: reduce flakiness in introspection-sources.td

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -216,8 +216,8 @@ true true
 
 > CREATE DEFAULT INDEX ii_empty ON t3
 
-> SELECT records, batches, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
-0 32 true true
+> SELECT records, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
+0 true true
 
 # Tests that arrangement sizes are approximate
 
@@ -227,13 +227,13 @@ true true
 
 # We have 16 workers, and only want to ensure that the sizes are not egregious.
 
-> SELECT records, batches, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-0 32 true true
+> SELECT records, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+0 true true
 
 > INSERT INTO t4 SELECT 1
 
-> SELECT records, batches, size < 16 * 1024, allocations > 0 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-1 32 true true
+> SELECT records, size < 16 * 1024, allocations > 0 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+1 true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
@@ -342,7 +342,7 @@ true true true true true
 # monotonic inputs. The latter is when there is a possibility for memory misestimation
 # since we include monoids in the diff field.
 > CREATE CLUSTER counter_cluster SIZE = '1';
-> CREATE SOURCE counter IN CLUSTER counter_cluster FROM LOAD GENERATOR COUNTER (TICK INTERVAL '2ms', UP TO 10000);
+> CREATE SOURCE counter IN CLUSTER counter_cluster FROM LOAD GENERATOR COUNTER (TICK INTERVAL '2ms');
 
 > CREATE VIEW input AS
   SELECT counter % 1000 + 1 AS f1, counter % 10 + 1 AS f2
@@ -361,10 +361,6 @@ true true true true true
   ORDER BY f1, f2 DESC;
 > CREATE DEFAULT INDEX ON m_top1;
 
-# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9261 is fixed
-$ skip-if
-SELECT true
-
 > SELECT
     records >= 2 * 1000,
     records < 1.1 * 2 * 1000,
@@ -374,8 +370,6 @@ SELECT true
   FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_minmax%';
 true true true true true
-
-$ skip-end
 
 > SELECT
     records >= 2 * 1000,


### PR DESCRIPTION
This PR fixes two sources of flakiness in `introspection-sources.td`:

* Removes exact checks for batch counts in `mz_arrangement_sizes`. The number of batches is a DD implementation detail that's subject to change. The affected tests really only care about the number of rows anyway.
* Removes an `UP TO` option that made a counter source shut down after some amount of time. The source shut down causes the source to advance to the empty frontier, which causes the operators of downstream indexes to shut down, which removes these indexes from `mz_dataflow_arrangement_sizes`, making queries for them fail.

### Motivation

Fixes https://github.com/MaterializeInc/database-issues/issues/9261

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
