### PR TITLE
Explicitly parse row estimate count as i64

### DIFF
--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -754,7 +754,7 @@ async fn collect_table_statistics(
         .set_at(&mut stats.count_latency)
         .await?;
         match estimate_row {
-            Some(row) => match row.get("estimate_count").unwrap().parse().unwrap() {
+            Some(row) => match row.get("estimate_count").unwrap().parse::<i64>().unwrap() {
                 -1 => stats.count = 0,
                 n => stats.count = n.try_into()?,
             },

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -754,10 +754,9 @@ async fn collect_table_statistics(
         .set_at(&mut stats.count_latency)
         .await?;
         match estimate_row {
-            Some(row) => match row.get("estimate_count").unwrap().parse::<i64>().unwrap() {
-                -1 => stats.count = 0,
-                n => stats.count = n.try_into()?,
-            },
+            Some(row) => {
+                stats.count = row.get("estimate_count").unwrap().parse().unwrap_or(0);
+            }
             None => bail!("failed to get estimate count for {table}"),
         };
     }


### PR DESCRIPTION
Compiler infers i32 as the target type for the parse command, but it should be i64 (bigint).

### Motivation

fixes https://github.com/MaterializeInc/incidents-and-escalations/issues/268

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
