### PR TITLE
ci: Use trufflehog to scan for secrets

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     git \
     gnupg2 \
     libxml2 \
+    pigz \
     python3 \
     python3.12-venv \
     && rm -rf /var/lib/apt/lists/*
@@ -404,6 +405,11 @@ RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linu
     && if [ $ARCH_GO = arm64 ]; then echo 'ceea73d4c86f2e5c91926ee0639157121f5360da42beeb8357783d79c2cc6a1d yq' | sha256sum --check; fi \
     && chmod +x yq \
     && mv yq /usr/local/bin
+
+RUN curl -fsSL https://github.com/trufflesecurity/trufflehog/releases/download/v3.89.1/trufflehog_3.89.1_linux_$ARCH_GO.tar.gz > trufflehog.tar.gz \
+    && if [ $ARCH_GO = amd64 ]; then echo 'c187e25dd1a68ba24a47cc15f334625cb5a7b77f4c75837398950accfc752d59 trufflehog.tar.gz' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo '5c3786dec219d17c1f3a5f2f97ef8fa16b029ce7df19ca2389e667eca492f78d trufflehog.tar.gz' | sha256sum --check; fi \
+    && tar -xzf trufflehog.tar.gz -C /usr/local/bin trufflehog
 
 # Hardcode some known SSH hosts, or else SSH will ask whether the host is
 # trustworthy on the first connection.

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -517,7 +517,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 120
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -1164,7 +1164,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1176,7 +1176,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1940,7 +1940,7 @@ steps:
     parallelism: 10
     agents:
       # Runs faster/more consistently on larger agent
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest

--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -87,7 +87,24 @@ for pod in $(kubectl get pods -o name | grep -v -E 'kubernetes|minio|cockroach|r
 done
 kubectl get events > kubectl-get-events.log || true
 kubectl get all > kubectl-get-all.log || true
-kubectl describe all > kubectl-describe-all.log || true
+kubectl describe all | awk '
+  BEGIN { redact=0 }
+  /^[[:space:]]*Environment:/ {
+    indent = match($0, /[^ ]/) - 1
+    print substr($0, 1, indent) "Environment: [REDACTED]"
+    redact = 1
+    next
+  }
+  redact {
+    current_indent = match($0, /[^ ]/) - 1
+    if (current_indent <= indent || NF == 0) {
+      redact = 0
+    } else {
+      next
+    }
+  }
+  { print }
+' > kubectl-describe-all.log || true
 kubectl get pods -o wide > kubectl-pods-with-nodes.log || true
 
 kubectl -n kube-system get events > kubectl-get-events-kube-system.log || true
@@ -97,8 +114,11 @@ kubectl -n kube-system describe all > kubectl-describe-all-kube-system.log || tr
 # shellcheck disable=SC2024
 sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 
-mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\n"; find . -name 'junit_*.xml')
+mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\ntrufflehog.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
+
+bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
 CI_ANNOTATE_ERRORS_RESULT=0
@@ -110,13 +130,14 @@ buildkite-agent artifact upload "ci-annotate-errors.log"
 # File should not be empty, see database-issues#7569
 test -s kubectl-get-logs-previous.log
 
-if [ "$CI_ANNOTATE_ERRORS_RESULT" -ne 0 ]; then
-  echo "+++ ci-annotate-errors failed, which indicates that an unknown error was found"
-  exit "$CI_ANNOTATE_ERRORS_RESULT"
-fi
 ci_unimportant_heading "cloudtest: Resetting..."
 bin/ci-builder run stable test/cloudtest/reset
 
 ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
 sudo systemctl restart docker
 docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+
+if [ "$CI_ANNOTATE_ERRORS_RESULT" -ne 0 ]; then
+  echo "+++ ci-annotate-errors failed, which indicates that an unknown error was found"
+  exit "$CI_ANNOTATE_ERRORS_RESULT"
+fi

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -27,7 +27,16 @@ fi
 
 echo "Collecting logs"
 # Run before potential "run down" in coverage
-docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log
+docker ps --all --quiet | xargs --no-run-if-empty docker inspect | jq '
+  .[]
+  | .Config.Env = ["[REDACTED]"]
+  | .Config.Cmd = ["[REDACTED]"]
+  | .Args? |= map(
+      if contains("BEGIN PRIVATE KEY")
+      then "[REDACTED]"
+      else .
+      end
+    )' > docker-inspect.log
 # services.log might already exist and contain logs from before composition was downed
 time=0
 if [ -f services.log ]; then
@@ -44,8 +53,7 @@ mv services-sorted.log services.log
 sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 netstat -ant > netstat-ant.log
 netstat -panelot > netstat-panelot.log
-ps aux > ps-aux.log
-docker ps -a --no-trunc > docker-ps-a.log
+ps aux | sed -E "s/\S*mzp_\S*/[REDACTED]/g" > ps-aux.log
 docker stats --all --no-stream > docker-stats.log
 
 mv "$HOME"/cores .
