### PR TITLE
tests: make more sqllogictests resilient to result ordering

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -107,14 +107,14 @@ SELECT a, sum(b) AS a FROM t GROUP BY a
 2 3
 3 1
 
-query I
+query I rowsort
 SELECT a FROM t GROUP BY t.a, t.a
 ----
 1
 2
 3
 
-query I
+query I rowsort
 SELECT a FROM t GROUP BY t.a, public.t.a
 ----
 1

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -214,7 +214,7 @@ Target cluster: quickstart
 EOF
 
 
-query IIII
+query IIII valuesort
 SELECT o_orderkey,
        l_quantity,
        o_custkey,
@@ -226,7 +226,7 @@ WHERE c_acctbal >= o_totalprice
   AND l_commitDATE > o_orderdate
   AND l_shipDATE >= o_orderdate
 ----
-12 values hashing to bbdaf71fed5d76e9b01f5e2909fc4880
+12 values hashing to 79e5bcae275835817dd6063a9395a0dc
 
 
 query T multiline

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -804,7 +804,7 @@ COMPLETE 0
 statement ok
 DROP CLUSTER REPLICA t1.r2
 
-query TTTTT
+query TTTTT rowsort
 SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
 ----
 u1  r1  u1  2  s1

--- a/test/sqllogictest/ct_snapshot.slt
+++ b/test/sqllogictest/ct_snapshot.slt
@@ -44,7 +44,7 @@ CREATE CONTINUAL TASK ct ON INPUT input AS (
 statement ok
 INSERT INTO input VALUES (3)
 
-query I
+query I rowsort
 SELECT * FROM ct
 ----
 1

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -132,7 +132,7 @@ Target cluster: quickstart
 
 EOF
 
-query II
+query II rowsort
 SELECT *
 FROM x,
      LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
@@ -296,7 +296,7 @@ FROM x,
 ----
 3  2  2
 
-query III
+query III rowsort
 SELECT *
 FROM x,
      LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
@@ -401,7 +401,7 @@ Target cluster: quickstart
 
 EOF
 
-query III
+query III rowsort
 SELECT *
 FROM x,
      LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)

--- a/test/sqllogictest/id.slt
+++ b/test/sqllogictest/id.slt
@@ -23,14 +23,14 @@ SELECT id FROM mz_catalog.mz_tables WHERE name = 'x'
 ----
 u1
 
-query I
+query I rowsort
 SELECT a FROM x
 ----
 1
 2
 3
 
-query I
+query I rowsort
 SELECT a FROM [u1 AS materialize.public.y]
 ----
 1
@@ -44,7 +44,7 @@ statement error column "x.a" does not exist
 SELECT x.a FROM [u1 AS materialize.public.y]
 
 # Referring to it by its assigned name should work.
-query I
+query I rowsort
 SELECT y.a FROM [u1 AS materialize.public.y]
 ----
 1

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -671,7 +671,7 @@ Target cluster: quickstart
 
 EOF
 
-query TT
+query TT rowsort
 SELECT lb, rb FROM l3 INNER JOIN r3 ON la = ra OR (ra IS NULL AND la IS NULL)
 ----
 l1  r1
@@ -698,7 +698,7 @@ Target cluster: quickstart
 
 EOF
 
-query TT
+query TT rowsort
 SELECT lb, rb FROM l3 INNER JOIN r3 ON (la IS NULL AND ra IS NULL) OR la = ra
 ----
 l1  r1

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1167,7 +1167,7 @@ statement ok
 SELECT mz_unsafe.mz_sleep(8+2);
 
 # Visible now.
-query I
+query I rowsort
 SELECT * FROM mvi1;
 ----
 25
@@ -1194,7 +1194,7 @@ SELECT DISTINCT x+x+x FROM t3;
 statement ok
 CREATE DEFAULT INDEX on mvi2;
 
-query I
+query I rowsort
 SELECT * FROM mvi2;
 ----
 15
@@ -1221,7 +1221,7 @@ SELECT DISTINCT 5*x FROM t3;
 statement ok
 CREATE DEFAULT INDEX ON mvi3;
 
-query I
+query I rowsort
 SELECT * FROM mvi3
 ----
 25
@@ -1247,7 +1247,7 @@ SELECT mz_unsafe.mz_sleep(2+2);
 statement ok
 INSERT INTO t3 VALUES (-1);
 
-query I
+query I rowsort
 SELECT * FROM mvi3
 ----
 25

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -99,7 +99,7 @@ SELECT owner_id FROM mz_databases GROUP BY owner_id
 ----
 s1
 
-query T
+query T rowsort
 SELECT owner_id FROM mz_clusters GROUP BY owner_id
 ----
 s1

--- a/test/sqllogictest/prepare.slt
+++ b/test/sqllogictest/prepare.slt
@@ -54,7 +54,7 @@ EXECUTE i3('x');
 ----
 x
 
