### PR TITLE
terraform tests: Enable creating table from source

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -95,7 +95,6 @@ COMPATIBLE_TESTDRIVE_FILES = [
     "oid.td",
     "orms.td",
     "pg-catalog.td",
-    "quickstart.td",
     "runtime-errors.td",
     "search_path.td",
     "self-test.td",

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -12,6 +12,9 @@ $ set-arg-default single-replica-cluster=quickstart
 
 # This test verifies the get started page works.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_table_from_source = true
+
 > SET cluster TO ${arg.single-replica-cluster}
 
 > CREATE SOURCE demo

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -10,7 +10,10 @@
 # This test verifies the Quickstart page works: https://materialize.com/docs/get-started/quickstart/
 # Uses shared compute+storage cluster
 
-> CREATE CLUSTER quickstart_tutorial REPLICAS (r1 (SIZE '4-4'));
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_table_from_source = true
+
+> CREATE CLUSTER quickstart_tutorial REPLICAS (r1 (SIZE '4'));
 
 > SET CLUSTER = quickstart_tutorial
 


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/12471#0197af60-8a3a-4bbe-b8f2-95b739f9fef9

and disable quickstart.td since it uses a separate cluster

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
