### PR TITLE
tests: Add trufflehog canary

### DIFF
--- a/ci/test/lint-main/checks/check-trufflehog.sh
+++ b/ci/test/lint-main/checks/check-trufflehog.sh
@@ -24,14 +24,14 @@ cd "$(dirname "$0")/../../../.."
 #  exit 1
 #fi
 #
-#git ls-files -z | xargs -0 trufflehog --no-fail --no-update --no-verification --json filesystem | trufflehog_jq_filter > trufflehog.log
+#git ls-files -z | xargs -0 trufflehog --no-fail --no-update --no-verification --json filesystem | trufflehog_jq_filter_files > trufflehog.log
 #
 #try [ ! -s trufflehog.log ]
 #
 #if try_last_failed; then
 #    echo "lint: $(red error:) new secrets found:"
 #    echo "lint: $(green hint:) don't check in secrets and revoke them immediately"
-#    echo "lint: $(green hint:) mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter"
+#    echo "lint: $(green hint:) mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter_(files|common)"
 #fi
 #
 #jq -c -r '. | "\(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line): Secret found: \(.Raw)"' trufflehog.log

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -786,6 +786,16 @@ steps:
       # Faster agent since it currently compiles mz-debug itself
       queue: hetzner-aarch64-8cpu-16gb
 
+  - id: secrets-logging
+    label: "Secrets Logging"
+    depends_on: build-aarch64
+    timeout_in_minutes: 45
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: secrets-logging
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+
   - id: deploy-website
     label: Deploy website
     depends_on: lint-docs

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -679,7 +679,7 @@ def annotate_logged_errors(
 
             handle_error(
                 f"Secret found on line {error.line}: {error.secret}",
-                f"Detector: {error.detector_name}. Don't print out secrets in tests/logs and revoke them immediately. Mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter(|_logs)",
+                f"Detector: {error.detector_name}. Don't print out secrets in tests/logs and revoke them immediately. Mark false positives in misc/shlib/shlib.bash's trufflehog_jq_filter_(logs|common)",
                 location,
                 location_url,
             )

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -808,6 +808,7 @@ class Composition:
         *args: str,
         rm: bool = False,
         mz_service: str | None = None,
+        quiet: bool = False,
     ) -> subprocess.CompletedProcess:
         if mz_service is not None:
             args = tuple(
@@ -823,7 +824,9 @@ class Composition:
             *args,
             rm=rm,
             # needed for sufficient error information in the junit.xml while still printing to stdout during execution
-            capture_and_print=True,
+            capture_and_print=not quiet,
+            capture=quiet,
+            capture_stderr=quiet,
             env_extra=environment,
         )
 

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -237,10 +237,10 @@ is_truthy() {
     return 0
 }
 
-# trufflehog_jq_filter
+# trufflehog_jq_filter_common
 #
