### PR TITLE
self-managed: Rename lts to self-managed internally

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -876,8 +876,8 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-lts-upgrade
-        label: "Checks LTS upgrade, whole-Mz restart"
+      - id: checks-self-managed-upgrade
+        label: "Checks Self-Managed upgrade, whole-Mz restart"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         parallelism: 3
@@ -886,7 +886,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeEntireMzFromLatestLTS, "--seed=$BUILDKITE_JOB_ID"]
+              args: [--scenario=UpgradeEntireMzFromLatestSelfManaged, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
@@ -1263,7 +1263,7 @@ steps:
             run: aws-temporary
             # Cleanup runs in pre-exit hook
             args: [--no-cleanup]
-      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      branches: "main v*.* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-aws-upgrade
       label: "Terraform + Helm Chart Upgrade on AWS"
@@ -1281,7 +1281,7 @@ steps:
             run: aws-upgrade
             # Cleanup runs in pre-exit hook
             args: [--no-cleanup]
-      branches: "main v*.* lts-v* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      branches: "main v*.* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-gcp
       label: "Terraform + Helm Chart E2E on GCP"
@@ -1298,7 +1298,7 @@ steps:
             run: gcp-temporary
             # Cleanup runs in pre-exit hook
             args: [--no-cleanup]
-      branches: "main v*.* lts-v* *gcp* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      branches: "main v*.* *gcp* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
     - id: terraform-azure
       label: "Terraform + Helm Chart E2E on Azure"
@@ -1315,7 +1315,7 @@ steps:
             run: azure-temporary
             # Cleanup runs in pre-exit hook
             args: [--no-cleanup]
-      branches: "main v*.* lts-v* *azure* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      branches: "main v*.* *azure* *tf* *terraform* *helm* *self-managed* *orchestratord*"
 
   - group: "Output consistency"
     key: output-consistency
@@ -1794,7 +1794,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: legacy-upgrade
-              args: ["--versions-source=docs", "--lts-upgrade"]
+              args: ["--versions-source=docs", "--self-managed-upgrade"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -772,7 +772,7 @@ steps:
           composition: skip-version-upgrade
     agents:
       queue: hetzner-aarch64-4cpu-8gb
-    skip: "Version upgrade skips are allowed for LTS releases now"
+    skip: "Version upgrade skips are allowed for Self-Managed releases now"
 
   - id: mz-debug
     label: "mz-debug tool"

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -213,4 +213,4 @@ include = "docs/**"
 
 # Avoid deleting the LTS and self-managed docs which are deployed from the
 # lts-docs and self-managed-docs branches.
-exclude = "docs/{lts,self-managed/v25.1}/**"
+exclude = "docs/{lts,self-managed/v25.1,self-managed/v25.2}/**"

--- a/doc/user/content/self-managed/_index.md
+++ b/doc/user/content/self-managed/_index.md
@@ -7,4 +7,4 @@ robots: "noindex, nofollow"
 draft: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/_index.md
+++ b/doc/user/content/self-managed/v25.1/_index.md
@@ -6,4 +6,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/_index.md
+++ b/doc/user/content/self-managed/v25.1/installation/_index.md
@@ -7,4 +7,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/configuration.md
+++ b/doc/user/content/self-managed/v25.1/installation/configuration.md
@@ -7,4 +7,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/install-on-aws.md
+++ b/doc/user/content/self-managed/v25.1/installation/install-on-aws.md
@@ -6,4 +6,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed/v25.1/installation/install-on-gcp.md
@@ -6,4 +6,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/install-on-local-kind.md
+++ b/doc/user/content/self-managed/v25.1/installation/install-on-local-kind.md
@@ -7,4 +7,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/install-on-local-minikube.md
+++ b/doc/user/content/self-managed/v25.1/installation/install-on-local-minikube.md
@@ -6,4 +6,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/operational-guidelines.md
+++ b/doc/user/content/self-managed/v25.1/installation/operational-guidelines.md
@@ -7,4 +7,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/troubleshooting.md
+++ b/doc/user/content/self-managed/v25.1/installation/troubleshooting.md
@@ -7,4 +7,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/doc/user/content/self-managed/v25.1/installation/upgrading.md
+++ b/doc/user/content/self-managed/v25.1/installation/upgrading.md
@@ -6,4 +6,4 @@ aliases:
 suppress_breadcrumb: true
 ---
 
-<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-LTS (circa Dec. 2024) self-managed docs -->
+<!-- Note: The self-managed docs are in a separate branch. The self-managed section in main is used for redirect purposes of the pre-self-managed (circa Dec. 2024) self-managed docs -->

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -24,7 +24,10 @@ from materialize.checks.mzcompose_actions import (
 from materialize.checks.scenarios import Scenario
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.materialized import LEADER_STATUS_HEALTHCHECK
-from materialize.version_list import get_lts_versions, get_published_minor_mz_versions
+from materialize.version_list import (
+    get_published_minor_mz_versions,
+    get_self_managed_versions,
+)
 
 # late initialization
 _minor_versions: list[MzVersion] | None = None
@@ -82,11 +85,11 @@ def start_mz_read_only(
     )
 
 
-class UpgradeEntireMzFromLatestLTS(Scenario):
-    """Upgrade the entire Mz instance from the last LTS version without any intermediate steps. This makes sure our LTS releases for self-managed Materialize stay upgradable."""
+class UpgradeEntireMzFromLatestSelfManaged(Scenario):
+    """Upgrade the entire Mz instance from the last Self-Managed version without any intermediate steps. This makes sure our Self-Managed releases for self-managed Materialize stay upgradable."""
 
     def base_version(self) -> MzVersion:
-        return get_lts_versions()[-1]
+        return get_self_managed_versions()[-1]
 
     def actions(self) -> list[Action]:
         print(f"Upgrading from tag {self.base_version()}")

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -30,7 +30,7 @@ from materialize.mz_version import MzVersion
 MZ_ROOT = Path(os.environ["MZ_ROOT"])
 
 
-def get_lts_versions() -> list[MzVersion]:
+def get_self_managed_versions() -> list[MzVersion]:
     result = set()
     for entry in yaml.safe_load(
         requests.get("https://materializeinc.github.io/materialize/index.yaml").text

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -2129,13 +2129,22 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn check_data_versions_with_lts_versions() {
+    fn check_data_versions_with_self_managed_versions() {
         #[track_caller]
-        fn testcase(code: &str, data: &str, lts_versions: &[Version], expected: Result<(), ()>) {
+        fn testcase(
+            code: &str,
+            data: &str,
+            self_managed_versions: &[Version],
+            expected: Result<(), ()>,
+        ) {
             let code = Version::parse(code).unwrap();
             let data = Version::parse(data).unwrap();
-            let actual = cfg::check_data_version_with_lts_versions(&code, &data, lts_versions)
-                .map_err(|_| ());
+            let actual = cfg::check_data_version_with_self_managed_versions(
+                &code,
+                &data,
+                self_managed_versions,
+            )
+            .map_err(|_| ());
             assert_eq!(actual, expected);
         }
 

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -31,7 +31,7 @@ from materialize.mzcompose.composition import (
     WorkflowArgumentParser,
 )
 from materialize.mzcompose.services.testdrive import Testdrive
-from materialize.version_list import get_lts_versions
+from materialize.version_list import get_self_managed_versions
 
 SERVICES = [
     Testdrive(),  # overridden below
@@ -804,7 +804,7 @@ def workflow_aws_upgrade(c: Composition, parser: WorkflowArgumentParser) -> None
     add_arguments_temporary_test(parser)
     args = parser.parse_args()
 
-    previous_tag = get_lts_versions()[-1]
+    previous_tag = get_self_managed_versions()[-1]
     tag = get_tag(args.tag)
     path = MZ_ROOT / "test" / "terraform" / "aws-upgrade"
     aws = AWS(path)


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
