### PR TITLE
docs: explicitly link to v25.2 since redirects could be cached in bro…

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -16,11 +16,12 @@ to transform, deliver, and act on fast changing data.
 
 ## What's new!
 
-- [Self-managed Materialize](/self-managed/). With Self-managed Materialize, you
-  can deploy and operate Materialize in your Kubernetes environment.
-  Self-managed Materialize is available in both Enterprise and Community
-  editions. For more information, see the [Self-managed
-  Materialize](/self-managed/) documentation.
+- [Self-managed Materialize v25.2], which includes support for password
+  authentication (private preview), RBAC, and more! With Self-managed
+  Materialize, you can deploy and operate Materialize in your Kubernetes
+  environment. Self-managed Materialize is available in both Enterprise and
+  Community editions. For more information, see the [Self-managed Materialize]
+  documentation.
 
 - [Materialize MCP Server](https://materialize.com/blog/materialize-turns-views-into-tools-for-agents/).
   The Materialize MCP Server bridges SQL and AI by transforming indexed views into well-typed tools
@@ -28,6 +29,8 @@ to transform, deliver, and act on fast changing data.
   data products automatically and reliably. For more information, see the
   [Materialize MCP Server](/integrations/llm/) documentation.
 
+[Self-managed Materialize]: https://materialize.com/docs/self-managed/v25.2/
+[Self-managed Materialize v25.2]: https://materialize.com/docs/self-managed/v25.2/
 {{</ callout >}}
 
 {{< callout
@@ -40,10 +43,11 @@ primary_text="Get Started">}}
    account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation)
    on Materialize Cloud. Alternatively, both the [Materialize Emulator Docker
    image](/get-started/install-materialize-emulator/) and the [Self-managed
-   Materialize](/self-managed/) are also available.
+   Materialize] are also available.
 2. Follow the quickstart guide to learn the basics.
 3. Connect your own data sources and start building.
 
+[Self-managed Materialize]: https://materialize.com/docs/self-managed/v25.2/
 {{</ callout >}}
 
 {{< multilinkbox >}}

--- a/doc/user/content/get-started/_index.md
+++ b/doc/user/content/get-started/_index.md
@@ -24,12 +24,13 @@ scratch.
 
 1. Sign up for a [free trial
    account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation)
-   on Materialize Cloud. Alternatively, both the [Self-managed Materialize](/self-managed/) and the
+   on Materialize Cloud. Alternatively, both the [Self-managed Materialize] and the
    [Materialize Emulator Docker image](/get-started/install-materialize-emulator/)
    are also available.
 2. Follow the quickstart guide to learn the basics.
 3. Connect your own data sources and start building.
 
+[Self-managed Materialize]: https://materialize.com/docs/self-managed/v25.2/
 {{</ callout >}}
 
 ## Key features

--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -99,7 +99,9 @@ not suitable for full feature set evaluations or production workloads.
   Cloud
   account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
   The full experience of Materialize is also available as a self-managed
-  offering. See [Self-managed Materialize](/self-managed/).
+  offering. See [Self-managed Materialize].
+
+[Self-managed Materialize]: https://materialize.com/docs/self-managed/v25.2/
 
 ### Technical Support
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -53,7 +53,9 @@ Alternatively:
 Emulator](/get-started/install-materialize-emulator/). However, the Materialize
 Emulator does not provide the full experience of using Materialize.
 
-- You can run against your [Self-managed Materialize](/self-managed/).
+- You can run against your [Self-managed Materialize].
+
+[Self-managed Materialize]: https://materialize.com/docs/self-managed/v25.2/
 
 ## Step 0. Open the SQL Shell
 
@@ -65,7 +67,7 @@ Emulator does not provide the full experience of using Materialize.
   your browser at [http://localhost:6874](http://localhost:6874).
 
 - If you are running against your own [Self-managed
-  Materialize](/self-managed/), open your deployment's Materialize Console.
+  Materialize], open your deployment's Materialize Console.
 
 ## Step 1. Create a schema
 


### PR DESCRIPTION
…wser (so that people don't have to clear browser data/files/cache from time immemorial)