-query I
+query I valuesort
 SELECT * FROM t;
 ----
 4

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -43,7 +43,7 @@ CREATE TABLE materialize.b1.t (x pg_catalog.int4);
 statement ok
 INSERT INTO b1.t VALUES (1), (2), (3)
 
-query I
+query I valuesort
 SELECT x FROM b1.t
 ----
 1
@@ -66,22 +66,23 @@ alter
 schema
 {"database_name":"materialize","id":"u10","new_name":"b2","old_name":"b1"}
 
-query I
+query I valuesort
 SELECT x FROM b2.t
 ----
 1
 2
 3
 
-query TT
+mode cockroach
+
+query TT rowsort
 SELECT database_id, name FROM mz_schemas WHERE id LIKE 'u%';
 ----
-u1
-a1
-u1
-b2
-u1
-public
+u1 a1
+u1 b2
+u1 public
+
+mode standard
 
 query TT
 SHOW CREATE TABLE b2.t;
@@ -95,7 +96,7 @@ CREATE SCHEMA friend;
 statement ok
 CREATE VIEW friend.v1 AS SELECT x FROM b2.t;
 
-query I
+query I valuesort
 SELECT * FROM friend.v1;
 ----
 1
@@ -111,7 +112,7 @@ CREATE VIEW materialize.friend.v1 AS SELECT x FROM materialize.b2.t;
 statement ok
 ALTER SCHEMA b2 RENAME TO b3;
 
-query I
+query I valuesort
 SELECT * FROM friend.v1;
 ----
 1
@@ -130,7 +131,7 @@ CREATE SCHEMA grand_friend;
 statement ok
 CREATE MATERIALIZED VIEW grand_friend.mv1 AS SELECT x FROM friend.v1;
 
-query I
+query I valuesort
 SELECT x FROM grand_friend.mv1;
 ----
 1
@@ -350,18 +351,16 @@ SHOW CREATE VIEW d.qualified_columns;
 materialize.d.qualified_columns
 CREATE VIEW⏎    materialize.d.qualified_columns⏎    AS SELECT materialize.d.values.x, materialize.d.values.y, z FROM materialize.d.values;
 
-query ITI
+mode cockroach
+
+query ITI rowsort
 SELECT * FROM d.qualified_columns;
 ----
-1
-foo
-100
-2
-bar
-200
-3
-baz
-300
+1 foo 100
+2 bar 200
+3 baz 300
+
+mode standard
 
 statement ok
 ALTER SCHEMA d RENAME TO d_renamed;

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -898,7 +898,7 @@ r2,r3,NO
 r4,r3,NO
 COMPLETE 3
 
-simple conn=r1,user=r1
+simple conn=r1,user=r1,rowsort
 SELECT * FROM information_schema.enabled_roles
 ----
 r1

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -581,7 +581,7 @@ Target cluster: quickstart
 
 EOF
 
-query I
+query I rowsort
 SELECT (SELECT (SELECT * FROM t1 WHERE t1.f1 = t2.f1) FROM t2 WHERE t2.f1 = t3.f1) FROM t3
 ----
 1

--- a/test/sqllogictest/swap.slt
+++ b/test/sqllogictest/swap.slt
@@ -41,7 +41,7 @@ SELECT * FROM blue.t2;
 statement ok
 ALTER SCHEMA blue SWAP WITH green;
 
-query I
+query I valuesort
 SELECT * FROM blue.t2;
 ----
 4
@@ -60,7 +60,7 @@ INSERT INTO "!\_\""w3😊_weird_name".t2 VALUES (7), (8), (9);
 statement ok
 ALTER SCHEMA blue SWAP WITH "!\_\""w3😊_weird_name";
 
-query I
+query I valuesort
 SELECT * FROM "!\_\""w3😊_weird_name".t2;
 ----
 4
@@ -70,7 +70,7 @@ SELECT * FROM "!\_\""w3😊_weird_name".t2;
 statement ok
 ALTER SCHEMA blue SWAP WITH blue;
 
-query I
+query I valuesort
 SELECT * FROM blue.t2;
 ----
 7
@@ -89,7 +89,7 @@ CREATE SCHEMA this_is_a_schema_with_a_super_long_name_of_exactly_255_characters_
 statement ok
 ALTER SCHEMA this_is_a_schema_with_a_super_long_name_of_exactly_255_characters_which_happens_to_be_the_maximum_we_allow_in_materialize_for_identifiers_of_any_kind_including_for_the_schema_name_so_this_should_still_work_perfectly_fine_as_long_as_we_dont_make_it_longer SWAP WITH blue;
 
-query I
+query I valuesort
 SELECT * FROM this_is_a_schema_with_a_super_long_name_of_exactly_255_characters_which_happens_to_be_the_maximum_we_allow_in_materialize_for_identifiers_of_any_kind_including_for_the_schema_name_so_this_should_still_work_perfectly_fine_as_long_as_we_dont_make_it_longer.t2;
 ----
 7

--- a/test/sqllogictest/table.slt
+++ b/test/sqllogictest/table.slt
@@ -17,14 +17,14 @@ CREATE TABLE t (a int)
 statement ok
 INSERT INTO t VALUES (1), (2), (3)
 
