### PR TITLE
test: Fix naming of slt's replica size config

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -85,9 +85,9 @@ struct Args {
     /// Wrapper program to start child processes
     #[clap(long, env = "ORCHESTRATOR_PROCESS_WRAPPER")]
     orchestrator_process_wrapper: Option<String>,
-    /// Number of replicas, defaults to 2
+    /// Replica size
     #[clap(long, default_value = "2")]
-    replicas: usize,
+    replica_size: usize,
     /// An list of NAME=VALUE pairs used to override static defaults
     /// for system parameters.
     #[clap(
@@ -189,7 +189,7 @@ async fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
         },
-        replicas: args.replicas,
+        replica_size: args.replica_size,
     };
 
     if let (Some(shard), Some(shard_count)) = (args.shard, args.shard_count) {

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -81,7 +81,7 @@ def workflow_selection(c: Composition, parser: WorkflowArgumentParser) -> None:
 def run_sqllogictest(
     c: Composition, parser: WorkflowArgumentParser, run_config: SltRunConfig
 ) -> None:
-    parser.add_argument("--replicas", default=2, type=int)
+    parser.add_argument("--replica-size", default=2, type=int)
     args = parser.parse_args()
 
     c.up(c.metadata_store())
@@ -100,7 +100,7 @@ def run_sqllogictest(
             # Since we run multiple commands, generate a unique junit report for each
             junit_report_path = ci_util.junit_report_filename(f"{c.name}-{i}-{j}")
             cmd = step.to_command(
-                file, args.replicas, junit_report_path, c.metadata_store()
+                file, args.replica_size, junit_report_path, c.metadata_store()
             )
             try:
                 c.run(container_name, *cmd)
@@ -134,7 +134,7 @@ class SltRunStepConfig:
     def to_command(
         self,
         file: str,
-        replicas: int,
+        replica_size: int,
         junit_report_path: Path,
         metadata_store: str,
         metadata_store_port: int = COCKROACH_DEFAULT_PORT,
@@ -142,7 +142,7 @@ class SltRunStepConfig:
         sqllogictest_config = [
             f"--junit-report={junit_report_path}",
             f"--postgres-url=postgres://root@{metadata_store}:{metadata_store_port}",
-            f"--replicas={replicas}",
+            f"--replica-size={replica_size}",
         ]
         command = [
             "sqllogictest",


### PR DESCRIPTION
https://github.com/MaterializeInc/database-issues/issues/9402

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9402

### Tips for reviewer



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
