### PR TITLE
Clean up type constraints in compute, introduce wrapper traits

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -317,7 +317,7 @@ where
 impl<G, K, V, R> ArrangementSize for Arranged<G, KeyValAgent<K, V, G::Timestamp, R>>
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     K: Data + MzData,
     V: Data + MzData,
     R: Semigroup + Ord + MzData + 'static,
@@ -346,7 +346,7 @@ where
 impl<G, K, R> ArrangementSize for Arranged<G, KeyAgent<K, G::Timestamp, R>>
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     K: Data + MzArrangeData,
     R: Semigroup + Ord + MzData + 'static,
 {
@@ -372,7 +372,7 @@ where
 impl<G, V, R> ArrangementSize for Arranged<G, RowValAgent<V, G::Timestamp, R>>
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     V: Data + MzArrangeData,
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
@@ -400,7 +400,7 @@ where
 impl<G, R> ArrangementSize for Arranged<G, RowRowAgent<G::Timestamp, R>>
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
@@ -427,7 +427,7 @@ where
 impl<G, R> ArrangementSize for Arranged<G, RowAgent<G::Timestamp, R>>
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
     fn log_arrangement_size(self) -> Self {

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -15,7 +15,7 @@
 
 use differential_dataflow::Data;
 use differential_dataflow::IntoOwned;
-use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::difference::Abelian;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
@@ -28,7 +28,7 @@ use crate::extensions::arrange::ArrangementSize;
 /// Extension trait for the `reduce_abelian` differential dataflow method.
 pub(crate) trait MzReduce<G: Scope, T1: TraceReader<Time = G::Timestamp>>
 where
-    G::Timestamp: Lattice + Ord,
+    G::Timestamp: Lattice,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     fn mz_reduce_abelian<L, K, V, Bu, T2>(
@@ -55,7 +55,6 @@ where
     G::Timestamp: Lattice + Ord,
     G: Scope,
     T1: TraceReader<Time = G::Timestamp> + Clone + 'static,
-    T1::Diff: Semigroup,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     fn mz_reduce_abelian<L, K, V, Bu, T2>(
@@ -87,7 +86,7 @@ where
 /// on an operator-pair approach.
 pub trait ReduceExt<G: Scope, Tr: TraceReader<Time = G::Timestamp>>
 where
-    G::Timestamp: Lattice + Ord,
+    G::Timestamp: Lattice,
 {
     /// This method produces a reduction pair based on the same input arrangement. Each reduction
     /// in the pair operates with its own logic and the two output arrangements from the reductions
@@ -127,9 +126,8 @@ where
 
 impl<G: Scope, Tr> ReduceExt<G, Tr> for Arranged<G, Tr>
 where
-    G::Timestamp: Lattice + Ord,
+    G::Timestamp: Lattice,
     Tr: TraceReader<Time = G::Timestamp> + Clone + 'static,
-    Tr::Diff: Semigroup,
 {
     fn reduce_pair<L1, K, V1, Bu1, T1, L2, V2, Bu2, T2>(
         &self,

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -52,8 +52,8 @@ where
 
 impl<G, T1> MzReduce<G, T1> for Arranged<G, T1>
 where
-    G::Timestamp: Lattice + Ord,
     G: Scope,
+    G::Timestamp: Lattice,
     T1: TraceReader<Time = G::Timestamp> + Clone + 'static,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
@@ -84,9 +84,11 @@ where
 
 /// Extension trait for `ReduceCore`, currently providing a reduction based
 /// on an operator-pair approach.
-pub trait ReduceExt<G: Scope, Tr: TraceReader<Time = G::Timestamp>>
+pub trait ReduceExt<G, Tr>
 where
+    G: Scope,
     G::Timestamp: Lattice,
+    Tr: TraceReader<Time = G::Timestamp>,
 {
     /// This method produces a reduction pair based on the same input arrangement. Each reduction
     /// in the pair operates with its own logic and the two output arrangements from the reductions
@@ -124,8 +126,9 @@ where
         Arranged<G, TraceAgent<T2>>: ArrangementSize;
 }
 
-impl<G: Scope, Tr> ReduceExt<G, Tr> for Arranged<G, Tr>
+impl<G, Tr> ReduceExt<G, Tr> for Arranged<G, Tr>
 where
+    G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time = G::Timestamp> + Clone + 'static,
 {

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1333,7 +1333,7 @@ where
 
 #[allow(dead_code)] // Some of the methods on this trait are unused, but useful to have.
 /// A timestamp type that can be used for operations within MZ's dataflow layer.
-pub trait RenderTimestamp: MzTimestamp + Lattice + Refines<mz_repr::Timestamp> {
+pub trait RenderTimestamp: MzTimestamp + Refines<mz_repr::Timestamp> {
     /// The system timestamp component of the timestamp.
     ///
     /// This is useful for manipulating the system time, as when delaying

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -17,7 +17,6 @@ use std::sync::mpsc;
 
 use differential_dataflow::IntoOwned;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, Collection, Data};
@@ -66,8 +65,8 @@ use crate::typedefs::{
 /// of regions or iteration.
 pub struct Context<S: Scope, T = mz_repr::Timestamp>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// The scope within which all managed collections exist.
     ///
@@ -106,7 +105,7 @@ where
 
 impl<S: Scope> Context<S>
 where
-    S::Timestamp: MzTimestamp + Lattice + Refines<mz_repr::Timestamp>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Creates a new empty Context.
     pub fn for_dataflow_in<Plan>(
@@ -159,8 +158,8 @@ where
 
 impl<S: Scope, T> Context<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Insert a collection bundle by an identifier.
     ///
@@ -208,8 +207,8 @@ where
 
 impl<S: Scope, T> Context<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
@@ -330,8 +329,8 @@ impl HydrationLogger {
 #[derive(Clone)]
 pub enum ArrangementFlavor<S: Scope, T = mz_repr::Timestamp>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// A dataflow-local arrangement.
     Local(
@@ -351,8 +350,8 @@ where
 
 impl<S: Scope, T> ArrangementFlavor<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Presents `self` as a stream of updates.
     ///
@@ -435,8 +434,8 @@ where
 }
 impl<S: Scope, T> ArrangementFlavor<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> S {
@@ -463,8 +462,8 @@ where
 }
 impl<'a, S: Scope, T> ArrangementFlavor<Child<'a, S, S::Timestamp>, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Extracts the arrangement flavor from a region.
     pub fn leave_region(&self) -> ArrangementFlavor<S, T> {
@@ -486,8 +485,8 @@ where
 #[derive(Clone)]
 pub struct CollectionBundle<S: Scope, T = mz_repr::Timestamp>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     pub collection: Option<(Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)>,
     pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<S, T>>,
@@ -495,8 +494,8 @@ where
 
 impl<S: Scope, T> CollectionBundle<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
@@ -568,8 +567,8 @@ where
 
 impl<'a, S: Scope, T> CollectionBundle<Child<'a, S, S::Timestamp>, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Extracts the collection bundle from a region.
     pub fn leave_region(&self) -> CollectionBundle<S, T> {
@@ -589,8 +588,8 @@ where
 
 impl<S: Scope, T> CollectionBundle<S, T>
 where
-    T: MzTimestamp + Lattice,
-    S::Timestamp: MzTimestamp + Lattice + Refines<T>,
+    T: MzTimestamp,
+    S::Timestamp: MzTimestamp + Refines<T>,
 {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,
@@ -761,7 +760,7 @@ where
 
 impl<S, T> CollectionBundle<S, T>
 where
-    T: MzTimestamp + Lattice,
+    T: MzTimestamp,
     S: Scope,
     S::Timestamp: Refines<T> + RenderTimestamp,
 {

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -9,10 +9,6 @@
 
 //! Helpers for handling errors encountered by operators.
 
-use std::hash::Hash;
-
-use differential_dataflow::ExchangeData;
-use differential_dataflow::containers::Columnation;
 use mz_repr::Row;
 
 use crate::render::context::ShutdownProbe;
@@ -20,7 +16,7 @@ use crate::render::context::ShutdownProbe;
 /// Used to make possibly-validating code generic: think of this as a kind of `MaybeResult`,
 /// specialized for use in compute.  Validation code will only run when the error constructor is
 /// Some.
-pub(super) trait MaybeValidatingRow<T, E>: ExchangeData + Columnation + Hash {
+pub(super) trait MaybeValidatingRow<T, E> {
     fn ok(t: T) -> Self;
     fn into_error() -> Option<fn(E) -> Self>;
 }
@@ -45,10 +41,7 @@ impl<E> MaybeValidatingRow<(), E> for () {
     }
 }
 
-impl<E, R> MaybeValidatingRow<Vec<R>, E> for Vec<R>
-where
-    R: ExchangeData + Columnation + Hash,
-{
+impl<E, R> MaybeValidatingRow<Vec<R>, E> for Vec<R> {
     fn ok(t: Vec<R>) -> Self {
         t
     }
@@ -58,11 +51,7 @@ where
     }
 }
 
-impl<T, E> MaybeValidatingRow<T, E> for Result<T, E>
-where
-    T: ExchangeData + Columnation + Hash,
-    E: ExchangeData + Columnation + Hash,
-{
+impl<T, E> MaybeValidatingRow<T, E> for Result<T, E> {
     fn ok(row: T) -> Self {
         Ok(row)
     }

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use columnar::Columnar;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use mz_expr::MfpPlan;
 use mz_expr::{MapFilterProject, MirScalarExpr, TableFunc};
@@ -27,7 +26,6 @@ impl<G> Context<G>
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
 {
     /// Applies a `TableFunc` to every row, followed by an `mfp`.
     pub fn render_flat_map(
@@ -133,7 +131,6 @@ fn drain_through_mfp<T>(
     >,
 ) where
     T: crate::render::RenderTimestamp,
-    <T as Columnar>::Container: Clone + Send,
 {
     let temp_storage = RowArena::new();
     let mut row_builder = SharedRow::get();

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -15,7 +15,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use columnar::Columnar;
 use differential_dataflow::IntoOwned;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::operators::arrange::Arranged;
@@ -43,8 +42,6 @@ impl<G> Context<G>
 where
     G: Scope,
     G::Timestamp: RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
 {
     /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
     ///
@@ -337,8 +334,6 @@ fn build_halfjoin<G, Tr, CF>(
 where
     G: Scope,
     G::Timestamp: RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
     Tr: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
     for<'a> Tr::Key<'a>: IntoOwned<'a, Owned = Row>,
     for<'a> Tr::Val<'a>: ToDatumIter,
@@ -467,8 +462,6 @@ fn build_update_stream<G, Tr>(
 where
     G: Scope,
     G::Timestamp: RenderTimestamp,
-    <G::Timestamp as Columnar>::Container: Clone + Send,
-    for<'a> <G::Timestamp as Columnar>::Ref<'a>: Ord + Copy,
     for<'a, 'b> &'a G::Timestamp: PartialEq<Tr::TimeGat<'b>>,
     Tr: for<'a> TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
     for<'a> Tr::Key<'a>: ToDatumIter,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -189,8 +189,8 @@ impl YieldSpec {
 enum JoinedFlavor<G, T>
 where
     G: Scope,
-    G::Timestamp: Lattice + Refines<T> + MzTimestamp,
-    T: MzTimestamp + Lattice,
+    G::Timestamp: Refines<T> + MzTimestamp,
+    T: MzTimestamp,
 {
     /// Streamed data as a collection.
     Collection(Collection<G, Row, Diff>),
@@ -204,7 +204,7 @@ impl<G, T> Context<G, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T> + RenderTimestamp,
-    T: MzTimestamp + Lattice,
+    T: MzTimestamp,
 {
     pub(crate) fn render_join(
         &self,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -20,7 +20,6 @@ use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::containers::{Columnation, CopyRegion};
 use differential_dataflow::difference::{IsZero, Multiply, Semigroup};
 use differential_dataflow::hashable::Hashable;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Diff as _};
@@ -61,8 +60,8 @@ use crate::typedefs::{
 impl<G, T> Context<G, T>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Lattice + Refines<T>,
-    T: MzTimestamp + Lattice,
+    G::Timestamp: MzTimestamp + Refines<T>,
+    T: MzTimestamp,
 {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -13,7 +13,6 @@ use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::{Rc, Weak};
 
-use columnar::Columnar;
 use differential_dataflow::Collection;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc};
 use mz_expr::{EvalError, MapFilterProject, permutation_for_arrangement};
@@ -39,8 +38,6 @@ impl<'g, G, T> Context<Child<'g, G, T>>
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     T: RenderTimestamp,
-    <T as Columnar>::Container: Clone + Send,
-    for<'a> <T as Columnar>::Ref<'a>: Ord + Copy,
 {
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -13,7 +13,6 @@
 
 use differential_dataflow::Data;
 use differential_dataflow::IntoOwned;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
 use mz_compute_types::plan::threshold::{BasicThresholdPlan, ThresholdPlan};
@@ -38,7 +37,7 @@ fn threshold_arrangement<G, K, V, T1, Bu2, T2, L>(
 ) -> Arranged<G, TraceAgent<T2>>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Lattice,
+    G::Timestamp: MzTimestamp,
     V: MzData + Data,
     T1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
     for<'a> T1::Key<'a>: IntoOwned<'a, Owned = K>,
@@ -75,8 +74,8 @@ pub fn build_threshold_basic<G, T>(
 ) -> CollectionBundle<G, T>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Lattice + Refines<T>,
-    T: MzTimestamp + Lattice,
+    G::Timestamp: MzTimestamp + Refines<T>,
+    T: MzTimestamp,
 {
     let arrangement = input
         .arrangement(&key)
@@ -107,8 +106,8 @@ where
 impl<G, T> Context<G, T>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Lattice + Refines<T>,
-    T: MzTimestamp + Lattice,
+    G::Timestamp: MzTimestamp + Refines<T>,
+    T: MzTimestamp,
 {
     pub(crate) fn render_threshold(
         &self,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -529,7 +529,7 @@ fn build_topk_negated_stage<G, V, Bu, Tr>(
 )
 where
     G: Scope,
-    G::Timestamp: Lattice + MzTimestamp,
+    G::Timestamp: MzTimestamp,
     V: Data + MaybeValidatingRow<Row, Row>,
     Bu: Builder<Time = G::Timestamp, Output = Tr::Batch>,
     Bu::Input: Container + PushInto<((Row, V), G::Timestamp, Diff)>,

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -123,12 +123,16 @@ pub type KeyValBatcher<K, V, T, D> =
     MergeBatcher<Vec<((K, V), T, D)>, ColumnationChunker<((K, V), T, D)>, ColMerger<(K, V), T, D>>;
 
 /// Timestamp trait for rendering, constraint to support [`MzData`] and [timely::progress::Timestamp].
-pub trait MzTimestamp: MzData + timely::progress::Timestamp {}
+pub trait MzTimestamp:
+    MzData + timely::progress::Timestamp + differential_dataflow::lattice::Lattice
+{
+}
 
 impl<T> MzTimestamp for T
 where
     T: MzData,
     T: timely::progress::Timestamp,
+    T: differential_dataflow::lattice::Lattice,
 {
 }
 

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -121,3 +121,31 @@ pub type RowErrBuilder<T, R> = RowValBuilder<DataflowError, T, R>;
 pub type KeyBatcher<K, T, D> = KeyValBatcher<K, (), T, D>;
 pub type KeyValBatcher<K, V, T, D> =
     MergeBatcher<Vec<((K, V), T, D)>, ColumnationChunker<((K, V), T, D)>, ColMerger<(K, V), T, D>>;
+
+/// Timestamp trait for rendering, constraint to support [`MzData`] and [timely::progress::Timestamp].
+pub trait MzTimestamp: MzData + timely::progress::Timestamp {}
+
+impl<T> MzTimestamp for T
+where
+    T: MzData,
+    T: timely::progress::Timestamp,
+{
+}
+
+/// Trait for data types that can be used in Materialize's dataflow, supporting both columnar and
+/// columnation.
+pub trait MzData:
+    differential_dataflow::containers::Columnation
+    + for<'a> columnar::Columnar<Container: Clone + Send, Ref<'a>: Copy + Ord>
+{
+}
+
+impl<T> MzData for T
+where
+    T: differential_dataflow::containers::Columnation,
+    T: for<'a> columnar::Columnar<Container: Clone + Send, Ref<'a>: Copy + Ord>,
+{
+}
+
+pub trait MzArrangeData: differential_dataflow::containers::Columnation {}
+impl<T> MzArrangeData for T where T: differential_dataflow::containers::Columnation {}


### PR DESCRIPTION
Introduce `MzData` complementing other data traits, and constraining implementors to support columnation and columnar, with the right constraints on the GATs. Introduce a `MzTimestamp` extending `MzData`. This allows us to clean up and simplify some type definitions used throughout rendering.
