### PR TITLE
tests: Add self-managed upgrades from 2 versions back

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -889,6 +889,18 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFromLatestSelfManaged, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-self-managed-upgrade-previous
+        label: "Checks Self-Managed upgrade from previous, whole-Mz restart"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        parallelism: 3
+        agents:
+          queue: hetzner-aarch64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzFromPreviousSelfManaged, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -31,13 +31,16 @@ MZ_ROOT = Path(os.environ["MZ_ROOT"])
 
 
 def get_self_managed_versions() -> list[MzVersion]:
+    prefixes = set()
     result = set()
     for entry in yaml.safe_load(
         requests.get("https://materializeinc.github.io/materialize/index.yaml").text
     )["entries"]["materialize-operator"]:
         version = MzVersion.parse_mz(entry["appVersion"])
-        if not version.prerelease:
+        prefix = (version.major, version.minor)
+        if not version.prerelease and prefix not in prefixes:
             result.add(version)
+            prefixes.add(prefix)
     return sorted(result)
 
 


### PR DESCRIPTION
Test runs: https://buildkite.com/materialize/nightly/builds/12425 & https://buildkite.com/materialize/nightly/builds/12430
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
