### PR TITLE
orchestrator: prepare for initializing Timely at process creation

### DIFF
--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -643,13 +643,16 @@ where
                     let mut args = vec![
                         format!(
                             "--storage-controller-listen-addr={}",
-                            assigned["storagectl"]
+                            assigned.listen_addrs["storagectl"]
                         ),
                         format!(
                             "--compute-controller-listen-addr={}",
-                            assigned["computectl"]
+                            assigned.listen_addrs["computectl"]
                         ),
-                        format!("--internal-http-listen-addr={}", assigned["internal-http"]),
+                        format!(
+                            "--internal-http-listen-addr={}",
+                            assigned.listen_addrs["internal-http"]
+                        ),
                         format!("--opentelemetry-resource=cluster_id={}", cluster_id),
                         format!("--opentelemetry-resource=replica_id={}", replica_id),
                         format!("--persist-pubsub-url={}", persist_pubsub_url),

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -9,7 +9,6 @@
 
 //! Service orchestration for tracing-aware services.
 
-use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt;
 use std::sync::Arc;
@@ -24,7 +23,7 @@ use mz_build_info::BuildInfo;
 #[cfg(feature = "tokio-console")]
 use mz_orchestrator::ServicePort;
 use mz_orchestrator::{
-    NamespacedOrchestrator, Orchestrator, Service, ServiceConfig, ServiceEvent,
+    NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments, ServiceConfig, ServiceEvent,
     ServiceProcessMetrics,
 };
 use mz_ore::cli::KeyValueArg;
@@ -398,10 +397,10 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let tracing_args = self.tracing_args.clone();
         let log_prefix_arg = format!("{}-{}", self.namespace, id);
-        let args_fn = move |listen_addrs: &BTreeMap<String, String>| {
+        let args_fn = move |assigned: ServiceAssignments| {
             #[cfg(feature = "tokio-console")]
-            let tokio_console_listen_addr = listen_addrs.get("tokio-console");
-            let mut args = (service_config.args)(listen_addrs);
+            let tokio_console_listen_addr = assigned.listen_addrs.get("tokio-console");
+            let mut args = (service_config.args)(assigned);
             let TracingCliArgs {
                 startup_log_filter,
                 log_prefix,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -198,7 +198,7 @@ pub struct ServiceConfig {
     /// A function that generates the arguments for each process of the service
     /// given the assigned listen addresses for each named port.
     #[derivative(Debug = "ignore")]
-    pub args: Box<dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync>,
+    pub args: Box<dyn Fn(ServiceAssignments) -> Vec<String> + Send + Sync>,
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.
@@ -253,6 +253,18 @@ pub struct ServicePort {
     ///
     /// Not all orchestrator backends will make use of the hint.
     pub port_hint: u16,
+}
+
+/// Assignments that the orchestrator has made for a process in a service.
+#[derive(Clone, Debug)]
+pub struct ServiceAssignments<'a> {
+    /// For each specified [`ServicePort`] name, a listen address.
+    pub listen_addrs: &'a BTreeMap<String, String>,
+    /// The listen addresses of each peer in the service.
+    ///
+    /// The order of peers is significant. Each peer is uniquely identified by its position in the
+    /// list.
+    pub peer_addrs: &'a [BTreeMap<String, String>],
 }
 
 /// Describes a limit on memory.


### PR DESCRIPTION
This PR changes the orchestrator to support initializing the Timely runtime at clusterd process creation. These changes have been pulled out of https://github.com/MaterializeInc/materialize/pull/31710, to make that PR more digestible.

The main thing that changes here is that the orchestrator now also passes the listen addresses of peer processes to the `args` closure used to construct the process command line arguments. This change requires some restructuring in the process orchestrator, which is also included here (commits 1 and 2).

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I recommend reviewing the commits separately.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
