### PR TITLE
Selective www authenticate header

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -101,6 +101,8 @@ pub const MAX_REQUEST_SIZE: usize = u64_to_usize(5 * bytesize::MIB);
 
 const SESSION_DURATION: Duration = Duration::from_secs(3600); // 1 hour
 
+const PROFILING_API_ENDPOINTS: &[&str] = &["/memory", "/hierarchical-memory", "/prof/"];
+
 #[derive(Debug)]
 pub struct HttpConfig {
     pub source: &'static str,
@@ -843,7 +845,7 @@ async fn http_auth(
 
     let path = req.uri().path();
     let include_www_authenticate_header = path == "/"
-        || ["/memory", "/hierarchical-memory", "/prof/"]
+        || PROFILING_API_ENDPOINTS
             .iter()
             .any(|prefix| path.starts_with(prefix));
     let user = auth(


### PR DESCRIPTION
* Redirect HTTP to HTTPS instead of returning unauthorized.
* Allow basic auth for `AuthenticatorKind::Password`. We still support sessions, but they are no longer the only way to authenticate. At present, this doesn't initiate a session.
* Selectively add the `www-authenticate` header to only some `AuthError`s. This may be an incomplete list, and it feels a bit gross to do additional path comparisons in the auth functions, but it should unblock access to the debug pages without spamming other pages with login boxes.
* Renamed `AuthError::InvalidLogin` to `AuthError::RoleDisallowed` for clarity.

### Motivation

The debug pages have no way of logging in with `AuthenticatorKind::Password`.
Discussion at https://materializeinc.slack.com/archives/C07PN7KSB0T/p1750849485776399

Redirecting HTTP to HTTPS is a better user experience.
Allowing basic auth rather than forcing a login request to create a session is a better user experience.

### Tips for reviewer

It is easier to review commit by commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
