### PR TITLE
Lock minio install yamls to commit before they moved

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/minio.py
+++ b/misc/python/materialize/cloudtest/k8s/minio.py
@@ -10,9 +10,7 @@
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
 
-MINIO_YAML_DIRECTORY_URL = (
-    "https://raw.githubusercontent.com/kubernetes/examples/master/staging/storage/minio"
-)
+MINIO_YAML_DIRECTORY_URL = "https://raw.githubusercontent.com/kubernetes/examples/1b8cbf894ead6b25e9e870af6ae04f49dfdedfc9/staging/storage/minio"
 
 
 class Minio(K8sResource):


### PR DESCRIPTION
The kubernetes examples repo moved almost everything into an `_archived` directory https://github.com/kubernetes/examples/commit/3ae9fb0d13e8c9c952c862d38dfbc03a85ecb7c6 .

This PR locks our minio install yamls to the commit before they were moved.

We should eventually swap to some supported yamls and/or reevaluate our use of minio, but for now this should fix the nightly tests.

### Motivation

  * This PR fixes a previously unreported bug.
Many nightly tests are failing.
```
failed on setup with "subprocess.CalledProcessError: Command '['kubectl', '--context', 'kind-mzcloud', '--namespace', 'default', 'create', '-f', 'https://raw.githubusercontent.com/kubernetes/examples/master/staging/storage/minio/minio-standalone-deployment.yaml']' returned non-zero exit status 1."
```

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
