### PR TITLE
Add back opentelemetry resource organization_id

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1034,6 +1034,10 @@ fn create_environmentd_statefulset_object(
         args.extend([
             format!("--opentelemetry-endpoint={}", endpoint),
             format!(
+                "--opentelemetry-resource=organization_id={}",
+                mz.spec.environment_id
+            ),
+            format!(
                 "--opentelemetry-resource=environment_name={}",
                 mz.name_unchecked()
             ),


### PR DESCRIPTION
Add back `--opentelemetry-resource` `organization_id` so sentry has this information when it catches panics.

### Motivation

  * This PR fixes a previously unreported bug.
https://materializeinc.slack.com/archives/CL68GT3AT/p1749126281628409
This was lost in the migration to reconciling materialize CRs.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
