### PR TITLE
ci: Ignore ExpirationReaper in secrets

### DIFF
--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -297,6 +297,7 @@ trufflehog_jq_filter_logs() {
     (.Raw | contains("jdbc:postgresql://127.0.0") | not) and
     (.Raw | contains("jdbc:postgresql://cockroach") | not) and
     (.Raw | contains("materialize:materialize") | not) and
+    (.Raw | contains("ExpirationReaper") | not) and
     .Raw != "[REDACTED]"
   )'
 }


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/105006#01978f32-ffd8-46ca-958a-d15c87bde2b7

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
