### PR TITLE
testdrive: Fix test writing to file with current day

### DIFF
--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -94,6 +94,9 @@ contains:MAX FILE SIZE cannot be less than 16MB
 > CREATE CLUSTER c1 REPLICAS (r1 (size '2'), r2 (size '2'));
 > SET cluster = c1;
 
+$ set-from-sql var=key-1
+SELECT TO_CHAR(now(), 'YYYY-MM-DD')
+
 # functions like now() should work in the s3 path
 > COPY t TO 's3://copytos3/test/1/' || TO_CHAR(now(), 'YYYY-MM-DD')
   WITH (
@@ -101,6 +104,13 @@ contains:MAX FILE SIZE cannot be less than 16MB
     MAX FILE SIZE = "100MB",
     FORMAT = 'csv'
   );
+
+$ set-from-sql var=key-2
+SELECT TO_CHAR(now(), 'YYYY-MM-DD')
+
+# The test depends on the day not changing at this specific time
+> SELECT '${key-1}' = '${key-2}'
+true
 
 > SELECT a FROM t
 1
@@ -164,9 +174,6 @@ contains:S3 bucket path is not empty
     FORMAT = 'csv'
   );
 
-$ set-from-sql var=key-1
-SELECT TO_CHAR(now(), 'YYYY-MM-DD')
-
 $ s3-verify-data bucket=copytos3 key=test/1/${key-1} sort-rows=true
 1
 2
@@ -203,12 +210,22 @@ $ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=^test/5/mz.*\.cs
 
 # Test with parquet formatting
 
+$ set-from-sql var=key-1
+SELECT TO_CHAR(now(), 'YYYY-MM-DD')
+
 > COPY t TO 's3://copytos3/parquet_test/1/' || TO_CHAR(now(), 'YYYY-MM-DD')
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
     FORMAT = 'parquet'
   );
+
+$ set-from-sql var=key-2
+SELECT TO_CHAR(now(), 'YYYY-MM-DD')
+
+# The test depends on the day not changing at this specific time
+> SELECT '${key-1}' = '${key-2}'
+true
 
 > COPY (SELECT a FROM t) TO 's3://copytos3/parquet_test/2'
   WITH (


### PR DESCRIPTION
Fails when the day changes during test execution. This PR decreases the likelihood of that.

Seen in https://buildkite.com/materialize/nightly/builds/12524#0197cd7a-df08-41a9-8495-08ef240134e0
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
