### PR TITLE
ci: Nightly fixes (2025-05-15)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -307,6 +307,7 @@ steps:
         label: ":racing_car: testdrive with SIZE 8 and :azure: blob store"
         depends_on: build-aarch64
         timeout_in_minutes: 180
+        parallelism: 2
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -443,7 +444,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy

--- a/misc/python/materialize/checks/all_checks/cluster.py
+++ b/misc/python/materialize/checks/all_checks/cluster.py
@@ -37,6 +37,8 @@ class CreateCluster(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=240s
+
                 > CREATE TABLE create_cluster1_table (f1 INTEGER);
                 > CREATE TABLE create_cluster2_table (f1 INTEGER);
 


### PR DESCRIPTION
Based on failures in https://buildkite.com/materialize/nightly/builds/12017


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
