### PR TITLE
tests: Skip `5_repeat_row_dataflow.slt` and `5_repeat_row_folding.slt`

### DIFF
--- a/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_dataflow.slt
@@ -13,6 +13,8 @@ mode cockroach
 # repeat row (=> this panics!)
 # -------------------------------
 
+halt
+
 statement ok
 CREATE TABLE t_base (data int, diff bigint);
 

--- a/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_folding.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/5_repeat_row_folding.slt
@@ -13,6 +13,8 @@ mode cockroach
 # repeat row (=> this panics!)
 # -------------------------------
 
+halt
+
 statement ok
 CREATE TABLE t_base (data int, diff bigint);
 


### PR DESCRIPTION
It's not clear what this test was supposed to test, and is flaky.
https://materializeinc.slack.com/archives/CTESPM7FU/p1748365186543639?thread_ts=1748363700.222229&cid=CTESPM7FU

cc @def- 

### Motivation


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
