### PR TITLE
WIP add sni tenant lookups to balancer pgwire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,9 +4733,12 @@ version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener 5.4.0",
+ "futures-util",
  "loom 0.7.2",
  "parking_lot",
  "portable-atomic",
@@ -5143,6 +5146,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "launchdarkly-server-sdk",
+ "moka",
  "mz-alloc",
  "mz-alloc-default",
  "mz-build-info",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -25,6 +25,7 @@ hyper-openssl = "0.10.2"
 hyper-util = "0.1.14"
 jsonwebtoken = "9.3.1"
 launchdarkly-server-sdk = { version = "2.5.1", default-features = false }
+moka = { version = "0.12", features = ["future"] }
 mz-alloc = { path = "../alloc" }
 mz-alloc-default = { path = "../alloc-default", optional = true }
 mz-build-info = { path = "../build-info" }

--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -43,6 +43,34 @@ pub const INJECT_PROXY_PROTOCOL_HEADER_HTTP: Config<bool> = Config::new(
     "Whether to inject tcp proxy protocol headers to downstream http servers.",
 );
 
+/// Whether to enable SNI-based tenant resolution for PgWire connections.
+pub const PGWIRE_SNI_TENANT_RESOLUTION: Config<bool> = Config::new(
+    "balancerd_pgwire_sni_tenant_resolution",
+    true,
+    "Whether to enable SNI-based tenant resolution for PgWire connections.",
+);
+
+/// Whether to enable frontegg-based tenant resolution for PgWire connections.
+pub const PGWIRE_FRONTEGG_TENANT_RESOLUTION: Config<bool> = Config::new(
+    "balancerd_pgwire_frontegg_tenant_resolution",
+    false,
+    "Whether to enable frontegg-based tenant resolution for PgWire connections.",
+);
+
+/// TTL for DNS tenant resolution cache entries.
+pub const TENANT_CACHE_TTL: Config<Duration> = Config::new(
+    "balancerd_tenant_cache_ttl",
+    Duration::from_secs(300), // 5 minutes
+    "TTL for DNS tenant resolution cache entries.",
+);
+
+/// TTL for DNS address resolution cache entries.
+pub const ADDR_CACHE_TTL: Config<Duration> = Config::new(
+    "balancerd_addr_cache_ttl",
+    Duration::from_secs(1), // 1 second for fast rollover
+    "TTL for DNS address resolution cache entries.",
+);
+
 /// Sets the filter to apply to stderr logging.
 pub const LOGGING_FILTER: Config<&str> = Config::new(
     "balancerd_log_filter",
@@ -98,6 +126,10 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&SIGTERM_CONNECTION_WAIT)
         .add(&SIGTERM_LISTEN_WAIT)
         .add(&INJECT_PROXY_PROTOCOL_HEADER_HTTP)
+        .add(&PGWIRE_SNI_TENANT_RESOLUTION)
+        .add(&PGWIRE_FRONTEGG_TENANT_RESOLUTION)
+        .add(&TENANT_CACHE_TTL)
+        .add(&ADDR_CACHE_TTL)
         .add(&LOGGING_FILTER)
         .add(&OPENTELEMETRY_FILTER)
         .add(&LOGGING_FILTER_DEFAULTS)
