### PR TITLE
Broaden types converted to jsonb numeric

### DIFF
--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -911,7 +911,7 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
         Bool | Jsonb | Numeric { .. } => {
             expr.call_unary(UnaryFunc::CastJsonbableToJsonb(func::CastJsonbableToJsonb))
         }
-        Int16 | Int32 | Float32 | Float64 => plan_cast(
+        Int16 | Int32 | Int64 | UInt16 | UInt32 | UInt64 | Float32 | Float64 => plan_cast(
             ecx,
             CastContext::Explicit,
             expr,

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -974,7 +974,28 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
 
             expr.call_unary(func)
         }
-        _ => to_string(ecx, expr)
+        Date
+        | Time
+        | Timestamp { .. }
+        | TimestampTz { .. }
+        | Interval
+        | PgLegacyChar
+        | PgLegacyName
+        | Bytes
+        | String
+        | Char { .. }
+        | VarChar { .. }
+        | Uuid
+        | Oid
+        | Map { .. }
+        | RegProc
+        | RegType
+        | RegClass
+        | Int2Vector
+        | MzTimestamp
+        | Range { .. }
+        | MzAclItem
+        | AclItem => to_string(ecx, expr)
             .call_unary(UnaryFunc::CastJsonbableToJsonb(func::CastJsonbableToJsonb)),
     }
 }


### PR DESCRIPTION
We detect a few scalar types that can convert into jsonb's numeric representation, but types we don't explicitly match are converted to strings.

Todo:
1. add tests that cover these cases. The user reported error was for `select jsonb_build_object('data', count(*)) from ..`.
2. add exhaustive matches, to avoid missing cases like this in the future.

Putting up without this work to raise for discussion. Specifically, the code comments say
```
///   * All numeric types are converted to `Float64`s, then become JSON numbers.
```
which .. isn't actually what happens (they are directly converted to `Numeric { max_scale: None }`). If it is important that something very close to that happens we should discuss, but we already convert `Numeric`, which subsumes all of our integer types, into `Numeric` rather than `Float64` or anything similar.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
