### PR TITLE
Bump kind to v0.29.0 and set all node images to v1.31.x

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -356,10 +356,10 @@ RUN if [ $ARCH_GCC = x86_64 ]; then \
 
 # Install KinD, kubectl, helm & helm-docs
 
-RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
+RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
     && chmod +x /usr/local/bin/kind \
-    && if [ $ARCH_GO = amd64 ]; then echo 'af5e8331f2165feab52ec2ae07c427c7b66f4ad044d09f253004a20252524c8b /usr/local/bin/kind' | sha256sum --check; fi \
-    && if [ $ARCH_GO = arm64 ]; then echo '95c9601f21fdb2c286442339d5e370149b4fe2fc7c49f615647e4e27bdfb17e2 /usr/local/bin/kind' | sha256sum --check; fi
+    && if [ $ARCH_GO = amd64 ]; then echo 'c72eda46430f065fb45c5f70e7c957cc9209402ef309294821978677c8fb3284 /usr/local/bin/kind' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo '03d45095dbd9cc1689f179a3e5e5da24b77c2d1b257d7645abf1b4174bebcf2a /usr/local/bin/kind' | sha256sum --check; fi
 
 RUN curl -fsSL https://dl.k8s.io/release/v1.24.3/bin/linux/$ARCH_GO/kubectl > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -48,7 +48,7 @@ official [`kubernetes`] Python library to control the Kubernetes cluster.
     On Linux, use:
 
     ```
-    curl -fL https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64 > kind
+    curl -fL https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64 > kind
     chmod +x kind
     sudo mv kind /usr/local/bin
     ```

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.7
+    image: kindest/node:v1.31.6
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000
@@ -154,16 +154,19 @@ nodes:
         hostPort: 32063
 
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
@@ -171,6 +174,7 @@ nodes:
 
   # no-disk
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: false
       materialize.cloud/availability-zone: "1"
@@ -178,11 +182,13 @@ nodes:
 
   # others
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
+    image: kindest/node:v1.31.6
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"

--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -79,7 +79,7 @@ sudo systemctl enable docker.service --now
 sudo sh -c 'curl -L "https://dl.k8s.io/release/v1.24.3/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl'
 sudo chmod +x /usr/local/bin/kubectl
 ## kind
-sudo sh -c 'curl -L "https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64" > /usr/local/bin/kind'
+sudo sh -c 'curl -L "https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64" > /usr/local/bin/kind'
 sudo chmod +x /usr/local/bin/kind
 ## k9s
 curl -L 'https://github.com/derailed/k9s/releases/download/v0.26.3/k9s_Linux_x86_64.tar.gz' \


### PR DESCRIPTION
* Bumps kind to v0.29.0.
* Sets all kind node images to v1.31.x to match cloud.

This is needed to handle newer kind versions, which will use a newer version for the nodes without a version set.

There is no version that supports both v0.29.x and v0.33.x nodes.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Keep up to date.

  * This PR fixes a previously unreported bug.
Users with newer kind releases cannot run cloudtest, as our kind cluster.yaml does not specify versions for all nodes. Nodes that are unspecified will use the latest version supported by kind, which is not compatible with other nodes on 1.29. Version 1.29 is also out of support, and our cloud product is mostly on 1.31, so lets use that one. The v0.14.0 kind is ancient, and doesn't support 1.31, so we also need to bump that.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
