### PR TITLE
cluster: use CTP as the transport for compute and storage protocol connections

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -561,6 +561,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_peek_stash_batch_size",
     "persist_enable_incremental_compaction",
     "storage_statistics_retention_duration",
+    "enable_ctp_cluster_protocols",
 ]
 
 

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -36,6 +36,7 @@ class Clusterd(Service):
         environment = [
             "CLUSTERD_LOG_FILTER",
             f"CLUSTERD_GRPC_HOST={name}",
+            "CLUSTERD_USE_CTP=true",
             "MZ_SOFT_ASSERTIONS=1",
             "MZ_EAT_MY_DATA=1",
             *environment_extra,

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1299,6 +1299,7 @@ class FlipFlagsAction(Action):
             "compute_peek_response_stash_read_memory_budget_bytes",
             "persist_enable_incremental_compaction",
             "storage_statistics_retention_duration",
+            "enable_ctp_cluster_protocols",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -720,6 +720,7 @@ where
         replica_id: ReplicaId,
         location: ClusterReplicaLocation,
         config: ComputeReplicaConfig,
+        enable_ctp: bool,
     ) -> Result<(), ReplicaCreationError> {
         use ReplicaCreationError::*;
 
@@ -747,6 +748,7 @@ where
             },
             grpc_client: self.config.grpc_client.clone(),
             expiration_offset: (!expiration_offset.is_zero()).then_some(expiration_offset),
+            enable_ctp,
         };
 
         let instance = self.instance_mut(instance_id).expect("validated");

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -38,7 +38,7 @@ include!(concat!(
 /// from the compute controller.
 ///
 /// [`ComputeCommand`]: super::command::ComputeCommand
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// `Frontiers` announces the advancement of the various frontiers of the specified compute
     /// collection.
@@ -322,7 +322,7 @@ impl Arbitrary for FrontiersResponse {
 ///
 /// Note that each `Peek` expects to generate exactly one `PeekResponse`, i.e.
 /// we expect a 1:1 contract between `Peek` and `PeekResponse`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PeekResponse {
     /// Returned rows of a successful peek.
     Rows(RowCollection),
@@ -381,7 +381,7 @@ impl Arbitrary for PeekResponse {
 }
 
 /// Response from a peek whose results have been stashed into persist.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StashedPeekResponse {
     /// The number of rows stored in response batches. This is the sum of the
     /// diff values of the contained rows.

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -68,6 +68,12 @@ pub const ARRANGEMENT_EXERT_PROPORTIONALITY: Config<u32> = Config::new(
     "Value that controls how much merge effort to exert on arrangements.",
 );
 
+pub const ENABLE_CTP_CLUSTER_PROTOCOLS: Config<bool> = Config::new(
+    "enable_ctp_cluster_protocols",
+    true,
+    "Enable CTP (instead of gRPC) for the compute and storage cluster protocols.",
+);
+
 /// Adds the full set of all controller `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -80,4 +86,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_TIMELY_ZERO_COPY_LGALLOC)
         .add(&TIMELY_ZERO_COPY_LIMIT)
         .add(&ARRANGEMENT_EXERT_PROPORTIONALITY)
+        .add(&ENABLE_CTP_CLUSTER_PROTOCOLS)
 }

--- a/src/expr/src/row/collection.rs
+++ b/src/expr/src/row/collection.rs
@@ -29,7 +29,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_expr.row.collection.rs"));
 ///
 /// Note: the encoding format we use to represent [`Row`]s in this struct is
 /// not stable, and thus should never be persisted durably.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RowCollection {
     /// Contiguous blob of encoded Rows.
     encoded: Bytes,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -405,6 +405,7 @@ pub trait StorageController: Debug {
         instance_id: StorageInstanceId,
         replica_id: ReplicaId,
         location: ClusterReplicaLocation,
+        enable_ctp: bool,
     );
 
     /// Disconnects the storage instance from the specified replica.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -560,6 +560,7 @@ where
         instance_id: StorageInstanceId,
         replica_id: ReplicaId,
         location: ClusterReplicaLocation,
+        enable_ctp: bool,
     ) {
         let instance = self
             .instances
@@ -570,6 +571,7 @@ where
             build_info: self.build_info,
             location,
             grpc_client: self.config.parameters.grpc_client.clone(),
+            enable_ctp,
         };
         instance.add_replica(replica_id, config);
     }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2455,18 +2455,8 @@ class Metrics:
     def get_commands_total(self, command_type: str) -> float:
         return self.get_command_count("mz_compute_commands_total", command_type)
 
-    def get_command_bytes_total(self, command_type: str) -> float:
-        return self.get_command_count(
-            "mz_compute_command_message_bytes_total", command_type
-        )
-
     def get_responses_total(self, response_type: str) -> float:
         return self.get_response_count("mz_compute_responses_total", response_type)
-
-    def get_response_bytes_total(self, response_type: str) -> float:
-        return self.get_response_count(
-            "mz_compute_response_message_bytes_total", response_type
-        )
 
     def get_peeks_total(self, result: str) -> float:
         metrics = self.with_name("mz_compute_peeks_total")
@@ -2712,24 +2702,6 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_commands_total("update_configuration")
     assert count == 1, f"got {count}"
 
-    # mz_compute_command_message_bytes_total
-    count = metrics.get_command_bytes_total("hello")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("create_instance")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("allow_compaction")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("create_dataflow")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("peek")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("cancel_peek")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("initialization_complete")
-    assert count > 0, f"got {count}"
-    count = metrics.get_command_bytes_total("update_configuration")
-    assert count > 0, f"got {count}"
-
     # mz_compute_responses_total
     count = metrics.get_responses_total("frontiers")
     assert count > 0, f"got {count}"
@@ -2738,14 +2710,10 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_responses_total("subscribe_response")
     assert count > 0, f"got {count}"
 
-    # mz_compute_response_message_bytes_total
-    count = metrics.get_response_bytes_total("frontiers")
+    count = metrics.get_value("mz_compute_command_message_bytes_total")
     assert count > 0, f"got {count}"
-    count = metrics.get_response_bytes_total("peek_response")
+    count = metrics.get_value("mz_compute_response_message_bytes_total")
     assert count > 0, f"got {count}"
-    count = metrics.get_response_bytes_total("subscribe_response")
-    assert count > 0, f"got {count}"
-
     count = metrics.get_value("mz_compute_controller_replica_count")
     assert count == 1, f"got {count}"
     count = metrics.get_value("mz_compute_controller_collection_count")

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2379,13 +2379,11 @@ def workflow_test_clusterd_death_detection(c: Composition) -> None:
             """
             )
         )
-        # Should detect broken connection after a few seconds, works with c.kill("clusterd1")
+        # Should detect broken connection after a few seconds.
         time.sleep(10)
         envd = c.invoke("logs", "materialized", capture=True)
-        assert (
-            "error reading a body from connection: stream closed because of a broken pipe"
-            in envd.stdout
-        )
+        print(envd.stdout)
+        assert "replica task failed: timed out" in envd.stdout
 
 
 class Metrics:


### PR DESCRIPTION
This PR starts making use of the Cluster Transport Protocol introduced in #32330, to replace gRPC in both the compute and the storage protocol. CTP has been designed with that use case in mind, so the amount of required changes is relatively low.

To de-risk the rollout, we want to be able to fall back to gRPC for now. To this end, a feature flag, `enable_ctp_cluster_protocols` is introduced and wired through the controller. Replicas need to select the controller protocol at startup and they do so using a new clusterd command line flag, `--use-ctp`.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/5038.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
