### PR TITLE
cluster: don't panic on `LocalClient` send failure

### DIFF
--- a/src/service/src/local.rs
+++ b/src/service/src/local.rs
@@ -12,6 +12,7 @@
 use std::fmt;
 use std::thread::Thread;
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use crossbeam_channel::Sender;
 use itertools::Itertools;
@@ -37,10 +38,7 @@ where
     R: fmt::Debug + Send,
 {
     async fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
-        self.tx
-            .send(cmd)
-            .expect("worker command receiver should not drop first");
-
+        self.tx.send(cmd).map_err(|_| anyhow!("receiver dropped"))?;
         self.thread.unpark();
 
         Ok(())


### PR DESCRIPTION
The `LocalClient` made the incorrect assumption that its receiver would never drop first. It is incorrect at least if the receiver is a compute worker. Compute workers can learn about disconnects from other workers, before their own GRPC server learns about the disconnect, in which case they'll drop their receiver before the `LocalClient`'s sender is dropped.

The fix is to not panic in the `LocalClient` on send failure but to return an error instead. The error will make the GRPC server end the connection and wait for a new one.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9414

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
