### PR TITLE
[EXPLAIN] Better `Arrange` output

### DIFF
--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -504,7 +504,7 @@ impl Plan {
                 } else {
                     write!(f, "{}→Arrange", ctx.indent)?;
 
-                    if forms.arranged.len() > 0 {
+                    if !forms.arranged.is_empty() {
                         let mode = HumanizedExplain::new(ctx.config.redacted);
                         for (key, _, _) in &forms.arranged {
                             if !key.is_empty() {
@@ -515,8 +515,8 @@ impl Plan {
                                 write!(f, " (empty key)")?;
                             }
                         }
-                        writeln!(f, "{annotations}")?;
                     }
+                    writeln!(f, "{annotations}")?;
                 }
 
                 ctx.indented(|ctx| {

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -390,9 +390,8 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// The input collection.
         input: Box<Plan<T>>,
         /// A list of arrangement keys, and possibly a raw collection,
-        /// that will be added to those of the input.
-        ///
-        /// If any of these collection forms are already present in the input, they have no effect.
+        /// that will be added to those of the input. Does not include
+        /// any other existing arrangements.
         forms: AvailableCollections,
         /// The key that must be used to access the input.
         input_key: Option<Vec<MirScalarExpr>>,

--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -274,9 +274,7 @@ pub enum Expr<T = mz_repr::Timestamp> {
         /// The input collection.
         input: LirId,
         /// A list of arrangement keys, and possibly a raw collection, that will be added to those
-        /// of the input.
-        ///
-        /// If any of these collection forms are already present in the input, they have no effect.
+        /// of the input. Does not include any other existing arrangements.
         forms: AvailableCollections,
         /// The key that must be used to access the input.
         input_key: Option<Vec<MirScalarExpr>>,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -25,6 +25,7 @@ use mz_compute_types::dyncfgs::ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTI
 use mz_compute_types::plan::{AvailableCollections, LirId};
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
+use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
@@ -872,6 +873,13 @@ where
         //
         // Note(btv): If we ever do that, we would then only need to make the raw collection here
         // if `collections.raw` is true.
+
+        for (key, _, _) in collections.arranged.iter() {
+            soft_assert_or_log!(
+                !self.arranged.contains_key(key),
+                "LIR ArrangeBy tried to create an existing arrangement"
+            );
+        }
 
         // We need the collection if either (1) it is explicitly demanded, or (2) we are going to render any arrangement
         let form_raw_collection = collections.raw

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -242,9 +242,7 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 Explained Query:
   →Threshold Diffs #0
-    →Arrange
-      Keys: 1 arrangement available, no raw stream
-        Arrangement 0: #0
+    →Arrange (#0)
       →Consolidating Union
         →Unarranged Raw Stream
           →Distinct GroupAggregate
@@ -272,9 +270,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 Explained Query:
   →Threshold Diffs #0
-    →Arrange
-      Keys: 1 arrangement available, no raw stream
-        Arrangement 0: #0
+    →Arrange (#0)
       →Consolidating Union
         →Arranged materialize.public.t
           Key: (#0{a})
@@ -395,38 +391,26 @@ Explained Query:
             Join stage 0 in %1
               project=(#0)
               filter=((#0{a} < #1{a}))
-            →Arrange
-              Keys: 2 arrangements available, no raw stream
-                Arrangement 0: (empty key)
-                Arrangement 1: #0
+            →Arrange (empty key)
               →Distinct GroupAggregate
                 →Arranged materialize.public.t
                   Key: (#0{a})
-            →Arrange
-              Keys: 1 arrangement available, plus raw stream
-                Arrangement 0: (empty key)
+            →Arrange (empty key)
               →Read materialize.public.mv
   →Return
     →Differential Join %1 » %0
       Join stage 0 in %0 with lookup key #1
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #1
+      →Arrange (#1)
         →Stream l0
       →Distinct GroupAggregate
         →Differential Join %0 » %1
           Join stage 0 in %1
             project=(#0)
             filter=((#0{b} > #1{b}))
-          →Arrange
-            Keys: 2 arrangements available, no raw stream
-              Arrangement 0: (empty key)
-              Arrangement 1: #0
+          →Arrange (empty key)
             →Distinct GroupAggregate
               →Read l0
-          →Arrange
-            Keys: 1 arrangement available, plus raw stream
-              Arrangement 0: (empty key)
+          →Arrange (empty key)
             →Read materialize.public.mv
 
 Used Indexes:
@@ -465,9 +449,7 @@ Explained Query:
         →Differential Join %0 » %1
           Join stage 0 in %1 with lookup key #1{b}
           →Arranged l2
-          →Arrange
-            Keys: 1 arrangement available, plus raw stream
-              Arrangement 0: #1{b}
+          →Arrange (#1{b})
             →Read materialize.public.mv
   →Return
     →Delta Join [%0 » %1 » %2] [%1 » %2 » %0] [%2 » %1 » %0]
@@ -480,13 +462,9 @@ Explained Query:
       Delta join path for input %2
         stage 0 for %1: lookup key #0
         stage 1 for %0: lookup key #0
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Stream l0
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Union
           →Stream l3
           →Map/Filter/Project
@@ -496,9 +474,7 @@ Explained Query:
                   →Read l3
                 →Unarranged Raw Stream
                   →Arranged l1
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Union
           →Stream l4
           →Map/Filter/Project
@@ -536,14 +512,10 @@ Explained Query:
           →Arranged materialize.public.t
             Key: (#0{a})
     cte l1 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #1{b}
+      →Arrange (#1{b})
         →Stream l0
     cte l2 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0{b}
+      →Arrange (#0{b})
         →Read l0
     cte l3 =
       →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
@@ -589,9 +561,7 @@ WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 Explained Query:
   →With
     cte l0 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: (empty key)
+      →Arrange (empty key)
         →Fused Map/Filter/Project
           Map: (#0{a} * #1{b})
             →Arranged materialize.public.t
@@ -617,9 +587,7 @@ EXPLAIN WITH(humanized expressions)
 INDEX t_a_idx
 ----
 materialize.public.t_a_idx:
-  →Arrange
-    Keys: 1 arrangement available, plus raw stream
-      Arrangement 0: #0{a}
+  →Arrange (#0{a})
     →Stream materialize.public.t
 
 Source materialize.public.t
@@ -634,9 +602,7 @@ EXPLAIN WITH(humanized expressions)
 INDEX iv_a_idx;
 ----
 materialize.public.iv_a_idx:
-  →Arrange
-    Keys: 1 arrangement available, plus raw stream
-      Arrangement 0: #0{a}
+  →Arrange (#0{a})
     →Stream materialize.public.iv
 
 materialize.public.iv:
@@ -658,10 +624,7 @@ EXPLAIN WITH(humanized expressions)
 INDEX iv_b_idx;
 ----
 materialize.public.iv_b_idx:
-  →Arrange
-    Keys: 2 arrangements available, no raw stream
-      Arrangement 0: #0{a}
-      Arrangement 1: #1{b}
+  →Arrange (#1{b})
     →Arranged materialize.public.iv
 
 Used Indexes:
@@ -719,9 +682,7 @@ Explained Query:
       →Arranged materialize.public.t
         Key: (#0{a})
     cte l1 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: (empty key)
+      →Arrange (empty key)
         →Stream l0
     cte l2 =
       →Differential Join %1 » %0
@@ -733,10 +694,7 @@ Explained Query:
           Aggregations: max
           →Differential Join %0 » %1
             Join stage 0 in %1
-            →Arrange
-              Keys: 2 arrangements available, no raw stream
-                Arrangement 0: (empty key)
-                Arrangement 1: #0
+            →Arrange (empty key)
               →Distinct GroupAggregate
                 →Stream l0
             →Arranged l1
@@ -745,18 +703,13 @@ Explained Query:
       Join stage 0 in %0 with lookup key #0
         project=(#0, #2, #3, #1)
         filter=((#0 != #1{m}))
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Stream l2
       →Consolidating Monotonic GroupAggregate
         Aggregations: max
         →Differential Join %0 » %1
           Join stage 0 in %1
-          →Arrange
-            Keys: 2 arrangements available, no raw stream
-              Arrangement 0: (empty key)
-              Arrangement 1: #0
+          →Arrange (empty key)
             →Distinct GroupAggregate
               →Read l2
           →Arranged l1
@@ -776,9 +729,7 @@ SELECT t1.a, t2.a FROM t as t1, t as t2
 Explained Query:
   →With
     cte l0 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: (empty key)
+      →Arrange (empty key)
         →Arranged materialize.public.t
           Key: (#0{a})
   →Return
@@ -812,9 +763,7 @@ Explained Query:
           →Arranged materialize.public.t
             Key: (#0{a})
     cte l1 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #1{b}
+      →Arrange (#1{b})
         →Stream l0
   →Return
     →Delta Join [%0 » %1 » %2] [%1 » %0 » %2] [%2 » %0 » %1]
@@ -829,9 +778,7 @@ Explained Query:
         stage 1 for %1: lookup key #1{b}
       →Arranged l1
       →Arranged l1
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0{b}
+      →Arrange (#0{b})
         →Read l0
 
 Used Indexes:
@@ -872,9 +819,7 @@ Explained Query:
       filter=((#0{a}) IS NOT NULL)
     →Arranged materialize.public.t
     →Arranged materialize.public.u
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{e}, #1{f}
+    →Arrange (#0{e}, #1{f})
       →Fused Map/Filter/Project
         Filter: (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
           →Arranged materialize.public.v
@@ -903,9 +848,7 @@ Explained Query:
       filter=((#0{a}) IS NOT NULL)
     →Arranged materialize.public.t
     →Arranged materialize.public.u
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{e}, #1{f}
+    →Arrange (#0{e}, #1{f})
       →Fused Map/Filter/Project
         Filter: (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
           →Arranged materialize.public.v
@@ -1062,9 +1005,7 @@ Explained Query:
         →Differential Join %1 » %0
           Join stage 0 in %0 with lookup key #0{a}
           →Arranged materialize.public.t
-          →Arrange
-            Keys: 1 arrangement available, plus raw stream
-              Arrangement 0: #0
+          →Arrange (#0)
             →Constant (1 row)
 
 Used Indexes:
@@ -1093,9 +1034,7 @@ Explained Query:
     →Differential Join %1 » %0
       Join stage 0 in %0 with lookup key #0{a}, #1{b}
       →Arranged materialize.public.t
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0, #1
+      →Arrange (#0, #1)
         →Constant (3 rows)
 
 Used Indexes:
@@ -1150,9 +1089,7 @@ WHERE
 Explained Query:
   →With
     cte l0 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16}
+      →Arrange (#0{f0}, #2{f2}..=#4{f4}, #6{f6}, #8{f8}, #9{f9}, #11{f11}..=#13{f13}, #15{f15}, #16{f16})
         →Read materialize.public.r
   →Return
     →Differential Join %0 » %1
@@ -1291,9 +1228,7 @@ WHERE t.b = u.c;
 Explained Query:
   →Differential Join %1 » %0
     Join stage 0 in %0 with lookup key #1{b}
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #1{b}
+    →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
 
@@ -1316,9 +1251,7 @@ WHERE t.b = u.d;
 Explained Query:
   →Differential Join %1 » %0
     Join stage 0 in %0 with lookup key #1{b}
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #1{b}
+    →Arrange (#1{b})
       →Read materialize.public.t
     →Arranged materialize.public.u
 
@@ -1353,9 +1286,7 @@ Explained Query:
   →Differential Join %0 » %1
     Join stage 0 in %1 with lookup key #0{c}
     →Arranged materialize.public.t
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{c}
+    →Arrange (#0{c})
       →Fused Map/Filter/Project
         Filter: (#1{c}) IS NOT NULL
           →Arranged materialize.public.u
@@ -1457,9 +1388,7 @@ UNION
 Explained Query:
   →With
     cte l0 =
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #1{b}
+      →Arrange (#1{b})
         →Fused Map/Filter/Project
           Filter: (#1{b}) IS NOT NULL
             →Arranged materialize.public.t
@@ -1510,10 +1439,7 @@ UNION
 Explained Query:
   →With
     cte l0 =
-      →Arrange
-        Keys: 2 arrangements available, no raw stream
-          Arrangement 0: #0{a}
-          Arrangement 1: #1{b}
+      →Arrange (#1{b})
         →Arranged materialize.public.t_non_null
   →Return
     →Distinct GroupAggregate
@@ -1555,15 +1481,9 @@ Explained Query:
         Join stage 0 in %1 with lookup key (#1{b} + 1)
           project=(#4, #5)
           map=((#1{a} + #2{a}), (#0{b} + #3{b}))
-        →Arrange
-          Keys: 2 arrangements available, no raw stream
-            Arrangement 0: #0{a}
-            Arrangement 1: #1{b}
+        →Arrange (#1{b})
           →Arranged materialize.public.t_non_null
-        →Arrange
-          Keys: 2 arrangements available, no raw stream
-            Arrangement 0: #0{a}
-            Arrangement 1: (#1{b} + 1)
+        →Arrange ((#1{b} + 1))
           →Arranged materialize.public.t_non_null
       →Fused Map/Filter/Project
         Filter: (#1{b} > 5)
@@ -1592,9 +1512,7 @@ Explained Query:
       →Differential Join %1 » %0
         Join stage 0 in %0 with lookup key #0{a}
         →Arranged materialize.public.t
-        →Arrange
-          Keys: 1 arrangement available, plus raw stream
-            Arrangement 0: #0
+        →Arrange (#0)
           →Constant (1 row)
 
 Used Indexes:
@@ -1628,16 +1546,12 @@ Explained Query:
     →Differential Join %1 » %0
       Join stage 0 in %0 with lookup key #1{b}
       →Arranged materialize.public.t
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Constant (1 row)
     →Differential Join %1 » %0
       Join stage 0 in %0 with lookup key #0{a}
       →Arranged materialize.public.t
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Constant (1 row)
     →Fused Map/Filter/Project
       Filter: (#1{c} = 3)
@@ -1646,9 +1560,7 @@ Explained Query:
     →Differential Join %1 » %0
       Join stage 0 in %0 with lookup key #1{d}
       →Arranged materialize.public.u
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: #0
+      →Arrange (#0)
         →Constant (1 row)
 
 Used Indexes:
@@ -1800,13 +1712,9 @@ WHERE x = a AND b IN (8,9);
 Explained Query:
   →Differential Join %1 » %0
     Join stage 0 in %0 with lookup key #0{x}
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{x}
+    →Arrange (#0{x})
       →Read materialize.public.t5
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{a}
+    →Arrange (#0{a})
       →Read materialize.public.t6
 
 Source materialize.public.t5
@@ -1827,13 +1735,9 @@ WHERE x = a AND b IN (8,9);
 Explained Query:
   →Differential Join %1 » %0
     Join stage 0 in %0 with lookup key #0{x}
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{x}
+    →Arrange (#0{x})
       →Read materialize.public.t5
-    →Arrange
-      Keys: 1 arrangement available, plus raw stream
-        Arrangement 0: #0{a}
+    →Arrange (#0{a})
       →Read materialize.public.t6
 
 Source materialize.public.t5
@@ -1989,13 +1893,9 @@ Explained Query:
       Join stage 0 in %1
         project=(#3, #2)
         map=((#0{a} + #1{b}))
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: (empty key)
+      →Arrange (empty key)
         →Read materialize.public.t4
-      →Arrange
-        Keys: 1 arrangement available, plus raw stream
-          Arrangement 0: (empty key)
+      →Arrange (empty key)
         →Union
           →Stream l1
           →Map/Filter/Project

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1022,8 +1022,7 @@ materialize.public.ov_b_idx:
   ArrangeBy
     input_key=[#0{a}]
     raw=false
-    arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    arrangements[1]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
     types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=false

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1007,8 +1007,7 @@ materialize.public.ov_b_idx:
   ArrangeBy
     input_key=[#0{a}]
     raw=false
-    arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    arrangements[1]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
     types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=false

--- a/test/sqllogictest/github-2746.slt
+++ b/test/sqllogictest/github-2746.slt
@@ -146,7 +146,6 @@ Explained Query:
             input_key=[#0]
             raw=false
             arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-            arrangements[1]={ key=[#0], permutation=id, thinning=() }
             types=[integer]
             Reduce::Distinct
               val_plan

--- a/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
+++ b/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
@@ -60,11 +60,11 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 u2  5  NULL  Differential␠Join␠%0␠»␠%1
-u2  4  5  ␠␠Arrange
+u2  4  5  ␠␠Arrange␠(#0)
 u2  3  4  ␠␠␠␠Read␠u1
-u2  2  5  ␠␠Arrange
+u2  2  5  ␠␠Arrange␠(#0)
 u2  1  2  ␠␠␠␠Read␠u1
-u3  7  NULL  Arrange
+u3  7  NULL  Arrange␠(#0)
 u3  6  7  ␠␠Stream␠u2
 
 # omitting pg_size_pretty(sum(size)) as size
@@ -77,11 +77,11 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 u2  5  NULL  Differential␠Join␠%0␠»␠%1
-u2  4  5  ␠␠Arrange
+u2  4  5  ␠␠Arrange␠(#0)
 u2  3  4  ␠␠␠␠Read␠u1
-u2  2  5  ␠␠Arrange
+u2  2  5  ␠␠Arrange␠(#0)
 u2  1  2  ␠␠␠␠Read␠u1
-u3  7  NULL  Arrange
+u3  7  NULL  Arrange␠(#0)
 u3  6  7  ␠␠Stream␠u2
 
 statement ok
@@ -143,9 +143,9 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 t44  5  NULL  Differential␠Join␠%0␠»␠%1
-t44  4  5  ␠␠Arrange
+t44  4  5  ␠␠Arrange␠(#0)
 t44  3  4  ␠␠␠␠Read␠u4
-t44  2  5  ␠␠Arrange
+t44  2  5  ␠␠Arrange␠(#0)
 t44  1  2  ␠␠␠␠Read␠u4
 
 # omitting pg_size_pretty(sum(size)) as size
@@ -158,9 +158,9 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 t44  5  NULL  Differential␠Join␠%0␠»␠%1
-t44  4  5  ␠␠Arrange
+t44  4  5  ␠␠Arrange␠(#0)
 t44  3  4  ␠␠␠␠Read␠u4
-t44  2  5  ␠␠Arrange
+t44  2  5  ␠␠Arrange␠(#0)
 t44  1  2  ␠␠␠␠Read␠u4
 
 statement ok
@@ -420,7 +420,7 @@ ORDER BY global_id, lir_id DESC;
 t69  Returning␠Distinct␠GroupAggregate
 t69  ␠␠Union
 t69  ␠␠␠␠Differential␠Join␠%0␠»␠%1
-t69  ␠␠␠␠␠␠Arrange
+t69  ␠␠␠␠␠␠Arrange␠(#0)
 t69  ␠␠␠␠␠␠␠␠Stream␠l0
 t69  ␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠Arranged␠u13
@@ -428,30 +428,30 @@ t69  With␠Recursive␠l0␠=␠Unarranged␠Raw␠Stream
 t69  ␠␠Distinct␠GroupAggregate
 t69  ␠␠␠␠Union
 t69  ␠␠␠␠␠␠Differential␠Join␠%0␠»␠%1
-t69  ␠␠␠␠␠␠␠␠Arrange
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#0)
 t69  ␠␠␠␠␠␠␠␠␠␠Read␠l0
-t69  ␠␠␠␠␠␠␠␠Arrange
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#1)
 t69  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠␠␠Differential␠Join␠%1␠»␠%0
 t69  ␠␠␠␠␠␠␠␠Arranged␠u13
-t69  ␠␠␠␠␠␠␠␠Arrange
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#1)
 t69  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠␠␠Arranged␠u13
-u10  Arrange
+u10  Arrange␠(#1)
 u10  ␠␠Stream␠u9
-u11  Arrange
+u11  Arrange␠(#2)
 u11  ␠␠Arranged␠u9
-u12  Arrange
+u12  Arrange␠(#1,␠#2)
 u12  ␠␠Arranged␠u9
-u14  Arrange
+u14  Arrange␠(#1)
 u14  ␠␠Stream␠u13
-u16  Arrange
+u16  Arrange␠(#1)
 u16  ␠␠Stream␠u15
-u18  Arrange
+u18  Arrange␠(#1)
 u18  ␠␠Stream␠u17
-u19  Arrange
+u19  Arrange␠(#12)
 u19  ␠␠Arranged␠u17
-u20  Arrange
+u20  Arrange␠(#9)
 u20  ␠␠Arranged␠u17
 u21  Returning␠Union
 u21  ␠␠Read␠l0
@@ -461,15 +461,15 @@ u21  ␠␠Accumulable␠GroupAggregate
 u21  ␠␠␠␠Delta␠Join␠[%0␠»␠%1␠»␠%2][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u21  ␠␠␠␠␠␠Arranged␠u9
 u21  ␠␠␠␠␠␠Arranged␠u17
-u21  ␠␠␠␠␠␠Arrange
+u21  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
 u21  ␠␠␠␠␠␠␠␠Arranged␠u17
-u22  Arrange
+u22  Arrange␠(#0)
 u22  ␠␠Stream␠u21
 u23  Returning␠Differential␠Join␠%1␠»␠%0
-u23  ␠␠Arrange
+u23  ␠␠Arrange␠(#0)
 u23  ␠␠␠␠Bucketed␠Hierarchical␠GroupAggregate␠(buckets:␠268435456␠16777216␠1048576␠65536␠4096␠256␠16)
 u23  ␠␠␠␠␠␠Read␠l5
-u23  ␠␠Arrange
+u23  ␠␠Arrange␠(#2)
 u23  ␠␠␠␠Stream␠l5
 u23  With␠Recursive␠l7␠=␠Union
 u23  ␠␠Map/Filter/Project
@@ -484,19 +484,19 @@ u23  ␠␠␠␠Arranged␠l5
 u23  l5␠=␠Unarranged␠Raw␠Stream
 u23  ␠␠Bucketed␠Hierarchical␠GroupAggregate␠(buckets:␠268435456␠16777216␠1048576␠65536␠4096␠256␠16)
 u23  ␠␠␠␠Differential␠Join␠%0␠»␠%1
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(#1)
 u23  ␠␠␠␠␠␠␠␠Read␠l4
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(#1)
 u23  ␠␠␠␠␠␠␠␠Read␠l3
 u23  l4␠=␠Non-monotonic␠TopK
 u23  ␠␠Union
 u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
 u23  ␠␠␠␠␠␠␠␠Read␠l4
 u23  ␠␠␠␠Differential␠Join␠%1␠»␠%0
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(#0)
 u23  ␠␠␠␠␠␠␠␠Constant␠(1␠rows)
 u23  ␠␠␠␠␠␠Arranged␠l0
 u23  l3␠=␠Non-monotonic␠TopK
@@ -504,13 +504,13 @@ u23  ␠␠Union
 u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
 u23  ␠␠␠␠␠␠␠␠Read␠l3
 u23  ␠␠␠␠Differential␠Join␠%1␠»␠%0
-u23  ␠␠␠␠␠␠Arrange
+u23  ␠␠␠␠␠␠Arrange␠(#0)
 u23  ␠␠␠␠␠␠␠␠Constant␠(1␠rows)
 u23  ␠␠␠␠␠␠Arranged␠l0
-u23  l2␠=␠Arrange
+u23  l2␠=␠Arrange␠(empty␠key)
 u23  ␠␠Union
 u23  ␠␠␠␠Map/Filter/Project
 u23  ␠␠␠␠␠␠Consolidating␠Union
@@ -520,11 +520,11 @@ u23  ␠␠␠␠␠␠␠␠␠␠Read␠l7
 u23  ␠␠␠␠Read␠l7
 u23  With␠l1␠=␠Arranged␠u21
 u23  l0␠=␠Arranged␠u6
-u24  Arrange
+u24  Arrange␠(#0)
 u24  ␠␠Stream␠u23
-u7  Arrange
+u7  Arrange␠(#1)
 u7  ␠␠Stream␠u6
-u8  Arrange
+u8  Arrange␠(#8)
 u8  ␠␠Arranged␠u6
 
 statement ok
@@ -556,7 +556,7 @@ ORDER BY mlm.global_id, lir_id DESC;
 ----
 u26  2  NULL  Non-monotonic␠TopK  8  7  3808  15.000
 u26  1  2  ␠␠Stream␠u25  NULL  NULL  NULL  NULL
-u27  4  NULL  Arrange  NULL  NULL  NULL  NULL
+u27  4  NULL  Arrange␠(#0)  NULL  NULL  NULL  NULL
 u27  3  4  ␠␠Stream␠u26  NULL  NULL  NULL  NULL
 
 # rebuild everything other stuff, make sure it all shows up as mappable objects
@@ -1047,7 +1047,7 @@ EOF
 query TIIIT
 EXPLAIN ANALYZE HINTS FOR INDEX v2_idx_x;
 ----
-Arrange  NULL  NULL  NULL  NULL
+Arrange␠(#0)  NULL  NULL  NULL  NULL
 ␠␠Stream␠u26  NULL  NULL  NULL  NULL
 Non-monotonic␠TopK  8  7  15  3808␠bytes
 ␠␠Stream␠u25  NULL  NULL  NULL  NULL

--- a/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
+++ b/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
@@ -60,11 +60,11 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 u2  5  NULL  Differential␠Join␠%0␠»␠%1
-u2  4  5  ␠␠Arrange␠(#0)
+u2  4  5  ␠␠Arrange␠(#0{y})
 u2  3  4  ␠␠␠␠Read␠u1
-u2  2  5  ␠␠Arrange␠(#0)
+u2  2  5  ␠␠Arrange␠(#0{x})
 u2  1  2  ␠␠␠␠Read␠u1
-u3  7  NULL  Arrange␠(#0)
+u3  7  NULL  Arrange␠(#0{x})
 u3  6  7  ␠␠Stream␠u2
 
 # omitting pg_size_pretty(sum(size)) as size
@@ -77,11 +77,11 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 u2  5  NULL  Differential␠Join␠%0␠»␠%1
-u2  4  5  ␠␠Arrange␠(#0)
+u2  4  5  ␠␠Arrange␠(#0{y})
 u2  3  4  ␠␠␠␠Read␠u1
-u2  2  5  ␠␠Arrange␠(#0)
+u2  2  5  ␠␠Arrange␠(#0{x})
 u2  1  2  ␠␠␠␠Read␠u1
-u3  7  NULL  Arrange␠(#0)
+u3  7  NULL  Arrange␠(#0{x})
 u3  6  7  ␠␠Stream␠u2
 
 statement ok
@@ -143,9 +143,9 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 t44  5  NULL  Differential␠Join␠%0␠»␠%1
-t44  4  5  ␠␠Arrange␠(#0)
+t44  4  5  ␠␠Arrange␠(#0{y})
 t44  3  4  ␠␠␠␠Read␠u4
-t44  2  5  ␠␠Arrange␠(#0)
+t44  2  5  ␠␠Arrange␠(#0{x})
 t44  1  2  ␠␠␠␠Read␠u4
 
 # omitting pg_size_pretty(sum(size)) as size
@@ -158,9 +158,9 @@ GROUP BY global_id, lir_id, operator, parent_lir_id, nesting
 ORDER BY global_id, lir_id DESC;
 ----
 t44  5  NULL  Differential␠Join␠%0␠»␠%1
-t44  4  5  ␠␠Arrange␠(#0)
+t44  4  5  ␠␠Arrange␠(#0{y})
 t44  3  4  ␠␠␠␠Read␠u4
-t44  2  5  ␠␠Arrange␠(#0)
+t44  2  5  ␠␠Arrange␠(#0{x})
 t44  1  2  ␠␠␠␠Read␠u4
 
 statement ok
@@ -420,7 +420,7 @@ ORDER BY global_id, lir_id DESC;
 t69  Returning␠Distinct␠GroupAggregate
 t69  ␠␠Union
 t69  ␠␠␠␠Differential␠Join␠%0␠»␠%1
-t69  ␠␠␠␠␠␠Arrange␠(#0)
+t69  ␠␠␠␠␠␠Arrange␠(#0{messageid})
 t69  ␠␠␠␠␠␠␠␠Stream␠l0
 t69  ␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠Arranged␠u13
@@ -428,30 +428,30 @@ t69  With␠Recursive␠l0␠=␠Unarranged␠Raw␠Stream
 t69  ␠␠Distinct␠GroupAggregate
 t69  ␠␠␠␠Union
 t69  ␠␠␠␠␠␠Differential␠Join␠%0␠»␠%1
-t69  ␠␠␠␠␠␠␠␠Arrange␠(#0)
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#0{messageid})
 t69  ␠␠␠␠␠␠␠␠␠␠Read␠l0
-t69  ␠␠␠␠␠␠␠␠Arrange␠(#1)
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentcommentid})
 t69  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠␠␠Differential␠Join␠%1␠»␠%0
 t69  ␠␠␠␠␠␠␠␠Arranged␠u13
-t69  ␠␠␠␠␠␠␠␠Arrange␠(#1)
+t69  ␠␠␠␠␠␠␠␠Arrange␠(#1{parentpostid})
 t69  ␠␠␠␠␠␠␠␠␠␠Arranged␠u15
 t69  ␠␠␠␠␠␠Arranged␠u13
-u10  Arrange␠(#1)
+u10  Arrange␠(#1{person1id})
 u10  ␠␠Stream␠u9
-u11  Arrange␠(#2)
+u11  Arrange␠(#2{person2id})
 u11  ␠␠Arranged␠u9
-u12  Arrange␠(#1,␠#2)
+u12  Arrange␠(#1{person1id},␠#2{person2id})
 u12  ␠␠Arranged␠u9
-u14  Arrange␠(#1)
+u14  Arrange␠(#1{id})
 u14  ␠␠Stream␠u13
-u16  Arrange␠(#1)
+u16  Arrange␠(#1{id})
 u16  ␠␠Stream␠u15
-u18  Arrange␠(#1)
+u18  Arrange␠(#1{messageid})
 u18  ␠␠Stream␠u17
-u19  Arrange␠(#12)
+u19  Arrange␠(#12{parentmessageid})
 u19  ␠␠Arranged␠u17
-u20  Arrange␠(#9)
+u20  Arrange␠(#9{creatorpersonid})
 u20  ␠␠Arranged␠u17
 u21  Returning␠Union
 u21  ␠␠Read␠l0
@@ -461,15 +461,15 @@ u21  ␠␠Accumulable␠GroupAggregate
 u21  ␠␠␠␠Delta␠Join␠[%0␠»␠%1␠»␠%2][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u21  ␠␠␠␠␠␠Arranged␠u9
 u21  ␠␠␠␠␠␠Arranged␠u17
-u21  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
+u21  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{parentmessageid})
 u21  ␠␠␠␠␠␠␠␠Arranged␠u17
-u22  Arrange␠(#0)
+u22  Arrange␠(#0{src})
 u22  ␠␠Stream␠u21
 u23  Returning␠Differential␠Join␠%1␠»␠%0
 u23  ␠␠Arrange␠(#0)
 u23  ␠␠␠␠Bucketed␠Hierarchical␠GroupAggregate␠(buckets:␠268435456␠16777216␠1048576␠65536␠4096␠256␠16)
 u23  ␠␠␠␠␠␠Read␠l5
-u23  ␠␠Arrange␠(#2)
+u23  ␠␠Arrange␠(#2{w})
 u23  ␠␠␠␠Stream␠l5
 u23  With␠Recursive␠l7␠=␠Union
 u23  ␠␠Map/Filter/Project
@@ -484,16 +484,16 @@ u23  ␠␠␠␠Arranged␠l5
 u23  l5␠=␠Unarranged␠Raw␠Stream
 u23  ␠␠Bucketed␠Hierarchical␠GroupAggregate␠(buckets:␠268435456␠16777216␠1048576␠65536␠4096␠256␠16)
 u23  ␠␠␠␠Differential␠Join␠%0␠»␠%1
-u23  ␠␠␠␠␠␠Arrange␠(#1)
+u23  ␠␠␠␠␠␠Arrange␠(#1{dst})
 u23  ␠␠␠␠␠␠␠␠Read␠l4
-u23  ␠␠␠␠␠␠Arrange␠(#1)
+u23  ␠␠␠␠␠␠Arrange␠(#1{dst})
 u23  ␠␠␠␠␠␠␠␠Read␠l3
 u23  l4␠=␠Non-monotonic␠TopK
 u23  ␠␠Union
 u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
-u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
+u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{dst})
 u23  ␠␠␠␠␠␠␠␠Read␠l4
 u23  ␠␠␠␠Differential␠Join␠%1␠»␠%0
 u23  ␠␠␠␠␠␠Arrange␠(#0)
@@ -504,7 +504,7 @@ u23  ␠␠Union
 u23  ␠␠␠␠Delta␠Join␠[%0␠»␠%2␠»␠%1][%1␠»␠%0␠»␠%2][%2␠»␠%0␠»␠%1]
 u23  ␠␠␠␠␠␠Arranged␠l1
 u23  ␠␠␠␠␠␠Arranged␠l2
-u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1)
+u23  ␠␠␠␠␠␠Arrange␠(empty␠key)␠(#1{dst})
 u23  ␠␠␠␠␠␠␠␠Read␠l3
 u23  ␠␠␠␠Differential␠Join␠%1␠»␠%0
 u23  ␠␠␠␠␠␠Arrange␠(#0)
@@ -520,11 +520,11 @@ u23  ␠␠␠␠␠␠␠␠␠␠Read␠l7
 u23  ␠␠␠␠Read␠l7
 u23  With␠l1␠=␠Arranged␠u21
 u23  l0␠=␠Arranged␠u6
-u24  Arrange␠(#0)
+u24  Arrange␠(#0{f})
 u24  ␠␠Stream␠u23
-u7  Arrange␠(#1)
+u7  Arrange␠(#1{id})
 u7  ␠␠Stream␠u6
-u8  Arrange␠(#8)
+u8  Arrange␠(#8{locationcityid})
 u8  ␠␠Arranged␠u6
 
 statement ok
@@ -556,7 +556,7 @@ ORDER BY mlm.global_id, lir_id DESC;
 ----
 u26  2  NULL  Non-monotonic␠TopK  8  7  3808  15.000
 u26  1  2  ␠␠Stream␠u25  NULL  NULL  NULL  NULL
-u27  4  NULL  Arrange␠(#0)  NULL  NULL  NULL  NULL
+u27  4  NULL  Arrange␠(#0{x})  NULL  NULL  NULL  NULL
 u27  3  4  ␠␠Stream␠u26  NULL  NULL  NULL  NULL
 
 # rebuild everything other stuff, make sure it all shows up as mappable objects
@@ -1047,7 +1047,7 @@ EOF
 query TIIIT
 EXPLAIN ANALYZE HINTS FOR INDEX v2_idx_x;
 ----
-Arrange␠(#0)  NULL  NULL  NULL  NULL
+Arrange␠(#0{x})  NULL  NULL  NULL  NULL
 ␠␠Stream␠u26  NULL  NULL  NULL  NULL
 Non-monotonic␠TopK  8  7  15  3808␠bytes
 ␠␠Stream␠u25  NULL  NULL  NULL  NULL


### PR DESCRIPTION
Per @ggevay, the LIR `PlanNode::ArrangeBy` was reporting _all_ arrangements, not just the new ones. This PR changes it so that it only reports new ones.

### Motivation

  * This PR fixes a previously unreported bug.

  Gevay 2025, personal communication.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
