### PR TITLE
Adding Intercom Widget for the Docs site

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -71,31 +71,35 @@
 <script src="https://cdn.jsdelivr.net/npm/simple-scrollspy@2.0.3/dist/simple-scrollspy.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 
+{{/* Intercom */}}
+<script>
+  const APP_ID = "r8661p0d";
+  window.intercomSettings = {
+    api_base: "https://api-iam.intercom.io",
+    app_id: APP_ID
+  };
+</script>
+<script>
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+ </script>
+
 {{/* Sass processing here */}} {{ $style := resources.Get "sass/main.scss" |
 toCSS | fingerprint }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 
-{{/* Kapa.ai */}}
-<script
-  async
-  src="https://widget.kapa.ai/kapa-widget.bundle.js"
-  data-website-id="c9f86179-22af-46ef-8196-289a621ef96c"
-  data-project-name="Materialize"
-  data-project-color="#472E85"
-  data-project-logo="https://avatars.githubusercontent.com/u/47674186?s=200&v=4"
-  data-modal-title="Materialize"
-  data-modal-disclaimer="This AI bot is experimental and might provide inaccurate or incomplete answers. Always consult the official Materialize documentation to verify any answers provided here. __To search the docs instead__, switch to the __Search__ mode (upper-right hand corner).
-
-  Interactions with this AI bot may be monitored or recorded. By submitting your information on this form, you agree to our [website terms](https://materialize.com/site-terms-of-service/) and [privacy policy](https://materialize.com/privacy-policy/)."
-  data-modal-example-questions="Why is my query slow?,How do I check my source's status?"
-  data-search-mode-enabled="true"
-  data-modal-override-open-class-search="docs-search-button"
-  data-user-analytics-fingerprint-enabled="true"
-  data-modal-open-on-command-k="true"
-  data-modal-command-k-search-mode-default="true"
-  data-search-result-link-target="_self"
-  data-search-include-source-names='["Documentation Cloud"]'
-  >
+{{/* Algolia DocSearch */}}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script defer>
+  addEventListener("DOMContentLoaded", () => {
+    docsearch({
+      appId: "MB06X1VH88",
+      apiKey: "eee636ad1283d7ab634257ac1b61d429",
+      indexName: "Self-Managed-25.2",
+      insights: true,
+      container: "#docsearch",
+    });
+  });
 </script>
 
 {{if hugo.IsProduction}} {{/* Google Tag Manager */}}


### PR DESCRIPTION
This change adds Intercom widget to the docs site and let's the users interact with Matty -- AI agent for materialize. 
### Motivation
This is part of the effort to integrate Intercom in Materialize. 
Intercom documentation: https://developers.intercom.com/installing-intercom/web/installation


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
![image](https://github.com/user-attachments/assets/da10c4bf-2bd1-4e7b-b0eb-68b3152d7032)
