### PR TITLE
persist: add param to disable validation in compare and append

### DIFF
--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -545,6 +545,7 @@ fn continual_task_sink<G: Scope<Timestamp = Timestamp>>(
                     &mut [],
                     Antichain::from_elem(Timestamp::minimum()),
                     as_of.clone(),
+                    true,
                 )
                 .await
                 .expect("usage was valid");

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -1326,7 +1326,7 @@ mod append {
             loop {
                 let result = self
                     .persist_writer
-                    .compare_and_append_batch(&mut to_append, lower.clone(), upper.clone())
+                    .compare_and_append_batch(&mut to_append, lower.clone(), upper.clone(), true)
                     .await
                     .expect("valid usage");
 

--- a/src/durable-cache/src/lib.rs
+++ b/src/durable-cache/src/lib.rs
@@ -103,7 +103,12 @@ impl<C: DurableCacheCodec> DurableCache<C> {
             .expect("shard codecs should not change");
         // Ensure that at least one ts is immediately readable, for convenience.
         let res = write
-            .compare_and_append_batch(&mut [], Antichain::from_elem(0), Antichain::from_elem(1))
+            .compare_and_append_batch(
+                &mut [],
+                Antichain::from_elem(0),
+                Antichain::from_elem(1),
+                true,
+            )
             .await
             .expect("usage was valid");
         match res {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1262,6 +1262,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
     batch: &HollowBatch<T>,
     truncate: &Description<T>,
     any_batch_rewrite: bool,
+    enforce_single_batch: bool,
 ) -> Result<(), InvalidUsage<T>> {
     // If rewrite_ts is used, we don't allow truncation, to keep things simpler
     // to reason about.
@@ -1291,6 +1292,10 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         }
     }
 
+    if !enforce_single_batch {
+        return Ok(());
+    }
+
     let batch = &batch.desc;
     if !PartialOrder::less_equal(batch.lower(), truncate.lower())
         || PartialOrder::less_than(batch.upper(), truncate.upper())
@@ -1302,6 +1307,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
             append_upper: truncate.upper().clone(),
         });
     }
+
     Ok(())
 }
 

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1262,7 +1262,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
     batch: &HollowBatch<T>,
     truncate: &Description<T>,
     any_batch_rewrite: bool,
-    enforce_single_batch: bool,
+    enforce_matching_batch_boundaries: bool,
 ) -> Result<(), InvalidUsage<T>> {
     // If rewrite_ts is used, we don't allow truncation, to keep things simpler
     // to reason about.
@@ -1292,7 +1292,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         }
     }
 
