### PR TITLE
[persist] Lower some thresholds for persist in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -154,6 +154,8 @@ def get_default_system_parameters(
         ),
         # 16 MiB - large enough to avoid a big perf hit, small enough to get more coverage...
         "persist_blob_target_size": "16777216",
+        # 5 times the default part size - 4 is the bare minimum.
+        "persist_compaction_memory_bound_bytes": "83886080",
         "persist_stats_audit_percent": "100",
         "persist_use_critical_since_catalog": "true",
         "persist_use_critical_since_snapshot": "false" if zero_downtime else "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1064,6 +1064,13 @@ class FlipFlagsAction(Action):
             "16",
             "1000",
         ]
+        self.flags_with_values["persist_compaction_memory_bound_bytes"] = [
+            # 64 MiB, 1 * 128 MiB, 4 * 128 MiB, 8 * 128 MiB
+            "67108864",
+            "134217728",
+            "536870912",
+            "1073741824",
+        ]
         self.flags_with_values["persist_part_decode_format"] = [
             "row_with_validate",
             "arrow",

--- a/src/persist-types/src/txn.rs
+++ b/src/persist-types/src/txn.rs
@@ -17,7 +17,9 @@ use crate::stats::PartStats;
 use crate::{Codec, Codec64, ShardId};
 
 /// The in-mem representation of an update in the txns shard.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// The ord implementation is not guaranteed to be meaningful; it's there for consolidation
+/// purposes only.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum TxnsEntry {
     /// A data shard register operation.
     ///

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -15,6 +15,7 @@ use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
@@ -462,6 +463,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
         // which is not what we want. If we ever expose an interface for
         // registering and committing to a data shard at the same
         // timestamp, this will also have to sort registrations first.
+        consolidate_updates(&mut entries);
         entries.sort_by(|(a, _, _), (b, _, _)| a.ts::<T>().cmp(&b.ts::<T>()));
         for (e, t, d) in entries {
             match e {


### PR DESCRIPTION
- Make the code more robust to aggressive compaction limits. (Instead of panicking, we fall back to the already-existing code for when we can't fit two runs in memory.)
- Exercise a wider range of configs in CI.
- Fix a `txn-wal` bug, which could be triggered when data had undergone compaction but wasn't globally consolidated. (Which can happen when memory limits are too small to compact all parts in one go.)

### Motivation

Turns out we're missing some test coverage in this area!

### Tips for reviewer

I'd love a review from a `txn-wal` expert, since I'm not that familiar with the code there.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
