### PR TITLE
build: don't disable asserts in librdkafka

### DIFF
--- a/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
@@ -30,6 +30,7 @@ cmake(
         # Note: casing here is important.
         "OpenSSL_ROOT": "$(execpath @openssl//:openssl_root)",
     },
+    copts = ["-UNDEBUG"],
     generate_args = [
         # Features enabled by the Rust `rdkafka-sys` crate.
         "-DRDKAFKA_BUILD_STATIC=1",
@@ -55,6 +56,12 @@ cmake(
         "-DCMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH=0",
         "-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=0",
         "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
+        # When builing with `CMAKE_BUILD_TYPE=Release`, cmake automatically
+        # sets `-DNDEBUG` flags. This breaks librdkafka, which uses asserts for
+        # runtime error checking (confluentinc/librdkafka#5099). We unset
+        # `NDEBUG` by manually overwriting the cmake's `C_FLAGS` variables.
+        "-DCMAKE_C_FLAGS_RELEASE=-O3",
+        "-DCMAKE_CXX_FLAGS_RELEASE=-O3",
         # Uncomment this if you ever need to debug what library cmake is resolving.
         # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
     ] + select({


### PR DESCRIPTION
[librdkafka uses asserts to handle runtime errors.](https://github.com/confluentinc/librdkafka/issues/5099) If asserts are disabled, runtime errors can turn into memory safety bugs instead, which is something we should avoid.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9313

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
