### PR TITLE
bazel: Use `clang 19.1.6-2`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -224,7 +224,7 @@ http_archive(
 LLVM_VERSION = "19.1.6"
 
 # We have a few variants of our clang toolchain, either improving how it's built or adding new tools.
-LLVM_VERSION_SUFFIX = "1"
+LLVM_VERSION_SUFFIX = "2"
 
 # Version of the "toolchains_llvm" rule set, _not_ the version of clang/llvm.
 #
@@ -251,10 +251,10 @@ llvm_toolchain(
     name = "llvm_toolchain",
     llvm_version = LLVM_VERSION,
     sha256 = {
-        "darwin-aarch64": "94ed965925dbdc25b29e6fcfa9a84b28d915d5c9da7c71405fc20bbcf8396bd1",
-        "darwin-x86_64": "9395b07fd5018816bcaee84522d9c9386fdbefe62fdf8afff89b57e1b7095463",
-        "linux-aarch64": "24fd3405f65ccbc39f0d14a5126ee2edb5904d7a9525ae483f34a510a1bdce3e",
-        "linux-x86_64": "bad3d776c222c99056eba8b64c085a1e08edd783cb102e1b6eba43b78ce2fe2b",
+        "darwin-aarch64": "204a05a12aaa7c59791aea7c70f9c3e4c71e8a414002ae5026faaf4da0e21ef1",
+        "darwin-x86_64": "3990b08cedea77d1c72fc3ba37bde2b79493bc4214a9fa3b5bc9560338b9741a",
+        "linux-aarch64": "d5cb31841299c00e72e26a3dc1db7bd980d65e058b952c93a8f5304d1f17c325",
+        "linux-x86_64": "d0dbc6cecb7798cf5c22eb07413a0773615edfdf24d832f0096e13e88105d51b",
     },
     sysroot = {
         "darwin-aarch64": "@sysroot_darwin_universal//:sysroot",
@@ -436,10 +436,10 @@ rust_bindgen_dependencies()
 bindgen_toolchains(
     "{0}-{1}".format(LLVM_VERSION, LLVM_VERSION_SUFFIX),
     {
-        "darwin_aarch64": "sha256-wni7a1Wu6qGeNVOZOjc6ks1ACXf+RBoXu6YcSVkleos=",
-        "darwin_x86_64": "sha256-MKjPkNE2g2nw75SkOvjnieKnTtubUKyE3/o7olQm8j0=",
-        "linux_aarch64": "sha256-BvzsXMuiObNStcP86QwgBRDcTVBRsWUYio1iRCMhgxo=",
-        "linux_x86_64": "sha256-9PgulfHhsOd03ZhEO7ljp2EuDafIbME1oCJ/Rj/R7pU=",
+        "darwin_aarch64": "sha256-8u9xQ+3q4SO810j6wue+lM6njkucOyChRQRTk246tSE=",
+        "darwin_x86_64": "sha256-rf03+b1xaxYpQiSkYTDazfr1jcfn5O7dTtd1rBRog7s=",
+        "linux_aarch64": "sha256-e8Wj26Md/qLdw23Eq0FxbVsTNQa/4jKmrfeUEJ078iE=",
+        "linux_x86_64": "sha256-Dgtp3+gN+Iq0POdhkl8ny/tKdV8hG/ZrtLOLYPgc/4A=",
     },
 )
 


### PR DESCRIPTION
This PR updates the `clang` toolchain we use to `19.1.6-2` which statically links `libxml` to reduce the number of dynamically linked dependencies and thus makes the toolchain more portable.

Before:
```
$ ldd lld
        linux-vdso.so.1 (0x00007c8767a3d000)
        libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x00007c876121e000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007c876793e000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007c8767910000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007c8761000000)
        /lib64/ld-linux-x86-64.so.2 (0x00007c8767a3f000)
        libicuuc.so.74 => /lib/x86_64-linux-gnu/libicuuc.so.74 (0x00007c8760c00000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007c87678f2000)
        liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007c87678c0000)
        libicudata.so.74 => /lib/x86_64-linux-gnu/libicudata.so.74 (0x00007c875ee00000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007c875ea00000)
```

After:
```
$ ldd bin/lld
    linux-vdso.so.1 (0x000072e5d750c000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000072e5d0b17000)
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000072e5d74c8000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000072e5d0800000)
    /lib64/ld-linux-x86-64.so.2 (0x000072e5d750e000)
```

### Motivation

Fix an issue I ran into when debugging an issue with @ggevay 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
