### PR TITLE
compute: don't reset PartitionedComputeState

### DIFF
--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -208,25 +208,9 @@ impl<T> PartitionedComputeState<T>
 where
     T: ComputeControllerTimestamp,
 {
-    fn reset(&mut self) {
-        let PartitionedComputeState {
-            parts: _,
-            max_result_size: _,
-            frontiers,
-            peek_responses,
-            pending_subscribes,
-            copy_to_responses,
-        } = self;
-        frontiers.clear();
-        peek_responses.clear();
-        pending_subscribes.clear();
-        copy_to_responses.clear();
-    }
-
-    /// Observes commands that move past, and prepares state for responses.
+    /// Observes commands that move past.
     pub fn observe_command(&mut self, command: &ComputeCommand<T>) {
         match command {
-            ComputeCommand::CreateTimely { .. } => self.reset(),
             ComputeCommand::UpdateConfiguration(config) => {
                 if let Some(max_result_size) = config.max_result_size {
                     self.max_result_size = max_result_size;

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -809,11 +809,7 @@ where
         //
         // TODO(guswynn): cluster-unification: consolidate this with compute.
         let _ = match command {
-            StorageCommand::CreateTimely { .. } => {
-                // Similarly, we don't reset state here like compute, because,
-                // until we are required to manage multiple replicas, we can handle
-                // keeping track of state across restarts of storage server(s).
-            }
+            StorageCommand::CreateTimely { .. } => {}
             StorageCommand::RunIngestion(ingestion) => {
                 self.insert_new_uppers(ingestion.description.collection_ids());
             }


### PR DESCRIPTION
Resetting the `PartitionedComputeState` upon seeing a `CreateTimely` command is not necessary. Both sides of the controller-replica connections throw away their existing partitioned state and create a new instance when the connection fails, implicitly resetting the state.

### Motivation

   * This PR refactors existing code.

Pulled out from https://github.com/MaterializeInc/materialize/pull/31710.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
