### PR TITLE
Unsplit logged error message

### DIFF
--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -481,7 +481,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 *rewind_cap_set = CapabilitySet::new();
 
                 if snapshot_staged < snapshot_total {
-                    error!(%id, "timely-{worker_id} snapshot size {snapshot_total} is somehow\
+                    error!(%id, "timely-{worker_id} snapshot size {snapshot_total} is somehow \
                                  bigger than records staged {snapshot_staged}");
                     snapshot_staged = snapshot_total;
                 }


### PR DESCRIPTION
We have a single error to log which uses multiple lines in Rust, but without a `\` at the end of the line, so that the logged message misses the rest of the error.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
