### PR TITLE
ci: Use min agent on debug symbol upload and wasm build

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -85,7 +85,7 @@ steps:
         label: "Upload debug symbols for x86_64"
         env:
           CI_BAZEL_BUILD: 0
-        command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
+        command: bin/ci-builder run min bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
         inputs:
           - "*"
         depends_on: [build-x86_64]
@@ -100,7 +100,7 @@ steps:
         label: "Upload debug symbols for aarch64"
         env:
           CI_BAZEL_BUILD: 0
-        command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
+        command: bin/ci-builder run min bin/pyactivate -m materialize.ci_util.upload_debug_symbols_to_polarsignals
         inputs:
           - "*"
         depends_on: [build-aarch64]
@@ -113,7 +113,7 @@ steps:
 
       - id: build-wasm
         label: Build WASM
-        command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm --no-release
+        command: bin/ci-builder run min bin/pyactivate -m ci.deploy.npm --no-release
         inputs:
           - "*"
         depends_on: []


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