-query I
+query I rowsort
 TABLE t
 ----
 1
 2
 3
 
-query I
+query I rowsort
 TABLE materialize.public.t
 ----
 1

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -168,7 +168,7 @@ SELECT * FROM x x1, x x2, generate_series(x2.a, x2.b) WHERE x1.b = x2.b
 3  4  3  4  4
 
 # One from each.
-query IIIII
+query IIIII rowsort
 SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
 1  2  1  2  1
@@ -189,7 +189,7 @@ SELECT x.a, generate_series FROM x, LATERAL (SELECT * FROM generate_series(1, x.
 
 # Regression test for database-issues#1700: crash when a filter references an output column of
 # a table function
-query IIIII
+query IIIII rowsort
 SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b
 ----
 1 2 1 2 1

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -534,7 +534,7 @@ SELECT pk FROM tab0 WHERE (((col4 >= 660.98) AND ((col4 IN (724.71,445.29,441.2,
 statement ok
 CREATE INDEX idx_t1_b ON t1(b)
 
-query I
+query I rowsort
 SELECT a FROM t1
 WHERE (a < 3 OR a > 0) AND b IN ('l1', 'l2', 'l3', 'l9')
 ----
@@ -560,7 +560,7 @@ EOF
 
 # More tricky tests for `remove_literal_constraints`
 
-query I
+query I rowsort
 SELECT a FROM t1
 WHERE (a < 3 OR a > 0 OR a < 7) AND b IN ('l1', 'l2', 'l3', 'l9') AND (b like 'l%' OR a > 5)
 ----
@@ -1350,34 +1350,6 @@ Target cluster: quickstart
 EOF
 
 # Check literal constraints with LIMIT
-
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
-SELECT a,b
-FROM t1
-WHERE a IN (4,3,2,1)
-LIMIT 1;
-----
-Explained Query (fast path):
-  Finish limit=1 output=[#0, #1]
-    Project (#0{a}, #1{b})
-      ReadIndex on=materialize.public.t1 idx_t1_a=[lookup values=[(1); (2); (3); (4)]]
-
-Used Indexes:
-  - materialize.public.idx_t1_a (lookup)
-
-Target cluster: quickstart
-
-EOF
-
-# Note: This has LIMIT but no ORDER BY, so this is ok to change when row representation changes.
-query IT
-SELECT a,b
-FROM t1
-WHERE a IN (4,3,2,1)
-LIMIT 1;
-----
-1  a
 
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -197,7 +197,7 @@ Target cluster: quickstart
 
 EOF
 
-query II
+query II rowsort
 SELECT a1.* FROM t3 AS a1 LEFT JOIN t2 AS a2 ON (a1.f1 = a2.nokey);
 ----
 2 3

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -321,7 +321,7 @@ SELECT * FROM t1, LATERAL(SELECT t2.*, ROW_NUMBER() OVER() FROM t2 WHERE t1.f2 =
 2  2  1  2  1
 2  2  2  2  2
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f1 = t2.f1) AS foo;
 ----
 1  1  1  1  1
@@ -334,7 +334,7 @@ SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f1 =
 1  1  1  1  1
 2  2  2  2  1
 
-query IIIII
+query IIIII rowsort
 SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 = t2.f2) AS foo;
 ----
 1  1  1  1  1
@@ -514,7 +514,7 @@ ORDER BY dense_rank
 2  b
 3  a
 
-query IIT
+query IIT rowsort
 SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ----
 1  1  a
@@ -590,7 +590,7 @@ CREATE TABLE t(x string, y int);
 statement ok
 INSERT INTO t VALUES ('a', 98), ('b', 99), ('c', 98);
 
-query IIT
+query IIT rowsort
 SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t;
 ----
 1  1  a
@@ -651,7 +651,7 @@ ORDER BY dense_rank, x;
 1  c
 2  a
 
-query IIT
+query IIT rowsort
 SELECT rank() OVER (PARTITION BY x ORDER BY x), dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t;
 ----
 1  1  a
@@ -666,7 +666,7 @@ ORDER BY dense_rank, x;
 1  b
 1  c
 
-query IIT
+query IIT rowsort
 SELECT rank() OVER (PARTITION BY NULL ORDER BY 10000), dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
 FROM t AS a1, t AS a2;
 ----

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -402,7 +402,7 @@ ORDER BY i;
 ## Tests for RECURSION LIMIT
 ## (See plans in `normalize_lets.slt`)
 
-query I
+query I rowsort
 WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 3)
   cnt (i int) AS (
     SELECT 1 AS i
@@ -414,7 +414,7 @@ SELECT * FROM cnt;
 2
 3
 
-query I
+query I rowsort
 WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT = 3)
   cnt (i int) AS (
     SELECT 1 AS i


### PR DESCRIPTION
More work towards https://github.com/MaterializeInc/database-issues/issues/9180.

Changing the way we deliver results can change their ordering, which is okay by the SQL standard. This prepares more tests for that.