### PR TITLE
[bazel] move sanitizer builds off the RAM backed FS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -154,10 +154,10 @@ build:check --output_groups=build_metadata
 # Note: This shouldn't change any config of the built binary, just the way it
 # gets built.
 #
-# `/dev/shm` is a RAM backed temporary filesystem, it should speedup sandbox creation.
-build:ci --sandbox_base=/dev/shm
 # Always enable verbose failures in CI, makes it easier to debug failures.
 build:ci --verbose_failures
+# `/dev/shm` is a RAM backed temporary filesystem, it should speedup sandbox creation.
+build:in-mem-sandbox --sandbox_base=/dev/shm
 
 # Release Build Configuration
 #

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -176,7 +176,7 @@ class RepositoryDetails:
                 flags.append("--config=in-mem-sandbox")
 
         # Add flags for the Sanitizer
-        bazel_build.extend(self.sanitizer.bazel_flags())
+        flags.extend(self.sanitizer.bazel_flags())
 
         return flags
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -170,6 +170,14 @@ class RepositoryDetails:
         if ui.env_is_truthy("CI"):
             flags.append("--config=ci")
 
+            # Building with sanitizers causes the intermediate artifacts to be
+            # quite large so we'll skip using the RAM backed sandbox.
+            if self.sanitizer == Sanitizer.NONE:
+                flags.append("--config=in-mem-sandbox")
+
+        # Add flags for the Sanitizer
+        bazel_build.extend(self.sanitizer.bazel_flags())
+
         return flags
 
     def rewrite_builder_path_for_host(self, path: Path) -> Path:
@@ -401,8 +409,6 @@ class CargoBuild(CargoPreImage):
 
         # Add extra Bazel config flags.
         bazel_build.extend(rd.bazel_config())
-        # Add flags for the Sanitizer
-        bazel_build.extend(rd.sanitizer.bazel_flags())
 
         return bazel_build
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -172,7 +172,7 @@ class RepositoryDetails:
 
             # Building with sanitizers causes the intermediate artifacts to be
             # quite large so we'll skip using the RAM backed sandbox.
-            if self.sanitizer == Sanitizer.NONE:
+            if self.sanitizer == Sanitizer.none:
                 flags.append("--config=in-mem-sandbox")
 
         # Add flags for the Sanitizer


### PR DESCRIPTION
The x86 ASan build is currently broken because it OOMs. For CI builds we use a RAM backed temp filesystem for the Bazel sandbox to get maximum performance, but the intermediate artifacts for the ASan build appear to large to fit in RAM.

### Motivation

Fix x86 ASan

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
