### PR TITLE
Code comments about redaction in plan printing

### DIFF
--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -490,7 +490,8 @@ impl<T> PlanNode<T> {
 
 impl Plan {
     /// Pretty-print this [Plan] to a string.
-    pub fn pretty(&self) -> String {
+    /// Don't use this in prod to print log msgs!
+    pub fn pretty_non_redacted(&self) -> String {
         let config = ExplainConfig::default();
         self.explain(&config, None)
     }

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -1677,6 +1677,7 @@ impl MirRelationExpr {
     }
 
     /// Pretty-print this [MirRelationExpr] to a string.
+    /// This can be used in prod logs, because it automatically redacts in prod.
     pub fn pretty(&self) -> String {
         let config = ExplainConfig::default();
         self.explain(&config, None)

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -297,6 +297,7 @@ impl HirRelationExpr {
     }
 }
 
+/// WARNING: This does not redact yet. Don't use this in prod to print log msgs!
 impl fmt::Display for HirScalarExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use HirRelationExpr::Get;


### PR DESCRIPTION
This PR just adds some comments and renames a function to make it more clear whether redaction happens, and therefore whether they can be used to print plans in prod logs.

### Motivation


### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
