### PR TITLE
RQG: Don't use serializable transaction isolation in WMR

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1550,7 +1550,6 @@ steps:
               # Postgres does not support WMR, so our only hope for a comparison
               # test is to use a previous Mz version via --other-tag=...
               args: ["wmr", "--seed=$BUILDKITE_JOB_ID", "--other-tag=common-ancestor"]
-        skip: "database-issues#9439"
 
       - id: rqg-banking
         label: "RQG banking workload"

--- a/test/rqg/Dockerfile
+++ b/test/rqg/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/MaterializeInc/RQG/git/refs/heads/main version.
 
 RUN git clone --single-branch https://github.com/MaterializeInc/RQG.git \
     && cd RQG \
-    && git checkout d041a829252e2cdabb2588af5d537b27017f09e4
+    && git checkout 4fe4e6f09f9599ce9f8ffd3f75d593b20518cc50
 
 ENTRYPOINT ["/usr/bin/perl"]
 

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -138,6 +138,8 @@ WORKLOADS = [
         # test is to use a previous Mz version via --other-tag=...
         reference_implementation=ReferenceImplementation.MATERIALIZE,
         validator="ResultsetComparatorSimplify",
+        # See https://github.com/MaterializeInc/database-issues/issues/9439
+        threads=1,
     ),
     Workload(
         # A workload that performs DML that preserve the dataset's invariants


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9439

This PR uses https://github.com/MaterializeInc/RQG/pull/7

My understanding is that `t1` was missing when running the query, thus it failed, causing RQG to recreate the table, thus causing the apparent wrong results in the other running threads. In the end this seems to be badly designed in RQG, but I'm not that familiar with the design to fix it in another way.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
