### PR TITLE
ci: Try lowering agents further (probably a bad idea)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -108,7 +108,7 @@ steps:
           composition: cargo-test
           args: [--miri-full]
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     sanitizer: skip
 
   - group: Benchmarks
@@ -277,7 +277,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -300,7 +300,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -324,7 +324,7 @@ steps:
         timeout_in_minutes: 180
         agents:
           # Larger agent because Azurite is slow
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -336,7 +336,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: testdrive
@@ -404,7 +404,7 @@ steps:
         # disabled by default
         skip: true
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: bounded-memory
@@ -468,11 +468,10 @@ steps:
 
       - id: zippy-kafka-sources-azurite
         label: "Zippy Kafka Sources with :azure: blob store"
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          # Azurite is rather slow, prevent timeouts by using dedicated CPUs
-          queue: hetzner-x86-64-dedi-16cpu-64gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -572,7 +571,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -685,7 +684,7 @@ steps:
               composition: testdrive-old-kafka-src-syntax
               run: migration
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: AWS
     key: aws
@@ -736,7 +735,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -750,7 +749,7 @@ steps:
         parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -763,7 +762,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -780,7 +779,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -792,7 +791,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -804,7 +803,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -822,7 +821,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -834,7 +833,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -846,7 +845,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -858,7 +857,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -870,7 +869,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -882,7 +881,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -894,7 +893,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -906,7 +905,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -918,7 +917,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -930,7 +929,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -942,7 +941,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -954,7 +953,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -966,7 +965,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -1474,7 +1473,7 @@ steps:
         timeout_in_minutes: 60
         agents:
           # Runs into timeout/OoM on small agents
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1617,7 +1616,7 @@ steps:
       timeout_in_minutes: 90
       parallelism: 2
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: data-ingest
@@ -1633,7 +1632,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1645,7 +1644,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1657,7 +1656,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1670,7 +1669,7 @@ steps:
         timeout_in_minutes: 90
         agents:
           # Sporadic OoM otherwise
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1683,7 +1682,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1695,7 +1694,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1708,7 +1707,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Reenable when database-issues#835 is fixed"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1720,7 +1719,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1733,7 +1732,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1745,7 +1744,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1867,7 +1866,7 @@ steps:
             composition: copy-to-s3
             run: nightly
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
 
     - id: copy-to-s3-2-replicas
       label: "Copy To S3 (2 replicas)"
@@ -1879,7 +1878,7 @@ steps:
             run: nightly
             args: [--default-size=2]
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
 
   - id: backup-restore
     label: "CRDB / Persist backup and restore"
@@ -1920,7 +1919,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: 0dt
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: emulator
     label: Materialize Emulator
@@ -1939,7 +1938,7 @@ steps:
     parallelism: 10
     agents:
       # Runs faster/more consistently on larger agent
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
@@ -1965,7 +1964,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-8cpu-16gb
+           queue: hetzner-aarch64-4cpu-8gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1976,7 +1975,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-8cpu-16gb
+           queue: hetzner-aarch64-4cpu-8gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1987,7 +1986,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-8cpu-16gb
+           queue: hetzner-aarch64-4cpu-8gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -1998,7 +1997,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-8cpu-16gb
+           queue: hetzner-aarch64-4cpu-8gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
@@ -2009,7 +2008,7 @@ steps:
          depends_on: build-aarch64
          timeout_in_minutes: 360
          agents:
-           queue: hetzner-aarch64-8cpu-16gb
+           queue: hetzner-aarch64-4cpu-8gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -58,7 +58,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -71,7 +71,7 @@ steps:
       # 24h
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -83,7 +83,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -96,7 +96,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -107,7 +107,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -119,7 +119,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -130,7 +130,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -142,7 +142,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -154,7 +154,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -199,7 +199,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-4cpu-8gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -248,7 +248,7 @@ steps:
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           # Increased memory usage following new source syntax
-          queue: hetzner-x86-64-16cpu-32gb
+          queue: hetzner-x86-64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -325,7 +325,7 @@ steps:
         parallelism: 3
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -337,7 +337,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -349,7 +349,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -361,7 +361,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 4
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -373,7 +373,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -385,7 +385,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -397,7 +397,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -409,7 +409,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -420,7 +420,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -432,7 +432,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -445,7 +445,7 @@ steps:
         parallelism: 3
         agents:
           # Seems to require more memory on aarch64
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -457,7 +457,7 @@ steps:
         timeout_in_minutes: 120
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -467,7 +467,7 @@ steps:
     label: "Product limits (finding new limits)"
     depends_on: build-aarch64
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -133,7 +133,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         if: "build.pull_request.id != null"
         coverage: skip
         sanitizer: skip
@@ -301,7 +301,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: cluster-tests
     label: "Cluster tests"
@@ -326,7 +326,7 @@ steps:
           composition: sqllogictest
           run: fast-tests
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: restarts
     label: "Restart test"
@@ -455,7 +455,7 @@ steps:
               composition: pg-cdc-resumption
         agents:
           # Larger agent for faster runtime
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: pg-rtr
         label: "Postgres RTR tests"
@@ -606,7 +606,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -624,7 +624,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -642,7 +642,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -783,7 +783,7 @@ steps:
           composition: mz-debug
     agents:
       # Faster agent since it currently compiles mz-debug itself
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: deploy-website
     label: Deploy website
@@ -884,7 +884,7 @@ steps:
     inputs: ["*"]
     priority: 1
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-4cpu-8gb
     coverage: only
 
   - wait: ~


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
