### PR TITLE
[scratch] Fix scratch instance bootstrap script

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -264,7 +264,10 @@ async def setup(
 
 def mkrepo(i: Instance, rev: str, init: bool = True, force: bool = False) -> None:
     if init:
-        mssh(i, "git clone https://github.com/MaterializeInc/materialize.git")
+        mssh(
+            i,
+            "git clone https://github.com/MaterializeInc/materialize.git --recurse-submodules",
+        )
 
     rev = git.rev_parse(rev)
 

--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -70,6 +70,7 @@ aws/install
 rm -r aws awscliv2.zip
 
 # Allow the Ubuntu user to access the Docker daemon.
+sudo groupadd docker
 adduser ubuntu docker
 
 # Install tools for Kubernetes testing and debugging

--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -71,7 +71,9 @@ rm -r aws awscliv2.zip
 
 # Allow the Ubuntu user to access the Docker daemon.
 sudo groupadd docker
-adduser ubuntu docker
+sudo usermod -aG docker ubuntu
+sudo systemctl enable containerd.service --now
+sudo systemctl enable docker.service --now
 
 # Install tools for Kubernetes testing and debugging
 ## kubectl


### PR DESCRIPTION
### Motivation

Noticed that bin/scratch was no longer able to create an instance, and `tail -f /var/log/cloud-init-output.log` pointed me to the issue.

This is now in the postinstall list for docker here: https://docs.docker.com/engine/install/linux-postinstall/

Presumably this changed recently? 

### Tips for reviewer

I don't think we have tests for this - if it's not obviously correct you may want to spin up and down a scratch machine to check.

I have also added a recursive fetch to the `git clone` - this was not technically broken but I did have to do it manually for every new machine which is annoying.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
