### PR TITLE
storage-controller: don't error on missing oneshot ingestions

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2387,9 +2387,10 @@ where
                                 // Send the results down our channel.
                                 (pending.result_tx)(batches)
                             }
-                            // TODO(cf2): When we support running COPY FROM on multiple
-                            // replicas we can probably just ignore the case of `None`.
-                            None => mz_ore::soft_panic_or_log!("no sender for {ingestion_id}!"),
+                            None => {
+                                // We might not be tracking this oneshot ingestion anymore because
+                                // it was canceled.
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If a oneshot ingestion is canceled in the storage controller, the controller may still observe a response for it subsequently. If this happens, we should not error but instead ignore the response.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9095

### Tips for reviewer

We also have the option to only remove the entry in `pending_oneshot_ingestions` when we see the response to it. I decided to take the other approach because (a) it's easier to implement and (b) it's what compute does for peeks.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
