### PR TITLE
ci: Reenable PG Resumption test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -457,7 +457,6 @@ steps:
         agents:
           # Larger agent for faster runtime
           queue: hetzner-aarch64-8cpu-16gb
-        skip: "Reenable when database-issues#9362 is fixed"
 
       - id: pg-rtr
         label: "Postgres RTR tests"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -778,7 +778,7 @@ steps:
   - id: mz-debug
     label: "mz-debug tool"
     depends_on: build-aarch64
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     plugins:
       - ./ci/plugins/mzcompose:
           composition: mz-debug


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/32732

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
