### PR TITLE
storage/pg: attempt exact snapshot count only when estimate is low enough

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -143,8 +143,6 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         statistics_collection_interval: config.storage_statistics_collection_interval(),
         pg_snapshot_config: PgSourceSnapshotConfig {
             collect_strict_count: config.pg_source_snapshot_collect_strict_count(),
-            fallback_to_strict_count: config.pg_source_snapshot_fallback_to_strict_count(),
-            wait_for_count: config.pg_source_snapshot_wait_for_count(),
         },
         user_storage_managed_collections_batch_duration: config
             .user_storage_managed_collections_batch_duration(),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1135,8 +1135,6 @@ impl SystemVars {
             &PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT,
             &PG_SOURCE_WAL_SENDER_TIMEOUT,
             &PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT,
-            &PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT,
-            &PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT,
             &MYSQL_SOURCE_TCP_KEEPALIVE,
             &MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME,
             &MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT,
@@ -1785,14 +1783,6 @@ impl SystemVars {
     pub fn pg_source_snapshot_collect_strict_count(&self) -> bool {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT)
     }
-    /// Returns the `pg_source_snapshot_fallback_to_strict_count` configuration parameter.
-    pub fn pg_source_snapshot_fallback_to_strict_count(&self) -> bool {
-        *self.expect_value(&PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT)
-    }
-    /// Returns the `pg_source_snapshot_collect_strict_count` configuration parameter.
-    pub fn pg_source_snapshot_wait_for_count(&self) -> bool {
-        *self.expect_value(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
-    }
 
     /// Returns the `mysql_source_tcp_keepalive` configuration parameter.
     pub fn mysql_source_tcp_keepalive(&self) -> Duration {
@@ -2219,8 +2209,6 @@ impl SystemVars {
             || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
             || name == PG_SOURCE_WAL_SENDER_TIMEOUT.name()
             || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
-            || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
-            || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
             || name == MYSQL_SOURCE_TCP_KEEPALIVE.name()
             || name == MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME.name()
             || name == MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT.name()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1024,26 +1024,6 @@ pub static PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: VarDefinition = VarDefinitio
     false,
 );
 
-/// Please see `PgSourceSnapshotConfig`.
-pub static PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: VarDefinition = VarDefinition::new(
-    "pg_source_snapshot_fallback_to_strict_count",
-    value!(bool; mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count),
-    "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.fallback_to_strict_count>",
-    false,
-);
-
-/// Please see `PgSourceSnapshotConfig`.
-pub static PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: VarDefinition = VarDefinition::new(
-    "pg_source_snapshot_wait_for_count",
-    value!(bool; mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count),
-    "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
-    false,
-);
-
 /// Sets the time between TCP keepalive probes when connecting to MySQL via `mz_mysql_util`.
 pub static MYSQL_SOURCE_TCP_KEEPALIVE: VarDefinition = VarDefinition::new(
     "mysql_source_tcp_keepalive",

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -53,8 +53,6 @@ message ProtoStorageParameters {
 
 message ProtoPgSourceSnapshotConfig {
   bool collect_strict_count = 1;
-  bool fallback_to_strict_count = 2;
-  bool wait_for_count = 3;
 }
 
 message ProtoMySqlSourceTimeouts {

--- a/src/storage/src/metrics/source/postgres.rs
+++ b/src/storage/src/metrics/source/postgres.rs
@@ -78,7 +78,7 @@ impl PgSourceMetricDefs {
             table_count_latency: registry.register(metric!(
                 name: "mz_postgres_snapshot_count_latency",
                 help: "The wall time used to obtain snapshot sizes.",
-                var_labels: ["source_id", "table_name", "strict"],
+                var_labels: ["source_id", "table_name"],
             )),
         }
     }
@@ -95,20 +95,11 @@ pub(crate) struct PgSnapshotMetrics {
 }
 
 impl PgSnapshotMetrics {
-    pub(crate) fn record_table_count_latency(
-        &self,
-        table_name: String,
-        latency: f64,
-        strict: bool,
-    ) {
+    pub(crate) fn record_table_count_latency(&self, table_name: String, latency: f64) {
         let latency_gauge = self
             .defs
             .table_count_latency
-            .get_delete_on_drop_metric(vec![
-                self.source_id.to_string(),
-                table_name,
-                strict.to_string(),
-            ]);
+            .get_delete_on_drop_metric(vec![self.source_id.to_string(), table_name]);
         latency_gauge.set(latency);
         self.gauges.lock().expect("poisoned").push(latency_gauge)
     }

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -149,6 +149,7 @@ use mz_postgres_util::{Client, PostgresError, simple_query_opt};
 use mz_repr::{Datum, DatumVec, Diff, Row};
 use mz_sql_parser::ast::{Ident, display::AstDisplay};
 use mz_storage_types::errors::DataflowError;
+use mz_storage_types::parameters::PgSourceSnapshotConfig;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
@@ -517,21 +518,12 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             }
             *rewind_cap_set = CapabilitySet::new();
 
-            let strict_count = config.config.parameters.pg_snapshot_config.collect_strict_count;
-            if strict_count {
-                mz_ore::soft_assert_eq_or_log!(
-                    snapshot_staged,
-                    snapshot_total,
-                    "timely-{worker_id} size mimatch for snapshot of source {id}. \
-                        expected: {snapshot_total} actual: {snapshot_staged}"
-                );
-            }
             // Report the same known and staged records to signify that the snapshot is complete.
             stats_output.give(
                 &stats_cap[0],
                 ProgressStatisticsUpdate::Snapshot {
-                    records_known: snapshot_total,
-                    records_staged: snapshot_total,
+                    records_known: snapshot_staged,
+                    records_staged: snapshot_staged,
                 },
             );
 
@@ -717,14 +709,8 @@ async fn fetch_snapshot_size(
 
     let mut total = 0;
     for (table, oid, output_count) in tables {
-        let stats =
-            collect_table_statistics(client, snapshot_config.collect_strict_count, &table, oid)
-                .await?;
-        metrics.record_table_count_latency(
-            table,
-            stats.count_latency,
-            snapshot_config.collect_strict_count,
-        );
+        let stats = collect_table_statistics(client, snapshot_config, &table, oid).await?;
+        metrics.record_table_count_latency(table, stats.count_latency);
         total += stats.count * u64::cast_from(output_count);
     }
     Ok(total)
@@ -738,41 +724,38 @@ struct TableStatistics {
 
 async fn collect_table_statistics(
     client: &Client,
-    strict: bool,
+    config: PgSourceSnapshotConfig,
     table: &str,
     oid: u32,
 ) -> Result<TableStatistics, anyhow::Error> {
     use mz_ore::metrics::MetricsFutureExt;
     let mut stats = TableStatistics::default();
 
-    if strict {
+    let estimate_row = simple_query_opt(
+        client,
+        &format!("SELECT reltuples::bigint AS estimate_count FROM pg_class WHERE oid = '{oid}'"),
+    )
+    .wall_time()
+    .set_at(&mut stats.count_latency)
+    .await?;
+    stats.count = match estimate_row {
+        Some(row) => row.get("estimate_count").unwrap().parse().unwrap_or(0),
+        None => bail!("failed to get estimate count for {table}"),
+    };
+
+    // If the estimate is low enough we can attempt to get an exact count. Note that not yet
+    // vacuumed tables will report zero rows here and there is a possibility that they are very
+    // large. We accept this risk and we offer the feature flag as an escape hatch if it becomes
+    // problematic.
+    if config.collect_strict_count && stats.count < 1_000_000 {
         let count_row = simple_query_opt(client, &format!("SELECT count(*) as count from {table}"))
             .wall_time()
             .set_at(&mut stats.count_latency)
             .await?;
-        match count_row {
-            Some(row) => {
-                let count: i64 = row.get("count").unwrap().parse().unwrap();
-                stats.count = count.try_into()?;
-            }
+        stats.count = match count_row {
+            Some(row) => row.get("count").unwrap().parse().unwrap(),
             None => bail!("failed to get count for {table}"),
         }
-    } else {
-        let estimate_row = simple_query_opt(
-            client,
-            &format!(
-                "SELECT reltuples::bigint AS estimate_count FROM pg_class WHERE oid = '{oid}'"
-            ),
-        )
-        .wall_time()
-        .set_at(&mut stats.count_latency)
-        .await?;
-        match estimate_row {
-            Some(row) => {
-                stats.count = row.get("estimate_count").unwrap().parse().unwrap_or(0);
-            }
-            None => bail!("failed to get estimate count for {table}"),
-        };
     }
 
     Ok(stats)


### PR DESCRIPTION
We have recently seen cases where the exact count of rows is problematic when the target table contains many rows. The value of this exact count is not worth the resources spent since the result only informs the snapshot progress reporting.

This PR changes the logic to always collect the estimated number of rows first and if it's below a threshold (currently one million) attempt an exact count as well. Otherwise we just use the estimate.

I retained the flag to compeltely disable exact counting in case the current threshold is problematic.

This PR also removes the assertion that the total number of ingested rows match the number of counted rows. This assertion effectively checks that PostgreSQL transactions work, which doesn't seem very useful and due to other reasons cause CI flakes. See MaterializeInc/database-issues#9362

Fixes MaterializeInc/database-issues#9362

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
