### PR TITLE
ci: Half the agent sizes (using new zram)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -85,7 +85,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         sanitizer: skip
 
       - id: cargo-deny-check-advisories
@@ -108,7 +108,7 @@ steps:
           composition: cargo-test
           args: [--miri-full]
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
     sanitizer: skip
 
   - group: Benchmarks
@@ -220,7 +220,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-matrix
@@ -244,7 +244,7 @@ steps:
               composition: kafka-resumption
               args: [--redpanda]
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
 
   - group: Testdrive
@@ -255,7 +255,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -266,7 +266,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -277,7 +277,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -300,7 +300,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -324,7 +324,7 @@ steps:
         timeout_in_minutes: 180
         agents:
           # Larger agent because Azurite is slow
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -336,7 +336,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 2
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -351,7 +351,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
@@ -392,7 +392,7 @@ steps:
         timeout_in_minutes: 90
         parallelism: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: bounded-memory
@@ -404,7 +404,7 @@ steps:
         # disabled by default
         skip: true
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: bounded-memory
@@ -460,7 +460,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -483,7 +483,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -494,7 +494,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -505,7 +505,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -516,7 +516,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -527,7 +527,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -538,7 +538,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -549,7 +549,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -560,7 +560,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -572,7 +572,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -674,7 +674,7 @@ steps:
               composition: testdrive-old-kafka-src-syntax
               args: [--azurite]
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: testdrive-kafka-migration
         label: "Testdrive (before Kafka source versioning) migration tests"
@@ -685,7 +685,7 @@ steps:
               composition: testdrive-old-kafka-src-syntax
               run: migration
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
 
   - group: AWS
     key: aws
@@ -736,7 +736,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -750,7 +750,7 @@ steps:
         parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -763,7 +763,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -780,7 +780,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -792,7 +792,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -804,7 +804,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-x86-64-16cpu-32gb
+          queue: hetzner-x86-64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -822,7 +822,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -834,7 +834,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -846,7 +846,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -858,7 +858,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -870,7 +870,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -882,7 +882,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -894,7 +894,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -906,7 +906,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -918,7 +918,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -930,7 +930,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -942,7 +942,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -954,7 +954,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -966,7 +966,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -977,7 +977,7 @@ steps:
         depends_on: build-x86_64
         timeout_in_minutes: 240
         agents:
-          queue: hetzner-x86-64-dedi-32cpu-128gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -992,7 +992,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/cloudtest:
@@ -1016,7 +1016,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-medium
         inputs:
           - test/cloudtest
@@ -1042,7 +1042,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1068,7 +1068,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1094,7 +1094,7 @@ steps:
               limit: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64
         inputs:
           - test/cloudtest
@@ -1139,7 +1139,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1151,7 +1151,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1163,7 +1163,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1175,7 +1175,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1437,7 +1437,7 @@ steps:
         timeout_in_minutes: 40
         agents:
           # Ran out of memory retrieving query results.
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -1474,7 +1474,7 @@ steps:
         timeout_in_minutes: 60
         agents:
           # Runs into timeout/OoM on small agents
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1521,7 +1521,7 @@ steps:
         skip: "flaky until database-issues#7433 is fixed"
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1566,7 +1566,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 60
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: pubsub-disruption
@@ -1577,7 +1577,7 @@ steps:
     skip: "database-issues#7310"
     timeout_in_minutes: 30
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: retain-history
@@ -1591,7 +1591,7 @@ steps:
       timeout_in_minutes: 90
       parallelism: 2
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1604,7 +1604,7 @@ steps:
       timeout_in_minutes: 90
       parallelism: 2
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1617,7 +1617,7 @@ steps:
       timeout_in_minutes: 90
       parallelism: 2
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1633,7 +1633,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1645,7 +1645,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1657,7 +1657,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1670,7 +1670,7 @@ steps:
         timeout_in_minutes: 90
         agents:
           # Sporadic OoM otherwise
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1683,7 +1683,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1695,7 +1695,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1708,7 +1708,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Reenable when database-issues#835 is fixed"
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1720,7 +1720,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1733,7 +1733,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1741,11 +1741,11 @@ steps:
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-dedi-16cpu-64gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1756,7 +1756,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 60
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
@@ -1823,7 +1823,7 @@ steps:
                 ]
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64
         sanitizer: skip
 
@@ -1836,7 +1836,7 @@ steps:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           # TODO: Debezium DNS flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
@@ -1853,7 +1853,7 @@ steps:
           composition: txn-wal-fencing
           args: [--azurite]
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Copy To S3"
     key: copy-to-s3