@@ -82,9 +90,13 @@ rm -rf cores
 echo "Compressing parallel-workload-queries.log"
 bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
 
-echo "Uploading log artifacts"
-mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml'; find mz_debug_* -name '*.log')
+mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-inspect.log\ntrufflehog.log\n"; find . -name 'junit_*.xml'; find mz_debug_* -name '*.log')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
+
+echo "--- Running trufflehog to scan artifacts for secrets"
+bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+
+echo "Uploading log artifacts"
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
 CI_ANNOTATE_ERRORS_RESULT=0

--- a/ci/test/lint-main/checks/check-protobuf.sh
+++ b/ci/test/lint-main/checks/check-protobuf.sh
@@ -21,6 +21,7 @@ cd "$(dirname "$0")/../../../.."
 if ! buf --version >/dev/null 2>/dev/null; then
   echo "lint: buf is not installed"
   echo "hint: refer to https://buf.build/docs/installation for install instructions"
+  exit 1
 fi
 
 CURRENT_GIT_BRANCH=$(try git branch --show-current)

--- a/ci/test/lint-main/checks/check-trufflehog.sh
+++ b/ci/test/lint-main/checks/check-trufflehog.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# check-trufflehog.sh - Scan repository for secrets
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+
+. misc/shlib/shlib.bash
+
+# Currently blocked by https://github.com/trufflesecurity/trufflehog/issues/4229
+#if ! trufflehog --version >/dev/null 2>/dev/null; then
+#  echo "lint: trufflehog is not installed"
+#  echo "hint: refer to https://github.com/trufflesecurity/trufflehog?tab=readme-ov-file#floppy_disk-installation for install instructions"
+#  exit 1
+#fi
+#
+#git ls-files -z | xargs -0 trufflehog --no-fail --no-update --no-verification --json filesystem | trufflehog_jq_filter > trufflehog.log
+#
+#try [ ! -s trufflehog.log ]
+#
+#if try_last_failed; then
+#    echo "lint: $(red error:) new secrets found:"
+#    echo "lint: $(green hint:) don't check in secrets and revoke them immediately"
+#    echo "lint: $(green hint:) mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter"
+#fi
+#
+#jq -c -r '. | "\(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line): Secret found: \(.Raw)"' trufflehog.log
+#
+#rm -f trufflehog.log
+#
+#try_status_report

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -225,6 +225,14 @@ class ErrorLog:
 
 
 @dataclass
+class Secret:
+    secret: str
+    file: str
+    line: int
+    detector_name: str
+
+
+@dataclass
 class JunitError:
     testclass: str
     testcase: str
@@ -659,6 +667,22 @@ def annotate_logged_errors(
                     additional_collapsed_error_details_header=additional_collapsed_error_details_header,
                     additional_collapsed_error_details=additional_collapsed_error_details,
                 )
