### PR TITLE
kafka tests: Update available versions for Redpanda and CP

### DIFF
--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -13,7 +13,7 @@ from materialize.mzcompose.service import (
     ServiceConfig,
 )
 
-REDPANDA_VERSION = "v25.1.3"
+REDPANDA_VERSION = "v25.1.4"
 
 
 class Redpanda(Service):

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -28,9 +28,9 @@ REDPANDA_VERSIONS = [
     "v23.1.21",
     "v23.2.29",
     "v23.3.21",
-    "v24.1.19",
-    "v24.2.22",
-    "v24.3.11",
+    "v24.1.21",
+    "v24.2.24",
+    "v24.3.14",
     REDPANDA_VERSION,
     "latest",
 ]
@@ -46,7 +46,10 @@ CONFLUENT_PLATFORM_VERSIONS = [
     "7.7.3",
     "7.8.2",
     DEFAULT_CONFLUENT_PLATFORM_VERSION,
-    "latest",
+    # There is currently a mismatch in the latest versions between zookeeper
+    # (7.9.0) and cp-kafka (8.0.0), making running them in combination
+    # impossible
+    # "latest",
 ]
 
 SERVICES = [


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/nightly/builds/12296#01976155-4cbe-49db-a288-dd7b1b357f0b
Test run: https://buildkite.com/materialize/nightly/builds/12303

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