@@ -1867,7 +1867,7 @@ steps:
             composition: copy-to-s3
             run: nightly
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
 
     - id: copy-to-s3-2-replicas
       label: "Copy To S3 (2 replicas)"
@@ -1879,7 +1879,7 @@ steps:
             run: nightly
             args: [--default-size=2]
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
 
   - id: backup-restore
     label: "CRDB / Persist backup and restore"
@@ -1914,13 +1914,13 @@ steps:
 
   - id: 0dt
     label: Zero downtime
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 180
     plugins:
       - ./ci/plugins/mzcompose:
           composition: 0dt
     agents:
-      queue: hetzner-x86-64-dedi-16cpu-64gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: emulator
     label: Materialize Emulator
@@ -1939,7 +1939,7 @@ steps:
     parallelism: 10
     agents:
       # Runs faster/more consistently on larger agent
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
@@ -1955,7 +1955,7 @@ steps:
           composition: cluster
           args: ["--azurite"]
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Race Condition"
     key: race-condition
@@ -1965,7 +1965,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-16cpu-32gb
+           queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1976,7 +1976,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-16cpu-32gb
+           queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1987,7 +1987,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-16cpu-32gb
+           queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1998,7 +1998,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-16cpu-32gb
+           queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -2009,7 +2009,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-16cpu-32gb
+           queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -58,7 +58,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -71,7 +71,7 @@ steps:
       # 24h
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -83,7 +83,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -96,7 +96,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -107,7 +107,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -119,7 +119,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -130,7 +130,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -142,7 +142,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -154,7 +154,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -199,7 +199,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: hetzner-aarch64-16cpu-32gb
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -210,7 +210,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -248,7 +248,7 @@ steps:
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           # Increased memory usage following new source syntax
-          queue: hetzner-x86-64-dedi-16cpu-64gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -325,7 +325,7 @@ steps:
         parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -337,7 +337,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -349,7 +349,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -361,7 +361,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -373,7 +373,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -385,7 +385,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -397,7 +397,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -409,7 +409,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -420,7 +420,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -432,7 +432,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -445,7 +445,7 @@ steps:
         parallelism: 3
         agents:
           # Seems to require more memory on aarch64
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -457,7 +457,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -467,7 +467,7 @@ steps:
     label: "Product limits (finding new limits)"
     depends_on: build-aarch64
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -133,7 +133,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         if: "build.pull_request.id != null"
         coverage: skip
         sanitizer: skip
@@ -301,7 +301,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: cluster-tests
     label: "Cluster tests"
@@ -313,7 +313,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: sqllogictest-fast
     label: "Fast SQL logic tests"
@@ -326,7 +326,7 @@ steps:
           composition: sqllogictest
           run: fast-tests
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: restarts
     label: "Restart test"
@@ -336,7 +336,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: legacy-upgrade-docs-ignore-missing
     label: "Legacy upgrade tests (last version from docs, ignore missing)"
@@ -363,7 +363,7 @@ steps:
               composition: debezium
               run: postgres
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: debezium-sql-server
         label: "Debezium SQL Server tests"
@@ -415,7 +415,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: mysql-rtr
         label: "MySQL RTR tests"
@@ -455,7 +455,7 @@ steps:
               composition: pg-cdc-resumption
         agents:
           # Larger agent for faster runtime
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
 
       - id: pg-rtr
         label: "Postgres RTR tests"
@@ -509,7 +509,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ssh-connection
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: fivetran-destination-tests
         label: Fivetran Destination tests
@@ -548,7 +548,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-resumption
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: kafka-auth
         label: Kafka auth test
@@ -582,7 +582,7 @@ steps:
               composition: kafka-rtr
         agents:
           # Larger agent to run test faster
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -606,7 +606,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -624,7 +624,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-x86-64-16cpu-32gb
+          queue: hetzner-x86-64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -642,7 +642,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -759,7 +759,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: rtr-combined
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     skip: "Flakes because of database-issues#8489"
 
   - id: skip-version-upgrade
@@ -783,7 +783,7 @@ steps:
           composition: mz-debug
     agents:
       # Faster agent since it currently compiles mz-debug itself
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: deploy-website
     label: Deploy website
@@ -884,7 +884,7 @@ steps:
     inputs: ["*"]
     priority: 1
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
     coverage: only
 
   - wait: ~


### PR DESCRIPTION
Saves us some money for CI runs without much of a downside, tests didn't seem noticably slower, but maybe a few will still need larger agents.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
