### PR TITLE
testdrive: Remove comment in upsert source race test

### DIFF
--- a/test/testdrive/upsert-source-race.td
+++ b/test/testdrive/upsert-source-race.td
@@ -58,10 +58,6 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert partitions=1
 
-# Create some background load
-#> CREATE SOURCE counter FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1ms')
-#> CREATE MATERIALIZED VIEW counter_mv AS SELECT max(counter) FROM counter;
-
 $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000000
 {"b": "bdata", "a": ${kafka-ingest.iteration}} {"before": {"row": {"a": ${kafka-ingest.iteration}, "data": "fish", "b": "bdata"}}, "after": {"row": {"a": ${kafka-ingest.iteration}, "data": "fish2", "b": "bdata"}}}
 


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/31243#pullrequestreview-2954659560

I tried enabling it and it didn't do anything of interest, other than causing an OoM: https://buildkite.com/materialize/nightly/builds/12432
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
