### PR TITLE
adapter: Add a tokio canary metric

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -47,6 +47,7 @@ pub struct Metrics {
     pub pgwire_message_processing_seconds: HistogramVec,
     pub result_rows_first_to_last_byte_seconds: HistogramVec,
     pub pgwire_ensure_transaction_seconds: HistogramVec,
+    pub tokio_canary_delay_ms: HistogramVec,
 }
 
 impl Metrics {
@@ -206,7 +207,12 @@ impl Metrics {
                 help: "The time it takes to run `ensure_transactions` when processing pgwire messages.",
                 var_labels: ["message_type"],
                 buckets: histogram_seconds_buckets(0.001, 512.0),
-            ))
+            )),
+            tokio_canary_delay_ms: registry.register(metric!(
+                name: "mz_tokio_canary_delay_ms",
+                help: "How much later was the tokio canary task woken up than the requested time.",
+                buckets: histogram_milliseconds_buckets(1., 512000.),
+            )),
         }
     }
 

--- a/src/ore/src/stats.rs
+++ b/src/ore/src/stats.rs
@@ -46,9 +46,9 @@ pub fn histogram_seconds_buckets(from: f64, to: f64) -> Vec<f64> {
 /// see `histogram_seconds_buckets` below.
 ///
 /// Note that any changes to this range may modify buckets for existing metrics.
-const HISTOGRAM_MILLISECOND_BUCKETS: [f64; 19] = [
+const HISTOGRAM_MILLISECOND_BUCKETS: [f64; 23] = [
     0.128, 0.256, 0.512, 1., 2., 4., 8., 16., 32., 64., 128., 256., 512., 1000., 2000., 4000.,
-    8000., 16000., 32000.,
+    8000., 16000., 32000., 64000., 128000., 256000., 512000.,
 ];
 
 /// Returns a `Vec` of time buckets that are both present in our standard


### PR DESCRIPTION
This PR adds a simple tokio task that just sleeps for 1 sec in a loop, and records how much later than 1 sec it got woken up. This way, we'll be able to see how overloaded tokio is.

### Motivation

  * This PR adds a known-desirable feature: This is for https://github.com/MaterializeInc/database-issues/issues/9140, discussed with @aljoscha

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
