### PR TITLE
k8s recovery tests: Bump kindest/node to v1.33.1

### DIFF
--- a/misc/kind/cluster-node-recovery-test.yaml
+++ b/misc/kind/cluster-node-recovery-test.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.7
+    image: kindest/node:v1.33.1
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/32694 Failures seen in https://buildkite.com/materialize/nightly/builds/12268#01975c36-7adf-4ace-9e81-67d43af9c4f8

> this version of kubeadm only supports deploying clusters with the control plane version >= 1.32.0. Current version: v1.29.7

Test run: https://buildkite.com/materialize/nightly/builds/12271

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
