### PR TITLE
terraform test: Fix upgrade test

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -614,6 +614,7 @@ class AWS(State):
         prefix: str,
         setup: bool,
         tag: str,
+        orchestratord_tag: str | None = None,
     ) -> None:
         if not setup:
             spawn.runv(
@@ -635,7 +636,7 @@ class AWS(State):
         ]
         vars += [
             "-var",
-            f"orchestratord_version={get_tag(tag)}",
+            f"orchestratord_version={get_tag(orchestratord_tag or tag)}",
         ]
 
         print("--- Setup")
@@ -813,7 +814,7 @@ def workflow_aws_upgrade(c: Composition, parser: WorkflowArgumentParser) -> None
     try:
         if args.run_mz_debug:
             mz_debug_build_thread = build_mz_debug_async()
-        aws.setup("aws-upgrade", args.setup, str(previous_tag))
+        aws.setup("aws-upgrade", args.setup, str(previous_tag), str(tag))
         aws.upgrade(tag)
         if args.test:
             # Try waiting a bit, otherwise connection error, should be handled better


### PR DESCRIPTION
Always use latest orchestratord version

Failure seen in https://buildkite.com/materialize/nightly/builds/12268#01975c2f-c9c9-4bbd-93ea-ec42d60726bc

```
$ kubectl logs -n materialize pod/aws-upgrade-dev-materialize-operator-77557b756-qrvzr --all-containers=true
error: unexpected argument '--disable-license-key-checks' found
```

Test run: https://buildkite.com/materialize/nightly/builds/12272

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
