### PR TITLE
Replacing Kappa AI with Algolia for Doc Search

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -110,6 +110,17 @@ table.inline-headings {
     }
 }
 
+/*
+ Theme override for the Algolia Docsearch modal
+*/
+
+
+.DocSearch-Modal {
+    --docsearch-primary-color: #{$purple-v2};
+    --docsearch-highlight-color: #{$purple-v2};
+    --docsearch-searchbox-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
+}
+
 .backdrop {
     position: fixed;
     height: 100vh;

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -1,3 +1,4 @@
+
 {{ $title := delimit (slice (cond (isset .Params "htmltitle") .Params.htmltitle
 .Page.Title) .Site.Title) " | " }} {{ $description := cond (isset .Params
 "description") .Params.description .Page.Description }}
@@ -75,27 +76,31 @@
 toCSS | fingerprint }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 
-{{/* Kapa.ai */}}
-<script
-  async
-  src="https://widget.kapa.ai/kapa-widget.bundle.js"
-  data-website-id="c9f86179-22af-46ef-8196-289a621ef96c"
-  data-project-name="Materialize"
-  data-project-color="#472E85"
-  data-project-logo="https://avatars.githubusercontent.com/u/47674186?s=200&v=4"
-  data-modal-title="Materialize"
-  data-modal-disclaimer="This AI bot is experimental and might provide inaccurate or incomplete answers. Always consult the official Materialize documentation to verify any answers provided here. __To search the docs instead__, switch to the __Search__ mode (upper-right hand corner).
+{{/* Intercom */}}
+<script>
+  const APP_ID = "r8661p0d";
+  window.intercomSettings = {
+    api_base: "https://api-iam.intercom.io",
+    app_id: APP_ID
+  };
+</script>
+<script>
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+ </script>
 
-  Interactions with this AI bot may be monitored or recorded. By submitting your information on this form, you agree to our [website terms](https://materialize.com/site-terms-of-service/) and [privacy policy](https://materialize.com/privacy-policy/)."
-  data-modal-example-questions="Why is my query slow?,How do I check my source's status?"
-  data-search-mode-enabled="true"
-  data-modal-override-open-class-search="docs-search-button"
-  data-user-analytics-fingerprint-enabled="true"
-  data-modal-open-on-command-k="true"
-  data-modal-command-k-search-mode-default="true"
-  data-search-result-link-target="_self"
-  data-search-include-source-names='["Documentation Cloud"]'
-  >
+{{/* Algolia DocSearch */}}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script defer>
+  addEventListener("DOMContentLoaded", () => {
+    docsearch({
+      appId: "MB06X1VH88",
+      apiKey: "d3aa325086974cdfb3912f28e5a8c168",
+      indexName: "materialize",
+      insights: true,
+      container: "#docsearch",
+    });
+  });
 </script>
 
 {{if hugo.IsProduction}} {{/* Google Tag Manager */}}

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -1,11 +1,9 @@
+
 <div class="sidebar-wrapper">
   {{ $currentPage := . }}
   <nav role="navigation" class="sidebar">
     <ul>
-      <div id="docsearch">
-        <input type="button" value="Search the Docs/Ask AI" class="btn-ghost docs-search-button"
-        title="cmd+K (⌘+K/⊞+K)" />
-      </div>
+      <div id="docsearch"></div>
       <select id="version-select" class="version-dropdown" style="width: 100%; box-sizing: border-box;">
       </select>
       <br><br>

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -266,7 +266,8 @@ trufflehog_jq_filter_common() {
       .Raw != "postgres" and
       .Raw != "slt" and
       .Raw != "e6d5833015b170e23ae819e8c5d7eaedb472ca98" and
-      .Raw != "postgresql://materialize:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech:5432"
+      .Raw != "postgresql://materialize:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech:5432" and
+      .Raw != "d3aa325086974cdfb3912f28e5a8c168"
     )'
 }
 


### PR DESCRIPTION
This PR replaces Kappa with Algolia for our doc search in Materalize website.

### Motivation

- We are working on replacing Kappa AI for Docsearch and AI questions with Intercom and Algolia for Doc Search. More details here:
https://www.notion.so/materialize/Algolia-Replacement-1f813f48d37b80fcb45fd8635ae32a10?source=copy_link

### Tips for reviewer
This only impacts the html and doc search in the codebase. I have added styles to match our theme and tested this in a local environment. 
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
![image](https://github.com/user-attachments/assets/0b237af9-20ca-414e-a262-59592ff5b1f6)
