### PR TITLE
ci: Fix two further occurrences of secrets being printed

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -31,12 +31,8 @@ docker ps --all --quiet | xargs --no-run-if-empty docker inspect | jq '
   .[]
   | .Config.Env = ["[REDACTED]"]
   | .Config.Cmd = ["[REDACTED]"]
-  | .Args? |= map(
-      if contains("BEGIN PRIVATE KEY")
-      then "[REDACTED]"
-      else .
-      end
-    )' > docker-inspect.log
+  | .Config.Entrypoint = ["[REDACTED]"]
+  | .Args = ["[REDACTED]"]' > docker-inspect.log
 # services.log might already exist and contain logs from before composition was downed
 time=0
 if [ -f services.log ]; then

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -1105,7 +1105,7 @@ def workflow_azure_temporary(c: Composition, parser: WorkflowArgumentParser) -> 
             assert username, "AZURE_SERVICE_ACCOUNT_USERNAME has to be set"
             assert password, "AZURE_SERVICE_ACCOUNT_PASSWORD has to be set"
             assert tenant, "AZURE_SERVICE_ACOUNT_TENANT has to be set"
-            spawn.runv(
+            subprocess.run(
                 [
                     "az",
                     "login",


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/12369
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
