### PR TITLE
Update Timely to 0.21.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11163,9 +11163,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239467171b75d33f86d33b1d003e93546ef7002a3aad6af9d6e28c23673f30cf"
+checksum = "17c9007b6f132ad1983f50665419e157c3386e5ab2706b3a6d29f832aef211ad"
 dependencies = [
  "bincode",
  "byteorder",
@@ -11188,9 +11188,9 @@ checksum = "ee3700cd9c50f14046eb86deb4f2825758966b40231ad8ffc479c510c42869a1"
 
 [[package]]
 name = "timely_communication"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016e319f2ae5b72caa5ded8dec250f3a327c2e0de713a75653bea98cb42b0507"
+checksum = "c0913c463e192579113ebf1f2a50cdfd9d2c682281490b6c704ffbf951568c29"
 dependencies = [
  "byteorder",
  "columnar",
@@ -11203,15 +11203,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122f41e658e166b7a95a02b78265bc3f5272a4d0d28d1008f0da11b9a4cf79cd"
+checksum = "7c7ebe2a0ecd8afd17682e963b44749c6e92cfb87826ab41673645e8bc9b28bf"
 
 [[package]]
 name = "timely_logging"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c57fb79cb66b7a3dc1beb4165c111e0e1900a18a9d33a73e2148ad7299b0bf"
+checksum = "0946cc7209a60906cd2e8df8e16d9330a2c69cee2a08160e858712b24d4ec614"
 dependencies = [
  "timely_container",
 ]

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.219"
-timely = "0.21.2"
+timely = "0.21.3"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 tracing = "0.1.37"
 

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -84,7 +84,7 @@ serde_plain = "1.0.2"
 sha2 = "0.10.9"
 smallvec = { version = "1.15.1", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.17"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -61,7 +61,7 @@ serde_plain = "1.0.2"
 static_assertions = "1.1"
 sha2 = "0.10.9"
 thiserror = "2.0.12"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1" }
 tracing = "0.1.37"
 uuid = "1.17.0"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -21,7 +21,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing"] }
 mz-service = { path = "../service" }
 rand = "0.8.5"
 regex = "1.11.1"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -44,7 +44,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "2.0.12"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -24,7 +24,7 @@ proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -41,7 +41,7 @@ prometheus = { version = "0.13.4", default-features = false }
 scopeguard = "1.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -34,7 +34,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = "1.44.1"
 tracing = "0.1.37"
 uuid = { version = "1.17.0" }

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -158,7 +158,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.127"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.7"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = "1.0.127"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 subtle = "2.6.1"
-timely = "0.21.2"
+timely = "0.21.3"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.17.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -33,7 +33,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 prost-reflect = "0.15.3"
 seahash = "4"
 serde_json = "1.0.140"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde"] }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -41,7 +41,7 @@ num_enum = "0.7.4"
 prometheus = { version = "0.13.4", default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -59,7 +59,7 @@ sentry-tracing = "0.38.1"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-timely = "0.21.2"
+timely = "0.21.3"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.4.2"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-timely = "0.21.2"
+timely = "0.21.3"
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -60,7 +60,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 reqwest = { version = "0.12", features = ["blocking", "json", "default-tls", "charset", "http2"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = { version = "1.0.127", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.11.1"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.34"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -35,7 +35,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 semver = "1.0.26"
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.29.11"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -36,7 +36,7 @@ smallvec = { version = "1.15.1", features = ["union"] }
 static_assertions = "1.1"
 thiserror = "2.0.11"
 tiberius = { version = "0.12", features = ["chrono", "sql-browser-tokio", "tds73"], default-features = false }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["net"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.15", features = ["compat"] }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127" }
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
 static_assertions = "1.1"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = [
     "fs",
     "rt",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -38,7 +38,7 @@ proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -48,7 +48,7 @@ reqwest = { version = "0.11.13", features = ["stream"] }
 sentry = { version = "0.38.1", default-features = false, features = [] }
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["union"] }
-timely = "0.21.2"
+timely = "0.21.3"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-stream = "0.1.17"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -67,7 +67,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127", features = ["preserve_order"] }
 thiserror = "2.0.12"
 tiberius = { version = "0.12", features = ["sql-browser-tokio", "tds73"], default-features = false }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -78,7 +78,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127" }
 serde_bytes = { version = "0.11.17" }
 sha2 = "0.10.9"
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -23,7 +23,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing", "test", "
 num-traits = "0.2"
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.21.2"
+timely = "0.21.3"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -129,7 +129,7 @@ subtle = { version = "2.6.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.104", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.37", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
-timely = { version = "0.21.2" }
+timely = { version = "0.21.3" }
 tokio = { version = "1.44.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }
@@ -269,7 +269,7 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.104", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.37", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.19", default-features = false, features = ["formatting", "parsing", "serde"] }
-timely = { version = "0.21.2" }
+timely = { version = "0.21.3" }
 tokio = { version = "1.44.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }


### PR DESCRIPTION
No functional changes in this release relevant for Materialize (yet).
