### PR TITLE
remove `drain_filter_swapping` in favor of std's `Vec::extract_if`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -123,7 +123,6 @@ use mz_ore::task::{JoinHandle, spawn};
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
 use mz_ore::url::SensitiveUrl;
-use mz_ore::vec::VecExt;
 use mz_ore::{
     assert_none, instrument, soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log, stack,
 };
@@ -2203,7 +2202,7 @@ impl Coordinator {
         let migrated_updates_fut = if self.controller.read_only() {
             let min_timestamp = Timestamp::minimum();
             let migrated_builtin_table_updates: Vec<_> = builtin_table_updates
-                .drain_filter_swapping(|update| {
+                .extract_if(.., |update| {
                     let gid = self.catalog().get_entry(&update.id).latest_global_id();
                     migrated_storage_collections_0dt.contains(&update.id)
                         && self

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -35,7 +35,6 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::task::{self, JoinHandle, spawn};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_ore::vec::VecExt;
 use mz_ore::{assert_none, instrument};
 use mz_persist_client::stats::SnapshotPartStats;
 use mz_repr::adt::jsonb::Jsonb;
@@ -1733,7 +1732,7 @@ impl Coordinator {
             let role_membership =
                 session_catalog.collect_role_membership(session.current_role_id());
             let invalid_revokes: BTreeSet<_> = privilege_revokes
-                .drain_filter_swapping(|(_, privilege)| {
+                .extract_if(.., |(_, privilege)| {
                     !role_membership.contains(&privilege.grantor)
                 })
                 .map(|(object_id, _)| object_id)

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -23,7 +23,6 @@ use mz_expr::CollectionPlan;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_ore::now::{EpochMillis, NowFn, to_datetime};
-use mz_ore::vec::VecExt;
 use mz_repr::{CatalogItemId, GlobalId, Timestamp};
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaSpecifier};
 use mz_storage_types::sources::Timeline;
@@ -417,7 +416,7 @@ impl Coordinator {
         // transaction counter number because those counters are unrelated to the
         // other.
         let timelines: Vec<_> = timeline_contexts
-            .drain_filter_swapping(|timeline_context| timeline_context.contains_timeline())
+            .extract_if(.., |timeline_context| timeline_context.contains_timeline())
             .collect();
 
         // A single or group of objects may contain multiple compatible timeline

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -90,62 +90,6 @@ impl Vector<u8> for compact_bytes::CompactBytes {
 
 /// Extension methods for `std::vec::Vec`
 pub trait VecExt<T> {
-    /// Creates an iterator which uses a closure to determine if an element should be removed.
-    ///
-    /// If the closure returns true, then the element is removed and yielded.
-    /// If the closure returns false, the element will remain in the vector and will not be yielded
-    /// by the iterator.
-    ///
-    /// Using this method and consuming the iterator is equivalent to the following code:
-    ///
-    /// ```
-    /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
-    /// # let mut vec = vec![1, 2, 3, 4, 5, 6];
-    /// let mut i = 0;
-    /// while i < vec.len() {
-    ///     if some_predicate(&mut vec[i]) {
-    ///         let val = vec.swap_remove(i);
-    ///         // your code here
-    ///     } else {
-    ///         i += 1;
-    ///     }
-    /// }
-    ///
-    /// # assert_eq!(vec, vec![1, 5, 4]);
-    /// ```
-    ///
-    /// But `drain_filter_swapping` is easier to use.
-    ///
-    /// Note that `drain_filter_swapping` also lets you mutate every element in the filter closure,
-    /// regardless of whether you choose to keep or remove it.
-    ///
-    /// # Note
-    ///
-    /// Because the elements are removed using [`Vec::swap_remove`] the order of elements yielded
-    /// by the iterator and the order of the remaining elements in the original vector is **not**
-    /// maintained.
-    ///
-    /// # Examples
-    ///
-    /// Splitting an array into evens and odds, reusing the original allocation. Notice how the
-    /// order is not preserved in either results:
-    ///
-    /// ```
-    /// use mz_ore::vec::VecExt;
-    ///
-    /// let mut numbers = vec![1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
-    ///
-    /// let evens = numbers.drain_filter_swapping(|x| *x % 2 == 0).collect::<Vec<_>>();
-    /// let odds = numbers;
-    ///
-    /// assert_eq!(evens, vec![2, 4, 14, 6, 8]);
-    /// assert_eq!(odds, vec![1, 15, 3, 13, 5, 11, 9]);
-    /// ```
-    #[must_use = "The vector is modified only if the iterator is consumed"]
-    fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
-    where
-        F: FnMut(&mut T) -> bool;
-
     /// Returns whether the vector is sorted using the given comparator function.
     fn is_sorted_by<F>(&self, compare: F) -> bool
     where
@@ -162,17 +106,6 @@ pub trait PartialOrdVecExt<T> {
 }
 
 impl<T> VecExt<T> for Vec<T> {
-    fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
-    where
-        F: FnMut(&mut T) -> bool,
-    {
-        DrainFilterSwapping {
-            vec: self,
-            idx: 0,
-            pred: filter,
-        }
-    }
-
     // implementation is from Vec::is_sorted_by, but with `windows` instead of
     // the unstable `array_windows`
     fn is_sorted_by<F>(&self, mut compare: F) -> bool
@@ -193,52 +126,6 @@ where
 
     fn is_strictly_sorted(&self) -> bool {
         self.is_sorted_by(|a, b| a < b)
-    }
-}
-
-/// An iterator which uses a closure to determine if an element should be removed.
-///
-/// This struct is created by [`VecExt::drain_filter_swapping`].
-/// See its documentation for more.
-///
-/// Warning: The vector is modified only if the iterator is consumed!
-///
-/// # Example
-///
-/// ```
-/// use mz_ore::vec::VecExt;
-///
-/// let mut v = vec![0, 1, 2];
-/// let iter: mz_ore::vec::DrainFilterSwapping<_, _> = v.drain_filter_swapping(|x| *x % 2 == 0);
-/// ```
-#[derive(Debug)]
-pub struct DrainFilterSwapping<'a, T, F> {
-    vec: &'a mut Vec<T>,
-    /// The index of the item that will be inspected by the next call to `next`.
-    idx: usize,
-    /// The filter test predicate.
-    pred: F,
-}
-
-impl<'a, T, F> Iterator for DrainFilterSwapping<'a, T, F>
-where
-    F: FnMut(&mut T) -> bool,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let item = self.vec.get_mut(self.idx)?;
-            if (self.pred)(item) {
-                return Some(self.vec.swap_remove(self.idx));
-            } else {
-                self.idx += 1;
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.vec.len() - self.idx))
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -29,7 +29,6 @@ use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::num::NonNeg;
 use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
-use mz_ore::vec::VecExt;
 use mz_postgres_util::tunnel::PostgresFlavor;
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
@@ -6995,7 +6994,7 @@ pub fn plan_alter_sink(
             // And then we find the existing version of the sink and increase it by one
             let cur_version = stmt
                 .with_options
-                .drain_filter_swapping(|o| o.name == CreateSinkOptionName::Version)
+                .extract_if(.., |o| o.name == CreateSinkOptionName::Version)
                 .map(|o| u64::try_from_value(o.value).expect("invalid sink create_sql"))
                 .max()
                 .unwrap_or(0);

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -80,7 +80,6 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::retry::Retry;
 use mz_ore::soft_panic_or_log;
 use mz_ore::task::AbortOnDropHandle;
-use mz_ore::vec::VecExt;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_types::Codec64;
@@ -865,7 +864,7 @@ where
                 self.to_write.extend(updates);
             }
             StorageWriteOp::Delete { filter } => {
-                let to_delete = self.desired.drain_filter_swapping(|(row, _)| filter(row));
+                let to_delete = self.desired.extract_if(.., |(row, _)| filter(row));
                 let retractions = to_delete.map(|(row, diff)| (row, -diff));
                 self.to_write.extend(retractions);
             }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -104,7 +104,6 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::task::{self, AbortOnDropHandle};
-use mz_ore::vec::VecExt;
 use mz_persist_client::Diagnostics;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_types::codec_impls::UnitSchema;
@@ -781,7 +780,7 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                         deferred_updates.shrink_to(buffer_min_capacity.get());
                         extra_updates.extend(
                             deferred_updates
-                                .drain_filter_swapping(|(_, time, _)| !progress.less_equal(time)),
+                                .extract_if(.., |(_, time, _)| !progress.less_equal(time)),
                         );
                         extra_updates.sort_unstable_by(|a, b| a.1.cmp(&b.1));
 

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -21,7 +21,6 @@ use fail::fail_point;
 use futures::StreamExt;
 use futures::stream::LocalBoxStream;
 use mz_ore::soft_panic_or_log;
-use mz_ore::vec::VecExt;
 use mz_persist_client::Diagnostics;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::error::UpperMismatch;
@@ -227,7 +226,7 @@ where
                     // Peel off a batch of pending data
                     let batch = self
                         .pending_batch
-                        .drain_filter_swapping(|(_, ts, _)| !new_upper.less_equal(ts))
+                        .extract_if(.., |(_, ts, _)| !new_upper.less_equal(ts))
                         .collect();
                     return Some((batch, new_upper));
                 }

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -18,7 +18,6 @@ use differential_dataflow::hashable::Hashable;
 use differential_dataflow::{AsCollection, Collection};
 use indexmap::map::Entry;
 use itertools::Itertools;
-use mz_ore::vec::VecExt;
 use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::errors::{DataflowError, EnvelopeError, UpsertError};
 use mz_timely_util::builder_async::{
@@ -620,7 +619,7 @@ where
     let mut min_remaining_time = Antichain::new();
 
     let mut eligible_updates = stash
-        .drain_filter_swapping(|(ts, _, _, _)| {
+        .extract_if(.., |(ts, _, _, _)| {
             let eligible = match &drain_style {
                 DrainStyle::ToUpper {
                     input_upper,


### PR DESCRIPTION
The std method has finally stabilized and it additionally preserves ordering!

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
