### PR TITLE
Fix RunId parsing

### DIFF
--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -49,7 +49,7 @@ impl std::str::FromStr for CriticalReaderId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('c', "CriticalReaderId", s).map(CriticalReaderId)
+        parse_id("c", "CriticalReaderId", s).map(CriticalReaderId)
     }
 }
 

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -194,7 +194,7 @@ impl<T: Message + Default> RustType<Bytes> for LazyProto<T> {
     }
 }
 
-pub(crate) fn parse_id(id_prefix: char, id_type: &str, encoded: &str) -> Result<[u8; 16], String> {
+pub(crate) fn parse_id(id_prefix: &str, id_type: &str, encoded: &str) -> Result<[u8; 16], String> {
     let uuid_encoded = match encoded.strip_prefix(id_prefix) {
         Some(x) => x,
         None => return Err(format!("invalid {} {}: incorrect prefix", id_type, encoded)),

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -41,7 +41,7 @@ impl FromStr for PartId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('p', "PartId", s).map(PartId)
+        parse_id("p", "PartId", s).map(PartId)
     }
 }
 
@@ -169,7 +169,7 @@ impl FromStr for RollupId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('r', "RollupId", s).map(RollupId)
+        parse_id("r", "RollupId", s).map(RollupId)
     }
 }
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -150,7 +150,7 @@ impl std::str::FromStr for IdempotencyToken {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('i', "IdempotencyToken", s).map(IdempotencyToken)
+        parse_id("i", "IdempotencyToken", s).map(IdempotencyToken)
     }
 }
 
@@ -757,7 +757,7 @@ impl std::str::FromStr for RunId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('r', "RunId", s).map(RunId)
+        parse_id("ri", "RunId", s).map(RunId)
     }
 }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -78,7 +78,7 @@ impl std::str::FromStr for LeasedReaderId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('r', "LeasedReaderId", s).map(LeasedReaderId)
+        parse_id("r", "LeasedReaderId", s).map(LeasedReaderId)
     }
 }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -77,7 +77,7 @@ impl std::str::FromStr for WriterId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_id('w', "WriterId", s).map(WriterId)
+        parse_id("w", "WriterId", s).map(WriterId)
     }
 }
 


### PR DESCRIPTION
I had originally used prefix `r` before realizing I was overloading an existing prefix. When I changed it to `ri` I forgot to fix it everywhere. Allowing multi character prefixes requires a small change to the parse_id function signature but it is a trivial one.
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
