### PR TITLE
Refactor compaction to use a stream

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -761,7 +761,7 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
                 write.write_schemas.clone(),
             )
             .await;
-            let (res, apply_maintenance) = match res {
+            let apply_maintenance = match res {
                 Ok(x) => x,
                 Err(err) => {
                     warn!(
@@ -775,11 +775,10 @@ pub async fn dangerous_force_compaction_and_break_pushdown<K, V, T, D>(
             };
             machine.applier.metrics.compaction.admin_count.inc();
             info!(
-                "force_compaction {} {} compacted in {:?}: {:?}",
+                "force_compaction {} {} compacted in {:?}",
                 machine.applier.shard_metrics.name,
                 machine.applier.shard_metrics.shard_id,
                 start.elapsed(),
-                res
             );
             maintenance.merge(apply_maintenance);
         }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -19,7 +19,8 @@ use anyhow::anyhow;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use futures_util::{StreamExt, TryFutureExt};
+use futures::{Stream, pin_mut};
+use futures_util::StreamExt;
 use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
@@ -112,7 +113,7 @@ pub struct Compactor<K, V, T, D> {
         Instant,
         CompactReq<T>,
         Machine<K, V, T, D>,
-        oneshot::Sender<Result<ApplyMergeResult, anyhow::Error>>,
+        oneshot::Sender<Result<(), anyhow::Error>>,
     )>,
     _phantom: PhantomData<fn() -> D>,
 }
@@ -172,7 +173,7 @@ where
             Instant,
             CompactReq<T>,
             Machine<K, V, T, D>,
-            oneshot::Sender<Result<ApplyMergeResult, anyhow::Error>>,
+            oneshot::Sender<Result<(), anyhow::Error>>,
         )>(cfg.compaction_queue_size);
         let concurrency_limit = Arc::new(tokio::sync::Semaphore::new(
             cfg.compaction_concurrency_limit,
@@ -237,14 +238,13 @@ where
                     let res = Self::compact_and_apply(&machine, req, write_schemas)
                         .instrument(compact_span)
                         .await;
-                    let res = res.map(|(res, maintenance)| {
+                    if let Ok(maintenance) = res {
                         maintenance.start_performing(&machine, &gc);
-                        res
-                    });
+                    }
 
                     // we can safely ignore errors here, it's possible the caller
                     // wasn't interested in waiting and dropped their receiver
-                    let _ = completer.send(res);
+                    let _ = completer.send(Ok(()));
 
                     // moves `permit` into async scope so it can be dropped upon completion
                     drop(permit);
@@ -268,7 +268,7 @@ where
         &self,
         req: CompactReq<T>,
         machine: &Machine<K, V, T, D>,
-    ) -> Option<oneshot::Receiver<Result<ApplyMergeResult, anyhow::Error>>> {
+    ) -> Option<oneshot::Receiver<Result<(), anyhow::Error>>> {
         // Run some initial heuristics to ignore some requests for compaction.
         // We don't gain much from e.g. compacting two very small batches that
         // were just written, but it does result in non-trivial blob traffic
@@ -311,7 +311,7 @@ where
         machine: &Machine<K, V, T, D>,
         req: CompactReq<T>,
         write_schemas: Schemas<K, V>,
-    ) -> Result<(ApplyMergeResult, RoutineMaintenance), anyhow::Error> {
+    ) -> Result<RoutineMaintenance, anyhow::Error> {
         let metrics = Arc::clone(&machine.applier.metrics);
         metrics.compaction.started.inc();
         let start = Instant::now();
@@ -373,84 +373,58 @@ where
             compaction_schema.id,
         );
 
+        let isolated_runtime = Arc::clone(&machine.isolated_runtime);
+        let machine_clone = machine.clone();
+        let metrics_clone = Arc::clone(&machine.applier.metrics);
         let compact_span = debug_span!("compact::consolidate");
         let res = tokio::time::timeout(
             timeout,
             // Compaction is cpu intensive, so be polite and spawn it on the isolated runtime.
-            machine
-                .isolated_runtime
-                .spawn_named(
-                    || "persist::compact::consolidate",
-                    Self::compact(
-                        CompactConfig::new(&machine.applier.cfg, machine.shard_id()),
-                        Arc::clone(&machine.applier.state_versions.blob),
-                        Arc::clone(&metrics),
-                        Arc::clone(&machine.applier.shard_metrics),
-                        Arc::clone(&machine.isolated_runtime),
-                        req,
+            isolated_runtime.spawn_named(
+                || "persist::compact::consolidate",
+                async move {
+                    let stream = Self::compact_stream(
+                        CompactConfig::new(&machine_clone.applier.cfg, machine_clone.shard_id()),
+                        Arc::clone(&machine_clone.applier.state_versions.blob),
+                        Arc::clone(&metrics_clone),
+                        Arc::clone(&machine_clone.applier.shard_metrics),
+                        Arc::clone(&machine_clone.isolated_runtime),
+                        req.clone(),
                         compaction_schema,
+                    );
+                    let res = Self::compact_all(stream, req.clone()).await?;
+                    let maintenance = Self::apply(
+                        FueledMergeRes { output: res.output },
+                        &metrics_clone,
+                        &machine_clone,
                     )
-                    .instrument(compact_span),
-                )
-                .map_err(|e| anyhow!(e)),
+                    .await?;
+
+                    Ok::<_, anyhow::Error>(maintenance)
+                }
+                .instrument(compact_span),
+            ),
         )
         .await;
-
-        let res = match res {
-            Ok(res) => res,
-            Err(err) => {
-                metrics.compaction.timed_out.inc();
-                Err(anyhow!(err))
-            }
-        };
 
         metrics
             .compaction
             .seconds
             .inc_by(start.elapsed().as_secs_f64());
+        let res = res
+            .map_err(|e| {
+                metrics.compaction.timed_out.inc();
+                anyhow!(
+                    "compaction timed out after {}s: {}",
+                    timeout.as_secs_f64(),
+                    e
+                )
+            })?
+            .map_err(|e| anyhow!(e))?;
 
         match res {
-            Ok(Ok(res)) => {
-                let res = FueledMergeRes { output: res.output };
-                let (apply_merge_result, maintenance) = machine.merge_res(&res).await;
-                match &apply_merge_result {
-                    ApplyMergeResult::AppliedExact => {
-                        metrics.compaction.applied.inc();
-                        metrics.compaction.applied_exact_match.inc();
-                        machine.applier.shard_metrics.compaction_applied.inc();
-                        Ok((apply_merge_result, maintenance))
-                    }
-                    ApplyMergeResult::AppliedSubset => {
-                        metrics.compaction.applied.inc();
-                        metrics.compaction.applied_subset_match.inc();
-                        machine.applier.shard_metrics.compaction_applied.inc();
-                        Ok((apply_merge_result, maintenance))
-                    }
-                    ApplyMergeResult::NotAppliedNoMatch
-                    | ApplyMergeResult::NotAppliedInvalidSince
-                    | ApplyMergeResult::NotAppliedTooManyUpdates => {
-                        if let ApplyMergeResult::NotAppliedTooManyUpdates = &apply_merge_result {
-                            metrics.compaction.not_applied_too_many_updates.inc();
-                        }
-                        metrics.compaction.noop.inc();
-                        let mut part_deletes = PartDeletes::default();
-                        for part in res.output.parts {
-                            part_deletes.add(&part);
-                        }
-                        let () = part_deletes
-                            .delete(
-                                machine.applier.state_versions.blob.as_ref(),
-                                machine.shard_id(),
-                                GC_BLOB_DELETE_CONCURRENCY_LIMIT.get(&machine.applier.cfg),
-                                &*metrics,
-                                &metrics.retries.external.compaction_noop_delete,
-                            )
-                            .await;
-                        Ok((apply_merge_result, maintenance))
-                    }
-                }
-            }
-            Ok(Err(err)) | Err(err) => {
+            Ok(maintenance) => Ok(maintenance),
+            Err(err) => {
                 metrics.compaction.failed.inc();
                 debug!(
                     "compaction for {} failed: {}",
@@ -460,6 +434,91 @@ where
                 Err(err)
             }
         }
+    }
+
+    pub async fn compact_all(
+        stream: impl Stream<Item = Result<HollowBatch<T>, anyhow::Error>>,
+        req: CompactReq<T>,
+    ) -> Result<CompactRes<T>, anyhow::Error> {
+        pin_mut!(stream);
+
+        let mut all_parts = vec![];
+        let mut all_run_splits = vec![];
+        let mut all_run_meta = vec![];
+        let mut len = 0;
+
+        while let Some(res) = stream.next().await {
+            let res = res?;
+            let (parts, updates, run_meta, run_splits) =
+                (res.parts, res.len, res.run_meta, res.run_splits);
+
+            if updates == 0 {
+                continue;
+            }
+
+            let run_offset = all_parts.len();
+            if !all_parts.is_empty() {
+                all_run_splits.push(run_offset);
+            }
+            all_run_splits.extend(run_splits.iter().map(|r| r + run_offset));
+            all_run_meta.extend(run_meta);
+            all_parts.extend(parts);
+            len += updates;
+        }
+
+        Ok(CompactRes {
+            output: HollowBatch::new(
+                req.desc.clone(),
+                all_parts,
+                len,
+                all_run_meta,
+                all_run_splits,
+            ),
+        })
+    }
+
+    pub async fn apply(
+        res: FueledMergeRes<T>,
+        metrics: &Metrics,
+        machine: &Machine<K, V, T, D>,
+    ) -> Result<RoutineMaintenance, anyhow::Error> {
+        let (apply_merge_result, maintenance) = machine.merge_res(&res).await;
+
+        match &apply_merge_result {
+            ApplyMergeResult::AppliedExact => {
+                metrics.compaction.applied.inc();
+                metrics.compaction.applied_exact_match.inc();
+                machine.applier.shard_metrics.compaction_applied.inc();
+            }
+            ApplyMergeResult::AppliedSubset => {
+                metrics.compaction.applied.inc();
+                metrics.compaction.applied_subset_match.inc();
+                machine.applier.shard_metrics.compaction_applied.inc();
+            }
+            ApplyMergeResult::NotAppliedNoMatch
+            | ApplyMergeResult::NotAppliedInvalidSince
+            | ApplyMergeResult::NotAppliedTooManyUpdates => {
+                if let ApplyMergeResult::NotAppliedTooManyUpdates = &apply_merge_result {
+                    metrics.compaction.not_applied_too_many_updates.inc();
+                }
+                metrics.compaction.noop.inc();
+                let mut part_deletes = PartDeletes::default();
+                for part in &res.output.parts {
+                    part_deletes.add(part);
+                }
+                part_deletes
+                    .delete(
+                        machine.applier.state_versions.blob.as_ref(),
+                        machine.shard_id(),
+                        GC_BLOB_DELETE_CONCURRENCY_LIMIT.get(&machine.applier.cfg),
+                        &*metrics,
+                        &metrics.retries.external.compaction_noop_delete,
+                    )
+                    .await;
+            }
+        };
+
+        Ok(maintenance)
     }
 
     /// Compacts input batches in bounded memory.
@@ -485,6 +544,101 @@ where
     ///
     /// 3. If there is excess memory after accounting for (1) and (2), we increase the
     ///    number of outstanding parts we can keep in-flight to Blob.
+    pub fn compact_stream(
+        cfg: CompactConfig,
+        blob: Arc<dyn Blob>,
+        metrics: Arc<Metrics>,
+        shard_metrics: Arc<ShardMetrics>,
+        isolated_runtime: Arc<IsolatedRuntime>,
+        req: CompactReq<T>,
+        write_schemas: Schemas<K, V>,
+    ) -> impl Stream<Item = Result<HollowBatch<T>, anyhow::Error>> {
+        async_stream::stream! {
+            let () = Self::validate_req(&req)?;
+
+            // We introduced a fast-path optimization in https://github.com/MaterializeInc/materialize/pull/15363
+            // but had to revert it due to a very scary bug. Here we count how many of our compaction reqs
+            // could be eligible for the optimization to better understand whether it's worth trying to
+            // reintroduce it.
+            let mut single_nonempty_batch = None;
+            for batch in &req.inputs {
+                if batch.len > 0 {
+                    match single_nonempty_batch {
+                        None => single_nonempty_batch = Some(batch),
+                        Some(_previous_nonempty_batch) => {
+                            single_nonempty_batch = None;
+                            break;
+                        }
+                    }
+                }
+            }
+            if let Some(single_nonempty_batch) = single_nonempty_batch {
+                if single_nonempty_batch.run_splits.len() == 0
+                    && single_nonempty_batch.desc.since() != &Antichain::from_elem(T::minimum())
+                {
+                    metrics.compaction.fast_path_eligible.inc();
+                }
+            }
+
+            // Reserve space for the in-progress part to be held in-mem representation and columnar -
+            let in_progress_part_reserved_memory_bytes = 2 * cfg.batch.blob_target_size;
+            // - then remaining memory will go towards pulling down as many runs as we can.
+            // We'll always do at least two runs per chunk, which means we may go over this limit
+            // if parts are large or the limit is low... though we do at least increment a metric
+            // when that happens.
+            let run_reserved_memory_bytes = cfg
+                .compaction_memory_bound_bytes
+                .saturating_sub(in_progress_part_reserved_memory_bytes);
+
+            let ordered_runs =
+                Self::order_runs(&req, cfg.batch.preferred_order, &*blob, &*metrics).await?;
+            for (runs, run_chunk_max_memory_usage) in
+                Self::chunk_runs(&ordered_runs, &cfg, &*metrics, run_reserved_memory_bytes)
+            {
+                metrics.compaction.chunks_compacted.inc();
+                metrics
+                    .compaction
+                    .runs_compacted
+                    .inc_by(u64::cast_from(runs.len()));
+
+                // given the runs we actually have in our batch, we might have extra memory
+                // available. we reserved enough space to always have 1 in-progress part in
+                // flight, but if we have excess, we can use it to increase our write parallelism
+                let extra_outstanding_parts = (run_reserved_memory_bytes
+                    .saturating_sub(run_chunk_max_memory_usage))
+                    / cfg.batch.blob_target_size;
+                let mut run_cfg = cfg.clone();
+                run_cfg.batch.batch_builder_max_outstanding_parts = 1 + extra_outstanding_parts;
+                let batch = Self::compact_runs(
+                    &run_cfg,
+                    &req.shard_id,
+                    &req.desc,
+                    runs,
+                    Arc::clone(&blob),
+                    Arc::clone(&metrics),
+                    Arc::clone(&shard_metrics),
+                    Arc::clone(&isolated_runtime),
+                    write_schemas.clone(),
+                )
+                .await?;
+
+                assert!(
+                    (batch.len == 0 && batch.parts.len() == 0) || (batch.len > 0 && batch.parts.len() > 0),
+                    "updates={}, parts={}",
+                    batch.len,
+                    batch.parts.len(),
+                );
+
+
+                yield Ok(batch);
+            }
+        }
+    }
+
+    /// Compacts the input batches together, returning a single compacted batch.
+    /// Under the hood this just calls [Self::compact_stream] and
+    /// [Self::compact_all], but it is a convenience method that allows
+    /// the caller to not have to deal with the streaming API.
     pub async fn compact(
         cfg: CompactConfig,
         blob: Arc<dyn Blob>,
@@ -494,124 +648,17 @@ where
         req: CompactReq<T>,
         write_schemas: Schemas<K, V>,
     ) -> Result<CompactRes<T>, anyhow::Error> {
-        let () = Self::validate_req(&req)?;
+        let stream = Self::compact_stream(
+            cfg,
+            Arc::clone(&blob),
+            Arc::clone(&metrics),
+            Arc::clone(&shard_metrics),
+            Arc::clone(&isolated_runtime),
+            req.clone(),
+            write_schemas,
+        );
 
-        // We introduced a fast-path optimization in https://github.com/MaterializeInc/materialize/pull/15363
-        // but had to revert it due to a very scary bug. Here we count how many of our compaction reqs
-        // could be eligible for the optimization to better understand whether it's worth trying to
-        // reintroduce it.
-        let mut single_nonempty_batch = None;
-        for batch in &req.inputs {
-            if batch.len > 0 {
-                match single_nonempty_batch {
-                    None => single_nonempty_batch = Some(batch),
-                    Some(_previous_nonempty_batch) => {
-                        single_nonempty_batch = None;
-                        break;
-                    }
-                }
-            }
-        }
-        if let Some(single_nonempty_batch) = single_nonempty_batch {
-            if single_nonempty_batch.run_splits.len() == 0
-                && single_nonempty_batch.desc.since() != &Antichain::from_elem(T::minimum())
-            {
-                metrics.compaction.fast_path_eligible.inc();
-            }
-        }
-
-        // Reserve space for the in-progress part to be held in-mem representation and columnar -
-        let in_progress_part_reserved_memory_bytes = 2 * cfg.batch.blob_target_size;
-        // - then remaining memory will go towards pulling down as many runs as we can.
-        // We'll always do at least two runs per chunk, which means we may go over this limit
-        // if parts are large or the limit is low... though we do at least increment a metric
-        // when that happens.
-        let run_reserved_memory_bytes = cfg
-            .compaction_memory_bound_bytes
-            .saturating_sub(in_progress_part_reserved_memory_bytes);
-
-        let mut all_parts = vec![];
-        let mut all_run_splits = vec![];
-        let mut all_run_meta = vec![];
-        let mut len = 0;
-
-        let ordered_runs =
-            Self::order_runs(&req, cfg.batch.preferred_order, &*blob, &*metrics).await?;
-        for (runs, run_chunk_max_memory_usage) in
-            Self::chunk_runs(&ordered_runs, &cfg, &*metrics, run_reserved_memory_bytes)
-        {
-            metrics.compaction.chunks_compacted.inc();
-            metrics
-                .compaction
-                .runs_compacted
-                .inc_by(u64::cast_from(runs.len()));
-
-            // given the runs we actually have in our batch, we might have extra memory
-            // available. we reserved enough space to always have 1 in-progress part in
-            // flight, but if we have excess, we can use it to increase our write parallelism
-            let extra_outstanding_parts = (run_reserved_memory_bytes
-                .saturating_sub(run_chunk_max_memory_usage))
-                / cfg.batch.blob_target_size;
-            let mut run_cfg = cfg.clone();
-            run_cfg.batch.batch_builder_max_outstanding_parts = 1 + extra_outstanding_parts;
-            let batch = Self::compact_runs(
-                &run_cfg,
-                &req.shard_id,
-                &req.desc,
-                runs,
-                Arc::clone(&blob),
-                Arc::clone(&metrics),
-                Arc::clone(&shard_metrics),
-                Arc::clone(&isolated_runtime),
-                write_schemas.clone(),
-            )
-            .await?;
-            let (parts, run_splits, run_meta, updates) =
-                (batch.parts, batch.run_splits, batch.run_meta, batch.len);
-            assert!(
-                (updates == 0 && parts.len() == 0) || (updates > 0 && parts.len() > 0),
-                "updates={}, parts={}",
-                updates,
-                parts.len(),
-            );
-
-            if updates == 0 {
-                continue;
-            }
-            // merge together parts and runs from each compaction round.
-            // parts are appended onto our existing vec, and then we shift
-            // the latest run offsets to account for prior parts.
-            //
-            // e.g. if we currently have 3 parts and 2 runs (including the implicit one from 0):
-            //         parts: [k0, k1, k2]
-            //         runs:  [    1     ]
-            //
-            // and we merge in another result with 2 parts and 2 runs:
-            //         parts: [k3, k4]
-            //         runs:  [    1]
-            //
-            // we our result will contain 5 parts and 4 runs:
-            //         parts: [k0, k1, k2, k3, k4]
-            //         runs:  [    1       3   4 ]
-            let run_offset = all_parts.len();
-            if all_parts.len() > 0 {
-                all_run_splits.push(run_offset);
-            }
-            all_run_splits.extend(run_splits.iter().map(|run_start| run_start + run_offset));
-            all_run_meta.extend(run_meta);
-            all_parts.extend(parts);
-            len += updates;
-        }
-
-        Ok(CompactRes {
-            output: HollowBatch::new(
-                req.desc.clone(),
-                all_parts,
-                len,
-                all_run_meta,
-                all_run_splits,
-            ),
-        })
+        Self::compact_all(stream, req).await
     }
 
     /// Sorts and groups all runs from the inputs into chunks, each of which has been determined


### PR DESCRIPTION
This is a precursor to incremental compaction https://github.com/MaterializeInc/database-issues/issues/9194
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
