### PR TITLE
ci: Fix lint for dyncfg path

### DIFF
--- a/misc/python/materialize/cli/lint_test_flags.py
+++ b/misc/python/materialize/cli/lint_test_flags.py
@@ -36,7 +36,7 @@ def main() -> int:
     configs = []
 
     for path in Path("src").rglob("*.rs"):
-        if path == Path("src/dyncfg/src/lib.rs"):
+        if path in [Path("src/dyncfg/src/lib.rs"), Path("src/dyncfg-file/src/lib.rs")]:
             continue  # contains tests
         with path.open(encoding="utf-8") as file:
             content = file.read()


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/104573#01975f0c-3fdf-4042-8a24-1b65418cc7e4

Merge skew between https://github.com/MaterializeInc/materialize/pull/32317 and https://github.com/MaterializeInc/materialize/pull/32670

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
