### PR TITLE
Columnar merge batcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7874,6 +7874,7 @@ dependencies = [
  "either",
  "futures-util",
  "lgalloc",
+ "lz4_flex",
  "mz-ore",
  "num-traits",
  "proptest",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -185,6 +185,9 @@ def get_variable_system_parameters(
             "disk_cluster_replicas_default", "true", ["true", "false"]
         ),
         VariableSystemParameter(
+            "enable_columnar_compression", "true", ["true", "false"]
+        ),
+        VariableSystemParameter(
             "kafka_default_metadata_fetch_interval",
             "1s",
             ["100ms", "1s"],

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -125,6 +125,13 @@ pub const ENABLE_COLUMNAR_LGALLOC: Config<bool> = Config::new(
     "Enable allocating aligned regions in columnar from lgalloc.",
 );
 
+/// Enable compression for columnar.
+pub const ENABLE_COLUMNAR_COMPRESSION: Config<bool> = Config::new(
+    "enable_columnar_compression",
+    false,
+    "Enable compression in columnar.",
+);
+
 /// The interval at which the compute server performs maintenance tasks.
 pub const COMPUTE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
     "compute_server_maintenance_interval",
@@ -338,6 +345,7 @@ pub const PEEK_STASH_BATCH_SIZE: Config<usize> = Config::new(
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&ENABLE_COLUMNAR_COMPRESSION)
         .add(&ENABLE_CORRECTION_V2)
         .add(&ENABLE_MV_APPEND_SMEARING)
         .add(&LINEAR_JOIN_YIELDING)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -321,6 +321,12 @@ impl ComputeState {
         let enable_columnar_lgalloc = ENABLE_COLUMNAR_LGALLOC.get(config);
         mz_timely_util::containers::set_enable_columnar_lgalloc(enable_columnar_lgalloc);
 
+        let enable_columnar_compression = ENABLE_COLUMNAR_COMPRESSION.get(config);
+        mz_timely_util::containers::ENABLE_COLUMNAR_COMPRESSION.store(
+            enable_columnar_compression,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -22,7 +22,7 @@ use differential_dataflow::trace::{BatchReader, Cursor};
 use mz_compute_types::plan::LirId;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, GlobalId, Timestamp};
-use mz_timely_util::containers::{Column, ColumnBuilder, ProvidedBuilder};
+use mz_timely_util::containers::{Column, ColumnBuilder, ProvidedBuilder, Vec2Col2ValBatcher};
 use mz_timely_util::replay::MzReplay;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
@@ -39,7 +39,7 @@ use crate::logging::{
     ComputeLog, EventQueue, LogCollection, LogVariant, OutputSessionColumnar, OutputSessionVec,
     PermutedRowPacker, SharedLoggingState, Update,
 };
-use crate::row_spine::{RowRowBatcher, RowRowBuilder};
+use crate::row_spine::RowRowBuilderColumn;
 use crate::typedefs::RowRowSpine;
 
 /// Type alias for a logger of compute events.
@@ -567,7 +567,7 @@ pub(super) fn construct<S: Scheduler + 'static, G: Scope<Timestamp = Timestamp>>
             let variant = LogVariant::Compute(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange::<Vec2Col2ValBatcher<_, _, _, _>, RowRowBuilderColumn<_, _>, RowRowSpine<_, _>>(
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -36,7 +36,7 @@ use crate::logging::{
     DifferentialLog, EventQueue, LogCollection, LogVariant, SharedLoggingState,
     consolidate_and_pack,
 };
-use crate::row_spine::RowRowBuilder;
+use crate::row_spine::RowRowBuilderColumn;
 use crate::typedefs::{KeyBatcher, RowRowSpine};
 
 /// The return type of [`construct`].
@@ -169,7 +169,7 @@ pub(super) fn construct<G: Scope<Timestamp = Timestamp>>(
             let variant = LogVariant::Differential(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilderColumn<_, _>, RowRowSpine<_, _>>(
                         ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, mz_repr::Diff>),
                         &format!("Arrange {variant:?}"),
                     )

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -39,7 +39,7 @@ use crate::extensions::arrange::MzArrangeCore;
 use crate::logging::compute::{ComputeEvent, DataflowShutdown};
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
 use crate::logging::{LogCollection, SharedLoggingState, consolidate_and_pack};
-use crate::row_spine::RowRowBuilder;
+use crate::row_spine::RowRowBuilderColumn;
 use crate::typedefs::{KeyBatcher, KeyValBatcher, RowRowSpine};
 
 /// The return type of [`construct`].
@@ -312,7 +312,7 @@ pub(super) fn construct<G: Scope<Timestamp = Timestamp>>(
             let variant = LogVariant::Timely(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    .mz_arrange_core::<_, Col2ValBatcher<_, _, _, _>, RowRowBuilderColumn<_, _>, RowRowSpine<_, _>>(
                         ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<mz_repr::Row, mz_repr::Row, Timestamp, Diff>),
                         &format!("Arrange {variant:?}"),
                     )

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -134,6 +134,7 @@ use mz_repr::{Datum, Diff, GlobalId, Row, SharedRow};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
+use mz_timely_util::containers::Vec2Col2ValBatcher;
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use timely::PartialOrder;
@@ -158,7 +159,7 @@ use crate::logging::compute::{
 };
 use crate::render::context::{ArrangementFlavor, Context, ShutdownProbe, shutdown_token};
 use crate::render::continual_task::ContinualTaskCtx;
-use crate::row_spine::{RowRowBatcher, RowRowBuilder};
+use crate::row_spine::RowRowBuilderColumn;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
 
 pub mod context;
@@ -721,7 +722,7 @@ where
                 let mut oks = oks
                     .as_collection(|k, v| (k.into_owned(), v.into_owned()))
                     .leave()
-                    .mz_arrange::<RowRowBatcher<_, _>, RowRowBuilder<_, _>, _>(
+                    .mz_arrange::<Vec2Col2ValBatcher<_, _, _, _>, RowRowBuilderColumn<_, _>, _>(
                         "Arrange export iterative",
                     );
 

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -47,7 +47,7 @@ use crate::compute_state::{ComputeState, HydrationEvent};
 use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
 use crate::render::errors::ErrorLogger;
 use crate::render::{LinearJoinSpec, RenderTimestamp};
-use crate::row_spine::{DatumSeq, RowRowBuilder};
+use crate::row_spine::{DatumSeq, RowRowBuilderColumn};
 use crate::typedefs::{
     ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, MzTimestamp, RowRowAgent, RowRowEnter,
     RowRowSpine,
@@ -962,7 +962,7 @@ where
                 },
             );
         let oks = oks
-            .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilderColumn<_, _>, RowRowSpine<_, _>>(
                 ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, S::Timestamp, Diff>),name
             );
         (oks, errs.as_collection())

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -37,7 +37,7 @@ use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context, ShutdownProbe};
 use crate::render::join::mz_join_core::mz_join_core;
-use crate::row_spine::{RowRowBuilder, RowRowSpine};
+use crate::row_spine::{RowRowBuilderColumn, RowRowSpine};
 use crate::typedefs::{MzTimestamp, RowRowAgent, RowRowEnter};
 
 /// Available linear join implementations.
@@ -396,7 +396,7 @@ where
             errors.push(errs.as_collection());
 
             let arranged = keyed
-                .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                .mz_arrange_core::<_, Col2ValBatcher<_, _,_, _>, RowRowBuilderColumn<_, _>, RowRowSpine<_, _>>(
                     ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, S::Timestamp, Diff>),"JoinStage"
                 );
             joined = JoinedFlavor::Local(arranged);

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -11,8 +11,8 @@ pub use self::container::DatumContainer;
 pub use self::container::DatumSeq;
 pub use self::offset_opt::OffsetOptimized;
 pub use self::spines::{
-    RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowRowSpine, RowSpine, RowValBatcher,
-    RowValBuilder, RowValSpine,
+    RowBatcher, RowBuilder, RowRowBuilder, RowRowBuilderColumn, RowRowSpine, RowSpine,
+    RowValBatcher, RowValBuilder, RowValSpine,
 };
 use differential_dataflow::trace::implementations::OffsetList;
 
@@ -28,14 +28,16 @@ mod spines {
     use differential_dataflow::trace::implementations::spine_fueled::Spine;
     use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
     use mz_repr::Row;
+    use mz_timely_util::containers::ColumnValBuilder;
 
     use crate::row_spine::{DatumContainer, OffsetOptimized};
     use crate::typedefs::{KeyBatcher, KeyValBatcher};
 
     pub type RowRowSpine<T, R> = Spine<Rc<OrdValBatch<RowRowLayout<((Row, Row), T, R)>>>>;
-    pub type RowRowBatcher<T, R> = KeyValBatcher<Row, Row, T, R>;
     pub type RowRowBuilder<T, R> =
         RcBuilder<OrdValBuilder<RowRowLayout<((Row, Row), T, R)>, TimelyStack<((Row, Row), T, R)>>>;
+    pub type RowRowBuilderColumn<T, R> =
+        RcBuilder<ColumnValBuilder<RowRowLayout<((Row, Row), T, R)>>>;
 
     pub type RowValSpine<V, T, R> = Spine<Rc<OrdValBatch<RowValLayout<((Row, V), T, R)>>>>;
     pub type RowValBatcher<V, T, R> = KeyValBatcher<Row, V, T, R>;

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -19,8 +19,7 @@ differential-dataflow = "0.15.3"
 either = "1"
 futures-util = "0.3.31"
 lgalloc = "0.6"
-#lz4_flex = { version = "0.11", default-features = false }
-lz4_flex = { version = "0.11", default-features = true }
+lz4_flex = { version = "0.11", default-features = false }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test", "num-traits", "region", "differential-dataflow", "overflowing"] }
 num-traits = "0.2"
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -19,6 +19,8 @@ differential-dataflow = "0.15.3"
 either = "1"
 futures-util = "0.3.31"
 lgalloc = "0.6"
+#lz4_flex = { version = "0.11", default-features = false }
+lz4_flex = { version = "0.11", default-features = true }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test", "num-traits", "region", "differential-dataflow", "overflowing"] }
 num-traits = "0.2"
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }

--- a/src/timely-util/src/containers.rs
+++ b/src/timely-util/src/containers.rs
@@ -196,7 +196,7 @@ mod container {
                     }
                     compressed.decompress(&mut aligned[..uncompressed_size]);
                     *self = Column::Align(aligned);
-                    *&mut state.empty_compressed = compressed;
+                    state.empty_compressed = compressed;
                     assert_eq!(
                         self.len(),
                         elements,
@@ -367,7 +367,7 @@ mod builder {
     }
 
     impl<C: Columnar<Container: Push<T>>, T> PushInto<T> for ColumnBuilder<C> {
-        #[inline]
+        #[inline(always)]
         fn push_into(&mut self, item: T) {
             self.current.push(item);
             // If there is less than 10% slop with 2MB backing allocations, mint a container.

--- a/src/timely-util/src/containers/compressed.rs
+++ b/src/timely-util/src/containers/compressed.rs
@@ -46,7 +46,7 @@ impl CompressedColumn {
         let max_size = lz4_flex::block::get_maximum_output_size(align.len() * 8);
         buffer.resize(max_size, 0);
         let len = lz4_flex::block::compress_into(bytemuck::cast_slice(&*align), buffer).unwrap();
-        let mut region = Vec::from(std::mem::take(&mut empty.data));
+        let mut region = std::mem::take(&mut empty.data);
         region.clear();
         region.extend_from_slice(&buffer[..len]);
         Self {
@@ -61,7 +61,7 @@ impl CompressedColumn {
         assert_eq!(self.uncompressed_size, aligned.len() * 8);
         lz4_flex::block::decompress_into(
             &self.data[..self.valid],
-            &mut bytemuck::cast_slice_mut(aligned),
+            bytemuck::cast_slice_mut(aligned),
         )
         .expect("Failed to decompress block");
     }

--- a/src/timely-util/src/containers/compressed.rs
+++ b/src/timely-util/src/containers/compressed.rs
@@ -1,0 +1,356 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A compressed column that stores data in a compressed format using LZ4.
+///
+/// The column's type needs to be rememnbered outside of this struct.
+#[derive(Debug, Clone, Default)]
+pub struct CompressedColumn {
+    uncompressed_size: usize,
+    elements: usize,
+    data: Vec<u8>,
+    valid: usize,
+}
+
+impl CompressedColumn {
+    pub fn uncompressed_size(&self) -> usize {
+        self.uncompressed_size
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn elements(&self) -> usize {
+        self.elements
+    }
+
+    // fn get_region(len: usize, empty: &mut Self) -> Vec<u8> {
+    //     let mut region = Vec::from(std::mem::take(&mut empty.data));
+    //     region.clear();
+    //     region.resize(len, 0);
+    //     // if region.capacity() < len {
+    //     //     region.reserve(len - region.len());
+    //     // }
+    //     region
+    // }
+    //
+    pub fn compress_aligned(
+        column_len: usize,
+        align: &[u64],
+        buffer: &mut Vec<u8>,
+        empty: &mut Self,
+    ) -> Self {
+        let max_size = lz4_flex::block::get_maximum_output_size(align.len() * 8);
+        buffer.resize(max_size, 0);
+        let len = lz4_flex::block::compress_into(bytemuck::cast_slice(&*align), buffer).unwrap();
+        let mut region = Vec::from(std::mem::take(&mut empty.data));
+        region.clear();
+        region.extend_from_slice(&buffer[..len]);
+        // assert_eq!(
+        //     bytemuck::cast_slice::<_, u8>(&*align),
+        //     &*lz4_flex::block::decompress(&region[..len], align.len() * 8).unwrap()
+        // );
+        // println!(
+        //     "CompressedBlock: {} bytes into {len} bytes",
+        //     align.len() * 8
+        // );
+        Self {
+            uncompressed_size: align.len() * 8,
+            elements: column_len,
+            data: region,
+            valid: len,
+        }
+    }
+
+    pub fn decompress(&self, aligned: &mut [u64]) {
+        // println!(
+        //     "Decompressing CompressedBlock: {:.2} {} bytes into {} bytes",
+        //     1. - self.data.len() as f64 / self.uncompressed_size as f64,
+        //     self.data.len(),
+        //     self.uncompressed_size
+        // );
+        // let length_in_words = (self.uncompressed_size + 7) / 8;
+        // aligned.resize(length_in_words, 0);
+        assert_eq!(self.uncompressed_size, aligned.len() * 8);
+        lz4_flex::block::decompress_into(
+            &self.data[..self.valid],
+            &mut bytemuck::cast_slice_mut(aligned),
+        )
+        .expect("Failed to decompress block");
+    }
+    // pub fn decompress(&self, aligned: &mut Vec<u64>) {
+    //     println!(
+    //         "Decompressing CompressedBlock: {} bytes into {} bytes",
+    //         self.data.len(),
+    //         self.uncompressed_size
+    //     );
+    //     let length_in_words = (self.uncompressed_size + 7) / 8;
+    //     aligned.resize(length_in_words, 0);
+    //     lz4_flex::block::decompress_into(
+    //         &self.data,
+    //         &mut bytemuck::cast_slice_mut(&mut aligned[..length_in_words]),
+    //     )
+    //     .expect("Failed to decompress block");
+    // }
+}
+/*
+impl<C: Columnar> Default for CompressedColumn<C> {
+    fn default() -> Self {
+        CompressedColumn::Uncompressed(Column::default())
+    }
+}
+
+
+/// A queue for extracting items from a `Column` container.
+pub struct ColumnQueue<'a, T: Columnar> {
+    list: <T::Container as columnar::Container<T>>::Borrowed<'a>,
+    head: usize,
+}
+
+impl<'a, D, T, R> ContainerQueue<'a, CompressedColumn<(D, T, R)>> for ColumnQueue<'a, (D, T, R)>
+where
+    D: for<'b> Columnar<Ref<'b>: Ord>,
+    T: for<'b> Columnar<Ref<'b>: Ord>,
+    R: Columnar,
+{
+    type Item = <(D, T, R) as Columnar>::Ref<'a>;
+    type SelfGAT<'b> = ColumnQueue<'b, (D, T, R)>;
+    fn pop(&mut self) -> Self::Item {
+        self.head += 1;
+        self.list.get(self.head - 1)
+    }
+    fn is_empty(&mut self) -> bool {
+        use columnar::Len;
+        self.head == self.list.len()
+    }
+    fn cmp_heads<'b>(&mut self, other: &mut ColumnQueue<'b, (D, T, R)>) -> std::cmp::Ordering {
+        let (data1, time1, _) = self.peek();
+        let (data2, time2, _) = other.peek();
+
+        let data1 = D::reborrow(data1);
+        let time1 = T::reborrow(time1);
+        let data2 = D::reborrow(data2);
+        let time2 = T::reborrow(time2);
+
+        (data1, time1).cmp(&(data2, time2))
+    }
+    fn new(list: &'a mut CompressedColumn<(D, T, R)>) -> ColumnQueue<'a, (D, T, R)> {
+        ColumnQueue {
+            list: list.borrow(),
+            head: 0,
+        }
+    }
+}
+
+impl<'a, T: Columnar> ColumnQueue<'a, T> {
+    fn peek(&self) -> T::Ref<'a> {
+        self.list.get(self.head)
+    }
+}
+
+impl<D, T, R> MergerChunk for CompressedColumn<(D, T, R)>
+where
+    D: for<'a> Columnar<Ref<'a>: Ord>,
+    T: for<'a> Columnar<Ref<'a>: Ord> + Timestamp,
+    for<'a> <T as Columnar>::Ref<'a>: Copy,
+    R: Default + Semigroup + Columnar,
+{
+    type ContainerQueue<'a> = ColumnQueue<'a, (D, T, R)>;
+    type TimeOwned = T;
+
+    fn time_kept(
+        (_, time, _): &Self::Item<'_>,
+        upper: &AntichainRef<Self::TimeOwned>,
+        frontier: &mut Antichain<Self::TimeOwned>,
+        stash: &mut T,
+    ) -> bool {
+        stash.copy_from(*time);
+        if upper.less_equal(stash) {
+            frontier.insert_ref(stash);
+            true
+        } else {
+            false
+        }
+    }
+    fn account(&self) -> (usize, usize, usize, usize) {
+        let (mut size, mut cap, mut count) = (0, 0, 0);
+        match self {
+            Column::Typed(_typed) => {
+                // use columnar::HeapSize;
+                // let mut cb = |s, c| {
+                //     size += s;
+                //     cap += c;
+                //     count += 1;
+                // };
+                // data.heap_size(&mut cb);
+                // time.heap_size(&mut cb);
+                // diff.heap_size(&mut cb);
+            }
+            Column::Bytes(bytes) => {
+                size += bytes.len();
+                cap += bytes.len();
+                count += 1;
+            }
+            Column::Align(align) => {
+                size += align.len() * 8; // 8 bytes per u64
+                cap += align.len() * 8; // 8 bytes per u64
+                count += 1;
+            }
+        }
+        (self.len(), size, cap, count)
+    }
+}
+
+/// A container builder for `Column<C>`.
+pub struct CompressedColumnBuilder<C: Columnar> {
+    /// Container that we're writing to.
+    current: C::Container,
+    /// Finished container that we presented to callers of extract/finish.
+    ///
+    /// We don't recycle the column because for extract, it's not typed, and after calls
+    /// to finish it'll be `None`.
+    finished: Option<Column<C>>,
+    /// Completed containers pending to be sent.
+    pending: VecDeque<Column<C>>,
+}
+
+impl<C: Columnar<Container: Push<T>>, T> PushInto<T> for CompressedColumnBuilder<C> {
+    #[inline]
+    fn push_into(&mut self, item: T) {
+        self.current.push(item);
+        // If there is less than 10% slop with 2MB backing allocations, mint a container.
+        use columnar::Container;
+        let words = Indexed::length_in_words(&self.current.borrow());
+        let round = (words + ((1 << 18) - 1)) & !((1 << 18) - 1);
+        if round - words < round / 10 {
+            /// Move the contents from `current` to an aligned allocation, and push it to `pending`.
+            /// The contents must fit in `round` words (u64).
+            #[cold]
+            fn outlined_align<C>(
+                current: &mut C::Container,
+                round: usize,
+                pending: &mut VecDeque<Column<C>>,
+                empty: Option<Column<C>>,
+            ) where
+                C: Columnar,
+            {
+                let mut alloc = if let Some(Column::Align(mut alloc)) = empty {
+                    if alloc.capacity() >= round {
+                        unsafe { alloc.clear() };
+                        alloc.extend(std::iter::repeat(0).take(round));
+                        alloc
+                    } else {
+                        super::alloc_aligned_zeroed(round)
+                    }
+                } else {
+                    super::alloc_aligned_zeroed(round)
+                };
+                let writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
+                Indexed::write(writer, &current.borrow()).unwrap();
+                pending.push_back(Column::Align(alloc));
+                current.clear();
+            }
+
+            outlined_align(
+                &mut self.current,
+                round,
+                &mut self.pending,
+                self.finished.take(),
+            );
+        }
+    }
+}
+
+impl<C: Columnar> Default for CompressedColumnBuilder<C> {
+    #[inline(always)]
+    fn default() -> Self {
+        CompressedColumnBuilder {
+            current: Default::default(),
+            finished: None,
+            pending: Default::default(),
+        }
+    }
+}
+
+impl<C: Columnar> ContainerBuilder for CompressedColumnBuilder<C> {
+    type Container = Column<C>;
+
+    #[inline]
+    fn extract(&mut self) -> Option<&mut Self::Container> {
+        if let Some(container) = self.pending.pop_front() {
+            self.finished = Some(container);
+            self.finished.as_mut()
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn finish(&mut self) -> Option<&mut Self::Container> {
+        if !self.current.is_empty() {
+            use columnar::Container;
+            let words = Indexed::length_in_words(&self.current.borrow());
+            let mut alloc = if let Some(Column::Align(mut alloc)) = self.finished.take() {
+                if alloc.capacity() >= words {
+                    unsafe { alloc.clear() };
+                    alloc.extend(std::iter::repeat(0).take(words));
+                    alloc
+                } else {
+                    super::alloc_aligned_zeroed(words)
+                }
+            } else {
+                super::alloc_aligned_zeroed(words)
+            };
+            let writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
+            Indexed::write(writer, &self.current.borrow()).unwrap();
+            self.pending.push_back(Column::Align(alloc));
+            self.current.clear();
+        }
+        self.finished = self.pending.pop_front();
+        self.finished.as_mut()
+    }
+
+    #[inline]
+    fn relax(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl<D, T, R> PushAndAdd for CompressedColumnBuilder<(D, T, R)>
+where
+    D: Columnar,
+    T: timely::PartialOrder + Columnar,
+    R: Default + Semigroup + Columnar,
+{
+    type Item<'a> = <(D, T, R) as Columnar>::Ref<'a>;
+    type DiffOwned = R;
+
+    fn push_and_add(
+        &mut self,
+        (data, time, diff1): Self::Item<'_>,
+        (_, _, diff2): Self::Item<'_>,
+        stash: &mut Self::DiffOwned,
+    ) {
+        stash.copy_from(diff1);
+        let stash2: R = R::into_owned(diff2);
+        stash.plus_equals(&stash2);
+        if !stash.is_zero() {
+            use timely::container::PushInto;
+            self.push_into((data, time, &*stash));
+        }
+    }
+}
+*/

--- a/src/timely-util/src/containers/compressed.rs
+++ b/src/timely-util/src/containers/compressed.rs
@@ -15,7 +15,7 @@
 
 /// A compressed column that stores data in a compressed format using LZ4.
 ///
-/// The column's type needs to be rememnbered outside of this struct.
+/// The column's type needs to be remembered outside of this struct.
 #[derive(Debug, Clone, Default)]
 pub struct CompressedColumn {
     uncompressed_size: usize,
@@ -37,16 +37,6 @@ impl CompressedColumn {
         self.elements
     }
 
-    // fn get_region(len: usize, empty: &mut Self) -> Vec<u8> {
-    //     let mut region = Vec::from(std::mem::take(&mut empty.data));
-    //     region.clear();
-    //     region.resize(len, 0);
-    //     // if region.capacity() < len {
-    //     //     region.reserve(len - region.len());
-    //     // }
-    //     region
-    // }
-    //
     pub fn compress_aligned(
         column_len: usize,
         align: &[u64],
@@ -59,14 +49,6 @@ impl CompressedColumn {
         let mut region = Vec::from(std::mem::take(&mut empty.data));
         region.clear();
         region.extend_from_slice(&buffer[..len]);
-        // assert_eq!(
-        //     bytemuck::cast_slice::<_, u8>(&*align),
-        //     &*lz4_flex::block::decompress(&region[..len], align.len() * 8).unwrap()
-        // );
-        // println!(
-        //     "CompressedBlock: {} bytes into {len} bytes",
-        //     align.len() * 8
-        // );
         Self {
             uncompressed_size: align.len() * 8,
             elements: column_len,
@@ -76,14 +58,6 @@ impl CompressedColumn {
     }
 
     pub fn decompress(&self, aligned: &mut [u64]) {
-        // println!(
-        //     "Decompressing CompressedBlock: {:.2} {} bytes into {} bytes",
-        //     1. - self.data.len() as f64 / self.uncompressed_size as f64,
-        //     self.data.len(),
-        //     self.uncompressed_size
-        // );
-        // let length_in_words = (self.uncompressed_size + 7) / 8;
-        // aligned.resize(length_in_words, 0);
         assert_eq!(self.uncompressed_size, aligned.len() * 8);
         lz4_flex::block::decompress_into(
             &self.data[..self.valid],
@@ -91,266 +65,4 @@ impl CompressedColumn {
         )
         .expect("Failed to decompress block");
     }
-    // pub fn decompress(&self, aligned: &mut Vec<u64>) {
-    //     println!(
-    //         "Decompressing CompressedBlock: {} bytes into {} bytes",
-    //         self.data.len(),
-    //         self.uncompressed_size
-    //     );
-    //     let length_in_words = (self.uncompressed_size + 7) / 8;
-    //     aligned.resize(length_in_words, 0);
-    //     lz4_flex::block::decompress_into(
-    //         &self.data,
-    //         &mut bytemuck::cast_slice_mut(&mut aligned[..length_in_words]),
-    //     )
-    //     .expect("Failed to decompress block");
-    // }
 }
-/*
-impl<C: Columnar> Default for CompressedColumn<C> {
-    fn default() -> Self {
-        CompressedColumn::Uncompressed(Column::default())
-    }
-}
-
-
-/// A queue for extracting items from a `Column` container.
-pub struct ColumnQueue<'a, T: Columnar> {
-    list: <T::Container as columnar::Container<T>>::Borrowed<'a>,
-    head: usize,
-}
-
-impl<'a, D, T, R> ContainerQueue<'a, CompressedColumn<(D, T, R)>> for ColumnQueue<'a, (D, T, R)>
-where
-    D: for<'b> Columnar<Ref<'b>: Ord>,
-    T: for<'b> Columnar<Ref<'b>: Ord>,
-    R: Columnar,
-{
-    type Item = <(D, T, R) as Columnar>::Ref<'a>;
-    type SelfGAT<'b> = ColumnQueue<'b, (D, T, R)>;
-    fn pop(&mut self) -> Self::Item {
-        self.head += 1;
-        self.list.get(self.head - 1)
-    }
-    fn is_empty(&mut self) -> bool {
-        use columnar::Len;
-        self.head == self.list.len()
-    }
-    fn cmp_heads<'b>(&mut self, other: &mut ColumnQueue<'b, (D, T, R)>) -> std::cmp::Ordering {
-        let (data1, time1, _) = self.peek();
-        let (data2, time2, _) = other.peek();
-
-        let data1 = D::reborrow(data1);
-        let time1 = T::reborrow(time1);
-        let data2 = D::reborrow(data2);
-        let time2 = T::reborrow(time2);
-
-        (data1, time1).cmp(&(data2, time2))
-    }
-    fn new(list: &'a mut CompressedColumn<(D, T, R)>) -> ColumnQueue<'a, (D, T, R)> {
-        ColumnQueue {
-            list: list.borrow(),
-            head: 0,
-        }
-    }
-}
-
-impl<'a, T: Columnar> ColumnQueue<'a, T> {
-    fn peek(&self) -> T::Ref<'a> {
-        self.list.get(self.head)
-    }
-}
-
-impl<D, T, R> MergerChunk for CompressedColumn<(D, T, R)>
-where
-    D: for<'a> Columnar<Ref<'a>: Ord>,
-    T: for<'a> Columnar<Ref<'a>: Ord> + Timestamp,
-    for<'a> <T as Columnar>::Ref<'a>: Copy,
-    R: Default + Semigroup + Columnar,
-{
-    type ContainerQueue<'a> = ColumnQueue<'a, (D, T, R)>;
-    type TimeOwned = T;
-
-    fn time_kept(
-        (_, time, _): &Self::Item<'_>,
-        upper: &AntichainRef<Self::TimeOwned>,
-        frontier: &mut Antichain<Self::TimeOwned>,
-        stash: &mut T,
-    ) -> bool {
-        stash.copy_from(*time);
-        if upper.less_equal(stash) {
-            frontier.insert_ref(stash);
-            true
-        } else {
-            false
-        }
-    }
-    fn account(&self) -> (usize, usize, usize, usize) {
-        let (mut size, mut cap, mut count) = (0, 0, 0);
-        match self {
-            Column::Typed(_typed) => {
-                // use columnar::HeapSize;
-                // let mut cb = |s, c| {
-                //     size += s;
-                //     cap += c;
-                //     count += 1;
-                // };
-                // data.heap_size(&mut cb);
-                // time.heap_size(&mut cb);
-                // diff.heap_size(&mut cb);
-            }
-            Column::Bytes(bytes) => {
-                size += bytes.len();
-                cap += bytes.len();
-                count += 1;
-            }
-            Column::Align(align) => {
-                size += align.len() * 8; // 8 bytes per u64
-                cap += align.len() * 8; // 8 bytes per u64
-                count += 1;
-            }
-        }
-        (self.len(), size, cap, count)
-    }
-}
-
-/// A container builder for `Column<C>`.
-pub struct CompressedColumnBuilder<C: Columnar> {
-    /// Container that we're writing to.
-    current: C::Container,
-    /// Finished container that we presented to callers of extract/finish.
-    ///
-    /// We don't recycle the column because for extract, it's not typed, and after calls
-    /// to finish it'll be `None`.
-    finished: Option<Column<C>>,
-    /// Completed containers pending to be sent.
-    pending: VecDeque<Column<C>>,
-}
-
-impl<C: Columnar<Container: Push<T>>, T> PushInto<T> for CompressedColumnBuilder<C> {
-    #[inline]
-    fn push_into(&mut self, item: T) {
-        self.current.push(item);
-        // If there is less than 10% slop with 2MB backing allocations, mint a container.
-        use columnar::Container;
-        let words = Indexed::length_in_words(&self.current.borrow());
-        let round = (words + ((1 << 18) - 1)) & !((1 << 18) - 1);
-        if round - words < round / 10 {
-            /// Move the contents from `current` to an aligned allocation, and push it to `pending`.
-            /// The contents must fit in `round` words (u64).
-            #[cold]
-            fn outlined_align<C>(
-                current: &mut C::Container,
-                round: usize,
-                pending: &mut VecDeque<Column<C>>,
-                empty: Option<Column<C>>,
-            ) where
-                C: Columnar,
-            {
-                let mut alloc = if let Some(Column::Align(mut alloc)) = empty {
-                    if alloc.capacity() >= round {
-                        unsafe { alloc.clear() };
-                        alloc.extend(std::iter::repeat(0).take(round));
-                        alloc
-                    } else {
-                        super::alloc_aligned_zeroed(round)
-                    }
-                } else {
-                    super::alloc_aligned_zeroed(round)
-                };
-                let writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
-                Indexed::write(writer, &current.borrow()).unwrap();
-                pending.push_back(Column::Align(alloc));
-                current.clear();
-            }
-
-            outlined_align(
-                &mut self.current,
-                round,
-                &mut self.pending,
-                self.finished.take(),
-            );
-        }
-    }
-}
-
-impl<C: Columnar> Default for CompressedColumnBuilder<C> {
-    #[inline(always)]
-    fn default() -> Self {
-        CompressedColumnBuilder {
-            current: Default::default(),
-            finished: None,
-            pending: Default::default(),
-        }
-    }
-}
-
-impl<C: Columnar> ContainerBuilder for CompressedColumnBuilder<C> {
-    type Container = Column<C>;
-
-    #[inline]
-    fn extract(&mut self) -> Option<&mut Self::Container> {
-        if let Some(container) = self.pending.pop_front() {
-            self.finished = Some(container);
-            self.finished.as_mut()
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn finish(&mut self) -> Option<&mut Self::Container> {
-        if !self.current.is_empty() {
-            use columnar::Container;
-            let words = Indexed::length_in_words(&self.current.borrow());
-            let mut alloc = if let Some(Column::Align(mut alloc)) = self.finished.take() {
-                if alloc.capacity() >= words {
-                    unsafe { alloc.clear() };
-                    alloc.extend(std::iter::repeat(0).take(words));
-                    alloc
-                } else {
-                    super::alloc_aligned_zeroed(words)
-                }
-            } else {
-                super::alloc_aligned_zeroed(words)
-            };
-            let writer = std::io::Cursor::new(bytemuck::cast_slice_mut(&mut alloc[..]));
-            Indexed::write(writer, &self.current.borrow()).unwrap();
-            self.pending.push_back(Column::Align(alloc));
-            self.current.clear();
-        }
-        self.finished = self.pending.pop_front();
-        self.finished.as_mut()
-    }
-
-    #[inline]
-    fn relax(&mut self) {
-        *self = Self::default();
-    }
-}
-
-impl<D, T, R> PushAndAdd for CompressedColumnBuilder<(D, T, R)>
-where
-    D: Columnar,
-    T: timely::PartialOrder + Columnar,
-    R: Default + Semigroup + Columnar,
-{
-    type Item<'a> = <(D, T, R) as Columnar>::Ref<'a>;
-    type DiffOwned = R;
-
-    fn push_and_add(
-        &mut self,
-        (data, time, diff1): Self::Item<'_>,
-        (_, _, diff2): Self::Item<'_>,
-        stash: &mut Self::DiffOwned,
-    ) {
-        stash.copy_from(diff1);
-        let stash2: R = R::into_owned(diff2);
-        stash.plus_equals(&stash2);
-        if !stash.is_zero() {
-            use timely::container::PushInto;
-            self.push_into((data, time, &*stash));
-        }
-    }
-}
-*/

--- a/src/timely-util/src/containers/merger.rs
+++ b/src/timely-util/src/containers/merger.rs
@@ -1,0 +1,720 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+
+use differential_dataflow::logging::{BatcherEvent, Logger};
+use differential_dataflow::trace::implementations::merge_batcher::Merger;
+use differential_dataflow::trace::{Batcher, Builder, Description};
+use timely::container::{ContainerBuilder, PushInto};
+use timely::progress::frontier::AntichainRef;
+use timely::progress::{Antichain, Timestamp};
+use timely::{Container, Data, PartialOrder};
+
+/// Creates batches from containers of unordered tuples.
+///
+/// To implement `Batcher`, the container builder `C` must accept `&mut Input` as inputs,
+/// and must produce outputs of type `M::Chunk`.
+pub struct MergeBatcher<Input, C, M: Merger> {
+    /// Transforms input streams to chunks of sorted, consolidated data.
+    chunker: C,
+    /// A sequence of power-of-two length lists of sorted, consolidated containers.
+    ///
+    /// Do not push/pop directly but use the corresponding functions ([`Self::chain_push`]/[`Self::chain_pop`]).
+    chains: Vec<Vec<M::Chunk>>,
+    /// Stash of empty chunks, recycled through the merging process.
+    stash: Vec<M::Chunk>,
+    /// Merges consolidated chunks, and extracts the subset of an update chain that lies in an interval of time.
+    merger: M,
+    /// Current lower frontier, we sealed up to here.
+    lower: Antichain<M::Time>,
+    /// The lower-bound frontier of the data, after the last call to seal.
+    frontier: Antichain<M::Time>,
+    /// Logger for size accounting.
+    logger: Option<Logger>,
+    /// Timely operator ID.
+    operator_id: usize,
+    /// The `Input` type needs to be called out as the type of container accepted, but it is not otherwise present.
+    _marker: PhantomData<Input>,
+}
+
+impl<Input, C, M> Batcher for MergeBatcher<Input, C, M>
+where
+    C: ContainerBuilder<Container = M::Chunk> + Default + for<'a> PushInto<&'a mut Input>,
+    M: Merger<Time: Timestamp>,
+{
+    type Input = Input;
+    type Time = M::Time;
+    type Output = M::Chunk;
+
+    fn new(logger: Option<Logger>, operator_id: usize) -> Self {
+        Self {
+            logger,
+            operator_id,
+            chunker: C::default(),
+            merger: M::default(),
+            chains: Vec::new(),
+            stash: Vec::new(),
+            frontier: Antichain::new(),
+            lower: Antichain::from_elem(M::Time::minimum()),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Push a container of data into this merge batcher. Updates the internal chain structure if
+    /// needed.
+    fn push_container(&mut self, container: &mut Input) {
+        self.chunker.push_into(container);
+        let mut chain = Vec::new();
+        while let Some(chunk) = self.chunker.finish() {
+            let chunk = std::mem::take(chunk);
+            chain.push(chunk);
+        }
+        self.insert_chain(chain);
+    }
+
+    // Sealing a batch means finding those updates with times not greater or equal to any time
+    // in `upper`. All updates must have time greater or equal to the previously used `upper`,
+    // which we call `lower`, by assumption that after sealing a batcher we receive no more
+    // updates with times not greater or equal to `upper`.
+    fn seal<B: Builder<Input = Self::Output, Time = Self::Time>>(
+        &mut self,
+        upper: Antichain<M::Time>,
+    ) -> B::Output {
+        // Finish
+        while let Some(chunk) = self.chunker.finish() {
+            let chunk = std::mem::take(chunk);
+            self.insert_chain(vec![chunk]);
+        }
+
+        // Merge all remaining chains into a single chain.
+        while self.chains.len() > 1 {
+            let list1 = self.chain_pop().unwrap();
+            let list2 = self.chain_pop().unwrap();
+            let merged = self.merge_by(list1, list2);
+            self.chain_push(merged);
+        }
+        let merged = self.chain_pop().unwrap_or_default();
+
+        // Extract readied data.
+        let mut kept = Vec::new();
+        let mut readied = Vec::new();
+        self.frontier.clear();
+
+        self.merger.extract(
+            merged,
+            upper.borrow(),
+            &mut self.frontier,
+            &mut readied,
+            &mut kept,
+            &mut self.stash,
+        );
+
+        if !kept.is_empty() {
+            self.chain_push(kept);
+        }
+
+        self.stash.clear();
+
+        let description = Description::new(
+            self.lower.clone(),
+            upper.clone(),
+            Antichain::from_elem(M::Time::minimum()),
+        );
+        let seal = B::seal(&mut readied, description);
+        self.lower = upper;
+        seal
+    }
+
+    /// The frontier of elements remaining after the most recent call to `self.seal`.
+    #[inline(always)]
+    fn frontier(&mut self) -> AntichainRef<M::Time> {
+        self.frontier.borrow()
+    }
+}
+
+impl<Input, C, M: Merger> MergeBatcher<Input, C, M> {
+    /// Insert a chain and maintain chain properties: Chains are geometrically sized and ordered
+    /// by decreasing length.
+    fn insert_chain(&mut self, chain: Vec<M::Chunk>) {
+        if !chain.is_empty() {
+            self.chain_push(chain);
+            while self.chains.len() > 1
+                && (self.chains[self.chains.len() - 1].len()
+                    >= self.chains[self.chains.len() - 2].len() / 2)
+            {
+                let list1 = self.chain_pop().unwrap();
+                let list2 = self.chain_pop().unwrap();
+                let merged = self.merge_by(list1, list2);
+                self.chain_push(merged);
+            }
+        }
+    }
+
+    // merges two sorted input lists into one sorted output list.
+    fn merge_by(&mut self, list1: Vec<M::Chunk>, list2: Vec<M::Chunk>) -> Vec<M::Chunk> {
+        // TODO: `list1` and `list2` get dropped; would be better to reuse?
+        let mut output = Vec::with_capacity(list1.len() + list2.len());
+        self.merger
+            .merge(list1, list2, &mut output, &mut self.stash);
+
+        output
+    }
+
+    /// Pop a chain and account size changes.
+    #[inline]
+    fn chain_pop(&mut self) -> Option<Vec<M::Chunk>> {
+        let chain = self.chains.pop();
+        self.account(chain.iter().flatten().map(M::account), -1);
+        chain
+    }
+
+    /// Push a chain and account size changes.
+    #[inline]
+    fn chain_push(&mut self, chain: Vec<M::Chunk>) {
+        self.account(chain.iter().map(M::account), 1);
+        self.chains.push(chain);
+    }
+
+    /// Account size changes. Only performs work if a logger exists.
+    ///
+    /// Calculate the size based on the iterator passed along, with each attribute
+    /// multiplied by `diff`. Usually, one wants to pass 1 or -1 as the diff.
+    #[inline]
+    fn account<I: IntoIterator<Item = (usize, usize, usize, usize)>>(&self, items: I, diff: isize) {
+        if let Some(logger) = &self.logger {
+            let (mut records, mut size, mut capacity, mut allocations) =
+                (0isize, 0isize, 0isize, 0isize);
+            for (records_, size_, capacity_, allocations_) in items {
+                records = records.saturating_add_unsigned(records_);
+                size = size.saturating_add_unsigned(size_);
+                capacity = capacity.saturating_add_unsigned(capacity_);
+                allocations = allocations.saturating_add_unsigned(allocations_);
+            }
+            logger.log(BatcherEvent {
+                operator: self.operator_id,
+                records_diff: records * diff,
+                size_diff: size * diff,
+                capacity_diff: capacity * diff,
+                allocations_diff: allocations * diff,
+            })
+        }
+    }
+}
+
+impl<Input, C, M: Merger> Drop for MergeBatcher<Input, C, M> {
+    fn drop(&mut self) {
+        // Cleanup chain to retract accounting information.
+        while self.chain_pop().is_some() {}
+    }
+}
+
+/// An abstraction for a container that can be iterated over, and conclude by returning itself.
+pub trait ContainerQueue<'a, C> {
+    /// Items exposed by this queue.
+    type Item;
+    /// The same type as `Self`, but with a different lifetime.
+    type SelfGAT<'b>: ContainerQueue<'b, C>;
+    /// Returns the next item in the container. Might panic if the container is empty.
+    fn pop(&mut self) -> Self::Item;
+    /// Indicates whether `pop` will succeed.
+    fn is_empty(&mut self) -> bool;
+    /// Compare the heads of two queues, where empty queues come last.
+    fn cmp_heads(&mut self, other: &mut Self::SelfGAT<'_>) -> Ordering;
+    /// Create a new queue from an existing container.
+    fn new(container: &'a mut C) -> Self;
+}
+
+/// Behavior to observe the time of an item and account for a container's size.
+pub trait MergerChunk: Container {
+    /// The queue type that can be used to iterate over the container.
+    type ContainerQueue<'a>: ContainerQueue<'a, Self>;
+    /// An owned time type.
+    ///
+    /// This type is provided so that users can maintain antichains of something, in order to track
+    /// the forward movement of time and extract intervals from chains of updates.
+    type TimeOwned: Timestamp;
+
+    /// Relates a borrowed time to antichains of owned times.
+    ///
+    /// If `upper` is less or equal to `time`, the method returns `true` and ensures that `frontier` reflects `time`.
+    fn time_kept(
+        time1: &Self::Item<'_>,
+        upper: &AntichainRef<Self::TimeOwned>,
+        frontier: &mut Antichain<Self::TimeOwned>,
+        stash: &mut Self::TimeOwned,
+    ) -> bool;
+
+    /// Account the allocations behind the chunk.
+    // TODO: Find a more universal home for this: `Container`?
+    fn account(&self) -> (usize, usize, usize, usize) {
+        let (size, capacity, allocations) = (0, 0, 0);
+        (self.len(), size, capacity, allocations)
+    }
+}
+
+/// Push and add two items together, if their summed diff is non-zero.
+pub trait PushAndAdd {
+    /// The item type that can be pushed into the container.
+    type Item<'a>;
+    /// The owned diff type.
+    ///
+    /// This type is provided so that users can provide an owned instance to the `push_and_add` method,
+    /// to act as a scratch space when the type is substantial and could otherwise require allocations.
+    type DiffOwned: Default;
+
+    /// Push an entry that adds together two diffs.
+    ///
+    /// This is only called when two items are deemed mergeable by the container queue.
+    /// If the two diffs added together is zero do not push anything.
+    fn push_and_add(
+        &mut self,
+        item1: Self::Item<'_>,
+        item2: Self::Item<'_>,
+        stash: &mut Self::DiffOwned,
+    );
+}
+
+/// A merger for arbitrary containers.
+///
+/// `MC` is a [`Container`] that implements [`MergerChunk`].
+/// `CQ` is a [`ContainerQueue`] supporting `MC`.
+#[derive(Default, Debug)]
+pub struct ContainerMerger<MCB> {
+    builder: MCB,
+}
+
+impl<MCB: ContainerBuilder> ContainerMerger<MCB> {
+    /// Helper to extract chunks from the builder and push them into the output.
+    #[inline(always)]
+    fn extract_chunks(
+        builder: &mut MCB,
+        output: &mut Vec<MCB::Container>,
+        stash: &mut Vec<MCB::Container>,
+    ) {
+        while let Some(chunk) = builder.extract() {
+            let chunk = std::mem::replace(chunk, stash.pop().unwrap_or_default());
+            output.push_into(chunk);
+        }
+    }
+
+    /// Helper to finish the builder and push the chunks into the output.
+    #[inline]
+    fn finish_chunks(
+        builder: &mut MCB,
+        output: &mut Vec<MCB::Container>,
+        stash: &mut Vec<MCB::Container>,
+    ) {
+        while let Some(chunk) = builder.finish() {
+            let chunk = std::mem::replace(chunk, stash.pop().unwrap_or_default());
+            output.push_into(chunk);
+        }
+    }
+}
+
+/// The container queue for a merger chunk builder.
+type CQ<'a, MCB> = <<MCB as ContainerBuilder>::Container as MergerChunk>::ContainerQueue<'a>;
+/// The container queue's item for a merger chunk builder.
+type CQI<'a, MCB> = <CQ<'a, MCB> as ContainerQueue<'a, <MCB as ContainerBuilder>::Container>>::Item;
+
+/// The core of the algorithm, implementing the `Merger` trait for `ContainerMerger`.
+///
+/// The type bounds look intimidating, but they are not too complex:
+/// * `MCB` must be a container builder that can absorb its own container's items,
+///   and the items produced by the merger chunk's container queue.
+/// * The `MCB::Container` must implement `MergerChunk`, which defines the container queue.
+/// * The container queue has a `SelfGAT` type that is a lifetime-dependent version of itself,
+///   which allows it to be used in the `cmp_heads` function.
+impl<MCB> Merger for ContainerMerger<MCB>
+where
+    MCB: ContainerBuilder
+        + for<'a> PushInto<<MCB::Container as Container>::Item<'a>>
+        + for<'a> PushInto<CQI<'a, MCB>>
+        + for<'a> PushAndAdd<Item<'a> = CQI<'a, MCB>>,
+    for<'a, 'b> MCB::Container: MergerChunk<TimeOwned: Ord + PartialOrder + Data>,
+    for<'a, 'b> CQ<'a, MCB>: ContainerQueue<'a, MCB::Container, SelfGAT<'b> = CQ<'b, MCB>>,
+{
+    type Time = <MCB::Container as MergerChunk>::TimeOwned;
+    type Chunk = MCB::Container;
+
+    fn merge(
+        &mut self,
+        list1: Vec<Self::Chunk>,
+        list2: Vec<Self::Chunk>,
+        output: &mut Vec<Self::Chunk>,
+        stash: &mut Vec<Self::Chunk>,
+    ) {
+        let mut list1 = list1.into_iter();
+        let mut list2 = list2.into_iter();
+
+        let mut head1 = list1.next().unwrap_or_default();
+        let mut borrow1 = CQ::<MCB>::new(&mut head1);
+        let mut head2 = list2.next().unwrap_or_default();
+        let mut borrow2 = CQ::<MCB>::new(&mut head2);
+
+        let mut diff_owned = Default::default();
+
+        // while we have valid data in each input, merge.
+        while !borrow1.is_empty() && !borrow2.is_empty() {
+            while !borrow1.is_empty() && !borrow2.is_empty() {
+                let cmp = borrow1.cmp_heads(&mut borrow2);
+                // TODO: The following less/greater branches could plausibly be a good moment for
+                // `copy_range`, on account of runs of records that might benefit more from a
+                // `memcpy`.
+                match cmp {
+                    Ordering::Less => {
+                        self.builder.push_into(borrow1.pop());
+                    }
+                    Ordering::Greater => {
+                        self.builder.push_into(borrow2.pop());
+                    }
+                    Ordering::Equal => {
+                        let item1 = borrow1.pop();
+                        let item2 = borrow2.pop();
+                        self.builder.push_and_add(item1, item2, &mut diff_owned);
+                    }
+                }
+            }
+
+            Self::extract_chunks(&mut self.builder, output, stash);
+
+            if borrow1.is_empty() {
+                drop(borrow1);
+                let chunk = head1;
+                stash.push(chunk);
+                head1 = list1.next().unwrap_or_default();
+                borrow1 = CQ::<MCB>::new(&mut head1);
+            }
+            if borrow2.is_empty() {
+                drop(borrow2);
+                let chunk = head2;
+                stash.push(chunk);
+                head2 = list2.next().unwrap_or_default();
+                borrow2 = CQ::<MCB>::new(&mut head2);
+            }
+        }
+
+        while !borrow1.is_empty() {
+            self.builder.push_into(borrow1.pop());
+            Self::extract_chunks(&mut self.builder, output, stash);
+        }
+        Self::finish_chunks(&mut self.builder, output, stash);
+        output.extend(list1);
+
+        while !borrow2.is_empty() {
+            self.builder.push_into(borrow2.pop());
+            Self::extract_chunks(&mut self.builder, output, stash);
+        }
+        Self::finish_chunks(&mut self.builder, output, stash);
+        output.extend(list2);
+    }
+
+    fn extract(
+        &mut self,
+        merged: Vec<Self::Chunk>,
+        upper: AntichainRef<Self::Time>,
+        frontier: &mut Antichain<Self::Time>,
+        readied: &mut Vec<Self::Chunk>,
+        kept: &mut Vec<Self::Chunk>,
+        stash: &mut Vec<Self::Chunk>,
+    ) {
+        let mut keep = MCB::default();
+
+        let mut time_stash = Self::Time::minimum();
+
+        for mut buffer in merged {
+            for item in buffer.drain() {
+                if <MCB::Container as MergerChunk>::time_kept(
+                    &item,
+                    &upper,
+                    frontier,
+                    &mut time_stash,
+                ) {
+                    keep.push_into(item);
+                    Self::extract_chunks(&mut keep, kept, stash);
+                } else {
+                    self.builder.push_into(item);
+                    Self::extract_chunks(&mut self.builder, readied, stash);
+                }
+            }
+            // Recycling buffer.
+            stash.push(buffer);
+        }
+        // Finish the kept and readied data.
+        Self::finish_chunks(&mut keep, kept, stash);
+        Self::finish_chunks(&mut self.builder, readied, stash);
+    }
+
+    /// Account the allocations behind the chunk.
+    fn account(chunk: &Self::Chunk) -> (usize, usize, usize, usize) {
+        chunk.account()
+    }
+}
+
+/// Implementations of `ContainerQueue` and `MergerChunk` for `Vec` containers.
+pub mod vec {
+    use differential_dataflow::difference::Semigroup;
+    use timely::container::{CapacityContainerBuilder, PushInto};
+    use timely::progress::{Antichain, Timestamp, frontier::AntichainRef};
+
+    use crate::containers::merger::{ContainerMerger, ContainerQueue, MergerChunk, PushAndAdd};
+
+    /// A `Merger` implementation backed by vector containers.
+    pub type VecMerger<D, T, R> = ContainerMerger<CapacityContainerBuilder<Vec<(D, T, R)>>>;
+
+    impl<D, T, R: Semigroup> PushAndAdd for CapacityContainerBuilder<Vec<(D, T, R)>> {
+        type Item<'a> = (D, T, R);
+        type DiffOwned = ();
+
+        fn push_and_add<'a>(
+            &mut self,
+            (data, time, mut diff1): (D, T, R),
+            (_, _, diff2): (D, T, R),
+            _stash: &mut Self::DiffOwned,
+        ) {
+            diff1.plus_equals(&diff2);
+            if !diff1.is_zero() {
+                self.push_into((data, time, diff1));
+            }
+        }
+    }
+
+    impl<'a, D, T, R> ContainerQueue<'a, Vec<(D, T, R)>>
+        for std::iter::Peekable<std::vec::Drain<'a, (D, T, R)>>
+    where
+        D: Ord + 'static,
+        T: Ord + 'static,
+        R: 'static,
+    {
+        type Item = (D, T, R);
+        type SelfGAT<'b> = std::iter::Peekable<std::vec::Drain<'b, (D, T, R)>>;
+        fn pop(&mut self) -> Self::Item {
+            self.next()
+                .expect("ContainerQueue: pop called on empty queue")
+        }
+        fn is_empty(&mut self) -> bool {
+            self.peek().is_none()
+        }
+        fn cmp_heads(&mut self, other: &mut Self::SelfGAT<'_>) -> std::cmp::Ordering {
+            let (data1, time1, _) = self.peek().unwrap();
+            let (data2, time2, _) = other.peek().unwrap();
+            (data1, time1).cmp(&(data2, time2))
+        }
+        fn new(list: &'a mut Vec<(D, T, R)>) -> Self {
+            list.drain(..).peekable()
+        }
+    }
+
+    impl<D: Ord + 'static, T: Timestamp, R: Semigroup + 'static> MergerChunk for Vec<(D, T, R)> {
+        type ContainerQueue<'a> = std::iter::Peekable<std::vec::Drain<'a, (D, T, R)>>;
+        type TimeOwned = T;
+
+        fn time_kept(
+            (_, time, _): &Self::Item<'_>,
+            upper: &AntichainRef<Self::TimeOwned>,
+            frontier: &mut Antichain<Self::TimeOwned>,
+            _stash: &mut T,
+        ) -> bool {
+            if upper.less_equal(time) {
+                frontier.insert_with(time, |time| time.clone());
+                true
+            } else {
+                false
+            }
+        }
+        fn account(&self) -> (usize, usize, usize, usize) {
+            let (size, capacity, allocations) = (0, 0, 0);
+            (self.len(), size, capacity, allocations)
+        }
+    }
+}
+
+/// Implementations of `ContainerQueue` and `MergerChunk` for `TimelyStack` containers (columnation).
+pub mod columnation {
+    use std::collections::VecDeque;
+
+    use columnation::Columnation;
+    use differential_dataflow::containers::TimelyStack;
+    use differential_dataflow::difference::Semigroup;
+    use timely::container::{ContainerBuilder, PushInto, SizableContainer};
+    use timely::progress::{Antichain, Timestamp, frontier::AntichainRef};
+
+    use crate::containers::merger::{ContainerMerger, ContainerQueue, MergerChunk, PushAndAdd};
+
+    /// A `Merger` implementation backed by `TimelyStack` containers (columnation).
+    pub type ColMerger<D, T, R> = ContainerMerger<TimelyStackBuilder<(D, T, R)>>;
+
+    impl<'a, D, T, R> ContainerQueue<'a, TimelyStack<(D, T, R)>>
+        for std::iter::Peekable<std::slice::Iter<'a, (D, T, R)>>
+    where
+        D: Ord + Columnation + 'static,
+        T: Ord + Columnation + 'static,
+        R: Columnation + 'static,
+    {
+        type Item = &'a (D, T, R);
+        type SelfGAT<'b> = std::iter::Peekable<std::slice::Iter<'b, (D, T, R)>>;
+
+        fn pop(&mut self) -> Self::Item {
+            self.next()
+                .expect("ContainerQueue: pop called on empty queue")
+        }
+        fn is_empty(&mut self) -> bool {
+            self.peek().is_none()
+        }
+        fn cmp_heads(&mut self, other: &mut Self::SelfGAT<'_>) -> std::cmp::Ordering {
+            let (data1, time1, _) = self.peek().unwrap();
+            let (data2, time2, _) = other.peek().unwrap();
+            (data1, time1).cmp(&(data2, time2))
+        }
+        fn new(list: &'a mut TimelyStack<(D, T, R)>) -> Self {
+            list.iter().peekable()
+        }
+    }
+
+    impl<D, T, R> MergerChunk for TimelyStack<(D, T, R)>
+    where
+        D: Ord + Columnation + 'static,
+        T: Timestamp + Columnation,
+        R: Default + Semigroup + Columnation + 'static,
+    {
+        type ContainerQueue<'a> = std::iter::Peekable<std::slice::Iter<'a, (D, T, R)>>;
+        type TimeOwned = T;
+        fn time_kept(
+            (_, time, _): &Self::Item<'_>,
+            upper: &AntichainRef<Self::TimeOwned>,
+            frontier: &mut Antichain<Self::TimeOwned>,
+            _stash: &mut T,
+        ) -> bool {
+            if upper.less_equal(time) {
+                frontier.insert_with(time, |time| time.clone());
+                true
+            } else {
+                false
+            }
+        }
+        fn account(&self) -> (usize, usize, usize, usize) {
+            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+            let cb = |siz, cap| {
+                size += siz;
+                capacity += cap;
+                allocations += 1;
+            };
+            self.heap_size(cb);
+            (self.len(), size, capacity, allocations)
+        }
+    }
+
+    /// A capacity container builder for TimelyStack where we have access to the internals.
+    /// We need to have a different `push_into` implementation that can call `copy_destructured`
+    /// to avoid unnecessary allocations.
+    ///
+    /// A container builder that uses length and preferred capacity to chunk data for [`TimelyStack`].
+    ///
+    /// Maintains a single empty allocation between [`Self::push_into`] and [`Self::extract`], but not
+    /// across [`Self::finish`] to maintain a low memory footprint.
+    ///
+    /// Maintains FIFO order.
+    #[derive(Debug)]
+    pub struct TimelyStackBuilder<C: Columnation> {
+        /// Container that we're writing to.
+        pub(crate) current: TimelyStack<C>,
+        /// Empty allocation.
+        pub(crate) empty: Option<TimelyStack<C>>,
+        /// Completed containers pending to be sent.
+        pub(crate) pending: VecDeque<TimelyStack<C>>,
+    }
+
+    impl<C: Columnation> Default for TimelyStackBuilder<C> {
+        fn default() -> Self {
+            Self {
+                current: TimelyStack::default(),
+                empty: None,
+                pending: VecDeque::new(),
+            }
+        }
+    }
+
+    impl<T: Columnation> PushInto<&T> for TimelyStackBuilder<T> {
+        #[inline(always)]
+        fn push_into(&mut self, item: &T) {
+            // Ensure capacity
+            self.current.ensure_capacity(&mut self.empty);
+
+            // Push item
+            self.current.copy(item);
+
+            // Maybe flush
+            if self.current.at_capacity() {
+                self.pending.push_back(std::mem::take(&mut self.current));
+            }
+        }
+    }
+
+    impl<C: Columnation + Clone + 'static> ContainerBuilder for TimelyStackBuilder<C> {
+        type Container = TimelyStack<C>;
+
+        #[inline]
+        fn extract(&mut self) -> Option<&mut TimelyStack<C>> {
+            if let Some(container) = self.pending.pop_front() {
+                self.empty = Some(container);
+                self.empty.as_mut()
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        fn finish(&mut self) -> Option<&mut TimelyStack<C>> {
+            if !self.current.is_empty() {
+                self.pending.push_back(std::mem::take(&mut self.current));
+            }
+            self.empty = self.pending.pop_front();
+            self.empty.as_mut()
+        }
+    }
+
+    impl<D, T, R> PushAndAdd for TimelyStackBuilder<(D, T, R)>
+    where
+        D: Columnation + 'static,
+        T: Columnation + 'static,
+        R: Columnation + Default + Semigroup + 'static,
+    {
+        type Item<'a> = &'a (D, T, R);
+        type DiffOwned = R;
+
+        fn push_and_add(
+            &mut self,
+            (data, time, diff1): &(D, T, R),
+            (_, _, diff2): &(D, T, R),
+            stash: &mut Self::DiffOwned,
+        ) {
+            stash.clone_from(diff1);
+            stash.plus_equals(diff2);
+            if !stash.is_zero() {
+                // Ensure capacity
+                self.current.ensure_capacity(&mut self.empty);
+
+                // Push item
+                self.current.copy_destructured(data, time, stash);
+
+                // Maybe flush
+                if self.current.at_capacity() {
+                    self.pending.push_back(std::mem::take(&mut self.current));
+                }
+            }
+        }
+    }
+}

--- a/src/timely-util/src/containers/merger.rs
+++ b/src/timely-util/src/containers/merger.rs
@@ -318,8 +318,10 @@ impl<MCB: PushAndAdd> ContainerMerger<MCB> {
     ) {
         while let Some(chunk) = builder.extract() {
             let mut chunk = std::mem::replace(chunk, stash.pop().unwrap_or_default());
-            builder.pack(&mut chunk, state);
-            output.push_into(chunk);
+            if output.len() > 2 {
+                builder.pack(&mut chunk, state);
+            }
+            output.push(chunk);
         }
     }
 
@@ -332,8 +334,7 @@ impl<MCB: PushAndAdd> ContainerMerger<MCB> {
         state: &mut MCB::State,
     ) {
         while let Some(chunk) = builder.finish() {
-            let mut chunk = std::mem::replace(chunk, stash.pop().unwrap_or_default());
-            builder.pack(&mut chunk, state);
+            let chunk = std::mem::replace(chunk, stash.pop().unwrap_or_default());
             output.push_into(chunk);
         }
     }


### PR DESCRIPTION
A merge batcher that stores its data as serialized columnar format, and optionally compresses the serialized representation.

Implements https://github.com/MaterializeInc/database-issues/issues/9437.

