### PR TITLE
Fix storage metric labels

### DIFF
--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -237,22 +237,22 @@ impl SourceStatisticsMetrics {
             offset_known: defs.offset_known.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
-                parent_source_id.to_string(),
+                shard.clone(),
             ]),
             offset_committed: defs.offset_committed.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
-                parent_source_id.to_string(),
+                shard.clone(),
             ]),
             snapshot_records_known: defs.snapshot_records_known.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
-                parent_source_id.to_string(),
+                shard.clone(),
             ]),
             snapshot_records_staged: defs.snapshot_records_staged.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
-                parent_source_id.to_string(),
+                shard.clone(),
             ]),
         }
     }


### PR DESCRIPTION
Fixes storage metrics that are incorrectly using `parent_source_id` instead of `shard_id` as labels. 

### Motivation

fixes https://github.com/MaterializeInc/database-issues/issues/9343

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
