### PR TITLE
optimizer: Fix `literal_domination` when `MSE::reduce` changes the number of args of a variadic call

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -728,7 +728,7 @@ fn literal_domination(old: &MirScalarExpr, new: &MirScalarExpr) -> bool {
                 },
             ) => {
                 use itertools::Itertools;
-                if f0 != f1 {
+                if f0 != f1 || e0s.len() != e1s.len() {
                     return false;
                 } else {
                     todo.extend(e0s.iter().zip_eq(e1s));

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -785,3 +785,6 @@ Source materialize.public.t1
 Target cluster: quickstart
 
 EOF
+
+statement ok
+SELECT mz_internal.mz_minimal_name_qualification(COALESCE(pg_catalog.string_to_array(pg_catalog."current_role"(), pg_catalog."user"()), COALESCE(mz_internal.mz_normalize_object_name(NULL), pg_catalog.regexp_match(CAST(0 AS text), CAST(0 AS text)))), mz_catalog.mz_version()) AS c1;


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9319

`literal_domination` is called on pairs of expressions where `MSE::reduce` was called on the first one to get the second one. `MSE::reduce` can easily change the number of arguments to a variadic function call, e.g., for `coalesce`  https://github.com/MaterializeInc/materialize/blob/4f729296d579c940eb04fd40bbdc7009b7e7ae4d/src/expr/src/scalar.rs#L1205-L1214
This PR adds an extra check for this situation.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