+        elif isinstance(error, Secret):
+            for artifact in artifacts:
+                if artifact["job_id"] == job and artifact["path"] == error.file:
+                    location: str = error.file
+                    location_url = get_artifact_url(artifact)
+                    break
+            else:
+                location: str = error.file
+                location_url = None
+
+            handle_error(
+                f"Secret found on line {error.line}: {error.secret}",
+                f"Detector: {error.detector_name}. Don't print out secrets in tests/logs and revoke them immediately. Mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter(|_logs)",
+                location,
+                location_url,
+            )
         else:
             raise RuntimeError(f"Unexpected error type: {type(error)}")
 
@@ -710,11 +734,13 @@ def annotate_logged_errors(
     return len(unknown_errors)
 
 
-def get_errors(log_file_names: list[str]) -> list[ErrorLog | JunitError]:
+def get_errors(log_file_names: list[str]) -> list[ErrorLog | JunitError | Secret]:
     error_logs = []
     for log_file_name in log_file_names:
         if "junit_" in log_file_name:
             error_logs.extend(_get_errors_from_junit_file(log_file_name))
+        elif log_file_name == "trufflehog.log":
+            error_logs.extend(_get_errors_from_trufflehog(log_file_name))
         else:
             error_logs.extend(_get_errors_from_log_file(log_file_name))
 
@@ -742,6 +768,27 @@ def _get_errors_from_junit_file(log_file_name: str) -> list[JunitError]:
                         testcase.name,
                         (result.message or "").replace("&#10;", "\n"),
                         result.text or "",
+                    )
+                )
+    return error_logs
+
+
+def _get_errors_from_trufflehog(log_file_name: str) -> list[Secret]:
+    error_logs = []
+    with open(log_file_name) as f:
+        for line in f:
+            data = json.loads(line)
+            # Only report each secret once
+            for error_log in error_logs:
+                if error_log.secret == data["Raw"]:
+                    break
+            else:
+                error_logs.append(
+                    Secret(
+                        data["Raw"],
+                        data["SourceMetadata"]["Data"]["Filesystem"]["file"],
+                        data["SourceMetadata"]["Data"]["Filesystem"]["line"],
+                        data["DetectorName"],
                     )
                 )
     return error_logs

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -316,7 +316,16 @@ class Composition:
         """
 
         if not self.silent and not silent:
-            print(f"$ docker compose {' '.join(args)}", file=sys.stderr)
+            # Don't print out secrets in test logs
+            filtered_args = [
+                (
+                    "[REDACTED]"
+                    if "mzp_" in arg or "-----BEGIN PRIVATE KEY-----" in arg
+                    else arg
+                )
+                for arg in args
+            ]
+            print(f"$ docker compose {' '.join(filtered_args)}", file=sys.stderr)
 
         stdout = None
         if capture:

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -236,3 +236,60 @@ is_truthy() {
     fi
     return 0
 }
+
+# trufflehog_jq_filter
+#
+# Filters out secrets we expect in both source code and logs
+trufflehog_jq_filter() {
+  jq -c '
+    select(
+      .Raw != "postgres://mz_system:materialize@materialized:5432" and
+      .Raw != "postgres://materialize:materialize@materialized:6875" and
+      .Raw != "postgres://mz_system:materialize@materialized:6877" and
+      .Raw != "postgres://superuser_login:some_bogus_password@materialized2:6875" and
+      .Raw != "jdbc:postgresql://127.0.0.1:26257/defaultdb?sslmode=disable" and
+      .Raw != "postgres://any:user@materialized:6875" and
+      .Raw != "https://materialize:sekurity@schema-registry:8081" and
+      .Raw != "postgresql://postgres:postgres@postgres:5432" and
+      .Raw != "postgres://postgres:postgres@postgres:5432" and
+      .Raw != "sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe" and
+      .Raw != "jdbc:postgresql://localhost:6875/materialize" and
+      .Raw != "postgres://yugabyte:yugabyte@yugabyte:5433" and
+      .Raw != "postgres://materialize_user:materialize_pass@postgres.materialize.svc.cluster.local:5432" and
+      .Raw != "jdbc:postgresql://%s:%s/materialize" and
+      .Raw != "postgres://postgres:$MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD@$MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME:5432" and
+      .Raw != "http://user:pass@example.com" and
+      .Raw != "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDC5MP3v1BHOgI\n5SsmrW8mjxzQGOz0IlC5jp1muW/kpEoE9TG317TEnO5Uye6zZudkFCP8YGEiN3Mc\nFbTM7eX6PjAPdnGU7khuUt/20ZM+NX5kWZPrmPTh4WQaDCL7ah1LqzBaUAMaSXq8\niuy7LGJNF8wdx8L5BjDiGTTxZXOg0Haxknc7Mbiwc9z8eb7omvzQzsOwyqocrF2u\nz86TzX1jtHP48i5CxoRHKxE94De3tNxjT/Y3OZlS4QS7iekAOQ04DVV3GIHvRUXN\n2H8ayy4+yOdhHn6ER5Jn3lti1Q5XSrxkrYn7L1Vcj6IwZQhhF5vc+ovxOYb+8ert\nEo97tIkLAgMBAAECggEAQteHHRPKz9Mzs8Sxvo4GPv0hnzFDl0DhUE4PJCKdtYoV\n8dADq2DJiu3LAZS4cJPt7Y63bGitMRg2oyPPM8G9pD5Goy3wq9zjRqexKDlXUCTt\n/T7zofRny7c94m1RWb7ablGq/vBXt90BqnajvVtvDsN+iKAqccQM4ZdI3QdrEmt1\ncHex924itzG/mqbFTAfAmVj1ZsRnJp55Txy2gqq7jX00xDM8+H49SRvUu49N64LQ\n6BUWCgWCJePRtgjSHjboAzPqSkMdaTE/WDY2zgGF3Qfq4f6JCHKfm4QylCH4gYUU\n1Kf7ttmhu9NoZO+hczobKkxP9RtXfyTRH2bsJXy2HQKBgQDhHgavxk/ln5mdMGGw\nrQud2vF9n7UwFiysYxocIC5/CWD0GAhnawchjPypbW/7vKM5Z9zhW3eH1U9P13sa\n2xHfrU5BZ16rxoBbKNpcr7VeEbUBAsDoGV24xjoecp7rB2hZ+mGik5/5Ig1Rk1KH\ndcvYy2KSi1h4Sm+mXwimmA4VDQKBgQDdzW+5FPbdM2sUB2gLMQtn3ICjDSu6IQ+k\nd0p3WlTIT51RUsPXXKkk96O5anUbeB3syY8tSKPGggsaXaeL3o09yIamtERgCnn3\nd9IS+4VKPWQlFUICU1KrD+TO7IYIX04iXBuVE5ihv0q3mslhDotmX4kS38NtKEFF\njLjA2RvAdwKBgAFkIxxw+Ett+hALnX7vAtRd5wIku4TpjisejanA1Si50RyRDXQ+\nKBQf/+u4HmoK12Nibe4Cl7GCMvRGW59l3S1pr8MdtWsQVfi6Puc1usQzDdBMyQ5m\nIbsjlnZbtPm02QM9Vd8gVGvAtx5a77aglrrnPtuy+r/7jccUbURCSkv9AoGAH9m3\nWGmVRZBzqO2jWDATxjdY1ZE3nUPQHjrvG5KCKD2ehqYO72cj9uYEwcRyyp4GFhGf\nmM4cjo3wEDowrBoqSBv6kgfC5dO7TfkL1qP9sPp93gFeeD0E2wGuRrSaTqt46eA2\nKcMloNx6W0FD98cB55KCeY5eXtdwAA/EHBVRMeMCgYAd3n6PcL6rVXyE3+wRTKK4\n+zvx5sjTAnljr5ttbEnpZafzrYIfDpB8NNjexy83AeC0O13LvSHIFoTwP8sywJRO\nRxbPMjhEBdVZ5NxlxYer7yKN+h5OBJfrLswPku7y4vdFYK3x/lMuNQO61hb1VFHc\nT2BDTbF0QSlPxFsv18B9zg==\n-----END PRIVATE KEY-----\n" and
+      .Raw != "postgres://materialize:materialize@environmentd:6875" and
+      .Raw != "postgres://MATERIALIZE_USERNAME:APP_SPECIFIC_PASSWORD@MATERIALIZE_HOST:6875" and
+      .Raw != "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize" and
+      .Raw != "postgres://user:password@host:6875" and
+      .Raw != "postgres" and
+      .Raw != "slt" and
+      .Raw != "e6d5833015b170e23ae819e8c5d7eaedb472ca98" and
+      .Raw != "postgresql://materialize:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech:5432"
+    )'
+}
+
+# trufflehog_jq_filter_logs
+#
+# Filters out secrets we expect only in logs during CI runs
+trufflehog_jq_filter_logs() {
+  trufflehog_jq_filter | jq -c '
+  select(
+    (.Raw | contains("mz_system:materialize") | not) and
+    .Raw != "jdbc:postgresql://postgres:5432/postgres" and
+    (.Raw | contains("mz_analytics:materialize") | not) and
+    (.Raw | contains("mz_support:materialize") | not) and
+    .Raw != "jdbc:mysql://mysql:3306/?useInformationSchema=true" and
+    (.Raw | contains("superuser_login:some_bogus_password") | not) and
+    (.Raw | contains("postgres:postgres") | not) and
+    (.Raw | contains("jdbc:postgresql://127.0.0") | not) and
+    .Raw != "jdbc:postgresql://cockroach0:26257/defaultdb?sslmode=disable" and
+    .Raw != "jdbc:postgresql://cockroach1:26257/defaultdb?sslmode=disable" and
+    .Raw != "jdbc:postgresql://cockroach2:26257/defaultdb?sslmode=disable" and
+    .Raw != "jdbc:postgresql://cockroach3:26257/defaultdb?sslmode=disable" and
+    (.Raw | contains("materialize:materialize") | not) and
+    .Raw != "[REDACTED]"
+  )'
+}

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -63,7 +63,11 @@ pub async fn postgres_client(
         })
         .await?;
 
-    println!("Connecting to PostgreSQL server at {}...", url);
+    if url.contains("mzp_") {
+        println!("Connecting to PostgreSQL server at [REDACTED]...");
+    } else {
+        println!("Connecting to PostgreSQL server at {}...", url);
+    }
     let handle = task::spawn(|| "postgres_client_task", connection);
 
     Ok((client, handle))

--- a/test/aws/mzcompose.py
+++ b/test/aws/mzcompose.py
@@ -123,7 +123,8 @@ def test_credentials(c: Composition, ctx: TestContext):
             ACCESS KEY ID = '{access_key_id}',
             SECRET ACCESS KEY = SECRET aws_secret_access_key
         );
-    """
+    """,
+        print_statement=False,
     )
     # Wait for IAM to propagate.
     c.sleep(ctx.iam_propagation_seconds)
@@ -132,7 +133,10 @@ def test_credentials(c: Composition, ctx: TestContext):
     # Corrupting the secret access key should cause authentication to fail with
     # an invalid signature error.
     bad_secret_access_key = codecs.encode(secret_access_key, "rot13")
-    c.sql(f"ALTER SECRET aws_secret_access_key AS '{bad_secret_access_key}'")
+    c.sql(
+        f"ALTER SECRET aws_secret_access_key AS '{bad_secret_access_key}'",
+        print_statement=False,
+    )
     try:
         c.sql("VALIDATE CONNECTION aws_credentials")
     except SystemError as e:
@@ -145,7 +149,8 @@ def test_credentials(c: Composition, ctx: TestContext):
     # Changing the access key to a nonexistent access key should fail with an
     # invalid client ID error.
     c.sql(
-        "ALTER CONNECTION aws_credentials SET (ACCESS KEY ID = 'AKIAV2KIV5LP3RAKAZUY')"
+        "ALTER CONNECTION aws_credentials SET (ACCESS KEY ID = 'AKIAV2KIV5LP3RAKAZUY')",
+        print_statement=False,
     )
     try:
         c.sql("VALIDATE CONNECTION aws_credentials")


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
