### PR TITLE
helm-chart publish: Fix git push

### DIFF
--- a/misc/helm-charts/publish.sh
+++ b/misc/helm-charts/publish.sh
@@ -222,7 +222,7 @@ fi
 git add $VERSIONS_YAML_PATH
 git commit -m "docs: Bump to helm-chart $CI_HELM_CHART_VERSION, environmentd $CI_MZ_VERSION, orchestratord $ORCHESTRATORD_VERSION"
 git diff HEAD~
-run_if_not_dry git push "https://github.com/MaterializeInc/materialize.git" "$DOCS_BRANCH"
+run_if_not_dry git push origin "$DOCS_BRANCH"
 
 if ! is_truthy "$CI_NO_TERRAFORM_BUMP"; then
   echo "--- Bumping versions in Terraform Nightly tests"
@@ -235,5 +235,5 @@ if ! is_truthy "$CI_NO_TERRAFORM_BUMP"; then
   git add test/terraform/*/main.tf
   git commit -m "terraform tests: Bump to AWS ${TERRAFORM_VERSION[terraform-aws-materialize]}, GCP ${TERRAFORM_VERSION[terraform-google-materialize]}, Azure ${TERRAFORM_VERSION[terraform-azurerm-materialize]}"
   git diff HEAD~
-  run_if_not_dry git push "https://github.com/MaterializeInc/materialize.git" main
+  run_if_not_dry git push origin main
 fi


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/publish-helm-charts/builds/46#0196d15d-62fc-4a0d-8475-feeadbaa113c
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
