### PR TITLE
adapter: Add `result_rows_first_to_last_byte_seconds` metric

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -989,6 +989,12 @@ impl InProgressRows {
             remaining,
         }
     }
+
+    /// Determines whether the underlying stream has ended and there are also no more rows
+    /// stashed in `current`.
+    pub fn no_more_rows(&self) -> bool {
+        self.remaining.no_more_rows && self.current.is_none()
+    }
 }
 
 /// A channel of batched rows.

--- a/src/ore/src/stats.rs
+++ b/src/ore/src/stats.rs
@@ -20,9 +20,10 @@
 /// see `histogram_seconds_buckets` below.
 ///
 /// Note that any changes to this range may modify buckets for existing metrics.
-const HISTOGRAM_SECOND_BUCKETS: [f64; 23] = [
+const HISTOGRAM_SECOND_BUCKETS: [f64; 31] = [
     0.000_008, 0.000_016, 0.000_032, 0.000_064, 0.000_128, 0.000_256, 0.000_512, 0.001, 0.002,
-    0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0,
+    0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0,
+    128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0,
 ];
 
 /// Returns a `Vec` of time buckets that are both present in our standard


### PR DESCRIPTION
Add histogram metric for time between first result row returned and last result row returned. (This is part of https://github.com/MaterializeInc/materialize/pull/32504, although it's not yet mentioned in the design doc.)

This is more involved than my other similar PRs from yesterday, because the control flow for returning results is a bit complex, with several variations in various situations, see tests. (I wanted to also add a test for a FETCH that has a timeout, but it seems FETCH's timeout is currently not working: https://github.com/MaterializeInc/database-issues/issues/9354 )

Nightly: https://buildkite.com/materialize/nightly/builds/12231

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