-# Filters out secrets we expect in both source code and logs
-trufflehog_jq_filter() {
+# Filters out secrets we expect in both checked in files and logs
+trufflehog_jq_filter_common() {
   jq -c '
     select(
       .Raw != "postgres://mz_system:materialize@materialized:5432" and
@@ -271,11 +271,21 @@ trufflehog_jq_filter() {
     )'
 }
 
+# trufflehog_jq_filter_files
+#
+# Filters out secrets we expect only in checked in files
+trufflehog_jq_filter_files() {
+  trufflehog_jq_filter_common | jq -c '
+  select(
+    .Raw != "ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN"
+  )'
+}
+
 # trufflehog_jq_filter_logs
 #
 # Filters out secrets we expect only in logs during CI runs
 trufflehog_jq_filter_logs() {
-  trufflehog_jq_filter | jq -c '
+  trufflehog_jq_filter_common | jq -c '
   select(
     (.Raw | contains("mz_system:materialize") | not) and
     (.Raw | contains("jdbc:postgresql://postgres") | not) and

--- a/test/secrets-logging/kafka-commit.td
+++ b/test/secrets-logging/kafka-commit.td
@@ -1,0 +1,74 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default default-storage-size=1
+
+# Test that the source ingestion pipeline commits offsets back to Kafka with
+# the expected group ID.
+
+# Initial setup.
+
+$ kafka-create-topic topic=topic partitions=1
+$ kafka-ingest format=bytes topic=topic
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN
+
+> CREATE CONNECTION conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+# Test that the default consumer group ID is
+# `materialize-$ENVIRONMENTID-$CONNECTIONID-$SOURCEID`.
+
+> CREATE CLUSTER topic_cluster SIZE '${arg.default-storage-size}';
+> CREATE SOURCE topic
+  IN CLUSTER topic_cluster
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-topic-${testdrive.seed}'
+  )
+
+> CREATE TABLE topic_tbl FROM SOURCE topic (REFERENCE "testdrive-topic-${testdrive.seed}")
+  FORMAT BYTES
+
+> SELECT * from topic_tbl
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN
+
+$ set-from-sql var=consumer-group-id
+SELECT
+  ks.group_id_prefix
+FROM mz_sources s
+JOIN mz_catalog.mz_kafka_sources ks ON s.id = ks.id
+WHERE s.name = 'topic'
+
+$ kafka-verify-commit consumer-group-id=${consumer-group-id} topic=topic partition=0
+1
+
+> DROP SOURCE topic CASCADE
+
+# Test than an arbitrary prefix can be prepended to the consumer group.
+
+> CREATE SOURCE topic
+  IN CLUSTER topic_cluster
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-topic-${testdrive.seed}',
+    GROUP ID PREFIX 'OVERRIDE-'
+  )
+
+> CREATE TABLE topic_tbl FROM SOURCE topic (REFERENCE "testdrive-topic-${testdrive.seed}")
+  FORMAT BYTES
+
+> SELECT * from topic_tbl
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN
+
+$ set-from-sql var=consumer-group-id
+SELECT
+  ks.group_id_prefix
+FROM mz_sources s
+JOIN mz_catalog.mz_kafka_sources ks ON s.id = ks.id
+WHERE s.name = 'topic'
+
+$ kafka-verify-commit consumer-group-id=${consumer-group-id} topic=topic partition=0
+1

--- a/test/secrets-logging/mysql-cdc.td
+++ b/test/secrets-logging/mysql-cdc.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t (f1 TEXT);
+INSERT INTO t VALUES ('ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN');
+
+> CREATE SOURCE mysql_source
+  FROM MYSQL CONNECTION mysql_conn;
+
+> CREATE TABLE t FROM SOURCE mysql_source (REFERENCE public.t);
+
+> SELECT * FROM t
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN

--- a/test/secrets-logging/mzcompose
+++ b/test/secrets-logging/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/secrets-logging/mzcompose.py
+++ b/test/secrets-logging/mzcompose.py
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Various ways of putting simulated secret data into Materialize, make sure it doesn't end up in any logs.
+"""
+
+import glob
+
+from materialize import MZ_ROOT, buildkite
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.azure import Azurite
+from materialize.mzcompose.services.fivetran_destination import FivetranDestination
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Minio
+from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.mz import Mz
+from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.services.redpanda import Redpanda
+from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.zookeeper import Zookeeper
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    Redpanda(),
+    Postgres(),
+    MySql(),
+    Azurite(),
+    Mz(app_password=""),
+    Minio(setup_materialize=True, additional_directories=["copytos3"]),
+    Materialized(),
+    FivetranDestination(volumes_extra=["tmp:/share/tmp"]),
+    Testdrive(),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Run testdrive."""
+    parser.add_argument(
+        "files",
+        nargs="*",
+        default=["*.td"],
+        help="run against the specified files",
+    )
+    (args, passthrough_args) = parser.parse_known_args()
+
+    dependencies = [
+        "fivetran-destination",
+        "materialized",
+        "postgres",
+        "mysql",
+        "minio",
+        "zookeeper",
+        "kafka",
+        "schema-registry",
+    ]
+    c.up(*dependencies)
+
+    def process(file: str) -> None:
+        c.run_testdrive_files(
+            f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+            *passthrough_args,
+            file,
+            quiet=True,  # Don't print out the secret here
+        )
+
+    files = buildkite.shard_list(
+        [
+            file
+            for pattern in args.files
+            for file in glob.glob(
+                pattern, root_dir=MZ_ROOT / "test" / "secrets-logging"
+            )
+        ],
+        lambda file: file,
+    )
+    c.test_parts(files, process)
+    c.sanity_restart_mz()

--- a/test/secrets-logging/objects.td
+++ b/test/secrets-logging/objects.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+! INSERT INTO t VALUES (1, 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN');
+contains:unknown catalog item 't'
+
+! SHOW CREATE TABLE t;
+contains:unknown catalog item 't'
+
+> CREATE TABLE t (a text NOT NULL)
+
+> INSERT INTO t VALUES ('ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN');
+
+> SELECT * FROM t
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN
+
+> UPDATE t SET a = 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN'
+
+> DELETE FROM t WHERE a = 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN'
+
+> CREATE VIEW v AS SELECT 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN'
+
+> CREATE MATERIALIZED VIEW mv AS SELECT 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN'
+
+> CREATE SECRET s AS 'ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN'

--- a/test/secrets-logging/pg-cdc.td
+++ b/test/secrets-logging/pg-cdc.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET pgpass AS 'postgres'
+
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE t (f1 TEXT);
+INSERT INTO t VALUES ('ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN');
+ALTER TABLE t REPLICA IDENTITY FULL;
+
+> CREATE SOURCE pg_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
+
+> CREATE TABLE t FROM SOURCE pg_source (REFERENCE t);
+
+> SELECT * FROM t
+ghp_9fK8sL3x7TqR1vEzYm2pDaN4WjXbQzUtV0aN


### PR DESCRIPTION
Writes an apparent token as content so that trufflehog will complain if we accidentally log user data.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
