### PR TITLE
Remove duplicate license key volume

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1340,34 +1340,6 @@ fn create_environmentd_statefulset_object(
         },
     ];
 
-    if mz.meets_minimum_version(&V140_DEV0) {
-        volume_mounts.push(VolumeMount {
-            name: "license-key".to_string(),
-            mount_path: "/license_key".to_string(),
-            ..Default::default()
-        });
-        volumes.push(Volume {
-            name: "license-key".to_string(),
-            secret: Some(SecretVolumeSource {
-                default_mode: Some(256),
-                optional: Some(false),
-                secret_name: Some(mz.backend_secret_name()),
-                items: Some(vec![KeyToPath {
-                    key: "license_key".to_string(),
-                    path: "license_key".to_string(),
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..Default::default()
-        });
-        env.push(EnvVar {
-            name: "MZ_LICENSE_KEY".to_string(),
-            value: Some("/license_key/license_key".to_string()),
-            ..Default::default()
-        });
-    }
-
     // Add networking arguments.
     if mz.meets_minimum_version(&V147_DEV0) {
         volume_mounts.push(VolumeMount {


### PR DESCRIPTION
Removes duplicate license key volume.

### Motivation

  * This PR fixes a previously unreported bug.
We duplicated this code somehow, and this one doesn't even have the correct `if` statement.

### Tips for reviewer
The correct code is at [line 1249](https://github.com/MaterializeInc/materialize/pull/32724/files#diff-4882726600268ef946ee674ccfd290e9af8f8a7ff0cf8b7f4da2287eee7bc68fR1249-R1277).
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  Orchestratord testing is out of scope for this PR. Discussion about how to test it better at https://materializeinc.slack.com/archives/C07PN7KSB0T/p1749639293686619
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
