### PR TITLE
always pass --opentelemetry-resource args

### DIFF
--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1122,18 +1122,19 @@ fn create_environmentd_statefulset_object(
     // Add logging and tracing arguments.
     args.extend(["--log-format=json".into()]);
     if let Some(endpoint) = &tracing.opentelemetry_endpoint {
-        args.extend([
-            format!("--opentelemetry-endpoint={}", endpoint),
-            format!(
-                "--opentelemetry-resource=organization_id={}",
-                mz.spec.environment_id
-            ),
-            format!(
-                "--opentelemetry-resource=environment_name={}",
-                mz.name_unchecked()
-            ),
-        ]);
+        args.push(format!("--opentelemetry-endpoint={}", endpoint));
     }
+    // --opentelemetry-resource also configures sentry tags
+    args.extend([
+        format!(
+            "--opentelemetry-resource=organization_id={}",
+            mz.spec.environment_id
+        ),
+        format!(
+            "--opentelemetry-resource=environment_name={}",
+            mz.name_unchecked()
+        ),
+    ]);
 
     if let Some(segment_api_key) = &config.segment_api_key {
         args.push(format!("--segment-api-key={}", segment_api_key));


### PR DESCRIPTION
### Motivation

apparently we also use them for sentry tagging

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
