### PR TITLE
ci: Disable some further steps during sanitizer runs

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -52,6 +52,7 @@ steps:
           queue: builder-linux-x86_64
         env:
           CI_SANITIZER: address
+        sanitizer: skip
 
       - id: build-aarch64-asan
         label: ":bazel: Build aarch64 (ASan)"
@@ -65,6 +66,7 @@ steps:
           queue: builder-linux-aarch64-mem
         env:
           CI_SANITIZER: address
+        sanitizer: skip
 
   - group: Linters
     key: linters

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -41,6 +41,7 @@ steps:
         priority: 50
         agents:
           queue: builder-linux-x86_64
+        sanitizer: skip
 
       - id: upload-debug-symbols-x86_64
         label: "Upload debug symbols for x86_64"
@@ -55,6 +56,7 @@ steps:
         agents:
           queue: linux-x86_64
         coverage: skip
+        sanitizer: skip
 
       - id: rust-build-aarch64
         label: ":rust: Build aarch64"
@@ -68,6 +70,7 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64-mem
+        sanitizer: skip
 
       - id: upload-debug-symbols-aarch64
         label: "Upload debug symbols for aarch64"
@@ -82,6 +85,7 @@ steps:
         agents:
           queue: linux-aarch64
         coverage: skip
+        sanitizer: skip
 
       - id: build-x86_64
         label: ":bazel: Build x86_64"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -458,6 +458,7 @@ steps:
         agents:
           # Larger agent for faster runtime
           queue: hetzner-aarch64-8cpu-16gb
+        skip: "Reenable when database-issues#9362 is fixed"
 
       - id: pg-rtr
         label: "Postgres RTR tests"


### PR DESCRIPTION
Based on recent runs: https://buildkite.com/materialize/test/builds/104624 & https://buildkite.com/materialize/nightly/builds/12300
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
