### PR TITLE
Add `pgwire_ensure_transaction_seconds` metric

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -140,7 +140,7 @@ impl Metrics {
                 name: "mz_slow_message_handling",
                 help: "Latency for ALL coordinator messages. 'slow' is in the name for legacy reasons, but is not accurate.",
                 var_labels: ["message_kind"],
-                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+                buckets: histogram_seconds_buckets(0.000_128, 512.0),
             )),
             optimization_notices: registry.register(metric!(
                 name: "mz_optimization_notices",
@@ -186,13 +186,13 @@ impl Metrics {
             parse_seconds: registry.register(metric!(
                 name: "mz_parse_seconds",
                 help: "The time it takes to parse a SQL statement. (Works for both Simple Queries and the Extended Query protocol.)",
-                buckets: histogram_seconds_buckets(0.000_128, 4.0),
+                buckets: histogram_seconds_buckets(0.001, 8.0),
             )),
             pgwire_message_processing_seconds: registry.register(metric!(
                 name: "mz_pgwire_message_processing_seconds",
                 help: "The time it takes to process each of the pgwire message types, measured in the Adapter frontend",
                 var_labels: ["message_type"],
-                buckets: histogram_seconds_buckets(0.000_128, 128.0),
+                buckets: histogram_seconds_buckets(0.001, 512.0),
             )),
             result_rows_first_to_last_byte_seconds: registry.register(metric!(
                 name: "mz_result_rows_first_to_last_byte_seconds",

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -46,6 +46,7 @@ pub struct Metrics {
     pub parse_seconds: HistogramVec,
     pub pgwire_message_processing_seconds: HistogramVec,
     pub result_rows_first_to_last_byte_seconds: HistogramVec,
+    pub pgwire_ensure_transaction_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -199,6 +200,12 @@ impl Metrics {
                 help: "The time from just before sending the first result row to sending a final response message after having successfully flushed the last result row to the connection. (This can span multiple FETCH statements.) (This is never observed for unbounded SUBSCRIBEs, i.e., which have no last result row.)",
                 var_labels: ["statement_type"],
                 buckets: histogram_seconds_buckets(0.001, 8192.0),
+            )),
+            pgwire_ensure_transaction_seconds: registry.register(metric!(
+                name: "mz_pgwire_ensure_transaction_seconds",
+                help: "The time it takes to run `ensure_transactions` when processing pgwire messages.",
+                var_labels: ["message_type"],
+                buckets: histogram_seconds_buckets(0.001, 512.0),
             ))
         }
     }


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/32668


### Motivation

This is for investigating the spikes in the processing time of simple pgwire messages, e.g., `parse`. Discussed with @aljoscha on zoom.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
