### PR TITLE
Add memory-request replica property

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -2059,6 +2059,7 @@ impl CatalogState {
                     size,
                     ReplicaAllocation {
                         memory_limit,
+                        memory_request: _,
                         cpu_limit,
                         disk_limit,
                         scale,
@@ -2083,7 +2084,6 @@ impl CatalogState {
                         u64::cast_from(*workers).into(),
                         cpu_limit.as_nanocpus().into(),
                         memory_bytes.into(),
-                        // TODO(guswynn): disk size will be filled in later.
                         disk_bytes.into(),
                         (*credits_per_hour).into(),
                     ]);

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -178,6 +178,7 @@ impl ClusterReplicaSizeMap {
                         name,
                         ReplicaAllocation {
                             memory_limit: memory_limit.map(|gib| MemoryLimit(ByteSize::gib(gib))),
+                            memory_request: None,
                             cpu_limit: None,
                             disk_limit: None,
                             scale: 1,
@@ -199,6 +200,7 @@ impl ClusterReplicaSizeMap {
                 format!("{scale}-1"),
                 ReplicaAllocation {
                     memory_limit: None,
+                    memory_request: None,
                     cpu_limit: None,
                     disk_limit: None,
                     scale,
@@ -215,6 +217,7 @@ impl ClusterReplicaSizeMap {
                 format!("{scale}-{scale}"),
                 ReplicaAllocation {
                     memory_limit: None,
+                    memory_request: None,
                     cpu_limit: None,
                     disk_limit: None,
                     scale,
@@ -231,6 +234,7 @@ impl ClusterReplicaSizeMap {
                 format!("mem-{scale}"),
                 ReplicaAllocation {
                     memory_limit: Some(MemoryLimit(ByteSize(u64::cast_from(scale) * (1 << 30)))),
+                    memory_request: None,
                     cpu_limit: None,
                     disk_limit: None,
                     scale: 1,
@@ -248,6 +252,7 @@ impl ClusterReplicaSizeMap {
             "2-4".to_string(),
             ReplicaAllocation {
                 memory_limit: None,
+                memory_request: None,
                 cpu_limit: None,
                 disk_limit: None,
                 scale: 2,
@@ -264,6 +269,7 @@ impl ClusterReplicaSizeMap {
             "free".to_string(),
             ReplicaAllocation {
                 memory_limit: None,
+                memory_request: None,
                 cpu_limit: None,
                 disk_limit: None,
                 scale: 0,
@@ -281,6 +287,7 @@ impl ClusterReplicaSizeMap {
                 size.to_string(),
                 ReplicaAllocation {
                     memory_limit: None,
+                    memory_request: None,
                     cpu_limit: None,
                     disk_limit: None,
                     scale: 1,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -72,6 +72,9 @@ pub struct ReplicaConfig {
 pub struct ReplicaAllocation {
     /// The memory limit for each process in the replica.
     pub memory_limit: Option<MemoryLimit>,
+    /// The memory limit for each process in the replica.
+    #[serde(default)]
+    pub memory_request: Option<MemoryLimit>,
     /// The CPU limit for each process in the replica.
     pub cpu_limit: Option<CpuLimit>,
     /// The disk limit for each process in the replica.
@@ -112,6 +115,7 @@ fn test_replica_allocation_deserialization() {
         {
             "cpu_limit": 1.0,
             "memory_limit": "10GiB",
+            "memory_request": "5GiB",
             "disk_limit": "100MiB",
             "scale": 16,
             "workers": 1,
@@ -132,6 +136,7 @@ fn test_replica_allocation_deserialization() {
             disk_limit: Some(DiskLimit(ByteSize::mib(100))),
             disabled: false,
             memory_limit: Some(MemoryLimit(ByteSize::gib(10))),
+            memory_request: Some(MemoryLimit(ByteSize::gib(5))),
             cpu_limit: Some(CpuLimit::from_millicpus(1000)),
             cpu_exclusive: false,
             is_cc: true,
@@ -166,6 +171,7 @@ fn test_replica_allocation_deserialization() {
             disk_limit: Some(DiskLimit(ByteSize::mib(0))),
             disabled: true,
             memory_limit: Some(MemoryLimit(ByteSize::gib(0))),
+            memory_request: None,
             cpu_limit: Some(CpuLimit::from_millicpus(0)),
             cpu_exclusive: true,
             is_cc: true,
@@ -705,6 +711,7 @@ where
                 ],
                 cpu_limit: location.allocation.cpu_limit,
                 memory_limit: location.allocation.memory_limit,
+                memory_request: location.allocation.memory_request,
                 scale: location.allocation.scale,
                 labels: BTreeMap::from([
                     ("replica-id".into(), replica_id.to_string()),

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -959,8 +959,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 image_pull_policy: Some(self.config.image_pull_policy.to_string()),
                 resources: Some(ResourceRequirements {
                     claims: None,
-                    // Set both limits and requests to the same values, to ensure a
-                    // `Guaranteed` QoS class for the pod.
                     limits: Some(limits.clone()),
                     requests: Some(requests.clone()),
                 }),
@@ -1161,8 +1159,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     security_context: container_security_context.clone(),
                     resources: Some(ResourceRequirements {
                         claims: None,
-                        // Set both limits and requests to the same values, to ensure a
-                        // `Guaranteed` QoS class for the pod.
                         limits: Some(limits),
                         requests: Some(requests),
                     }),

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -587,6 +587,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             args,
             ports: ports_in,
             memory_limit,
+            memory_request,
             cpu_limit,
             scale,
             labels: labels_in,
@@ -649,14 +650,29 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             labels.insert(key.clone(), value.clone());
         }
         let mut limits = BTreeMap::new();
+        let mut requests = BTreeMap::new();
         if let Some(memory_limit) = memory_limit {
             limits.insert(
                 "memory".into(),
                 Quantity(memory_limit.0.as_u64().to_string()),
             );
+            requests.insert(
+                "memory".into(),
+                Quantity(memory_limit.0.as_u64().to_string()),
+            );
+        }
+        if let Some(memory_request) = memory_request {
+            requests.insert(
+                "memory".into(),
+                Quantity(memory_request.0.as_u64().to_string()),
+            );
         }
         if let Some(cpu_limit) = cpu_limit {
             limits.insert(
+                "cpu".into(),
+                Quantity(format!("{}m", cpu_limit.as_millicpus())),
+            );
+            requests.insert(
                 "cpu".into(),
                 Quantity(format!("{}m", cpu_limit.as_millicpus())),
             );
@@ -946,7 +962,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     // Set both limits and requests to the same values, to ensure a
                     // `Guaranteed` QoS class for the pod.
                     limits: Some(limits.clone()),
-                    requests: Some(limits.clone()),
+                    requests: Some(requests.clone()),
                 }),
                 security_context: container_security_context.clone(),
                 env: Some(vec![
@@ -1147,8 +1163,8 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                         claims: None,
                         // Set both limits and requests to the same values, to ensure a
                         // `Guaranteed` QoS class for the pod.
-                        limits: Some(limits.clone()),
-                        requests: Some(limits),
+                        limits: Some(limits),
+                        requests: Some(requests),
                     }),
                     volume_mounts: if !volume_mounts.is_empty() {
                         Some(volume_mounts)

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -203,6 +203,9 @@ pub struct ServiceConfig {
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.
     pub memory_limit: Option<MemoryLimit>,
+    /// An optional request on the memory that the service can use. If unspecified,
+    /// use the same value as `memory_limit`.
+    pub memory_request: Option<MemoryLimit>,
     /// An optional limit on the CPU that the service can use.
     pub cpu_limit: Option<CpuLimit>,
     /// The number of copies of this service to run.


### PR DESCRIPTION
Add a `memory_request` property to replica allocations. While we normally set request to the limit to enforce guaranteed QoS scheduling, setting a separate request would allow us to switch to a lower QoS that would be compatible with swap.

Fixes MaterializeInc/database-issues/issues/9328

Context: https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/
