### PR TITLE
Revert "[bazel] cross language LTO (#32368)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -170,7 +170,6 @@ build:release --compilation_mode=opt
 build:release-lto --copt=-flto=thin
 build:release-lto --linkopt=-flto=thin
 build:release-lto --@rules_rust//rust/settings:lto=thin
-build:release-lto --@//misc/bazel/platforms:xlang_lto=True
 
 # Builds from `main` or tagged builds.
 #

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -180,6 +180,8 @@ so it is executed.""",
                     agent = "hetzner-aarch64-4cpu-8gb"
                 elif agent == "hetzner-aarch64-4cpu-8gb":
                     agent = "hetzner-aarch64-8cpu-16gb"
+                elif agent == "hetzner-aarch64-8cpu-16gb":
+                    agent = "hetzner-aarch64-16cpu-32gb"
                 elif agent == "hetzner-x86-64-2cpu-4gb":
                     agent = "hetzner-x86-64-4cpu-8gb"
                 elif agent == "hetzner-x86-64-4cpu-8gb":
@@ -187,11 +189,11 @@ so it is executed.""",
                 elif agent == "hetzner-x86-64-8cpu-16gb":
                     agent = "hetzner-x86-64-16cpu-32gb"
                 elif agent == "hetzner-x86-64-16cpu-32gb":
-                    agent = "hetzner-x86-64-16cpu-64gb"
+                    agent = "hetzner-x86-64-dedi-16cpu-64gb"
                 elif agent == "hetzner-x86-64-16cpu-64gb":
-                    agent = "hetzner-x86-64-32cpu-128gb"
-                elif agent == "hetzner-x86-64-32cpu-128gb":
-                    agent = "hetzner-x86-64-48cpu-192gb"
+                    agent = "hetzner-x86-64-dedi-32cpu-128gb"
+                elif agent == "hetzner-x86-64-dedi-32cpu-128gb":
+                    agent = "hetzner-x86-64-dedi-48cpu-192gb"
                 step["agents"] = {"queue": agent}
 
             if step.get("sanitizer") == "skip":

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -40,6 +40,32 @@ steps:
         agents:
           queue: builder-linux-aarch64-mem
 
+      - id: build-x86_64-asan
+        label: ":bazel: Build x86_64 (ASan)"
+        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        artifact_paths: bazel-explain.log
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        env:
+          CI_SANITIZER: address
+
+      - id: build-aarch64-asan
+        label: ":bazel: Build aarch64 (ASan)"
+        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        artifact_paths: bazel-explain.log
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-aarch64-mem
+        env:
+          CI_SANITIZER: address
+
   - group: Linters
     key: linters
     steps:

--- a/misc/bazel/cargo-gazelle/BUILD.bazel
+++ b/misc/bazel/cargo-gazelle/BUILD.bazel
@@ -90,10 +90,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = ["-Copt-level=3"] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = ["-Copt-level=3"],
     version = "0.0.0",
     deps = [":cargo_gazelle"] + all_crate_deps(normal = True),
 )

--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -13,7 +13,6 @@ use std::collections::BTreeMap;
 use guppy::graph::PackageMetadata;
 use std::sync::LazyLock;
 
-use crate::ToBazelDefinition;
 use crate::targets::{AdditiveContent, RustTestSize};
 
 const KEY_NAME: &str = "cargo-gazelle";
@@ -314,23 +313,5 @@ impl CommonConfig {
 
     pub fn rustc_env(&self) -> &BTreeMap<String, String> {
         &self.rustc_env
-    }
-}
-
-/// Values that are mirrored in `/misc/bazel/platforms/BUILD.bazel`.
-#[derive(Debug, Copy, Clone)]
-pub enum ConfigSettingGroup {
-    XlangLtoEnabled,
-}
-
-impl ToBazelDefinition for ConfigSettingGroup {
-    fn format(&self, w: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
-        match self {
-            ConfigSettingGroup::XlangLtoEnabled => {
-                write!(w, "\"@//misc/bazel/platforms:xlang_lto_enabled\"")?
-            }
-        }
-
-        Ok(())
     }
 }

--- a/misc/bazel/cargo-gazelle/src/targets.rs
+++ b/misc/bazel/cargo-gazelle/src/targets.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write};
 use std::str::FromStr;
 
-use crate::config::{ConfigSettingGroup, CrateConfig, GlobalConfig};
+use crate::config::{CrateConfig, GlobalConfig};
 use crate::context::CrateContext;
 use crate::platforms::PlatformVariant;
 use crate::rules::Rule;
