### PR TITLE
[expr] Handle NaNs specially in the abstract interpreter

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -772,6 +772,14 @@ impl<'a> ColumnSpecs<'a> {
                 nullable: true,
                 ..ResultSpec::nothing()
             },
+            Ok(Datum::Float64(a)) if a.is_nan() => ResultSpec {
+                values: Values::All,
+                ..ResultSpec::nothing()
+            },
+            Ok(Datum::Float32(a)) if a.is_nan() => ResultSpec {
+                values: Values::All,
+                ..ResultSpec::nothing()
+            },
             Ok(d) => ResultSpec {
                 values: Values::just(self.arena.make_datum(|packer| packer.push(d))),
                 ..ResultSpec::nothing()

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1756,6 +1756,45 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn test_nan() {
+        let arena = RowArena::new();
+
+        // (#0 / +Inf) = 0
+        let expr = MirScalarExpr::CallBinary {
+            func: BinaryFunc::Eq,
+            expr1: Box::new(MirScalarExpr::CallBinary {
+                func: BinaryFunc::DivFloat64,
+                expr1: Box::new(MirScalarExpr::column(0)),
+                expr2: Box::new(MirScalarExpr::literal_ok(
+                    Datum::Float64(f64::INFINITY.into()),
+                    ScalarType::Float64,
+                )),
+            }),
+            expr2: Box::new(MirScalarExpr::literal_ok(
+                Datum::Float64(0.0.into()),
+                ScalarType::Float64,
+            )),
+        };
+
+        let relation = RelationType::new(vec![ScalarType::Float64.nullable(false)]);
+        let mut interpreter = ColumnSpecs::new(&relation, &arena);
+        interpreter.push_column(
+            0,
+            ResultSpec::value_between(
+                Datum::Float64(f64::NEG_INFINITY.into()),
+                Datum::Float64(f64::INFINITY.into()),
+            )
+            .union(ResultSpec::null()),
+        );
+
+        let range_out = interpreter.expr(&expr).range;
+        assert!(!range_out.may_fail());
+        assert!(range_out.may_contain(Datum::True));
+        assert!(range_out.may_contain(Datum::False));
+        assert!(!range_out.may_contain(Datum::Null));
+    }
+
+    #[mz_ore::test]
     fn test_trace() {
         use super::Trace;
 


### PR DESCRIPTION
When we convert specific values to ranges, we now treat `NaN`s as though they might represent any value. (But not errors or nulls.)

### Motivation

The is_monotone function is documented to only apply over the range in which the function's "defined" - which in our case means non-error and non-null. One approach to https://github.com/MaterializeInc/database-issues/issues/9297 is to also add NaNs to this list. 

Effectively, if we call a function on our input range and get a NaN, that doesn't mean that NaN is a valid bound of the function... it means that we don't know anything about the range of values the function may return.

### Tips for reviewer

There are a couple ways we could express that idea. This is probably the smallest diff, but happy to chat through the other options if it doesn't feel good.

If this seems reasonable, though, I will follow up with some doc updates!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
