### PR TITLE
ci: Add ASan build in nightly and fix sanitizer agent scaling

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -180,6 +180,8 @@ so it is executed.""",
                     agent = "hetzner-aarch64-4cpu-8gb"
                 elif agent == "hetzner-aarch64-4cpu-8gb":
                     agent = "hetzner-aarch64-8cpu-16gb"
+                elif agent == "hetzner-aarch64-8cpu-16gb":
+                    agent = "hetzner-aarch64-16cpu-32gb"
                 elif agent == "hetzner-x86-64-2cpu-4gb":
                     agent = "hetzner-x86-64-4cpu-8gb"
                 elif agent == "hetzner-x86-64-4cpu-8gb":
@@ -187,11 +189,11 @@ so it is executed.""",
                 elif agent == "hetzner-x86-64-8cpu-16gb":
                     agent = "hetzner-x86-64-16cpu-32gb"
                 elif agent == "hetzner-x86-64-16cpu-32gb":
-                    agent = "hetzner-x86-64-16cpu-64gb"
+                    agent = "hetzner-x86-64-dedi-16cpu-64gb"
                 elif agent == "hetzner-x86-64-16cpu-64gb":
-                    agent = "hetzner-x86-64-32cpu-128gb"
-                elif agent == "hetzner-x86-64-32cpu-128gb":
-                    agent = "hetzner-x86-64-48cpu-192gb"
+                    agent = "hetzner-x86-64-dedi-32cpu-128gb"
+                elif agent == "hetzner-x86-64-dedi-32cpu-128gb":
+                    agent = "hetzner-x86-64-dedi-48cpu-192gb"
                 step["agents"] = {"queue": agent}
 
             if step.get("sanitizer") == "skip":

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -40,6 +40,32 @@ steps:
         agents:
           queue: builder-linux-aarch64-mem
 
+      - id: build-x86_64-asan
+        label: ":bazel: Build x86_64 (ASan)"
+        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        artifact_paths: bazel-explain.log
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        env:
+          CI_SANITIZER: address
+
+      - id: build-aarch64-asan
+        label: ":bazel: Build aarch64 (ASan)"
+        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        artifact_paths: bazel-explain.log
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-aarch64-mem
+        env:
+          CI_SANITIZER: address
+
   - group: Linters
     key: linters
     steps:

--- a/misc/bazel/platforms/BUILD.bazel
+++ b/misc/bazel/platforms/BUILD.bazel
@@ -63,6 +63,8 @@ selects.config_setting_group(
     match_all = [
         "@platforms//os:linux",
         ":use_xlang_lto",
+        # ASAN doesn't support being built when cross language LTO is enabled.
+        ":sanitizer_none",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Taken from https://github.com/MaterializeInc/materialize/pull/32499

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
