### PR TITLE
cluster test: Adapt to new error message when cluster replica is killed

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2440,6 +2440,7 @@ def workflow_test_clusterd_death_detection(c: Composition) -> None:
         assert (
             "error reading a body from connection: stream closed because of a broken pipe"
             in envd.stdout
+            or "error reading a body from connection: connection reset" in envd.stdout
         )
 
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/105348#0197ad3a-0949-467a-aa9f-c075ea827254

Follow-up to https://github.com/MaterializeInc/materialize/pull/32768 I think

@teskje Does this make sense? I checked the logs and that was the logging at this time:
```
cluster-materialized-1  | environmentd: 2025-06-26T17:17:35.673268Z  WARN mz_compute_client::controller::replica: replica task failed: status: Unknown, message: "h2 protocol error: error reading a body from connection", details: [], metadata: MetadataMap { headers: {} }: error reading a body from connection: connection reset replica=User(2)
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
