### PR TITLE
ci: Bump platform-checks parallelism

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -747,7 +747,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         # Sometimes runs into query timeouts or entire test timeouts with parallelism 1, too much state, same in all other platform-checks
-        parallelism: 2
+        parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
           queue: hetzner-aarch64-16cpu-32gb
@@ -778,7 +778,7 @@ steps:
         label: "Checks + backup + rollback to previous"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -790,7 +790,7 @@ steps:
         label: "Checks parallel + DROP/CREATE replica"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -802,7 +802,7 @@ steps:
         label: "Checks parallel + DROP/CREATE replica (x86_64)"
         depends_on: build-x86_64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-x86-64-16cpu-32gb
         plugins:
@@ -820,7 +820,7 @@ steps:
         label: "Checks parallel + restart compute clusterd"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -832,7 +832,7 @@ steps:
         label: "Checks parallel + restart of the entire Mz"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -844,7 +844,7 @@ steps:
         label: "Checks parallel + restart of environmentd & storage clusterd"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -856,7 +856,7 @@ steps:
         label: "Checks parallel + kill storage clusterd"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -868,7 +868,7 @@ steps:
         label: "Checks upgrade, whole-Mz restart"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -880,7 +880,7 @@ steps:
         label: "Checks LTS upgrade, whole-Mz restart"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -892,7 +892,7 @@ steps:
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -904,7 +904,7 @@ steps:
         label: "Checks upgrade across two versions"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -916,7 +916,7 @@ steps:
         label: "Checks upgrade across four versions"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -928,7 +928,7 @@ steps:
         label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-aarch64
         timeout_in_minutes: 180
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -940,7 +940,7 @@ steps:
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
         timeout_in_minutes: 120
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -952,7 +952,7 @@ steps:
         label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
         timeout_in_minutes: 120
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -964,7 +964,7 @@ steps:
         label: "Checks 0dt upgrade across four versions"
         depends_on: build-aarch64
         timeout_in_minutes: 120
-        parallelism: 2
+        parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -987,7 +987,7 @@ steps:
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64
         timeout_in_minutes: 240
-        parallelism: 2
+        parallelism: 3
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:


### PR DESCRIPTION
Seen going OoM in https://buildkite.com/materialize/nightly/builds/12101
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
