### PR TITLE
k8s: don't unwrap when getting disk metrics

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -1542,8 +1542,15 @@ impl OrchestratorWorker {
                 disk_bytes: Option<u64>,
             }
 
-            let service = self_.service_api.get(service_name).await.unwrap();
-            let namespace = service.metadata.namespace.unwrap();
+            let service = self_
+                .service_api
+                .get(service_name)
+                .await
+                .with_context(|| format!("failed to get service {service_name}"))?;
+            let namespace = service
+                .metadata
+                .namespace
+                .context("missing service namespace")?;
             let internal_http_port = service
                 .spec
                 .and_then(|spec| spec.ports)
@@ -1564,7 +1571,7 @@ impl OrchestratorWorker {
             let http_client = reqwest::Client::builder()
                 .timeout(Duration::from_secs(10))
                 .build()
-                .unwrap();
+                .context("error building HTTP client")?;
             let resp = http_client.get(metrics_url).send().await?;
             let usage: Usage = resp.json().await?;
 


### PR DESCRIPTION
The new code for collecting disk metrics from orchestrated processes is too liberal in its use of unwraps. Specifically, it is possible for the get-service call to fail, in which case the unwrap on that call would panic environmentd.

This is fixed by returning an error instead. The `get_disk_metrics` function contained two additional unwraps, which are replaced as well. They might be fine, but better to be safe than sorry.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9364

### Tips for reviewer

There are a bunch of other unwraps in the orchestrator code. They are probably fine, based on that we don't see them triggering in production. But they subconsciously encourage use of unwraps in adjacent code where they might not be fine, so we should consider removing them anyway, or at least replacing them with `expect`s.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
