### PR TITLE
ci: Further changes as follow up to smaller agents

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -120,7 +120,7 @@ steps:
         timeout_in_minutes: 720
         parallelism: 8
         agents:
-          queue: hetzner-x86-64-dedi-8cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -134,7 +134,7 @@ steps:
         timeout_in_minutes: 240
         agents:
           # Larger instance is more stable in performance
-          queue: hetzner-x86-64-dedi-8cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -505,7 +505,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -516,7 +516,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -527,7 +527,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -538,7 +538,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -549,7 +549,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -560,7 +560,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -1741,11 +1741,11 @@ steps:
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
-        depends_on: build-aarch64
+        depends_on: build-x86_64
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1963,57 +1963,57 @@ steps:
        - id: race-condition-subsequent
          label: "Race Condition Test (subsequent)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 180
          agents:
            queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent]
+               args: [--runtime=5600, --scenario=subsequent]
 
        - id: race-condition-subsequent-100
          label: "Race Condition Test (subsequent, 100 objects)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 180
          agents:
            queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent, --num-objects=100]
+               args: [--runtime=5600, --scenario=subsequent, --num-objects=100]
 
        - id: race-condition-subsequent-chain
          label: "Race Condition Test (subsequent chain)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 180
          agents:
            queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent-chain]
+               args: [--runtime=5600, --scenario=subsequent-chain]
 
        - id: race-condition-subsequent-chain-100
          label: "Race Condition Test (subsequent chain, 100 objects)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 180
          agents:
            queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=subsequent-chain, --num-objects=100]
+               args: [--runtime=5600, --scenario=subsequent-chain, --num-objects=100]
 
        - id: race-condition-concurrent
          label: "Race Condition Test (concurrent)"
          depends_on: build-aarch64
-         timeout_in_minutes: 360
+         timeout_in_minutes: 180
          agents:
            queue: hetzner-aarch64-8cpu-16gb
          plugins:
            - ./ci/plugins/mzcompose:
                composition: race-condition
-               args: [--runtime=10800, --scenario=concurrent]
+               args: [--runtime=5600, --scenario=concurrent]
          skip: "Not stable yet, not clear if this is a product issue"
 
   - group: "Language tests"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -337,7 +337,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -349,7 +349,7 @@ steps:
         timeout_in_minutes: 180
         parallelism: 3
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -313,7 +313,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: sqllogictest-fast
     label: "Fast SQL logic tests"


### PR DESCRIPTION
Undoes part of https://github.com/MaterializeInc/materialize/pull/32553 based on remaining flakes uncovered last week

@ggevay Sorry for all the test failures last week!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
