### PR TITLE
Improve error reporting for explain analyze

### DIFF
--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -353,18 +353,18 @@ EXPLAIN ANALYZE MEMORY, CPU, CPU WITH SKEW FOR MATERIALIZED VIEW w
 ----
 error: both CPU and MEMORY were specified, expected WITH SKEW or FOR
 EXPLAIN ANALYZE MEMORY, CPU, CPU WITH SKEW FOR MATERIALIZED VIEW w
-      ^
+                             ^
 
 parse-statement
 EXPLAIN ANALYZE HINTS FOR SELECT 1
 ----
-error: expected INDEX or MATERIALIZED VIEW
+error: Expected one of INDEX or MATERIALIZED, found SELECT
 EXPLAIN ANALYZE HINTS FOR SELECT 1
-    ^
+                          ^
 
 parse-statement
 EXPLAIN ANALYZE HINTS FOR idx_top_buyers
 ----
-error: expected INDEX or MATERIALIZED VIEW
+error: Expected one of INDEX or MATERIALIZED, found identifier "idx_top_buyers"
 EXPLAIN ANALYZE HINTS FOR idx_top_buyers
-    ^
+                          ^


### PR DESCRIPTION
The previous error reporting would report the index of the token as the offset in the statement, which is incorrect.  Fix this, and take the opportunity to simplify the logic by using existing functions to generate errors.  This improves readability of the code slightly, but doesn't produce necessarily better error messages.  Seems OK because our error messages aren't great anyway.
