### PR TITLE
Unify rocksdb core thread shutdown and cleanup

### DIFF
--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -659,8 +659,7 @@ fn rocksdb_core_loop<K, V, M, O, IM, F>(
     while let Some(cmd) = cmd_rx.blocking_recv() {
         match cmd {
             Command::Shutdown { done_sender } => {
-                db.cancel_all_background_work(true);
-                drop(db);
+                shutdown_and_cleanup(db, &instance_path);
                 drop(write_buffer_handle);
                 let _ = done_sender.send(());
                 return;
@@ -894,6 +893,10 @@ fn rocksdb_core_loop<K, V, M, O, IM, F>(
             }
         }
     }
+    shutdown_and_cleanup(db, &instance_path);
+}
+
+fn shutdown_and_cleanup(db: DB, instance_path: &PathBuf) {
     // Gracefully cleanup if the `RocksDBInstance` has gone away.
     db.cancel_all_background_work(true);
     drop(db);


### PR DESCRIPTION
RockDB instance would not clean up when the main loop exited due to shutdown command, but it did in most every other case. For the OOD upsert test, this could result in lgalloc failing to allocate disk space for a file, leading to SIBABRT.

### Motivation

fixes https://github.com/MaterializeInc/database-issues/issues/9277

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
