### PR TITLE
test: improve asserts in reconciliation cluster tests

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1850,14 +1850,10 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
     )
 
     reused, replaced = fetch_reconciliation_metrics("clusterd1")
-
-    assert reused == 15
-    assert replaced == 0
+    assert reused == 15 and replaced == 0, f"{reused=}, {replaced=}"
 
     reused, replaced = fetch_reconciliation_metrics("clusterd2")
-
-    assert reused > 10
-    assert replaced == 0
+    assert reused > 10 and replaced == 0, f"{reused=}, {replaced=}"
 
 
 def workflow_test_compute_reconciliation_replace(c: Composition) -> None:
@@ -1943,9 +1939,7 @@ def workflow_test_compute_reconciliation_replace(c: Composition) -> None:
     )
 
     reused, replaced = fetch_reconciliation_metrics("clusterd1")
-
-    assert reused == 0
-    assert replaced == 4
+    assert reused == 0 and replaced == 4, f"{reused=}, {replaced=}"
 
 
 def workflow_test_compute_reconciliation_no_errors(c: Composition) -> None:


### PR DESCRIPTION
This PR adds messages to the asserts in the compute reconciliation cluster tests, to get more details in case they fail.

### Motivation

  * This PR fixes a recognized bug.

Advances https://github.com/MaterializeInc/database-issues/issues/9404.

I didn't manage to reproduce that issue locally so far. By adding the additional logging I'm hoping that we can see in CI whether or not `reused` and `replaced` are both 0. If they are, we likely need to wait longer for the metrics to get populated.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
