### PR TITLE
[webhooks] Decompress request bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
+ "brotli 6.0.0",
  "bzip2",
  "flate2",
  "futures-core",
@@ -1430,6 +1431,17 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -5757,6 +5769,7 @@ dependencies = [
  "derivative",
  "fail",
  "fallible-iterator",
+ "flate2",
  "futures",
  "headers",
  "http 1.2.0",
@@ -8582,7 +8595,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.1",
- "brotli",
+ "brotli 7.0.0",
  "bytes",
  "chrono",
  "flate2",
@@ -11582,13 +11595,18 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bitflags 2.9.0",
  "bytes",
+ "futures-core",
  "http 1.2.0",
  "http-body 1.0.1",
+ "http-body-util",
  "mime",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,11 +442,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.11"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
- "brotli 6.0.0",
+ "brotli",
  "bzip2",
  "flate2",
  "futures-core",
@@ -1435,17 +1435,6 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
@@ -1557,12 +1546,11 @@ checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
@@ -8595,7 +8583,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.1",
- "brotli 7.0.0",
+ "brotli",
  "bytes",
  "chrono",
  "flate2",
@@ -12768,6 +12756,7 @@ dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.9.0",
+ "brotli",
  "bstr",
  "byteorder",
  "bytes",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -110,7 +110,13 @@ tokio = { version = "1.44.1", features = ["sync"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tower = { version = "0.5.2", features = ["buffer", "limit", "load-shed"] }
-tower-http = { version = "0.6.6", features = ["cors"] }
+tower-http = { version = "0.6.6", features = [
+    "cors",
+    "decompression-br",
+    "decompression-deflate",
+    "decompression-gzip",
+    "decompression-zstd",
+] }
 tower-sessions = "0.13.0"
 tower-sessions-memory-store = "0.13.0"
 tracing = "0.1.37"
@@ -127,6 +133,7 @@ assert_cmd = "2.0.17"
 bytes = "1.10.1"
 datadriven = "0.8.0"
 fallible-iterator = "0.2.0"
+flate2 = "1.1.1"
 http-body-util = "0.1.3"
 insta = { version = "1.43", features = ["json"] }
 itertools = "0.14.0"

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -234,6 +234,13 @@ impl HttpServer {
                     webhook_cache,
                 })
                 .layer(
+                    tower_http::decompression::RequestDecompressionLayer::new()
+                        .gzip(true)
+                        .deflate(true)
+                        .br(true)
+                        .zstd(true),
+                )
+                .layer(
                     CorsLayer::new()
                         .allow_methods(Method::POST)
                         .allow_origin(AllowOrigin::mirror_request())

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-async-compression = { version = "0.4.11", features = ["gzip", "tokio", "zstd"] }
+async-compression = { version = "0.4.19", features = ["gzip", "tokio", "zstd"] }
 bytes = "1.10.1"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 csv-async = { version = "1.3.1", default-features = false, features = ["tokio"] }

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.98"
 arrow = { version = "54.3.1", default-features = false }
-async-compression = { version = "0.4.11", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+async-compression = { version = "0.4.19", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 async-stream = "0.3.6"
 aws-types = "1.3.7"
 aws-smithy-types = "1.1.8"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.98"
-async-compression = { version = "0.4.11", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+async-compression = { version = "0.4.19", features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 async-trait = "0.1.88"
 aws-credential-types = { version = "1.2.3", features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "1.41.0", default-features = false, features = ["rt-tokio"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 [dependencies]
 ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.3" }
-async-compression = { version = "0.4.11", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+async-compression = { version = "0.4.19", default-features = false, features = ["brotli", "bzip2", "gzip", "tokio", "xz", "zlib", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.3", default-features = false, features = ["hardcoded-credentials", "test-util"] }
 aws-runtime = { version = "1.4.2", default-features = false, features = ["event-stream", "http-02x"] }
@@ -35,6 +35,7 @@ axum-core = { version = "0.4.5", default-features = false, features = ["tracing"
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
 bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
+brotli = { version = "7.0.0" }
 bstr = { version = "1.10.0" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.10.1", features = ["serde"] }
@@ -137,7 +138,7 @@ toml_datetime = { version = "0.6.11", default-features = false, features = ["ser
 toml_edit = { version = "0.22.26", features = ["serde"] }
 tonic = { version = "0.12.3", features = ["gzip"] }
 tower = { version = "0.5.2", default-features = false, features = ["balance", "buffer", "filter", "limit", "load-shed", "log", "retry", "timeout"] }
-tower-http = { version = "0.6.6", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower-http = { version = "0.6.6", features = ["auth", "cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-core = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
@@ -155,7 +156,7 @@ zstd-sys = { version = "2.0.13", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.3" }
-async-compression = { version = "0.4.11", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+async-compression = { version = "0.4.19", default-features = false, features = ["brotli", "bzip2", "gzip", "tokio", "xz", "zlib", "zstd"] }
 aws-config = { version = "1.2.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.3", default-features = false, features = ["hardcoded-credentials", "test-util"] }
 aws-runtime = { version = "1.4.2", default-features = false, features = ["event-stream", "http-02x"] }
@@ -171,6 +172,7 @@ axum-core = { version = "0.4.5", default-features = false, features = ["tracing"
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
 bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
+brotli = { version = "7.0.0" }
 bstr = { version = "1.10.0" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.10.1", features = ["serde"] }
@@ -276,7 +278,7 @@ toml_datetime = { version = "0.6.11", default-features = false, features = ["ser
 toml_edit = { version = "0.22.26", features = ["serde"] }
 tonic = { version = "0.12.3", features = ["gzip"] }
 tower = { version = "0.5.2", default-features = false, features = ["balance", "buffer", "filter", "limit", "load-shed", "log", "retry", "timeout"] }
-tower-http = { version = "0.6.6", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower-http = { version = "0.6.6", features = ["auth", "cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-core = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }


### PR DESCRIPTION
This PR adds support for compressed webhook bodies using the decompression layers in `tower_http`. It also adds a test to ensure the decompression actually works.

### Motivation

More advance support for webhook bodies.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
