### PR TITLE
Cluster node recovery test, set kind node image for all nodes.

### DIFF
--- a/misc/kind/cluster-node-recovery-test.yaml
+++ b/misc/kind/cluster-node-recovery-test.yaml
@@ -154,31 +154,37 @@ nodes:
         hostPort: 32063
 
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
@@ -186,12 +192,14 @@ nodes:
 
   # only envd (nodes will be tainted in the setup)
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       environmentd: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       materialize.cloud/disk: true
       environmentd: true
@@ -200,6 +208,7 @@ nodes:
 
   # for supporting services
   - role: worker
+    image: kindest/node:v1.33.1
     labels:
       supporting-services: true
       materialize.cloud/availability-zone: "3"


### PR DESCRIPTION
Explicitly set the node image for all kind nodes in the cluster node recovery tests.

### Motivation

  * This PR fixes a previously unreported bug.
If not specified, kind will choose the latest node image supported by that kind version. This is a moving target if developers have different versions of kind, and can just fail if we set the node image for some nodes but not others. If the version set for some nodes is old, the auto-selected version for the nodes not set may be more than one minor version newer than the one that was explicitly set, which is not supported by kubeadm (the kubeadm version is chosen by kind to be the version of the highest node version in the cluster).

This is a follow up to https://github.com/MaterializeInc/materialize/pull/32710 which should prevent this failure in the future (we'll still want to upgrade nodes from time to time, though).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
