### PR TITLE
ci: Adapt to recent nightly failures (July 1, 2)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -510,7 +510,8 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
-              args: [--scenario=UserTables, --actions=10000, --max-execution-time=30m, --azurite]
+              # Azurite is too slow, takes a lot of memory in this test
+              args: [--scenario=UserTables, --actions=10000, --max-execution-time=30m]
 
       - id: zippy-postgres-cdc
         label: "Zippy Postgres CDC"
@@ -1549,6 +1550,7 @@ steps:
               # Postgres does not support WMR, so our only hope for a comparison
               # test is to use a previous Mz version via --other-tag=...
               args: ["wmr", "--seed=$BUILDKITE_JOB_ID", "--other-tag=common-ancestor"]
+        skip: "database-issues#9439"
 
       - id: rqg-banking
         label: "RQG banking workload"

--- a/test/pg-cdc-old-syntax/statistics.td
+++ b/test/pg-cdc-old-syntax/statistics.td
@@ -128,7 +128,7 @@ true
 
 # We need to filter by "latest" replica because statistics for the old replica
 # might persist a while after it is dropped.
->[version>=14800] SELECT
+>[version>=14900] SELECT
     s.name,
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
@@ -140,7 +140,7 @@ true
   ORDER BY s.name
 mz_source 1 1
 
->[version<14800] SELECT
+>[version<14900] SELECT
     s.name,
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -128,7 +128,7 @@ true
 
 # We need to filter by "latest" replica because statistics for the old replica
 # might persist a while after it is dropped.
->[version>=14800] SELECT
+> SELECT
     s.name,
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
@@ -136,17 +136,6 @@ true
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('mz_source')
     AND u.replica_id = (SELECT MAX(u.replica_id) FROM mz_internal.mz_source_statistics_raw u JOIN mz_sources s ON s.id = u.id WHERE s.name IN ('mz_source'))
-  GROUP BY s.name
-  ORDER BY s.name
-mz_source 1 1
-
->[version<14800] SELECT
-    s.name,
-    SUM(u.snapshot_records_known),
-    SUM(u.snapshot_records_staged)
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
 mz_source 1 1

--- a/test/testdrive-old-kafka-src-syntax/indexes.td
+++ b/test/testdrive-old-kafka-src-syntax/indexes.td
@@ -379,7 +379,7 @@ pg_description_all_databases_ind                            pg_description_all_d
 pg_namespace_all_databases_ind                              pg_namespace_all_databases                   mz_catalog_server    {nspname}                                   ""
 pg_type_all_databases_ind                                   pg_type_all_databases                        mz_catalog_server    {oid}                                       ""
 
-?[13100<version<14800] SHOW INDEXES IN CLUSTER mz_catalog_server
+?[13100<version<14900] SHOW INDEXES IN CLUSTER mz_catalog_server
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_catalog_server    {id,worker_id}                              ""
 mz_arrangement_batches_raw_s2_primary_idx                   mz_arrangement_batches_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
 mz_arrangement_records_raw_s2_primary_idx                   mz_arrangement_records_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
@@ -483,7 +483,7 @@ pg_description_all_databases_ind                            pg_description_all_d
 pg_namespace_all_databases_ind                              pg_namespace_all_databases                   mz_catalog_server    {nspname}                                   ""
 pg_type_all_databases_ind                                   pg_type_all_databases                        mz_catalog_server    {oid}                                       ""
 
->[version>=14800] SHOW INDEXES IN CLUSTER mz_catalog_server
+>[version>=14900] SHOW INDEXES IN CLUSTER mz_catalog_server
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_catalog_server    {id,worker_id}                              ""
 mz_arrangement_batches_raw_s2_primary_idx                   mz_arrangement_batches_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
 mz_arrangement_records_raw_s2_primary_idx                   mz_arrangement_records_raw                   mz_catalog_server    {operator_id,worker_id}                     ""

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/8636 is fixed
+$ skip-if
+SELECT true
+
 $ set-arg-default single-replica-cluster=quickstart
 
 > CREATE CONNECTION kafka_conn
@@ -126,10 +130,6 @@ contains:canceling statement due to user request
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
 
 > INSERT INTO created_post_alter VALUES ('hundred', 99);
-
-# TODO: Reenable when database-issues#8636 is fixed
-$ skip-if
-SELECT true
 
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
 {"before": null, "after": {"created_post_name": "hundred", "created_post_value": 99}}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -296,7 +296,7 @@ bar_ind bar <VARIABLE_OUTPUT> {a}  ""
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
 
->[version<14800] SHOW INDEXES IN CLUSTER mz_catalog_server
+>[version<14900] SHOW INDEXES IN CLUSTER mz_catalog_server
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_catalog_server    {id,worker_id}                              ""
 mz_arrangement_batches_raw_s2_primary_idx                   mz_arrangement_batches_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
 mz_arrangement_records_raw_s2_primary_idx                   mz_arrangement_records_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
@@ -400,7 +400,7 @@ pg_description_all_databases_ind                            pg_description_all_d
 pg_namespace_all_databases_ind                              pg_namespace_all_databases                   mz_catalog_server    {nspname}                                   ""
 pg_type_all_databases_ind                                   pg_type_all_databases                        mz_catalog_server    {oid}                                       ""
 
->[version>=14800] SHOW INDEXES IN CLUSTER mz_catalog_server
+>[version>=14900] SHOW INDEXES IN CLUSTER mz_catalog_server
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_catalog_server    {id,worker_id}                              ""
 mz_arrangement_batches_raw_s2_primary_idx                   mz_arrangement_batches_raw                   mz_catalog_server    {operator_id,worker_id}                     ""
 mz_arrangement_records_raw_s2_primary_idx                   mz_arrangement_records_raw                   mz_catalog_server    {operator_id,worker_id}                     ""


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/12514 and https://buildkite.com/materialize/nightly/builds/12503

Verification: https://buildkite.com/materialize/nightly/builds/12515
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
