### PR TITLE
sanitizer: Use clang 18

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -204,9 +204,9 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     jq \
     lcov \
     libc-dbg \
-    libclang-common-15-dev \
+    libclang-common-18-dev \
     libclang-dev \
-    libclang-rt-15-dev \
+    libclang-rt-18-dev \
     libpq-dev \
     lld \
     llvm \

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -186,7 +186,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     "CXXSTDLIB": "stdc++",
                     "CC": "cc",
                     "CXX": "c++",
-                    "CPP": "clang-cpp-15",
+                    "CPP": "clang-cpp-18",
                     "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "cc",
                     "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER": "cc",
                     "PATH": f"/sanshim:/opt/x-tools/{target(Arch.host())}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -451,7 +451,7 @@ class CargoBuild(CargoPreImage):
                 "CXXSTDLIB": "stdc++",
                 "CC": "cc",
                 "CXX": "c++",
-                "CPP": "clang-cpp-15",
+                "CPP": "clang-cpp-18",
                 "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "cc",
                 "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER": "cc",
                 "PATH": f"/sanshim:/opt/x-tools/{target(rd.arch)}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/104624#01976330-d81d-4071-a0f4-8c6fa6e9cbec
```
rust-lld: error: cannot open /usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
rust-lld: error: cannot open /usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Verified locally, test run in CI: https://buildkite.com/materialize/test/builds/104636
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
