### PR TITLE
ci: Fix annotation for timeouts and another replication factor 2 in feature benchmark

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -89,7 +89,7 @@ ERROR_RE = re.compile(
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     | SUMMARY:\ .*Sanitizer
     | primary\ source\ \w+\ seemingly\ dropped\ before\ subsource
-    | Test\ .*\ timed\ out
+    | :\ test\ timed\ out
     # Only notifying on unexpected failures. INT, TRAP, BUS, FPE, SEGV, PIPE
     | \ ANOM_ABEND\ .*\ sig=(2|5|7|8|11|13)
     # \s\S is any character including newlines, so this matches multiline strings

--- a/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
@@ -59,7 +59,7 @@ $ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-sc
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
-> CREATE CLUSTER s{s}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
+> CREATE CLUSTER s{s}_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
 
 > CREATE SOURCE s{s}
   IN CLUSTER s{s}_cluster

--- a/misc/python/materialize/feature_benchmark/scenarios/subscribe.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/subscribe.py
@@ -117,7 +117,7 @@ class SubscribeParallelKafka(SubscribeParallel):
              > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 
              > DROP CLUSTER IF EXISTS source_cluster CASCADE;
-             > CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 2;
+             > CREATE CLUSTER source_cluster SIZE '{self._default_size}', REPLICATION FACTOR 1;
 
              > DROP SOURCE IF EXISTS s1 CASCADE;
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
