### PR TITLE
[webhooks] increase the HTTP requst body limit to 5MiB

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -92,7 +92,7 @@ pub use metrics::Metrics;
 pub use sql::{SqlResponse, WebSocketAuth, WebSocketResponse};
 
 /// Maximum allowed size for a request.
-pub const MAX_REQUEST_SIZE: usize = u64_to_usize(2 * bytesize::MB);
+pub const MAX_REQUEST_SIZE: usize = u64_to_usize(5 * bytesize::MIB);
 
 #[derive(Debug, Clone)]
 pub struct HttpConfig {


### PR DESCRIPTION
This PR increases the HTTP request body limit from 2MB to 5MiB. The original 2MB limit was picked arbitrarily and it should be safe to bump the limit up.

It also updates an existing test to ensure we'll get logging in prometheus if a request gets rejected for too large of a body.

### Motivation

Support larger webhook payloads

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
