### PR TITLE
Whether to enable RBAC checks moved to the Materialize CR

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -149,7 +149,6 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.defaultSizes.probe` |  | ``"mz_probe"`` |
 | `operator.clusters.defaultSizes.support` |  | ``"25cc"`` |
 | `operator.clusters.defaultSizes.system` |  | ``"25cc"`` |
-| `operator.features.authentication` | Whether to enable environmentd rbac checks TODO: this is not yet supported in the helm chart | ``false`` |
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
 | `operator.image.tag` | The tag/version of the operator image to be used | ``"v0.146.0"`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -85,9 +85,6 @@ spec:
         {{- range $key, $value := .Values.console.imageTagMapOverride }}
         - "--console-image-tag-map={{ $key }}={{ $value }}"
         {{- end }}
-        {{- if not .Values.operator.features.authentication }}
-        - "--disable-authentication"
-        {{- end }}
 
         {{/* Cluster Configuration */}}
         {{- if .Values.operator.clusters }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[14]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[13]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[14]
+      path: spec.template.spec.containers[0].args[13]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[14]
+      path: spec.template.spec.containers[0].args[13]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[14]
+      path: spec.template.spec.containers[0].args[13]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -23,11 +23,6 @@ operator:
     startupLogFilter: "INFO,mz_orchestratord=TRACE"
     enableInternalStatementLogging: true
 
-  features:
-    # -- Whether to enable environmentd rbac checks
-    # TODO: this is not yet supported in the helm chart
-    authentication: false
-
   # Cloud provider configuration
   cloudProvider:
     # -- Specifies cloud provider. Valid values are 'aws', 'gcp', 'azure' , 'generic', or 'local'

--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -68,6 +68,12 @@ def main():
     parser_environment.add_argument(
         "--external-login-password-mz-system", required=False
     )
+    parser_environment.add_argument(
+        "--enable-rbac",
+        type=bool,
+        default=False,
+        required=False,
+    )
     parser_environment.set_defaults(func=environment)
 
     parser_portforward = subparsers.add_parser("port-forward")
@@ -257,6 +263,7 @@ def environment(args: argparse.Namespace):
                 "backendSecretName": backend_secret_name,
                 "environmentId": environment_id,
                 "authenticatorKind": "None",
+                "enableRbac": args.enable_rbac,
             },
         },
     ]

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -136,6 +136,9 @@ pub mod v1alpha1 {
         // If set to Password, the backend secret must contain external_login_password_mz_system.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
+        // Whether to enable role based access control. Defaults to false.
+        #[serde(default)]
+        pub enable_rbac: bool,
 
         // The value used by environmentd (via the --environment-id flag) to
         // uniquely identify this instance. Must be globally unique, and

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1030,7 +1030,7 @@ fn create_environmentd_statefulset_object(
         args.push("--system-parameter-default=statement_logging_max_sample_rate=0".into());
     }
 
-    if config.disable_authentication {
+    if !mz.spec.enable_rbac {
         args.push("--system-parameter-default=enable_rbac_checks=false".into());
     }
 


### PR DESCRIPTION
Moves whether to enable RBAC checks from the helm values to the Materialize CR.

### Motivation

  * This PR fixes a previously unreported bug.
This was previously a global setting for all Materialize instances, which doesn't make a lot of sense. Different instances may need different permissions, authentication types, and rbac settings.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  Helm chart tests are very limited currently. Discussion about future improvements is at https://materializeinc.slack.com/archives/C07PN7KSB0T/p1749639293686619
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
