### PR TITLE
test: second attempt at unflaking node recovery

### DIFF
--- a/misc/kind/cluster-node-recovery-test.yaml
+++ b/misc/kind/cluster-node-recovery-test.yaml
@@ -190,6 +190,14 @@ nodes:
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
 
+  # node for the `quickstart` cluster replica
+  - role: worker
+    image: kindest/node:v1.33.1
+    labels:
+      materialize.cloud/disk: true
+      materialize.cloud/availability-zone: "quickstart"
+      topology.kubernetes.io/zone: "quickstart"
+
   # only envd (nodes will be tainted in the setup)
   - role: worker
     image: kindest/node:v1.33.1

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -262,6 +262,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             "--availability-zone=1",
             "--availability-zone=2",
             "--availability-zone=3",
+            "--availability-zone=quickstart",
             "--aws-account-id=123456789000",
             "--aws-external-id-prefix=eb5cb59b-e2fe-41f3-87ca-d2176a495345",
             "--environment-id=cloudtest-test-00000000-0000-0000-0000-000000000000-0",


### PR DESCRIPTION
Overriding the target cluster for each SELECT is too brittle, as it's easy to miss queries. Instead, we can schedule the quickstart cluster on a node with a different AZ than any node we are going to suspend, ensuring queries always run on a healthy cluster that way.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9406

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
