### PR TITLE
tests: Try removing some workarounds to get SQL Server working on macOS

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -63,7 +63,6 @@ from materialize.ui import (
     CommandFailureCausedUIError,
     UIError,
 )
-from materialize.xcompile import Arch
 
 
 class UnknownCompositionError(UIError):
@@ -206,22 +205,6 @@ class Composition:
                 if image_name not in self.repo.images:
                     raise UIError(f"mzcompose: unknown image {image_name}")
                 image = self.repo.images[image_name]
-                if "platform" in config:
-                    # Intentionally not copying the image.rd so that the
-                    # repository details of dependencies are also switched to
-                    # the wanted architecture. An alternative would be to
-                    # iterate over all the dependencies and change their arch
-                    # too, but this is messy. Architecting a cleaner approach
-                    # is probably not worth it since the platform-checks
-                    # scenarios for the x86-64-aarch64 migration are supposed
-                    # to be temporary.
-                    # image.rd = copy.deepcopy(image.rd)
-                    if config["platform"] == "linux/amd64":
-                        image.rd.arch = Arch.X86_64
-                    elif config["platform"] == "linux/arm64/v8":
-                        image.rd.arch = Arch.AARCH64
-                    else:
-                        raise ValueError(f"Unknown platform {config['platform']}")
                 if config.get("publish") is not None:
                     # Override whether an image is expected to be published, so
                     # that we will build it in CI instead of failing.

--- a/misc/python/materialize/mzcompose/services/sql_server.py
+++ b/misc/python/materialize/mzcompose/services/sql_server.py
@@ -30,9 +30,6 @@ class SqlServer(Service):
             name=name,
             config={
                 "image": image,
-                # WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
-                # See See https://github.com/microsoft/mssql-docker/issues/802 for current status
-                "platform": "linux/amd64",
                 "ports": [1433],
                 "environment": [
                     "ACCEPT_EULA=Y",


### PR DESCRIPTION
Not sure yet how happy CI will be with this.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
