### PR TITLE
ci: Also retry on SIGTERM in k8s tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1025,6 +1025,8 @@ steps:
           automatic:
             - exit_status: 1
               limit: 2
+            - exit_status: 143 # SIGTERM
+              limit: 2
             - exit_status: 255
               limit: 2
         agents:
@@ -1050,6 +1052,8 @@ steps:
         retry:
           automatic:
             - exit_status: 1
+              limit: 2
+            - exit_status: 143 # SIGTERM
               limit: 2
             - exit_status: 255
               limit: 2
@@ -1077,6 +1081,8 @@ steps:
           automatic:
             - exit_status: 1
               limit: 2
+            - exit_status: 143 # SIGTERM
+              limit: 2
             - exit_status: 255
               limit: 2
         agents:
@@ -1102,6 +1108,8 @@ steps:
         retry:
           automatic:
             - exit_status: 1
+              limit: 2
+            - exit_status: 143 # SIGTERM
               limit: 2
             - exit_status: 255
               limit: 2


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/12485#0197b3ba-a8f5-49fa-8f32-040d2758c107

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
