### PR TITLE
ci: Add more debugging prints to mkpipeline & speed up worst offenders

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -29,34 +29,6 @@ steps:
   - group: Builds
     key: builds
     steps:
-      - id: rust-build-x86_64
-        label: ":rust: Build x86_64"
-        env:
-          CI_BAZEL_BUILD: 0
-        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
-        inputs:
-          - "*"
-        depends_on: []
-        timeout_in_minutes: 60
-        priority: 50
-        agents:
-          queue: builder-linux-x86_64
-        sanitizer: skip
-
-      - id: rust-build-aarch64
-        label: ":rust: Build aarch64"
-        env:
-          CI_BAZEL_BUILD: 0
-        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
-        inputs:
-          - "*"
-        depends_on: []
-        priority: 50
-        timeout_in_minutes: 60
-        agents:
-          queue: builder-linux-aarch64-mem
-        sanitizer: skip
-
       - id: build-x86_64
         label: ":bazel: Build x86_64"
         env:


### PR DESCRIPTION
Runtime improves from 03:24 -> 02:19

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