-    if !enforce_single_batch {
+    if !enforce_matching_batch_boundaries {
         return Ok(());
     }
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1947,7 +1947,7 @@ pub mod datadriven {
             .expect("unknown batch")
             .clone();
         let truncated_desc = Description::new(lower, upper, batch.desc.since().clone());
-        let () = validate_truncate_batch(&batch, &truncated_desc, false)?;
+        let () = validate_truncate_batch(&batch, &truncated_desc, false, true)?;
         batch.desc = truncated_desc;
         datadriven.batches.insert(output.to_owned(), batch.clone());
         Ok(format!("parts={} len={}\n", batch.part_count(), batch.len))
@@ -2347,7 +2347,7 @@ pub mod datadriven {
         let mut batch_refs: Vec<_> = batches.iter_mut().collect();
 
         let () = writer
-            .compare_and_append_batch(batch_refs.as_mut_slice(), expected_upper, new_upper)
+            .compare_and_append_batch(batch_refs.as_mut_slice(), expected_upper, new_upper, true)
             .await?
             .map_err(|err| anyhow!("upper mismatch: {:?}", err))?;
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -455,7 +455,7 @@ where
     /// The clunky multi-level Result is to enable more obvious error handling
     /// in the caller. See <http://sled.rs/errors.html> for details.
     ///
-    /// If the `enforce_single_batch` flag is set to `false`:
+    /// If the `enforce_matching_batch_boundaries` flag is set to `false`:
     /// We no longer validate that every batch covers the entire range between
     /// the expected and new uppers, as we wish to allow combining batches that
     /// cover different subsets of that range, including subsets of that range
@@ -468,7 +468,7 @@ where
         batches: &mut [&mut Batch<K, V, T, D>],
         expected_upper: Antichain<T>,
         new_upper: Antichain<T>,
-        enforce_single_batch: bool,
+        enforce_matching_batch_boundaries: bool,
     ) -> Result<Result<(), UpperMismatch<T>>, InvalidUsage<T>>
     where
         D: Send + Sync,
@@ -518,7 +518,7 @@ where
                     &batch.batch,
                     &desc,
                     any_batch_rewrite,
-                    enforce_single_batch,
+                    enforce_matching_batch_boundaries,
                 )?;
                 for (run_meta, run) in batch.batch.runs() {
                     let start_index = parts.len();

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -338,7 +338,7 @@ where
             .batch(updates, expected_upper.clone(), new_upper.clone())
             .await?;
         match self
-            .compare_and_append_batch(&mut [&mut batch], expected_upper, new_upper)
+            .compare_and_append_batch(&mut [&mut batch], expected_upper, new_upper, true)
             .await
         {
             ok @ Ok(Ok(())) => ok,
@@ -390,7 +390,7 @@ where
     {
         loop {
             let res = self
-                .compare_and_append_batch(&mut [&mut batch], lower.clone(), upper.clone())
+                .compare_and_append_batch(&mut [&mut batch], lower.clone(), upper.clone(), true)
                 .await?;
             match res {
                 Ok(()) => {
@@ -454,12 +454,21 @@ where
     ///
     /// The clunky multi-level Result is to enable more obvious error handling
     /// in the caller. See <http://sled.rs/errors.html> for details.
+    ///
+    /// If the `enforce_single_batch` flag is set to `false`:
+    /// We no longer validate that every batch covers the entire range between
+    /// the expected and new uppers, as we wish to allow combining batches that
+    /// cover different subsets of that range, including subsets of that range
+    /// that include no data at all. The caller is responsible for guaranteeing
+    /// that the set of batches provided collectively include all updates for
+    /// the entire range between the expected and new upper.
     #[instrument(level = "debug", fields(shard = %self.machine.shard_id()))]
     pub async fn compare_and_append_batch(
         &mut self,
         batches: &mut [&mut Batch<K, V, T, D>],
         expected_upper: Antichain<T>,
         new_upper: Antichain<T>,
+        enforce_single_batch: bool,
     ) -> Result<Result<(), UpperMismatch<T>>, InvalidUsage<T>>
     where
         D: Send + Sync,
@@ -505,7 +514,12 @@ where
             let mut key_storage = None;
             let mut val_storage = None;
             for batch in batches.iter() {
-                let () = validate_truncate_batch(&batch.batch, &desc, any_batch_rewrite)?;
+                let () = validate_truncate_batch(
+                    &batch.batch,
+                    &desc,
+                    any_batch_rewrite,
+                    enforce_single_batch,
+                )?;
                 for (run_meta, run) in batch.batch.runs() {
                     let start_index = parts.len();
                     for part in run {
@@ -935,6 +949,7 @@ where
             batches,
             Antichain::from_elem(expected_upper),
             Antichain::from_elem(new_upper),
+            true,
         )
         .await
         .expect("invalid usage")

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -757,6 +757,7 @@ where
                 &mut [],
                 Antichain::from_elem(self.current_upper.clone()),
                 Antichain::from_elem(now.clone()),
+                true,
             )
             .await
             .expect("valid usage");

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -1235,6 +1235,7 @@ where
                                 &mut to_append[..],
                                 batch_lower.clone(),
                                 batch_upper.clone(),
+                                true,
                             )
                             .await
                             .expect("Invalid usage")

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -493,6 +493,7 @@ async fn apply_caa<K, V, T, D>(
                 batches.as_mut_slice(),
                 Antichain::from_elem(upper.clone()),
                 Antichain::from_elem(commit_ts.step_forward()),
+                true,
             )
             .await
             .expect("usage was valid");

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -999,7 +999,7 @@ mod tests {
 
         // Now finalize the shard to writes.
         let () = d0_write
-            .compare_and_append_batch(&mut [], Antichain::from_elem(6), Antichain::new())
+            .compare_and_append_batch(&mut [], Antichain::from_elem(6), Antichain::new(), true)
             .await
             .unwrap()
             .unwrap();

--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -1147,7 +1147,7 @@ mod tests {
 
         // Close shard to writes
         d0_write
-            .compare_and_append_batch(&mut [], d0_write.shared_upper(), Antichain::new())
+            .compare_and_append_batch(&mut [], d0_write.shared_upper(), Antichain::new(), true)
             .await
             .unwrap()
             .unwrap();
@@ -1160,7 +1160,7 @@ mod tests {
 
             // Close shards to writes
             di_write
-                .compare_and_append_batch(&mut [], di_write.shared_upper(), Antichain::new())
+                .compare_and_append_batch(&mut [], di_write.shared_upper(), Antichain::new(), true)
                 .await
                 .unwrap()
                 .unwrap();


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9275

see also: https://github.com/MaterializeInc/materialize/pull/32509

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
