### PR TITLE
pgtz: use static data for available formats

### DIFF
--- a/src/pgtz/src/timezone.rs
+++ b/src/pgtz/src/timezone.rs
@@ -281,19 +281,19 @@ fn build_timezone_offset_second(
     spec: TimezoneSpec,
 ) -> Result<Timezone, String> {
     use TimeStrToken::*;
-    let all_formats = [
-        vec![Plus, Num(0, 1), Colon, Num(0, 1), Colon, Num(0, 1)],
-        vec![Dash, Num(0, 1), Colon, Num(0, 1), Colon, Num(0, 1)],
-        vec![Plus, Num(0, 1), Colon, Num(0, 1)],
-        vec![Dash, Num(0, 1), Colon, Num(0, 1)],
-        vec![Plus, Num(0, 1), Num(0, 1), Num(0, 1)],
-        vec![Dash, Num(0, 1), Num(0, 1), Num(0, 1)],
-        vec![Plus, Num(0, 1), Num(0, 1)],
-        vec![Dash, Num(0, 1), Num(0, 1)],
-        vec![Plus, Num(0, 1)],
-        vec![Dash, Num(0, 1)],
-        vec![TzName("".to_string())],
-        vec![Zulu],
+    static ALL_FORMATS: [&[TimeStrToken]; 12] = [
+        &[Plus, Num(0, 1), Colon, Num(0, 1), Colon, Num(0, 1)],
+        &[Dash, Num(0, 1), Colon, Num(0, 1), Colon, Num(0, 1)],
+        &[Plus, Num(0, 1), Colon, Num(0, 1)],
+        &[Dash, Num(0, 1), Colon, Num(0, 1)],
+        &[Plus, Num(0, 1), Num(0, 1), Num(0, 1)],
+        &[Dash, Num(0, 1), Num(0, 1), Num(0, 1)],
+        &[Plus, Num(0, 1), Num(0, 1)],
+        &[Dash, Num(0, 1), Num(0, 1)],
+        &[Plus, Num(0, 1)],
+        &[Dash, Num(0, 1)],
+        &[TzName(String::new())],
+        &[Zulu],
     ];
 
     let mut is_positive = true;
@@ -301,7 +301,7 @@ fn build_timezone_offset_second(
     let mut minute_offset: Option<i32> = None;
     let mut second_offset: Option<i32> = None;
 
-    for format in all_formats.iter() {
+    for format in ALL_FORMATS {
         let actual = tokens.iter();
 
         if actual.len() != format.len() {


### PR DESCRIPTION
The temporary allocations used in this function accounted for 3% of overall CPU time in a recent ingestion.

https://pprof.me/d4043f4a5d560743f3d3baf0e0dfa4d3/

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
