### PR TITLE
controller/compute: simplify dyncfg handling

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1875,13 +1875,10 @@ impl Coordinator {
         let compute_config = flags::compute_config(system_config);
         let storage_config = flags::storage_config(system_config);
         let scheduling_config = flags::orchestrator_scheduling_config(system_config);
-        let exert_prop = system_config.arrangement_exert_proportionality();
         self.controller.compute.update_configuration(compute_config);
         self.controller.storage.update_parameters(storage_config);
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
-        self.controller
-            .set_arrangement_exert_proportionality(exert_prop);
 
         let mut policies_to_set: BTreeMap<CompactionWindow, CollectionIdBundle> =
             Default::default();

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -218,7 +218,6 @@ impl Coordinator {
         let mut update_metrics_retention = false;
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
-        let mut update_arrangement_exert_proportionality = false;
         let mut update_http_config = false;
 
         for op in &ops {
@@ -331,8 +330,6 @@ impl Coordinator {
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
                     update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
-                    update_arrangement_exert_proportionality |=
-                        name == vars::ARRANGEMENT_EXERT_PROPORTIONALITY.name();
                     update_http_config |= vars::is_http_config_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
@@ -346,7 +343,6 @@ impl Coordinator {
                     update_metrics_retention = true;
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
-                    update_arrangement_exert_proportionality = true;
                     update_http_config = true;
                 }
                 catalog::Op::RenameItem { id, .. } => {
@@ -820,9 +816,6 @@ impl Coordinator {
             if update_cluster_scheduling_config {
                 self.update_cluster_scheduling_config();
             }
-            if update_arrangement_exert_proportionality {
-                self.update_arrangement_exert_proportionality();
-            }
             if update_http_config {
                 self.update_http_config();
             }
@@ -1294,16 +1287,6 @@ impl Coordinator {
             .collect::<Vec<_>>();
         self.update_storage_read_policies(storage_policies);
         self.update_compute_read_policies(compute_policies);
-    }
-
-    fn update_arrangement_exert_proportionality(&mut self) {
-        let prop = self
-            .catalog()
-            .system_config()
-            .arrangement_exert_proportionality();
-        self.controller
-            .compute
-            .set_arrangement_exert_proportionality(prop);
     }
 
     fn update_http_config(&mut self) {

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -44,7 +44,8 @@ use mz_compute_types::config::ComputeReplicaConfig;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::COMPUTE_REPLICA_EXPIRATION_OFFSET;
 use mz_controller_types::dyncfgs::{
-    ENABLE_TIMELY_ZERO_COPY, ENABLE_TIMELY_ZERO_COPY_LGALLOC, TIMELY_ZERO_COPY_LIMIT,
+    ARRANGEMENT_EXERT_PROPORTIONALITY, ENABLE_TIMELY_ZERO_COPY, ENABLE_TIMELY_ZERO_COPY_LGALLOC,
+    TIMELY_ZERO_COPY_LIMIT,
 };
 use mz_dyncfg::ConfigSet;
 use mz_expr::RowSetFinishing;
@@ -384,11 +385,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         Ok(ids)
     }
 
-    /// Set the `arrangement_exert_proportionality` value to be passed to new replicas.
-    pub fn set_arrangement_exert_proportionality(&mut self, value: u32) {
-        self.initial_config.arrangement_exert_proportionality = value;
-    }
-
     /// Set the `enable_zero_copy` value to be passed to new replicas.
     pub fn set_enable_zero_copy(&mut self, value: bool) {
         self.initial_config.enable_zero_copy = value;
@@ -661,6 +657,9 @@ where
     pub fn update_configuration(&mut self, config_params: ComputeParameters) {
         // Apply dyncfg updates.
         config_params.dyncfg_updates.apply(&self.dyncfg);
+
+        self.initial_config.arrangement_exert_proportionality =
+            ARRANGEMENT_EXERT_PROPORTIONALITY.get(&self.dyncfg);
 
         // Update zero-copy settings.
         self.set_enable_zero_copy(ENABLE_TIMELY_ZERO_COPY.get(&self.dyncfg));

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -34,7 +34,7 @@ use crate::controller::{ComputeControllerTimestamp, ReplicaId};
 use crate::logging::LoggingConfig;
 use crate::metrics::IntCounter;
 use crate::metrics::ReplicaMetrics;
-use crate::protocol::command::{ComputeCommand, InitialComputeParameters};
+use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
@@ -48,7 +48,10 @@ pub(super) struct ReplicaConfig {
     pub grpc_client: GrpcClientParameters,
     /// The offset to use for replica expiration, if any.
     pub expiration_offset: Option<Duration>,
-    pub initial_config: InitialComputeParameters,
+    pub arrangement_exert_proportionality: u32,
+    pub enable_zero_copy: bool,
+    pub enable_zero_copy_lgalloc: bool,
+    pub zero_copy_limit: Option<usize>,
 }
 
 /// A client for a replica task.
@@ -282,11 +285,10 @@ where
                     addresses: self.config.location.dataflow_addrs.clone(),
                     arrangement_exert_proportionality: self
                         .config
-                        .initial_config
                         .arrangement_exert_proportionality,
-                    enable_zero_copy: self.config.initial_config.enable_zero_copy,
-                    enable_zero_copy_lgalloc: self.config.initial_config.enable_zero_copy_lgalloc,
-                    zero_copy_limit: self.config.initial_config.zero_copy_limit,
+                    enable_zero_copy: self.config.enable_zero_copy,
+                    enable_zero_copy_lgalloc: self.config.enable_zero_copy_lgalloc,
+                    zero_copy_limit: self.config.zero_copy_limit,
                 };
                 *epoch = self.epoch;
             }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -541,20 +541,6 @@ impl RustType<ProtoWorkloadClass> for Option<String> {
     }
 }
 
-/// Compute parameters supplied to new replicas as part of the Timely instantiation. Usually cannot
-/// be changed once set.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Arbitrary)]
-pub struct InitialComputeParameters {
-    /// `arrangement_exert_proportionality` value passed to new replicas.
-    pub arrangement_exert_proportionality: u32,
-    /// Enable zero copy allocator.
-    pub enable_zero_copy: bool,
-    /// Enable lgalloc to back the zero copy allocator.
-    pub enable_zero_copy_lgalloc: bool,
-    /// Optional limit on the number of empty buffers retained by the zero copy allocator.
-    pub zero_copy_limit: Option<usize>,
-}
-
 /// Metadata specific to the peek variant.
 #[derive(Arbitrary, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PeekTarget {

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -62,6 +62,12 @@ pub const TIMELY_ZERO_COPY_LIMIT: Config<Option<usize>> = Config::new(
     "Optional limit of the zero copy allocator in allocations (timely dataflow).",
 );
 
+pub const ARRANGEMENT_EXERT_PROPORTIONALITY: Config<u32> = Config::new(
+    "arrangement_exert_proportionality",
+    16,
+    "Value that controls how much merge effort to exert on arrangements.",
+);
+
 /// Adds the full set of all controller `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -73,4 +79,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_TIMELY_ZERO_COPY)
         .add(&ENABLE_TIMELY_ZERO_COPY_LGALLOC)
         .add(&TIMELY_ZERO_COPY_LIMIT)
+        .add(&ARRANGEMENT_EXERT_PROPORTIONALITY)
 }

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -203,10 +203,6 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
 }
 
 impl<T: ComputeControllerTimestamp> Controller<T> {
-    pub fn set_arrangement_exert_proportionality(&mut self, value: u32) {
-        self.compute.set_arrangement_exert_proportionality(value);
-    }
-
     /// Start sinking the compute controller's introspection data into storage.
     ///
     /// This method should be called once the introspection collections have been registered with

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1158,7 +1158,6 @@ impl SystemVars {
             &KEEP_N_SINK_STATUS_HISTORY_ENTRIES,
             &KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES,
             &REPLICA_STATUS_HISTORY_RETENTION_WINDOW,
-            &ARRANGEMENT_EXERT_PROPORTIONALITY,
             &ENABLE_STORAGE_SHARD_FINALIZATION,
             &ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE,
             &ENABLE_DEFAULT_CONNECTION_VALIDATION,
@@ -1986,11 +1985,6 @@ impl SystemVars {
 
     pub fn replica_status_history_retention_window(&self) -> Duration {
         *self.expect_value(&REPLICA_STATUS_HISTORY_RETENTION_WINDOW)
-    }
-
-    /// Returns the `arrangement_exert_proportionality` configuration parameter.
-    pub fn arrangement_exert_proportionality(&self) -> u32 {
-        *self.expect_value(&ARRANGEMENT_EXERT_PROPORTIONALITY)
     }
 
     /// Returns the `enable_storage_shard_finalization` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1361,13 +1361,6 @@ pub static STATEMENT_LOGGING_SAMPLE_RATE: VarDefinition = VarDefinition::new_laz
     true,
 ).with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-pub static ARRANGEMENT_EXERT_PROPORTIONALITY: VarDefinition = VarDefinition::new(
-    "arrangement_exert_proportionality",
-    value!(u32; 16),
-    "Value that controls how much merge effort to exert on arrangements.",
-    false,
-);
-
 pub static ENABLE_DEFAULT_CONNECTION_VALIDATION: VarDefinition = VarDefinition::new(
     "enable_default_connection_validation",
     value!(bool; true),


### PR DESCRIPTION
This PR cleans up handling of configs in the compute controller a little:

* The first committ makes `arrangement_exert_effort` a dyncfg, removing some boilerplate.
* The second PR removes the `InitialComputeParameters` type used to pass around config values used for replica configuration and instead reads these config values out of the dyncfg at the time of replica creation.

### Motivation

   * This PR refactors existing code.

I pulled some of this out of https://github.com/MaterializeInc/materialize/pull/31710, in hopes of making that diff smaller.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
