### PR TITLE
add minDomain for cluster topologySpread

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -204,6 +204,7 @@ pub fn orchestrator_scheduling_config(config: &SystemVars) -> ServiceSchedulingC
             enabled: config.cluster_enable_topology_spread(),
             ignore_non_singular_scale: config.cluster_topology_spread_ignore_non_singular_scale(),
             max_skew: config.cluster_topology_spread_max_skew(),
+            min_domains: config.cluster_topology_spread_set_min_domains(),
             soft: config.cluster_topology_spread_soft(),
         },
         soften_az_affinity: config.cluster_soften_az_affinity(),

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -783,7 +783,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
 
                 let constraint = TopologySpreadConstraint {
                     label_selector: Some(ls),
-                    min_domains: None,
+                    min_domains: config.min_domains,
                     max_skew: config.max_skew,
                     topology_key: "topology.kubernetes.io/zone".to_string(),
                     when_unsatisfiable: if config.soft {

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -418,6 +418,13 @@ pub mod scheduling_config {
         ///
         /// Defaults to `1`.
         pub max_skew: i32,
+        /// The `minDomains` for spread constraints.
+        /// See
+        /// <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/>
+        /// for more details.
+        ///
+        /// Defaults to None.
+        pub min_domains: Option<i32>,
         /// If `true`, make the spread constraints into a preference.
         ///
         /// Defaults to `false`.
@@ -466,6 +473,7 @@ pub mod scheduling_config {
     pub const DEFAULT_TOPOLOGY_SPREAD_ENABLED: bool = true;
     pub const DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: bool = true;
     pub const DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW: i32 = 1;
+    pub const DEFAULT_TOPOLOGY_SPREAD_MIN_DOMAIN: Option<i32> = None;
     pub const DEFAULT_TOPOLOGY_SPREAD_SOFT: bool = false;
 
     pub const DEFAULT_SOFTEN_AZ_AFFINITY: bool = false;
@@ -484,6 +492,7 @@ pub mod scheduling_config {
                     enabled: DEFAULT_TOPOLOGY_SPREAD_ENABLED,
                     ignore_non_singular_scale: DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
                     max_skew: DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
+                    min_domains: DEFAULT_TOPOLOGY_SPREAD_MIN_DOMAIN,
                     soft: DEFAULT_TOPOLOGY_SPREAD_SOFT,
                 },
                 soften_az_affinity: DEFAULT_SOFTEN_AZ_AFFINITY,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -39,7 +39,7 @@
 //! important.
 //!
 //! ## Structure
-//! Thw most meaningful exports from this module are:
+//! The most meaningful exports from this module are:
 //!
 //! - [`SessionVars`] represent per-session parameters, which each user can
 //!   access independently of one another, and are accessed via `SET`.
@@ -1180,6 +1180,7 @@ impl SystemVars {
             &cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD,
             &cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
             &cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW,
+            &cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MIN_DOMAINS,
             &cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT,
             &cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY,
             &cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT,
@@ -2081,6 +2082,10 @@ impl SystemVars {
 
     pub fn cluster_topology_spread_max_skew(&self) -> i32 {
         *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW)
+    }
+
+    pub fn cluster_topology_spread_set_min_domains(&self) -> Option<i32> {
+        *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MIN_DOMAINS)
     }
 
     pub fn cluster_topology_spread_soft(&self) -> bool {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1613,6 +1613,18 @@ pub mod cluster_scheduling {
         false,
     );
 
+    // `minDomains`, like maxSkew, is used to spread across a topology
+    // key. Unlike max skew, minDomains will force node creation to ensure
+    // distribution across a minimum number of keys.
+    // https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition
+    pub static CLUSTER_TOPOLOGY_SPREAD_MIN_DOMAINS: VarDefinition = VarDefinition::new(
+        "cluster_topology_spread_min_domains",
+        value!(Option<i32>; None),
+        "`minDomains` for replica topology spread constraints. \
+            Should be set to the number of Availability Zones (Materialize).",
+        false,
+    );
+
     pub static CLUSTER_TOPOLOGY_SPREAD_SOFT: VarDefinition = VarDefinition::new(
         "cluster_topology_spread_soft",
         value!(bool; DEFAULT_TOPOLOGY_SPREAD_SOFT),


### PR DESCRIPTION
Without a minDomain a topology spread constraint may place pods on only the subset of topology keys
where an existing node is provisioned. If we want to spread equally across all support availability zones rather than all availability zones that currently have nodes, then we need to set a minDomain value equal to the number of supported availability zones.

Perhaps a more appropriate way to handle this would be use the availability_zone's provided to environmentd. This was easier to throw together, it's more flexible, but less intuitive and easier to mess up.

There's some added trickiness to this one could imagine, where, for self-managed, this is not a global static, but a value that is dictated by the AZs available on the node_groups servicing a particular cluster or cluster size.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
We don't quite spread evenly.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
