### PR TITLE
adapter,storage: allow webhook sources on multi-replica clusters

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1268,7 +1268,8 @@ class AlterSinkWebhook(Check):
         return Testdrive(
             dedent(
                 """
-                > CREATE CLUSTER sink_webhook_cluster SIZE '1', REPLICATION FACTOR 1;
+                >[version>=14700] CREATE CLUSTER sink_webhook_cluster SIZE '1', REPLICATION FACTOR 2;
+                >[version<14700] CREATE CLUSTER sink_webhook_cluster SIZE '1', REPLICATION FACTOR 1;
                 > CREATE SOURCE webhook_alter1 IN CLUSTER sink_webhook_cluster FROM WEBHOOK BODY FORMAT TEXT;
                 > CREATE SINK sink_alter_wh FROM webhook_alter1
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-alter-wh')

--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -25,7 +25,8 @@ class Webhook(Check):
             schemas()
             + dedent(
                 """
-                > CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
+                >[version>=14700] CREATE CLUSTER webhook_cluster REPLICATION FACTOR 2, SIZE '1'
+                >[version<14700] CREATE CLUSTER webhook_cluster REPLICATION FACTOR 1, SIZE '1'
 
                 > CREATE SOURCE webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT;
 
@@ -144,7 +145,7 @@ class WebhookTable(Check):
             schemas()
             + dedent(
                 """
-                > CREATE CLUSTER webhook_table_cluster REPLICAS (r1 (SIZE '1'));
+                > CREATE CLUSTER webhook_table_cluster REPLICATION FACTOR 2, SIZE '1'
                 > SET cluster = webhook_table_cluster
                 > CREATE TABLE webhook_table_text FROM WEBHOOK BODY FORMAT TEXT;
                 > SET cluster = quickstart

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1956,14 +1956,6 @@ class BackupRestoreAction(Action):
 
 
 class CreateWebhookSourceAction(Action):
-    def errors_to_ignore(self, exe: Executor) -> list[str]:
-        result = super().errors_to_ignore(exe)
-        if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
-            result.extend(
-                ["cannot create webhook source in cluster with more than one replica"]
-            )
-        return result
-
     def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.webhook_sources) >= MAX_WEBHOOK_SOURCES:
@@ -1975,7 +1967,7 @@ class CreateWebhookSourceAction(Action):
         with schema.lock, cluster.lock:
             if schema not in exe.db.schemas:
                 return False
-            if cluster not in exe.db.clusters or len(cluster.replicas) != 1:
+            if cluster not in exe.db.clusters:
                 return False
 
             source = WebhookSource(webhook_source_id, cluster, schema, self.rng)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -335,10 +335,15 @@ impl Coordinator {
                 plan::DataSourceDesc::Webhook { .. } => {
                     let cluster_id = plan.in_cluster.expect("webhook plans must specify cluster");
                     if let Some(cluster) = self.catalog().try_get_cluster(cluster_id) {
-                        if cluster.replica_ids().len() > 1 {
-                            return Err(AdapterError::Unsupported(
-                                "webhook sources in clusters with >1 replicas",
-                            ));
+                        let enable_multi_replica_sources = ENABLE_MULTI_REPLICA_SOURCES
+                            .get(self.catalog().system_config().dyncfgs());
+
+                        if !enable_multi_replica_sources {
+                            if cluster.replica_ids().len() > 1 {
+                                return Err(AdapterError::Unsupported(
+                                    "webhook sources in clusters with >1 replicas",
+                                ));
+                            }
                         }
                     }
                 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -550,8 +550,12 @@ pub fn plan_create_webhook_source(
     // We will rewrite the cluster if one is not provided, so we must use the `in_cluster` value
     // we plan to normalize when we canonicalize the create statement.
     let in_cluster = source_sink_cluster_config(scx, &mut stmt.in_cluster)?;
-    if in_cluster.replica_ids().len() > 1 {
-        sql_bail!("cannot create webhook source in cluster with more than one replica")
+    let enable_multi_replica_sources =
+        ENABLE_MULTI_REPLICA_SOURCES.get(scx.catalog.system_vars().dyncfgs());
+    if !enable_multi_replica_sources {
+        if in_cluster.replica_ids().len() > 1 {
+            sql_bail!("cannot create webhook source in cluster with more than one replica")
+        }
     }
     let create_sql =
         normalize::create_statement(scx, Statement::CreateWebhookSource(stmt.clone()))?;

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -7,14 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-arg-default replicas=1
+$ set-arg-default replicas=2
 $ set-arg-default default-storage-size=1
+
 
 # Exercises Webhook sources.
 
-> CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '${arg.default-storage-size}'));
+> CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '${arg.default-storage-size}'), r2 (SIZE '${arg.default-storage-size}'));
 
-> CREATE CLUSTER webhook_compute REPLICAS (r1 (SIZE '${arg.default-storage-size}'));
+> CREATE CLUSTER webhook_compute REPLICAS (r1 (SIZE '${arg.default-storage-size}'), r2 (SIZE '${arg.default-storage-size}'));
 
 > CREATE SOURCE webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT;
@@ -535,10 +536,6 @@ $ check-shard-tombstone shard-id=${webhook-source-shard-id}
 
 # Cleanup.
 > DROP CLUSTER webhook_cluster CASCADE;
-
-# Creating a webhook source without specifying the cluster.
-$ skip-if
-SELECT ${arg.replicas} > 1;
 
 $ set-from-sql var=current-cluster
 SHOW cluster;


### PR DESCRIPTION
The restriction was artificial, webhooks don't actually run on clusters.

Implements https://github.com/MaterializeInc/database-issues/issues/9181

@def- Do we want more than this in terms of testing?