### PR TITLE
ci: Consider queues stuck faster

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -426,11 +426,7 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
                     if queue_prefix in stuck:
                         continue
 
-                    priority = job.get("priority", {}).get("number", 0)
-                    if priority < 0:
-                        continue
-
-                    if not job.get("state") == "scheduled":
+                    if job.get("state") != "scheduled":
                         continue
 
                     runnable = job.get("runnable_at")


### PR DESCRIPTION
Also use information from less important jobs. Hetzner is still struggling with aarch64 availability.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
