### PR TITLE
ci: Switch mkpipline jobs to x86-64

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -376,7 +376,7 @@ def prioritize_pipeline(pipeline: Any, priority: int) -> None:
 def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
     """Switch jobs to AWS if Hetzner is currently overloaded"""
 
-    branch = os.getenv("BUILDKITE_BRANCH")
+    # branch = os.getenv("BUILDKITE_BRANCH")
 
     # If Hetzner is entirely broken, you have to take these actions to switch everything back to AWS:
     # - CI_FORCE_SWITCH_TO_AWS env variable to 1
@@ -384,16 +384,19 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
     # - Reconfigure the agent from hetzner-aarch64-4cpu-8gb to linux-aarch64-small in ci/mkpipeline.sh
 
     stuck: set[str] = set()
+    # TODO(def-): Remove me when Hetzner fixes its aarch64 availability
+    stuck.add("aarch64")
 
     if ui.env_is_truthy("CI_FORCE_SWITCH_TO_AWS", "0"):
         stuck = set(["x86-64", "x86-64-dedi", "aarch64"])
     else:
+        # TODO(def-): Reenable me when Hetzner fixes its aarch64 availability
         # If priority has manually been set to be low, or on main branch, we can
         # wait for agents to become available
-        if branch == "main" or priority < 0:
-            return
+        # if branch == "main" or priority < 0:
+        #     return
 
-        # Consider Hetzner to be overloaded/broken when an important job is stuck waiting for an agent for > 30 minutes, once for x86-64 and once for aarch64
+        # Consider Hetzner to be overloaded/broken when an important job is stuck waiting for an agent for > 60 minutes, per arch (x86-64/x86-64-dedi/aarch64)
         try:
             builds = generic_api.get_multiple(
                 "builds",

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -50,7 +50,7 @@ steps:
     command: bin/ci-builder run min bin/pyactivate -m ci.mkpipeline $pipeline $@
     priority: 200
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      queue: hetzner-x86-64-4cpu-8gb
     retry:
       automatic:
         - exit_status: -1


### PR DESCRIPTION
To work around aarch64 availability being limited for a few days now: https://materializeinc.slack.com/archives/C01KV5PEZ9R/p1750206711215029
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
