### PR TITLE
ci: Tag sanitizer builds too

### DIFF
--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -22,12 +22,14 @@ def main() -> None:
     bazel_remote_cache = os.getenv("CI_BAZEL_REMOTE_CACHE")
 
     mz_version = ci_util.get_mz_version()
+    sanitizer = Sanitizer[os.getenv("CI_SANITIZER", "none")]
+
     repos = [
         mzbuild.Repository(
             Path("."),
             Arch.X86_64,
             coverage=False,
-            sanitizer=Sanitizer.none,
+            sanitizer=sanitizer,
             bazel=bazel,
             bazel_remote_cache=bazel_remote_cache,
         ),
@@ -35,7 +37,7 @@ def main() -> None:
             Path("."),
             Arch.AARCH64,
             coverage=False,
-            sanitizer=Sanitizer.none,
+            sanitizer=sanitizer,
             bazel=bazel,
             bazel_remote_cache=bazel_remote_cache,
         ),
@@ -47,8 +49,9 @@ def main() -> None:
     ]
     # Ideally we'd use SemVer metadata (e.g., `v1.0.0+metadata`), but `+` is not
     # a valid character in Docker tags, so we use `--` instead.
+    suffix = "pr" if sanitizer == Sanitizer.none else f"pr-{sanitizer}"
     mzbuild.publish_multiarch_images(
-        f'v{mz_version}--pr.g{git.rev_parse("HEAD")}', deps
+        f'v{mz_version}--{suffix}.g{git.rev_parse("HEAD")}', deps
     )
 
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -148,7 +148,6 @@ steps:
         agents:
           queue: linux-aarch64-small
         coverage: skip
-        sanitizer: skip
         # Fortify against intermittent DockerHub issues
         retry:
           automatic:


### PR DESCRIPTION
Required for https://materializeinc.slack.com/archives/C0914BQ0H5G/p1749718347200649
Test run: https://buildkite.com/materialize/test/builds/104643

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
