### PR TITLE
Metrics for query lifecycle

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -44,6 +44,7 @@ pub struct Metrics {
     pub row_set_finishing_seconds: HistogramVec,
     pub session_startup_table_writes_seconds: HistogramVec,
     pub parse_seconds: HistogramVec,
+    pub pgwire_message_processing_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -185,6 +186,12 @@ impl Metrics {
                 name: "mz_parse_seconds",
                 help: "The time it takes to parse a SQL statement. (Works for both Simple Queries and the Extended Query protocol.)",
                 buckets: histogram_seconds_buckets(0.000_128, 4.0),
+            )),
+            pgwire_message_processing_seconds: registry.register(metric!(
+                name: "mz_pgwire_message_processing_seconds",
+                help: "The time it takes to process each of the pgwire message types, measured in the Adapter frontend",
+                var_labels: ["message_type"],
+                buckets: histogram_seconds_buckets(0.000_128, 128.0),
             ))
         }
     }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -43,6 +43,7 @@ pub struct Metrics {
     pub handle_scheduling_decisions_seconds: HistogramVec,
     pub row_set_finishing_seconds: HistogramVec,
     pub session_startup_table_writes_seconds: HistogramVec,
+    pub parse_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -180,6 +181,11 @@ impl Metrics {
                 help: "If we had to wait for builtin table writes before processing a query, how long did we wait for.",
                 buckets: histogram_seconds_buckets(0.000_008, 4.0),
             )),
+            parse_seconds: registry.register(metric!(
+                name: "mz_parse_seconds",
+                help: "The time it takes to parse a SQL statement. (Works for both Simple Queries and the Extended Query protocol.)",
+                buckets: histogram_seconds_buckets(0.000_128, 4.0),
+            ))
         }
     }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -746,7 +746,8 @@ where
     }
 
     fn parse_sql<'b>(&self, sql: &'b str) -> Result<Vec<StatementParseResult<'b>>, ErrorResponse> {
-        match self.adapter_client.parse(sql) {
+        let parse_start = Instant::now();
+        let result = match self.adapter_client.parse(sql) {
             Ok(result) => result.map_err(|e| {
                 // Convert our 0-based byte position to pgwire's 1-based character
                 // position.
@@ -754,7 +755,14 @@ where
                 ErrorResponse::error(SqlState::SYNTAX_ERROR, e.error.message).with_position(pos)
             }),
             Err(msg) => Err(ErrorResponse::error(SqlState::PROGRAM_LIMIT_EXCEEDED, msg)),
-        }
+        };
+        self.adapter_client
+            .inner()
+            .metrics()
+            .parse_seconds
+            .with_label_values(&[])
+            .observe(parse_start.elapsed().as_secs_f64());
+        result
     }
 
     /// Executes a "Simple Query", see


### PR DESCRIPTION
This PR implements the next part of https://github.com/MaterializeInc/materialize/pull/32504, namely the following two metrics:
- parsing time
- processing time for the various pgwire messages to cover the Extended Query flow.

(I'm planning one more PR, which would add a metric for time between first result byte sent and last result byte sent. That one is somewhat less important, so I'd like to get just the above two merged first.)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
