### PR TITLE
test: unflake `frontier-rounding.td`

### DIFF
--- a/test/testdrive/frontier-rounding.td
+++ b/test/testdrive/frontier-rounding.td
@@ -40,22 +40,22 @@ true
 
 # tables
 # fails: frontiers are not rounded
-> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
-  FROM mz_internal.mz_frontiers
-  JOIN mz_tables ON id = object_id
-false
+# > SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+#   FROM mz_internal.mz_frontiers
+#   JOIN mz_tables ON id = object_id
+# true
 
 # compute introspection sources
 # fails: frontiers are rounded to `XX..XX000` instead of `XX..XX001`
-> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
-  FROM mz_internal.mz_frontiers
-  WHERE object_id LIKE 'si%'
-false
+# > SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+#   FROM mz_internal.mz_frontiers
+#   WHERE object_id LIKE 'si%'
+# true
 
 # storage-managed collections
 # fails: frontiers are not rounded
-> SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
-  FROM mz_internal.mz_frontiers
-  JOIN mz_sources ON id = object_id
-  WHERE object_id LIKE 's%'
-false
+# > SELECT DISTINCT write_frontier::text::uint8 % 1000 = 1
+#   FROM mz_internal.mz_frontiers
+#   JOIN mz_sources ON id = object_id
+#   WHERE object_id LIKE 's%'
+# true


### PR DESCRIPTION
This PR unflakes `frontier-rounding.td` by disabling the tests that check for frontier rounding _not_ working correctly. These tests were meant to document the status quo but they aren't that useful, especially when they are flaky.

As to why `frontier-rounding.td` was flaky before, I didn't manage to reproduce it but it can randomly happen for a collection with non-rounded frontiers to have a frontier that looks like it has been rounded.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9403

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
