### PR TITLE
fix 0dt cluster reconfig

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -561,7 +561,7 @@ impl Coordinator {
         let storage_hydrated = self
             .controller
             .storage
-            .collections_hydrated_on_replicas(Some(pending_replicas), &[].into())
+            .collections_hydrated_on_replicas(Some(pending_replicas), &cluster.id, &[].into())
             .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
 
         let span = Span::current();

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -319,6 +319,7 @@ pub trait StorageController: Debug {
     fn collections_hydrated_on_replicas(
         &self,
         target_replica_ids: Option<Vec<ReplicaId>>,
+        target_cluster_ids: &StorageInstanceId,
         exclude_collections: &BTreeSet<GlobalId>,
     ) -> Result<bool, StorageError<Self::Timestamp>>;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -398,8 +398,15 @@ where
     fn collections_hydrated_on_replicas(
         &self,
         target_replica_ids: Option<Vec<ReplicaId>>,
+        target_cluster_id: &StorageInstanceId,
         exclude_collections: &BTreeSet<GlobalId>,
     ) -> Result<bool, StorageError<Self::Timestamp>> {
+        // If an empty set of replicas is provided there can be
+        // no collections on them, we'll count this as hydrated.
+        if target_replica_ids.as_ref().is_some_and(|v| v.is_empty()) {
+            return Ok(true);
+        }
+
         // If target_replica_ids is provided, use it as the set of target
         // replicas. Otherwise check for hydration on any replica.
         let target_replicas: Option<BTreeSet<ReplicaId>> =
@@ -412,6 +419,9 @@ where
             }
             let hydrated = match &collection_state.extra_state {
                 CollectionStateExtra::Ingestion(state) => {
+                    if &state.instance_id != target_cluster_id {
+                        continue;
+                    }
                     match &target_replicas {
                         Some(target_replicas) => !state.hydrated_on.is_disjoint(target_replicas),
                         None => {


### PR DESCRIPTION
This limits the scope of storage collections we're checking to collections on the cluster we're attempting to alter.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This was previously holding the alter until all storage collections across the env were hydrated.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
