### PR TITLE
cluster test: Add back crash

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1409,10 +1409,8 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
         c.run_testdrive_files("pg-snapshot-resumption/02-create-sources.td")
         c.run_testdrive_files("pg-snapshot-resumption/03-ensure-source-down.td")
 
-        # Temporarily disabled because it is timing out.
-        # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/4145 is fixed
-        # # clusterd should crash
-        # c.run_testdrive_files("pg-snapshot-resumption/04-while-clusterd-down.td")
+        # clusterd should crash
+        c.run_testdrive_files("pg-snapshot-resumption/04-while-clusterd-down.td")
 
         with c.override(
             # turn off the failpoint


### PR DESCRIPTION
Since https://github.com/MaterializeInc/database-issues/issues/4145 is closed

seen in https://buildkite.com/materialize/nightly/builds/12453#0197a96e-50a1-44ef-9f50-5a2b0bf34047
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
