### PR TITLE
tests: Add check for negative accumulations in `pg_cdc.py`

### DIFF
--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -179,6 +179,27 @@ class PgCdcBase:
             # Can take longer after a restart
             $ set-sql-timeout duration=600s
 
+            # Trying to narrow down whether
+            # https://github.com/MaterializeInc/database-issues/issues/8102
+            # is a problem with the source or elsewhere.
+            > WITH t AS (SELECT * FROM postgres_source_tableA{self.suffix})
+              SELECT COUNT(*)
+              FROM t
+              GROUP BY row(t.*)
+              HAVING COUNT(*) < 0;
+
+            > WITH t AS (SELECT * FROM postgres_source_tableB{self.suffix})
+              SELECT COUNT(*)
+              FROM t
+              GROUP BY row(t.*)
+              HAVING COUNT(*) < 0;
+
+            > WITH t AS (SELECT * FROM postgres_source_tableC{self.suffix})
+              SELECT COUNT(*)
+              FROM t
+              GROUP BY row(t.*)
+              HAVING COUNT(*) < 0;
+
             > SELECT f1, max(f2), SUM(LENGTH(f3)) FROM postgres_source_tableA{self.suffix} GROUP BY f1;
             A 800 {self.expects}
             B 800 {self.expects}


### PR DESCRIPTION
This PR adds some negative accumulation checks in a flaking test, so that we can narrow down where the problem is. If it is inside the sources, then the newly added check will fail.

See
https://materializeinc.slack.com/archives/C08ACQNGSQK/p1748952911361349?thread_ts=1748947701.910469&cid=C08ACQNGSQK

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
