### PR TITLE
ci: Annotate timeouts

### DIFF
--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -29,6 +29,14 @@ export_cov() {
       > coverage/"$BUILDKITE_JOB_ID"-"$(basename "$1")".lcov
 }
 
+# Buildkite exposes no way to check if a test timed out (and wasn't cancelled manually), so we have to calculate it ourselves
+START_TIME=$(date -d "$(cat step_start_timestamp)" +%s)
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+if [ $ELAPSED -ge $((BUILDKITE_TIMEOUT * 60)) ]; then
+  printf "%s" "\n$BUILDKITE_LABEL: test timed out" >> run.log
+fi
+
 if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     ci_uncollapsed_heading "cloudtest: Fetching binaries for coverage"
     mkdir -p coverage/

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -17,6 +17,14 @@ run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
+# Buildkite exposes no way to check if a test timed out (and wasn't cancelled manually), so we have to calculate it ourselves
+START_TIME=$(date -d "$(cat step_start_timestamp)" +%s)
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+if [ $ELAPSED -ge $((BUILDKITE_TIMEOUT * 60)) ]; then
+  printf "%s" "\n$BUILDKITE_LABEL: test timed out" >> run.log
+fi
+
 echo "Collecting logs"
 # Run before potential "run down" in coverage
 docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -89,6 +89,7 @@ ERROR_RE = re.compile(
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     | SUMMARY:\ .*Sanitizer
     | primary\ source\ \w+\ seemingly\ dropped\ before\ subsource
+    | Test\ .*\ timed\ out
     # Only notifying on unexpected failures. INT, TRAP, BUS, FPE, SEGV, PIPE
     | \ ANOM_ABEND\ .*\ sig=(2|5|7|8|11|13)
     # \s\S is any character including newlines, so this matches multiline strings


### PR DESCRIPTION
Demo run: https://buildkite.com/materialize/test/builds/103821
This allows us to use https://ci-failures.dev.materialize.com/?key=test-failures to find patterns in timeouts.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
