### PR TITLE
ci: Try larger build agent

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -39,7 +39,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: xxl-builder-linux-x86_64
 
       - id: build-aarch64
         label: ":bazel: Build aarch64"
@@ -51,7 +51,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-aarch64-mem
+          queue: xxl-builder-linux-aarch64-mem
 
       - id: upload-debug-symbols-x86_64
         label: "Upload debug symbols for x86_64"

--- a/src/ore/src/netio/read_exact.rs
+++ b/src/ore/src/netio/read_exact.rs
@@ -76,5 +76,6 @@ where
             }
         }
         Poll::Ready(Ok(self.pos))
+
     }
 }


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
