### PR TITLE
tests: Recent nightly/RQ fixes

### DIFF
--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -117,7 +117,7 @@ sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge
 mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\ntrufflehog.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 
-bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
 
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -90,7 +90,7 @@ mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nne
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 
 echo "--- Running trufflehog to scan artifacts for secrets"
-bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
 
 echo "Uploading log artifacts"
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -189,6 +189,7 @@ IGNORE_RE = re.compile(
 PRODUCT_LIMITS_FIND_IGNORE_RE = re.compile(
     rb"""
     ( Memory\ cgroup\ out\ of\ memory
+    | [Oo]ut\ [Oo]f\ [Mm]emory
     | limits-materialized .* \| .* fatal\ runtime\ error:\ stack\ overflow
     | limits-materialized .* \| .* has\ overflowed\ its\ stack
     )

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -62,7 +62,6 @@ COMPATIBLE_TESTDRIVE_FILES = [
     "drop.td",
     "duplicate-table-names.td",
     "failpoints.td",
-    "fetch-tail-as-of.td",
     "fetch-tail-large-diff.td",
     "fetch-tail-limit-timeout.td",
     "fetch-tail-timestamp-zero.td",


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/880#01978bad-eed6-4317-af44-dbd9991f715b and https://buildkite.com/materialize/nightly/builds/12385#01978faf-5059-4f58-918e-7f427fc27a60

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
