### PR TITLE
compute: log errors upon encountering negative multiplicities

### DIFF
--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -372,10 +372,15 @@ where
                             let batch = row.hashed() % output_batch_count;
                             if !up_to.less_equal(ts) {
                                 if diff.is_negative() {
+                                    tracing::error!(
+                                        %sink_id, %diff, ?row,
+                                        "S3 oneshot sink encountered negative multiplicities",
+                                    );
                                     anyhow::bail!(
-                                        "Invalid data in source errors, saw retractions ({}) for \
-                                        row that does not exist",
+                                        "Invalid data in source, \
+                                         saw retractions ({}) for row that does not exist: {:?}",
                                         -*diff,
+                                        row,
                                     )
                                 }
                                 row_count += u64::try_from(diff.into_inner()).unwrap();


### PR DESCRIPTION
Negative multiplicities point to bugs in Materialize, so we should log them whenever we encounter them. This commit adds logging for more instances of this, specifically in peek and COPY TO S3 handling.

### Motivation

  * This PR adds logging.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