@@ -122,6 +154,16 @@ pub(crate) fn set_defaults(
         if k.as_str() == INJECT_PROXY_PROTOCOL_HEADER_HTTP.name() {
             config_updates.add_dynamic(
                 INJECT_PROXY_PROTOCOL_HEADER_HTTP.name(),
+                mz_dyncfg::ConfigVal::Bool(bool::from_str(v)?),
+            )
+        } else if k.as_str() == PGWIRE_SNI_TENANT_RESOLUTION.name() {
+            config_updates.add_dynamic(
+                PGWIRE_SNI_TENANT_RESOLUTION.name(),
+                mz_dyncfg::ConfigVal::Bool(bool::from_str(v)?),
+            )
+        } else if k.as_str() == PGWIRE_FRONTEGG_TENANT_RESOLUTION.name() {
+            config_updates.add_dynamic(
+                PGWIRE_FRONTEGG_TENANT_RESOLUTION.name(),
                 mz_dyncfg::ConfigVal::Bool(bool::from_str(v)?),
             )
         } else {

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -39,6 +39,7 @@ use futures::stream::BoxStream;
 use hyper::StatusCode;
 use hyper_util::rt::TokioIo;
 use launchdarkly_server_sdk as ld;
+use moka::future::Cache;
 use mz_build_info::{BuildInfo, build_info};
 use mz_dyncfg::ConfigSet;
 use mz_frontegg_auth::Authenticator as FronteggAuthentication;
@@ -74,7 +75,8 @@ use uuid::Uuid;
 
 use crate::codec::{BackendMessage, FramedConn};
 use crate::dyncfgs::{
-    INJECT_PROXY_PROTOCOL_HEADER_HTTP, SIGTERM_CONNECTION_WAIT, SIGTERM_LISTEN_WAIT,
+    ADDR_CACHE_TTL, INJECT_PROXY_PROTOCOL_HEADER_HTTP, PGWIRE_FRONTEGG_TENANT_RESOLUTION,
+    PGWIRE_SNI_TENANT_RESOLUTION, SIGTERM_CONNECTION_WAIT, SIGTERM_LISTEN_WAIT, TENANT_CACHE_TTL,
     has_tracing_config_update, tracing_config,
 };
 
@@ -315,6 +317,9 @@ impl BalancerService {
 
         let metrics = ServerMetricsConfig::register_into(&self.cfg.metrics_registry);
 
+        // Create shared tenant resolver for DNS caching
+        let tenant_resolver = Arc::new(TenantResolver::new(&self.configs));
+
         let mut set = JoinSet::new();
         let mut server_handles = Vec::new();
         let pgwire_addr = self.pgwire.0.local_addr();
@@ -323,11 +328,14 @@ impl BalancerService {
 
         {
             let pgwire = PgwireBalancer {
-                resolver: Arc::new(self.cfg.resolver),
-                cancellation_resolver: Arc::new(self.cfg.cancellation_resolver),
                 tls: pgwire_tls,
                 internal_tls: self.cfg.internal_tls,
+                cancellation_resolver: Arc::new(self.cfg.cancellation_resolver),
+                resolver: Arc::new(self.cfg.resolver),
+                dns_resolver: Arc::new(StubResolver::new()),
+                tenant_resolver: Arc::clone(&tenant_resolver),
                 metrics: ServerMetrics::new(metrics.clone(), "pgwire"),
+                configs: self.configs.clone(),
                 now: SYSTEM_TIME.clone(),
             };
             let (handle, stream) = self.pgwire;
@@ -359,6 +367,7 @@ impl BalancerService {
                 tls: https_tls,
                 resolve_template: Arc::from(addr),
                 port,
+                tenant_resolver: Arc::clone(&tenant_resolver),
                 metrics: Arc::from(ServerMetrics::new(metrics, "https")),
                 configs: self.configs.clone(),
                 internal_tls: self.cfg.internal_tls,
@@ -599,6 +608,187 @@ impl ServerMetrics {
     }
 }
 
+/// Shared DNS-based tenant resolution logic used by both HTTP and PgWire balancers.
+struct TenantResolver {
+    /// Cache for DNS CNAME lookups: hostname -> tenant_id
+    tenant_cache: Cache<String, Option<String>>,
+    /// Cache for IP address lookups: hostname -> SocketAddr
+    addr_cache: Cache<String, SocketAddr>,
+}
+
+impl TenantResolver {
+    /// Creates a new TenantResolver with configuration from the provided ConfigSet.
+    fn new(configs: &ConfigSet) -> Self {
+        Self {
+            tenant_cache: Cache::builder()
+                .max_capacity(1000)
+                .time_to_live(TENANT_CACHE_TTL.get(configs))
+                .build(),
+            addr_cache: Cache::builder()
+                .max_capacity(1000)
+                .time_to_live(ADDR_CACHE_TTL.get(configs))
+                .build(),
+        }
+    }
+
+    /// Resolves tenant information from SNI hostname using DNS CNAME lookup.
+    /// Returns None if DNS lookup fails or tenant cannot be determined.
+    async fn resolve_from_sni(
+        &self,
+        dns_resolver: &StubResolver,
+        servername: &str,
+        resolve_template: &str,
+    ) -> Option<ResolvedAddr> {
+        debug!("attempting SNI-based resolution with servername: {servername}");
+
+        // Construct address using the template
+        let addr = resolve_template.replace("{}", servername);
+        debug!("SNI address: {addr}");
+
+        // Attempt to get tenant from DNS CNAME lookup (cached)
+        let tenant = self.resolve_tenant_from_dns(dns_resolver, &addr).await?;
+
+        // Do the regular IP lookup (cached)
+        let envd_addr = match self.lookup_addr(&addr).await {
+            Ok(addr) => addr,
+            Err(err) => {
+                debug!("SNI-based address lookup failed: {err}");
+                return None;
+            }
+        };
+
+        Some(ResolvedAddr {
+            addr: envd_addr,
+            password: None, // No password needed for SNI-based resolution
+            tenant: Some(tenant),
+        })
+    }
+
+    /// Resolves tenant information from SNI hostname using DNS CNAME lookup with port.
+    /// Used by HTTPS balancer which needs to append port to the lookup address.
+    async fn resolve_from_sni_with_port(
+        &self,
+        dns_resolver: &StubResolver,
+        servername: &str,
+        resolve_template: &str,
+        port: u16,
+    ) -> Result<ResolvedAddr, anyhow::Error> {
+        let addr = resolve_template.replace("{}", servername);
+        debug!("https address: {addr}");
+
+        // Attempt to get tenant from DNS CNAME lookup (cached)
+        let tenant = self.resolve_tenant_from_dns(dns_resolver, &addr).await;
+
+        // Do the regular IP lookup with port (cached)
+        let addr_with_port = format!("{addr}:{port}");
+        let envd_addr = self.lookup_addr(&addr_with_port).await?;
+
+        Ok(ResolvedAddr {
+            addr: envd_addr,
+            password: None,
+            tenant,
+        })
+    }
+
+    /// Finds the tenant of a DNS address using CNAME lookup with caching.
+    /// Returns None if DNS lookup fails or tenant cannot be determined.
+    async fn resolve_tenant_from_dns(&self, resolver: &StubResolver, addr: &str) -> Option<String> {
+        // Check cache first
+        if let Some(cached_tenant) = self.tenant_cache.get(addr).await {
+            debug!("tenant cache hit for {addr}: {cached_tenant:?}");
+            return cached_tenant;
+        }
+
+        // Do actual DNS lookup
+        let result = self.resolve_tenant_from_dns_uncached(resolver, addr).await;
+
+        // Cache the result
+        self.tenant_cache
+            .insert(addr.to_string(), result.clone())
+            .await;
+
+        result
+    }
+
+    /// Finds the tenant of a DNS address using CNAME lookup without caching.
+    /// Returns None if DNS lookup fails or tenant cannot be determined.
+    async fn resolve_tenant_from_dns_uncached(
+        &self,
+        resolver: &StubResolver,
+        addr: &str,
+    ) -> Option<String> {
+        let Ok(dname) = Dname::<Vec<_>>::from_str(addr) else {
+            return None;
+        };
+
+        // Lookup the CNAME. If there's a CNAME, find the tenant.
+        let lookup = resolver.query((dname, Rtype::Cname)).await;
+        if let Ok(lookup) = lookup {
+            if let Ok(answer) = lookup.answer() {
+                let res = answer.limit_to::<AllRecordData<_, _>>();
+                for record in res {
+                    let Ok(record) = record else {
+                        continue;
+                    };
+                    if record.rtype() != Rtype::Cname {
+                        continue;
+                    }
+                    let cname = record.data();
+                    let cname = cname.to_string();
+                    debug!("cname: {cname}");
+                    return Self::extract_tenant_from_cname(&cname);
+                }
+            }
+        }
+        None
+    }
+
+    /// Looks up an IP address with caching.
+    /// Returns the first IP address resolved from the provided hostname.
+    async fn lookup_addr(&self, name: &str) -> Result<SocketAddr, anyhow::Error> {
+        // Check cache first
+        if let Some(cached_addr) = self.addr_cache.get(name).await {
+            debug!("addr cache hit for {name}: {cached_addr}");
+            return Ok(cached_addr);
+        }
+
+        // Do actual lookup
+        let result = lookup(name).await;
+
+        // Cache successful results
+        if let Ok(addr) = result {
+            self.addr_cache.insert(name.to_string(), addr).await;
+            Ok(addr)
+        } else {
+            result
+        }
+    }
+
+    /// Extracts the tenant from a CNAME record.
+    fn extract_tenant_from_cname(cname: &str) -> Option<String> {
+        let mut parts = cname.split('.');
+        let _service = parts.next();
+        let Some(namespace) = parts.next() else {
+            return None;
+        };
+        // Trim off the starting `environmentd-`.
+        let Some((_, namespace)) = namespace.split_once('-') else {
+            return None;
+        };
+        // Trim off the ending `-0` (or some other number).
+        let Some((tenant, _)) = namespace.rsplit_once('-') else {
+            return None;
+        };
+        // Convert to a Uuid so that this tenant matches the frontegg resolver exactly, because it
+        // also uses Uuid::to_string.
+        let Ok(tenant) = Uuid::parse_str(tenant) else {
+            error!("cname tenant not a uuid: {tenant}");
+            return None;
+        };
+        Some(tenant.to_string())
+    }
+}
+
 pub enum CancellationResolver {
     Directory(PathBuf),
     Static(String),
@@ -609,8 +799,42 @@ struct PgwireBalancer {
     internal_tls: bool,
     cancellation_resolver: Arc<CancellationResolver>,
     resolver: Arc<Resolver>,
+    dns_resolver: Arc<StubResolver>,
+    tenant_resolver: Arc<TenantResolver>,
     metrics: ServerMetrics,
+    configs: ConfigSet,
     now: NowFn,
+}
+
+impl Resolver {
+    /// Attempts to resolve tenant information from SNI hostname using DNS CNAME lookup.
+    /// Returns None if SNI is not available, DNS lookup fails, or tenant cannot be determined.
+    async fn try_resolve_from_sni<A>(
+        conn: &FramedConn<A>,
+        resolve_template: &str,
+        dns_resolver: &StubResolver,
+        tenant_resolver: &TenantResolver,
+    ) -> Option<ResolvedAddr>
+    where
+        A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
+    {
+        // Extract SNI hostname if this is an SSL connection
+        let servername = match conn.inner() {
+            Conn::Ssl(ssl_stream) => ssl_stream.ssl().servername(NameType::HOST_NAME).map(|sn| {
+                match sn.split_once('.') {
+                    Some((left, _right)) => left,
+                    None => sn,
+                }
+                .to_string()
+            }),
+            _ => None,
+        }?;
+
+        // Use shared tenant resolver
+        tenant_resolver
+            .resolve_from_sni(dns_resolver, &servername, resolve_template)
+            .await
+    }
 }
 
 impl PgwireBalancer {
@@ -623,6 +847,9 @@ impl PgwireBalancer {
         tls_mode: Option<TlsMode>,
         internal_tls: bool,
         metrics: &ServerMetrics,
+        dns_resolver: Option<&Arc<StubResolver>>,
+        tenant_resolver: Option<&Arc<TenantResolver>>,
+        configs: &ConfigSet,
     ) -> Result<(), io::Error>
     where
         A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
@@ -649,7 +876,10 @@ impl PgwireBalancer {
             return conn.send(err).await;
         }
 
-        let resolved = match resolver.resolve(conn, user).await {
+        let resolved = match resolver
+            .resolve(conn, user, dns_resolver, tenant_resolver, configs)
+            .await
+        {
             Ok(v) => v,
             Err(err) => {
                 return conn
@@ -784,9 +1014,12 @@ impl mz_server_core::Server for PgwireBalancer {
         let tls = self.tls.clone();
         let internal_tls = self.internal_tls;
         let resolver = Arc::clone(&self.resolver);
+        let dns_resolver = Arc::clone(&self.dns_resolver);
+        let tenant_resolver = Arc::clone(&self.tenant_resolver);
         let inner_metrics = self.metrics.clone();
         let outer_metrics = self.metrics.clone();
         let cancellation_resolver = Arc::clone(&self.cancellation_resolver);
+        let configs = self.configs.clone();
         let conn_uuid = epoch_to_uuid_v7(&(self.now)());
         let peer_addr = conn.peer_addr();
         conn.uuid_handle().set(conn_uuid);
@@ -850,6 +1083,9 @@ impl mz_server_core::Server for PgwireBalancer {
                                 tls.map(|tls| tls.mode),
                                 internal_tls,
                                 &inner_metrics,
+                                Some(&dns_resolver),
+                                Some(&tenant_resolver),
+                                &configs,
                             )
                             .await?;
                             conn.flush().await?;
@@ -1052,6 +1288,7 @@ struct HttpsBalancer {
     tls: Option<ReloadingSslContext>,
     resolve_template: Arc<str>,
     port: u16,
+    tenant_resolver: Arc<TenantResolver>,
     metrics: Arc<ServerMetrics>,
     configs: ConfigSet,
     internal_tls: bool,
@@ -1063,87 +1300,27 @@ impl HttpsBalancer {
         resolve_template: &str,
         port: u16,
         servername: Option<&str>,
+        tenant_resolver: &TenantResolver,
     ) -> Result<ResolvedAddr, anyhow::Error> {
-        let addr = match &servername {
-            Some(servername) => resolve_template.replace("{}", servername),
-            None => resolve_template.to_string(),
-        };
-        debug!("https address: {addr}");
-
-        // When we lookup the address using SNI, we get a hostname (`3dl07g8zmj91pntk4eo9cfvwe` for
-        // example), which you convert into a different form for looking up the environment address
-        // `blncr-3dl07g8zmj91pntk4eo9cfvwe`. When you do a DNS lookup in kubernetes for
-        // `blncr-3dl07g8zmj91pntk4eo9cfvwe`, you get a CNAME response pointing at environmentd
-        // `environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local`. This
-        // is of the form `<service>.<namespace>.svc.cluster.local`. That `<namespace>` is the same
-        // as the environment name, and is based on the tenant ID. `environment-<tenant_id>-<index>`
-        // We currently only support a single environment per tenant in a region, so `<index>` is
-        // always 0. Do not rely on this ending in `-0` so in the future multiple envds are
-        // supported.
-
-        // Attempt to get a tenant.
-        let tenant = Self::tenant(resolver, &addr).await;
-
-        // Now do the regular ip lookup, regardless of if there was a CNAME.
-        let envd_addr = lookup(&format!("{addr}:{port}")).await?;
-
-        Ok(ResolvedAddr {
-            addr: envd_addr,
-            password: None,
-            tenant,
-        })
-    }
-
-    /// Finds the tenant of a DNS address. Errors or lack of cname resolution here are ok, because
-    /// this is only used for metrics.
-    async fn tenant(resolver: &StubResolver, addr: &str) -> Option<String> {
-        let Ok(dname) = Dname::<Vec<_>>::from_str(addr) else {
-            return None;
-        };
-        // Lookup the CNAME. If there's a CNAME, find the tenant.
-        let lookup = resolver.query((dname, Rtype::Cname)).await;
-        if let Ok(lookup) = lookup {
-            if let Ok(answer) = lookup.answer() {
-                let res = answer.limit_to::<AllRecordData<_, _>>();
-                for record in res {
-                    let Ok(record) = record else {
-                        continue;
-                    };
-                    if record.rtype() != Rtype::Cname {
-                        continue;
-                    }
-                    let cname = record.data();
-                    let cname = cname.to_string();
-                    debug!("cname: {cname}");
-                    return Self::extract_tenant_from_cname(&cname);
-                }
+        match servername {
+            Some(servername) => {
+                // Use shared tenant resolver for SNI-based resolution if enabled
+                tenant_resolver
+                    .resolve_from_sni_with_port(resolver, servername, resolve_template, port)
+                    .await
+            }
+            _ => {
+                // No SNI or SNI disabled, construct address with template as-is
+                let addr = resolve_template.to_string();
+                debug!("https address (no SNI or SNI disabled): {addr}");
+                let envd_addr = lookup(&format!("{addr}:{port}")).await?;
+                Ok(ResolvedAddr {
+                    addr: envd_addr,
+                    password: None,
+                    tenant: None,
+                })
             }
         }
-        None
-    }
-
-    /// Extracts the tenant from a CNAME.
-    fn extract_tenant_from_cname(cname: &str) -> Option<String> {
-        let mut parts = cname.split('.');
-        let _service = parts.next();
-        let Some(namespace) = parts.next() else {
-            return None;
-        };
-        // Trim off the starting `environmentd-`.
-        let Some((_, namespace)) = namespace.split_once('-') else {
-            return None;
-        };
-        // Trim off the ending `-0` (or some other number).
-        let Some((tenant, _)) = namespace.rsplit_once('-') else {
-            return None;
-        };
-        // Convert to a Uuid so that this tenant matches the frontegg resolver exactly, because it
-        // also uses Uuid::to_string.
-        let Ok(tenant) = Uuid::parse_str(tenant) else {
-            error!("cname tenant not a uuid: {tenant}");
-            return None;
-        };
-        Some(tenant.to_string())
     }
 }
 
@@ -1157,6 +1334,7 @@ impl mz_server_core::Server for HttpsBalancer {
         let resolver = Arc::clone(&self.resolver);
         let resolve_template = Arc::clone(&self.resolve_template);
         let port = self.port;
+        let tenant_resolver = Arc::clone(&self.tenant_resolver);
         let inner_metrics = Arc::clone(&self.metrics);
         let outer_metrics = Arc::clone(&self.metrics);
         let peer_addr = conn.peer_addr();
@@ -1187,9 +1365,14 @@ impl mz_server_core::Server for HttpsBalancer {
                         }
                         _ => (Box::new(conn), None),
                     };
-                let resolved =
-                    Self::resolve(&resolver, &resolve_template, port, servername.as_deref())
-                        .await?;
+                let resolved = Self::resolve(
+                    &resolver,
+                    &resolve_template,
+                    port,
+                    servername.as_deref(),
+                    &tenant_resolver,
+                )
+                .await?;
                 let inner_active_guard = resolved
                     .tenant
                     .as_ref()
@@ -1264,40 +1447,73 @@ impl Resolver {
         &self,
         conn: &mut FramedConn<A>,
         user: &str,
+        dns_resolver: Option<&Arc<StubResolver>>,
+        tenant_resolver: Option<&Arc<TenantResolver>>,
+        configs: &ConfigSet,
     ) -> Result<ResolvedAddr, anyhow::Error>
     where
-        A: AsyncRead + AsyncWrite + Unpin,
+        A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
     {
         match self {
             Resolver::Frontegg(FronteggResolver {
                 auth,
                 addr_template,
             }) => {
-                conn.send(BackendMessage::AuthenticationCleartextPassword)
-                    .await?;
-                conn.flush().await?;
-                let password = match conn.recv().await? {
-                    Some(FrontendMessage::Password { password }) => password,
-                    _ => anyhow::bail!("expected Password message"),
-                };
-
-                let auth_response = auth.authenticate(user, &password).await;
-                let auth_session = match auth_response {
-                    Ok(auth_session) => auth_session,
-                    Err(e) => {
-                        warn!("pgwire connection failed authentication: {}", e);
-                        // TODO: fix error codes.
-                        anyhow::bail!("invalid password");
+                // Try SNI-based resolution first if enabled and we have access to the DNS resolver
+                if PGWIRE_SNI_TENANT_RESOLUTION.get(configs) {
+                    if let (Some(dns_resolver), Some(tenant_resolver)) =
+                        (dns_resolver, tenant_resolver)
+                    {
+                        if let Some(resolved) = Self::try_resolve_from_sni(
+                            conn,
+                            addr_template,
+                            dns_resolver,
+                            tenant_resolver,
+                        )
+                        .await
+                        {
+                            debug!(
+                                "successfully resolved tenant from SNI: {:?}",
+                                resolved.tenant
+                            );
+                            return Ok(resolved);
+                        }
+                        debug!(
+                            "SNI-based resolution failed, falling back to Frontegg authentication"
+                        );
                     }
-                };
+                }
 
-                let addr = addr_template.replace("{}", &auth_session.tenant_id().to_string());
-                let addr = lookup(&addr).await?;
-                Ok(ResolvedAddr {
-                    addr,
-                    password: Some(password),
-                    tenant: Some(auth_session.tenant_id().to_string()),
-                })
+                // Fall back to Frontegg authentication if enabled
+                if PGWIRE_FRONTEGG_TENANT_RESOLUTION.get(configs) {
+                    conn.send(BackendMessage::AuthenticationCleartextPassword)
+                        .await?;
+                    conn.flush().await?;
+                    let password = match conn.recv().await? {
+                        Some(FrontendMessage::Password { password }) => password,
+                        _ => anyhow::bail!("expected Password message"),
+                    };
+
+                    let auth_response = auth.authenticate(user, &password).await;
+                    let auth_session = match auth_response {
+                        Ok(auth_session) => auth_session,
+                        Err(e) => {
+                            warn!("pgwire connection failed authentication: {}", e);
+                            // TODO: fix error codes.
+                            anyhow::bail!("invalid password");
+                        }
+                    };
+
+                    let addr = addr_template.replace("{}", &auth_session.tenant_id().to_string());
+                    let addr = lookup(&addr).await?;
+                    Ok(ResolvedAddr {
+                        addr,
+                        password: Some(password),
+                        tenant: Some(auth_session.tenant_id().to_string()),
+                    })
+                } else {
+                    anyhow::bail!("Frontegg authentication is disabled");
+                }
             }
             Resolver::Static(addr) => {
                 let addr = lookup(addr).await?;
@@ -1385,12 +1601,90 @@ mod tests {
             ),
         ];
         for (name, expect) in tests {
-            let cname = HttpsBalancer::extract_tenant_from_cname(name);
+            let cname = TenantResolver::extract_tenant_from_cname(name);
             assert_eq!(
                 cname.as_deref(),
                 expect,
                 "{name} got {cname:?} expected {expect:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_tenant_resolver_caching() {
+        use mz_dyncfg::ConfigSet;
+
+        // Create a ConfigSet with test values
+        let mut configs = ConfigSet::default();
+        configs = crate::dyncfgs::all_dyncfgs(configs);
+
+        // Create a TenantResolver with short cache TTLs for testing
+        let tenant_resolver = TenantResolver::new(&configs);
+
+        // Test that the tenant resolver properly extracts tenant from CNAME
+        let test_cname =
+            "environmentd.environment-58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3-0.svc.cluster.local";
+        let expected_tenant = "58cd23ff-a4d7-4bd0-ad85-a6ff29cc86c3";
+
+        let result = TenantResolver::extract_tenant_from_cname(test_cname);
+        assert_eq!(result.as_deref(), Some(expected_tenant));
+
+        // Test that cache keys are properly formatted
+        let cache_key = "test-hostname";
+        let test_addr = "127.0.0.1:8080".parse().unwrap();
+
+        // Insert a test entry into the address cache
+        tenant_resolver
+            .addr_cache
+            .insert(cache_key.to_string(), test_addr)
+            .await;
+
+        // Verify we can retrieve it
+        let cached_addr = tenant_resolver.addr_cache.get(cache_key).await;
+        assert_eq!(cached_addr, Some(test_addr));
+
+        // Test tenant cache functionality
+        let tenant_cache_key = "test-tenant-hostname";
+        let test_tenant = Some("test-tenant".to_string());
+
+        tenant_resolver
+            .tenant_cache
+            .insert(tenant_cache_key.to_string(), test_tenant.clone())
+            .await;
+
+        let cached_tenant = tenant_resolver.tenant_cache.get(tenant_cache_key).await;
+        assert_eq!(cached_tenant, Some(test_tenant));
+    }
+
+    #[mz_ore::test]
+    fn test_sni_hostname_extraction() {
+        // Test the hostname extraction logic that would be used in SNI processing
+        let test_cases = vec![
+            // Basic hostname without domain
+            ("hostname1", "hostname1"),
+            // Hostname with domain - should extract left part
+            ("hostname2.example.com", "hostname2"),
+            // Complex domain - should still extract left part
+            ("myapp.staging.company.com", "myapp"),
+            // Single component - should return as-is
+            ("singlename", "singlename"),
+        ];
+
+        for (input, expected) in test_cases {
+            let result = match input.split_once('.') {
+                Some((left, _right)) => left,
+                None => input,
+            };
+            assert_eq!(result, expected, "Failed for input: {}", input);
+        }
+
+        // Test that tenant resolver can be created with default configs
+        use mz_dyncfg::ConfigSet;
+        let mut configs = ConfigSet::default();
+        configs = crate::dyncfgs::all_dyncfgs(configs);
+        let _tenant_resolver = TenantResolver::new(&configs);
+
+        // This test validates the SNI hostname extraction logic that would be used
+        // in the actual PGwire SNI resolution process
     }
 }


### PR DESCRIPTION
- Adds sni tenant lookups to the balancer pgwire sni will be the initial lookup with fe auth as the fallback.
- unifies the lookup code between http and pgwire balancers
- introduces a cache for this lookup to prevent accidental DOS
- introduces LD flags to control how pgwire tenant lookups are performed
- As a word of caution this was an exercise in using cursor

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
