### PR TITLE
ColumnName wraps boxed string

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -832,7 +832,7 @@ impl CatalogState {
                     &*MZ_COLUMNS,
                     Row::pack_slice(&[
                         Datum::String(&id.to_string()),
-                        Datum::String(column_name.as_str()),
+                        Datum::String(column_name),
                         Datum::UInt64(u64::cast_from(i + 1)),
                         Datum::from(column_type.nullable),
                         Datum::String(type_name),

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -79,7 +79,7 @@ impl ArrowReader {
         let mut readers = Vec::with_capacity(desc_columns.len());
         for (col_name, col_type) in desc.iter() {
             let column = array
-                .column_by_name(col_name.as_str())
+                .column_by_name(col_name)
                 .ok_or_else(|| anyhow::anyhow!("'{col_name}' not found"))?;
             let reader = scalar_type_and_array_to_reader(&col_type.scalar_type, Arc::clone(column))
                 .context(col_name.clone())?;
@@ -349,7 +349,7 @@ fn scalar_type_and_array_to_reader(
             let mut decoders = Vec::with_capacity(fields.len());
             for (name, typ) in fields.iter() {
                 let inner_array = record_array
-                    .column_by_name(name.as_str())
+                    .column_by_name(name)
                     .ok_or_else(|| anyhow::anyhow!("missing name '{name}'"))?;
                 let inner_array = mask_nulls(inner_array, null_mask);
                 let inner_decoder = scalar_type_and_array_to_reader(&typ.scalar_type, inner_array)

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -136,8 +136,7 @@ where
                         if datum.is_null() {
                             return Err(DataflowError::EvalError(Box::new(
                                 EvalError::MustNotBeNull(
-                                    format!("column {}", from_desc.get_name(i).as_str().quoted())
-                                        .into(),
+                                    format!("column {}", from_desc.get_name(i).quoted()).into(),
                                 ),
                             )));
                         }

--- a/src/interchange/src/encode.rs
+++ b/src/interchange/src/encode.rs
@@ -44,20 +44,26 @@ pub fn column_names_and_types(desc: RelationDesc) -> Vec<(ColumnName, ColumnType
     // Invent names for columns that don't have a name.
     let mut columns: Vec<_> = desc.into_iter().collect();
 
+    let mut name = String::new();
     // Deduplicate names.
     let mut seen = BTreeSet::new();
-    for (name, _ty) in &mut columns {
-        let stem_len = name.as_str().len();
+    for (column_name, _ty) in &mut columns {
+        name.clear();
+        name.push_str(column_name.as_str());
+        let stem_len = name.len();
         let mut i = 1;
-        while seen.contains(name) {
-            name.as_mut_str().truncate(stem_len);
-            if name.as_str().ends_with(|c: char| c.is_ascii_digit()) {
-                name.as_mut_str().push('_');
+        while seen.contains(&name) {
+            name.truncate(stem_len);
+            if name.ends_with(|c: char| c.is_ascii_digit()) {
+                name.push('_');
             }
-            name.as_mut_str().push_str(&i.to_string());
+            name.push_str(&i.to_string());
             i += 1;
         }
-        seen.insert(name);
+        seen.insert(name.clone());
+        if column_name.as_str() != name {
+            *column_name.as_mut_boxed_str() = name.clone().into();
+        }
     }
     columns
 }

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -415,7 +415,7 @@ fn build_row_schema_fields(
     let mut fields = Vec::new();
     let mut field_namer = Namer::default();
     for (name, typ) in columns.iter() {
-        let (name, _seen) = field_namer.valid_name(name.as_str());
+        let (name, _seen) = field_namer.valid_name(name);
         let field_type =
             build_row_schema_field_type(type_namer, custom_names, typ, item_id, options);
 

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -612,7 +612,7 @@ mod tests {
         let actual: StructStats = RustType::from_proto(actual).unwrap();
         let arena = RowArena::default();
         for (name, typ) in schema.iter() {
-            let col_stats = actual.col(name.as_str()).unwrap();
+            let col_stats = actual.col(name).unwrap();
             crate::stats::col_values(&typ.scalar_type, &col_stats.values, &arena);
         }
     }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -524,7 +524,7 @@ impl fmt::Display for PlanError {
             Self::AmbiguousColumn(column) => write!(
                 f,
                 "column reference {} is ambiguous",
-                column.as_str().quoted()
+                column.quoted()
             ),
             Self::TooManyColumns { max_num_columns, req_num_columns } => write!(
                 f,
@@ -534,7 +534,7 @@ impl fmt::Display for PlanError {
             Self::ColumnAlreadyExists { column_name, object_name } => write!(
                 f,
                 "column {} of relation {} already exists",
-                column_name.as_str().quoted(), object_name.quoted(),
+                column_name.quoted(), object_name.quoted(),
             ),
             Self::AmbiguousTable(table) => write!(
                 f,
@@ -544,13 +544,13 @@ impl fmt::Display for PlanError {
             Self::UnknownColumnInUsingClause { column, join_side } => write!(
                 f,
                 "column {} specified in USING clause does not exist in {} table",
-                column.as_str().quoted(),
+                column.quoted(),
                 join_side,
             ),
             Self::AmbiguousColumnInUsingClause { column, join_side } => write!(
                 f,
                 "common column name {} appears more than once in {} table",
-                column.as_str().quoted(),
+                column.quoted(),
                 join_side,
             ),
             Self::MisqualifiedName(name) => write!(
@@ -986,7 +986,7 @@ impl<'a> fmt::Display for ColumnDisplay<'a> {
         if let Some(table) = &self.table {
             format!("{}.{}", table.item, self.column).quoted().fmt(f)
         } else {
-            self.column.as_str().quoted().fmt(f)
+            self.column.quoted().fmt(f)
         }
     }
 }

--- a/src/sql/src/plan/notice.rs
+++ b/src/sql/src/plan/notice.rs
@@ -53,7 +53,7 @@ impl PlanNotice {
                     was a unique key of the underlying relation {}. If this key is not unique, \
                     the sink might produce multiple updates for the same key at the same time, \
                     which may confuse downstream consumers.",
-                    separated(", ", key.iter().map(|c| c.as_str().quoted())),
+                    separated(", ", key.iter().map(|c| c.quoted())),
                     name.quoted()
                 );
                 Some(details)

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -331,13 +331,13 @@ pub fn plan_insert_query(
             } else {
                 sql_bail!(
                     "column {} of relation {} does not exist",
-                    c.as_str().quoted(),
+                    c.quoted(),
                     table_name.full_name_str().quoted()
                 );
             }
         }
         if let Some(dup) = columns.iter().duplicates().next() {
-            sql_bail!("column {} specified more than once", dup.as_str().quoted());
+            sql_bail!("column {} specified more than once", dup.quoted());
         }
     };
 
@@ -395,7 +395,7 @@ pub fn plan_insert_query(
     let expr = cast_relation(&qcx, CastContext::Assignment, expr, source_types).map_err(|e| {
         sql_err!(
             "column {} is of type {} but expression is of type {}",
-            desc.get_name(ordering[e.column]).as_str().quoted(),
+            desc.get_name(ordering[e.column]).quoted(),
             qcx.humanize_scalar_type(&e.target_type, false),
             qcx.humanize_scalar_type(&e.source_type, false),
         )
@@ -580,13 +580,13 @@ pub fn plan_copy_item(
             } else {
                 sql_bail!(
                     "column {} of relation {} does not exist",
-                    c.as_str().quoted(),
+                    c.quoted(),
                     item_name.full_name_str().quoted()
                 );
             }
         }
         if let Some(dup) = columns.iter().duplicates().next() {
-            sql_bail!("column {} specified more than once", dup.as_str().quoted());
+            sql_bail!("column {} specified more than once", dup.quoted());
         }
 
         // The source data is a different shape than the destination table.
@@ -2192,7 +2192,7 @@ fn plan_values_insert(
                 Ok(val) => val,
                 Err(_) => sql_bail!(
                     "column {} is of type {} but expression is of type {}",
-                    target_names[column].as_str().quoted(),
+                    target_names[column].quoted(),
                     qcx.humanize_scalar_type(target_type, false),
                     qcx.humanize_scalar_type(source_type, false),
                 ),
@@ -3774,7 +3774,7 @@ fn plan_using_constraint(
             return Err(PlanError::Unsupported {
                 feature: format!(
                     "column name {} appears more than once in USING clause",
-                    c.as_str().quoted()
+                    c.quoted()
                 ),
                 discussion_no: None,
             });
@@ -3842,7 +3842,7 @@ fn plan_using_constraint(
         let mut exprs = coerce_homogeneous_exprs(
             &ecx.with_name(&format!(
                 "NATURAL/USING join column {}",
-                column_name.as_str().quoted()
+                column_name.quoted()
             )),
             vec![
                 CoercibleScalarExpr::Coerced(HirScalarExpr::named_column(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -293,7 +293,7 @@ pub fn plan_create_table(
         .collect();
 
     if let Some(dup) = names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     // Build initial relation type that handles declared data types
@@ -1086,7 +1086,7 @@ pub fn plan_create_source(
 
     let names: Vec<_> = desc.iter_names().cloned().collect();
     if let Some(dup) = names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     // Apply user-specified key constraint
@@ -1437,7 +1437,7 @@ fn plan_source_export_desc(
         .collect();
 
     if let Some(dup) = names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     // Build initial relation type that handles declared data types
@@ -1898,7 +1898,7 @@ pub fn plan_create_table_from_source(
 
     let names: Vec<_> = desc.iter_names().cloned().collect();
     if let Some(dup) = names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name.clone())?)?;
@@ -2539,7 +2539,7 @@ pub fn plan_view(
     let names: Vec<ColumnName> = desc.iter_names().cloned().collect();
 
     if let Some(dup) = names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     let view = View {
@@ -2846,7 +2846,7 @@ pub fn plan_create_materialized_view(
                 .ok_or_else(|| {
                     sql_err!(
                         "column {} in ASSERT NOT NULL option not found",
-                        assertion_name.as_str().quoted()
+                        assertion_name.quoted()
                     )
                 })
         })
@@ -2854,14 +2854,11 @@ pub fn plan_create_materialized_view(
     non_null_assertions.sort();
     if let Some(dup) = non_null_assertions.iter().duplicates().next() {
         let dup = &column_names[*dup];
-        sql_bail!(
-            "duplicate column {} in non-null assertions",
-            dup.as_str().quoted()
-        );
+        sql_bail!("duplicate column {} in non-null assertions", dup.quoted());
     }
 
     if let Some(dup) = column_names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     // Override the statement-level IfExistsBehavior with Skip if this is
@@ -3108,7 +3105,7 @@ pub fn plan_create_continual_task(
                     sql_err!(
                         "statement {}: column {} is of type {} but expression is of type {}",
                         idx,
-                        desc.get_name(e.column).as_str().quoted(),
+                        desc.get_name(e.column).quoted(),
                         qcx.humanize_scalar_type(&e.target_type, false),
                         qcx.humanize_scalar_type(&e.source_type, false),
                     )
@@ -3154,7 +3151,7 @@ pub fn plan_create_continual_task(
     let desc = desc.ok_or_else(|| sql_err!("TODO(ct3)"))?;
     let column_names: Vec<ColumnName> = desc.iter_names().cloned().collect();
     if let Some(dup) = column_names.iter().duplicates().next() {
-        sql_bail!("column {} specified more than once", dup.as_str().quoted());
+        sql_bail!("column {} specified more than once", dup.quoted());
     }
 
     // Check for an object in the catalog with this same name

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -923,7 +923,7 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
             let mut exprs = vec![];
             for (i, (name, _ty)) in fields.iter().enumerate() {
                 exprs.push(HirScalarExpr::literal(
-                    Datum::String(name.as_str()),
+                    Datum::String(name),
                     ScalarType::String,
                 ));
                 exprs.push(to_jsonb(

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2255,7 +2255,7 @@ impl<'a> RewriteBuffer<'a> {
         self.append(
             &names
                 .iter()
-                .map(|name| name.as_str().replace(' ', "␠"))
+                .map(|name| name.replace(' ', "␠"))
                 .collect::<Vec<_>>()
                 .join(" "),
         );


### PR DESCRIPTION
ColumnName currently owns a string, but doesn't need mutable access in all but one places. This change alters it to a boxed str, which reduces the size from 24 to 16 bytes. It also adds a deref implementation, which allows us to remove some of the `as_str` calls.

No urgency to merge it, just capturing what I found in my local changes.
