### PR TITLE
ci: Hetzner fallover to x86-64 instead of AWS when possible

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -458,16 +458,20 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
                 if "x86-64" not in stuck:
                     if agent == "hetzner-aarch64-2cpu-4gb":
                         config["agents"]["queue"] = "hetzner-x86-64-2cpu-4gb"
-                        config["depends_on"] = "build-x86_64"
+                        if config.get("depends_on") == "build-aarch64":
+                            config["depends_on"] = "build-x86_64"
                     elif agent == "hetzner-aarch64-4cpu-8gb":
                         config["agents"]["queue"] = "hetzner-x86-64-4cpu-8gb"
-                        config["depends_on"] = "build-x86_64"
+                        if config.get("depends_on") == "build-aarch64":
+                            config["depends_on"] = "build-x86_64"
                     elif agent == "hetzner-aarch64-8cpu-16gb":
                         config["agents"]["queue"] = "hetzner-x86-64-8cpu-16gb"
-                        config["depends_on"] = "build-x86_64"
+                        if config.get("depends_on") == "build-aarch64":
+                            config["depends_on"] = "build-x86_64"
                     elif agent == "hetzner-aarch64-16cpu-32gb":
                         config["agents"]["queue"] = "hetzner-x86-64-16cpu-32gb"
-                        config["depends_on"] = "build-x86_64"
+                        if config.get("depends_on") == "build-aarch64":
+                            config["depends_on"] = "build-x86_64"
                 else:
                     if agent in (
                         "hetzner-aarch64-4cpu-8gb",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -507,7 +507,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -1141,7 +1141,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1153,7 +1153,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
           - ./ci/plugins/mzcompose:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -327,7 +327,7 @@ steps:
           composition: sqllogictest
           run: fast-tests
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      queue: hetzner-aarch64-16cpu-32gb
 
   - id: restarts
     label: "Restart test"

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1139,6 +1139,9 @@ class AlterSinkLGSource(Check):
 
 
 @externally_idempotent(False)
+@disabled(
+    "manual sleep is impossible to get right, this check has to be reworked so as not to flake CI"
+)
 class AlterSinkPgSource(Check):
     """Check ALTER SINK with a postgres source"""
 

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -991,7 +991,7 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
         result = c.sql_query("SELECT count(*) FROM kafka_source_tbl", service="mz_new")
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            elapsed < 2
+            elapsed < 3
         ), f"Took {elapsed}s to SELECT on Kafka source after 0dt upgrade, is it hydrated?"
 
         start_time = time.time()
@@ -1136,7 +1136,7 @@ def workflow_kafka_source_rehydration_large_initial(c: Composition) -> None:
         result = c.sql_query("SELECT count(*) FROM kafka_source_tbl", service="mz_new")
         assert result[0][0] == count * repeats, f"Wrong result: {result}"
         assert (
-            elapsed < 2
+            elapsed < 3
         ), f"Took {elapsed}s to SELECT on Kafka source after 0dt upgrade, is it hydrated?"
 
         start_time = time.time()


### PR DESCRIPTION
We haven't seen aarch64-specific test failures. Nightly run triggered: https://buildkite.com/materialize/nightly/builds/12341

With this we should have reached the local optimum of how to handle Hetzner aarch64 unavailability.

Note that this doesn't switch over on main, so we'd still notice aarch64-only regressions basically immediately, even though I don't expect to see any based on past experience.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