@@ -382,17 +382,8 @@ impl RustBinary {
         let (paths, globs) = bin_config.common().compile_data();
         let compile_data = List::new(paths).concat_other(globs.map(Glob::new));
 
-        let xlang_lto_select: Select<List<QuotedString>> = Select::new(
-            [(
-                ConfigSettingGroup::XlangLtoEnabled,
-                vec![QuotedString::new("-Clinker-plugin-lto")],
-            )],
-            vec![],
-        );
-
         let env = Dict::new(bin_config.env());
-        let rustc_flags =
-            List::new(bin_config.common().rustc_flags()).concat_other(xlang_lto_select);
+        let rustc_flags = List::new(bin_config.common().rustc_flags());
         let rustc_env = Dict::new(bin_config.common().rustc_env());
 
         Ok(Some(RustBinary {

--- a/misc/bazel/platforms/BUILD.bazel
+++ b/misc/bazel/platforms/BUILD.bazel
@@ -16,7 +16,7 @@ support building Materialize for.
 """
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 # A flag that we can specify on the command line to configure whether or not we
 # build with a sanitizer.
@@ -43,28 +43,6 @@ config_setting(
 config_setting(
     name = "sanitizer_hwaddress",
     flag_values = {":sanitizer": "hwaddress"},
-)
-
-bool_flag(
-    name = "xlang_lto",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "use_xlang_lto",
-    flag_values = {":xlang_lto": "True"},
-)
-
-# With our current toolchain setup, cross language LTO is only supported when building for Linux.
-#
-# See <https://github.com/rust-lang/rust/issues/60059> for macOS support.
-selects.config_setting_group(
-    name = "xlang_lto_enabled",
-    match_all = [
-        "@platforms//os:linux",
-        ":use_xlang_lto",
-    ],
-    visibility = ["//visibility:public"],
 )
 
 # We only want to use jemalloc if we're building for Linux and we're not using sanitizers.

--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -179,10 +179,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         ":mz_balancerd",

--- a/src/catalog-debug/BUILD.bazel
+++ b/src/catalog-debug/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         "//src/adapter:mz_adapter",

--- a/src/clusterd/BUILD.bazel
+++ b/src/clusterd/BUILD.bazel
@@ -156,10 +156,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         ":mz_clusterd",

--- a/src/environmentd/BUILD.bazel
+++ b/src/environmentd/BUILD.bazel
@@ -793,10 +793,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         ":mz_environmentd",

--- a/src/fivetran-destination/BUILD.bazel
+++ b/src/fivetran-destination/BUILD.bazel
@@ -116,10 +116,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         ":mz_fivetran_destination",

--- a/src/frontegg-mock/BUILD.bazel
+++ b/src/frontegg-mock/BUILD.bazel
@@ -132,10 +132,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         ":mz_frontegg_mock",

--- a/src/interchange/BUILD.bazel
+++ b/src/interchange/BUILD.bazel
@@ -126,10 +126,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         ":mz_interchange",

--- a/src/kafka-util/BUILD.bazel
+++ b/src/kafka-util/BUILD.bazel
@@ -105,10 +105,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         ":mz_kafka_util",

--- a/src/lsp-server/BUILD.bazel
+++ b/src/lsp-server/BUILD.bazel
@@ -144,10 +144,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.3.0",
     deps = [
         ":mz_lsp_server",

--- a/src/materialized/BUILD.bazel
+++ b/src/materialized/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         "//src/clusterd:mz_clusterd",

--- a/src/mz-debug/BUILD.bazel
+++ b/src/mz-debug/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.1.0",
     deps = [
         "//src/build-info:mz_build_info",

--- a/src/mz/BUILD.bazel
+++ b/src/mz/BUILD.bazel
@@ -139,10 +139,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.3.0",
     deps = [
         ":mz",

--- a/src/orchestratord/BUILD.bazel
+++ b/src/orchestratord/BUILD.bazel
@@ -121,10 +121,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         ":mz_orchestratord",

--- a/src/persist-cli/BUILD.bazel
+++ b/src/persist-cli/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         "//src/dyncfg:mz_dyncfg",

--- a/src/pgtest/BUILD.bazel
+++ b/src/pgtest/BUILD.bazel
@@ -90,10 +90,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         ":mz_pgtest",

--- a/src/s3-datagen/BUILD.bazel
+++ b/src/s3-datagen/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         "//src/aws-util:mz_aws_util",

--- a/src/sqllogictest/BUILD.bazel
+++ b/src/sqllogictest/BUILD.bazel
@@ -203,10 +203,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.1",
     deps = [
         ":mz_sqllogictest",

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -165,10 +165,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.145.0-dev.0",
     deps = [
         ":mz_testdrive",

--- a/test/metabase/smoketest/BUILD.bazel
+++ b/test/metabase/smoketest/BUILD.bazel
@@ -30,10 +30,7 @@ rust_binary(
     lint_config = ":lints",
     proc_macro_deps = [] + all_crate_deps(proc_macro = True),
     rustc_env = {},
-    rustc_flags = [] + select({
-        "@//misc/bazel/platforms:xlang_lto_enabled": ["-Clinker-plugin-lto"],
-        "//conditions:default": [],
-    }),
+    rustc_flags = [],
     version = "0.0.0",
     deps = [
         "//src/metabase:mz_metabase",


### PR DESCRIPTION
This reverts commit a10724011797f0a80507d585d30b69b56b6fe183.

Checking if this helps with https://github.com/MaterializeInc/database-issues/issues/9277
Edit: Doesn't help with the root cause, but makes ASan work again.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
