### PR TITLE
zippy: Use random seeds

### DIFF
--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -15,6 +15,7 @@ expected state it can verify results for correctness.
 
 import random
 import re
+import time
 from datetime import timedelta
 from enum import Enum
 
@@ -135,7 +136,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         required=True,
     )
 
-    parser.add_argument("--seed", metavar="N", type=int, help="Random seed", default=1)
+    parser.add_argument(
+        "--seed", metavar="N", type=int, help="Random seed", default=int(time.time())
+    )
 
     parser.add_argument(
         "--actions",
@@ -195,6 +198,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.observability:
         c.up("prometheus", "grafana")
 
+    print(f"Using seed {args.seed}")
     random.seed(args.seed)
 
     additional_system_parameter_defaults = {}


### PR DESCRIPTION
Previously we always used seed=1, nightly run: https://buildkite.com/materialize/nightly/builds/12188
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
