### PR TITLE
Operator size tracking

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_introspection.md
+++ b/doc/user/content/sql/system-catalog/mz_introspection.md
@@ -63,14 +63,14 @@ The size, capacity, and allocations are an approximation, which may underestimat
 Specifically, reductions can use more memory than we show here.
 
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes -->
-| Field         | Type      | Meaning                                                                                                                   |
-|---------------|-----------|---------------------------------------------------------------------------------------------------------------------------|
-| `operator_id` | [`uint8`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `records`     | [`int8`]  | The number of records in the arrangement.                                                                                 |
-| `batches`     | [`int8`]  | Tnumber of batches in the arrangement.                                                                                    |
-| `size`        | [`int8`]  | Tutilized size in bytes of the arrangement.                                                                               |
-| `capacity`    | [`int8`]  | Tcapacity in bytes of the arrangement. Can be larger than the size.                                                       |
-| `allocations` | [`int8`]  | Tnumber of separate memory allocations backing the arrangement.                                                           |
+| Field         | Type       | Meaning                                                                                                                   |
+|---------------|------------| --------                                                                                                                  |
+| `operator_id` | [`uint8`]  | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
+| `records`     | [`bigint`] | The number of records in the arrangement.                                                                                 |
+| `batches`     | [`bigint`] | The number of batches in the arrangement.                                                                                 |
+| `size`        | [`bigint`] | The utilized size in bytes of the arrangement.                                                                            |
+| `capacity`    | [`bigint`] | The capacity in bytes of the arrangement. Can be larger than the size.                                                    |
+| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangement.                                                        |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sizes_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_records_raw -->
@@ -181,15 +181,15 @@ The `mz_dataflow_arrangement_sizes` view describes the size of arrangements per
 operators under each dataflow.
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_arrangement_sizes -->
-| Field         | Type        | Meaning                                                                      |
-|---------------|-------------|------------------------------------------------------------------------------|
-| `id`          | [`uint8`]   | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
-| `name`        | [`text`]    | The name of the [dataflow].                                                  |
-| `records`     | [`numeric`] | The number of records in all arrangements in the dataflow.                   |
-| `batches`     | [`numeric`] | The number of batches in all arrangements in the dataflow.                   |
-| `size`        | [`numeric`] | The utilized size in bytes of the arrangements.                              |
-| `capacity`    | [`numeric`] | The capacity in bytes of the arrangements. Can be larger than the size.      |
-| `allocations` | [`numeric`] | The number of separate memory allocations backing the arrangements.          |
+| Field         | Type       | Meaning                                                                      |
+|---------------|------------|------------------------------------------------------------------------------|
+| `id`          | [`uint8`]  | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
+| `name`        | [`text`]   | The name of the [dataflow].                                                  |
+| `records`     | [`bigint`] | The number of records in all arrangements in the dataflow.                   |
+| `batches`     | [`bigint`] | The number of batches in all arrangements in the dataflow.                   |
+| `size`        | [`bigint`] | The utilized size in bytes of the arrangements.                              |
+| `capacity`    | [`bigint`] | The capacity in bytes of the arrangements. Can be larger than the size.      |
+| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangements.          |
 
 ## `mz_dataflow_channels`
 
@@ -380,15 +380,15 @@ The `mz_peek_durations_histogram` view describes a histogram of the duration in 
 The `mz_records_per_dataflow` view describes the number of records in each [dataflow].
 
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow -->
-| Field         | Type        | Meaning                                                                    |
-| ------------  |-------------| --------                                                                   |
-| `id`          | [`uint8`]   | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
-| `name`        | [`text`]    | The internal name of the dataflow.                                         |
-| `records`     | [`numeric`] | The number of records in the dataflow.                                     |
-| `batches`     | [`numeric`] | The number of batches in the dataflow.                                     |
-| `size`        | [`numeric`] | The utilized size in bytes of the arrangements.                            |
-| `capacity`    | [`numeric`] | The capacity in bytes of the arrangements. Can be larger than the size.    |
-| `allocations` | [`numeric`] | The number of separate memory allocations backing the arrangements.        |
+| Field         | Type       | Meaning                                                                    |
+| ------------  |------------| --------                                                                   |
+| `id`          | [`uint8`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
+| `name`        | [`text`]   | The internal name of the dataflow.                                         |
+| `records`     | [`bigint`] | The number of records in the dataflow.                                     |
+| `batches`     | [`bigint`] | The number of batches in the dataflow.                                     |
+| `size`        | [`bigint`] | The utilized size in bytes of the arrangements.                            |
+| `capacity`    | [`bigint`] | The capacity in bytes of the arrangements. Can be larger than the size.    |
+| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangements.        |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_per_worker -->
 
@@ -397,16 +397,16 @@ The `mz_records_per_dataflow` view describes the number of records in each [data
 The `mz_records_per_dataflow_operator` view describes the number of records in each [dataflow] operator in the system.
 
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow_operator -->
-| Field          | Type        | Meaning                                                                                      |
-| -------------- |-------------| --------                                                                                     |
-| `id`           | [`uint8`]   | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `name`         | [`text`]    | The internal name of the operator.                                                           |
-| `dataflow_id`  | [`uint8`]   | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                   |
-| `records`      | [`numeric`] | The number of records in the operator.                                                       |
-| `batches`      | [`numeric`] | The number of batches in the dataflow.                                                       |
-| `size`         | [`numeric`] | The utilized size in bytes of the arrangement.                                               |
-| `capacity`     | [`numeric`] | The capacity in bytes of the arrangement. Can be larger than the size.                       |
-| `allocations`  | [`numeric`] | The number of separate memory allocations backing the arrangement.                           |
+| Field          | Type       | Meaning                                                                                      |
+| -------------- |------------| --------                                                                                     |
+| `id`           | [`uint8`]  | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
+| `name`         | [`text`]   | The internal name of the operator.                                                           |
+| `dataflow_id`  | [`uint8`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                   |
+| `records`      | [`bigint`] | The number of records in the operator.                                                       |
+| `batches`      | [`bigint`] | The number of batches in the dataflow.                                                       |
+| `size`         | [`bigint`] | The utilized size in bytes of the arrangement.                                               |
+| `capacity`     | [`bigint`] | The capacity in bytes of the arrangement. Can be larger than the size.                       |
+| `allocations`  | [`bigint`] | The number of separate memory allocations backing the arrangement.                           |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_operator_per_worker -->
 

--- a/doc/user/content/sql/system-catalog/mz_introspection.md
+++ b/doc/user/content/sql/system-catalog/mz_introspection.md
@@ -63,14 +63,14 @@ The size, capacity, and allocations are an approximation, which may underestimat
 Specifically, reductions can use more memory than we show here.
 
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes -->
-| Field         | Type        | Meaning                                                                                                                   |
-|---------------|-------------| --------                                                                                                                  |
-| `operator_id` | [`uint8`]   | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `records`     | [`numeric`] | The number of records in the arrangement.                                                                                 |
-| `batches`     | [`numeric`] | The number of batches in the arrangement.                                                                                 |
-| `size`        | [`numeric`] | The utilized size in bytes of the arrangement.                                                                            |
-| `capacity`    | [`numeric`] | The capacity in bytes of the arrangement. Can be larger than the size.                                                    |
-| `allocations` | [`numeric`] | The number of separate memory allocations backing the arrangement.                                                        |
+| Field         | Type      | Meaning                                                                                                                   |
+|---------------|-----------|---------------------------------------------------------------------------------------------------------------------------|
+| `operator_id` | [`uint8`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
+| `records`     | [`int8`]  | The number of records in the arrangement.                                                                                 |
+| `batches`     | [`int8`]  | Tnumber of batches in the arrangement.                                                                                    |
+| `size`        | [`int8`]  | Tutilized size in bytes of the arrangement.                                                                               |
+| `capacity`    | [`int8`]  | Tcapacity in bytes of the arrangement. Can be larger than the size.                                                       |
+| `allocations` | [`int8`]  | Tnumber of separate memory allocations backing the arrangement.                                                           |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sizes_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_records_raw -->

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2816,6 +2816,18 @@ mod tests {
 
                 let full_name = conn_catalog.resolve_full_name(item.name());
                 let actual_desc = item.desc(&full_name).expect("invalid item type");
+                for (index, ((actual_name, actual_typ), (expected_name, expected_typ))) in
+                    actual_desc.iter().zip(expected_desc.iter()).enumerate()
+                {
+                    assert_eq!(
+                        actual_name, expected_name,
+                        "item {schema}.{name} column {index} name did not match its expected name"
+                    );
+                    assert_eq!(
+                        actual_typ, expected_typ,
+                        "item {schema}.{name} column {index} ('{actual_name}') type did not match its expected type"
+                    );
+                }
                 assert_eq!(
                     &*actual_desc, expected_desc,
                     "item {schema}.{name} did not match its expected RelationDesc"

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -8951,7 +8951,7 @@ SELECT
     mdod.dataflow_id AS id,
     mdod.dataflow_name AS name,
     SUM(mas.records)::int8 AS records,
-    SUM(mas.batches::int8) AS batches,
+    SUM(mas.batches)::int8 AS batches,
     SUM(mas.size)::int8 AS size,
     SUM(mas.capacity)::int8 AS capacity,
     SUM(mas.allocations)::int8 AS allocations
@@ -8978,7 +8978,7 @@ pub static MZ_EXPECTED_GROUP_SIZE_ADVICE: LazyLock<BuiltinView> = LazyLock::new(
             ScalarType::Numeric {
                 max_scale: Some(NumericMaxScale::ZERO),
             }
-            .nullable(false),
+            .nullable(true),
         )
         .with_column("hint", ScalarType::Float64.nullable(false))
         .finish(),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6429,11 +6429,11 @@ pub static MZ_RECORDS_PER_DATAFLOW_OPERATOR_PER_WORKER: LazyLock<BuiltinView> =
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("worker_id", ScalarType::UInt64.nullable(false))
             .with_column("dataflow_id", ScalarType::UInt64.nullable(false))
-            .with_column("records", ScalarType::Int64.nullable(false))
-            .with_column("batches", ScalarType::Int64.nullable(false))
-            .with_column("size", ScalarType::Int64.nullable(false))
-            .with_column("capacity", ScalarType::Int64.nullable(false))
-            .with_column("allocations", ScalarType::Int64.nullable(false))
+            .with_column("records", ScalarType::Int64.nullable(true))
+            .with_column("batches", ScalarType::Int64.nullable(true))
+            .with_column("size", ScalarType::Int64.nullable(true))
+            .with_column("capacity", ScalarType::Int64.nullable(true))
+            .with_column("allocations", ScalarType::Int64.nullable(true))
             .finish(),
         column_comments: BTreeMap::new(),
         sql: "
@@ -6442,11 +6442,11 @@ SELECT
     dod.name,
     dod.worker_id,
     dod.dataflow_id,
-    COALESCE(ar_size.records, 0) AS records,
-    COALESCE(ar_size.batches, 0) AS batches,
-    COALESCE(ar_size.size, 0) AS size,
-    COALESCE(ar_size.capacity, 0) AS capacity,
-    COALESCE(ar_size.allocations, 0) AS allocations
+    ar_size.records AS records,
+    ar_size.batches AS batches,
+    ar_size.size AS size,
+    ar_size.capacity AS capacity,
+    ar_size.allocations AS allocations
 FROM
     mz_introspection.mz_dataflow_operator_dataflows_per_worker dod
     LEFT OUTER JOIN mz_introspection.mz_arrangement_sizes_per_worker ar_size ON
@@ -6464,41 +6464,11 @@ pub static MZ_RECORDS_PER_DATAFLOW_OPERATOR: LazyLock<BuiltinView> =
             .with_column("id", ScalarType::UInt64.nullable(false))
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("dataflow_id", ScalarType::UInt64.nullable(false))
-            .with_column(
-                "records",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "batches",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "size",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "capacity",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "allocations",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
+            .with_column("records", ScalarType::Int64.nullable(true))
+            .with_column("batches", ScalarType::Int64.nullable(true))
+            .with_column("size", ScalarType::Int64.nullable(true))
+            .with_column("capacity", ScalarType::Int64.nullable(true))
+            .with_column("allocations", ScalarType::Int64.nullable(true))
             .with_key(vec![0, 1, 2])
             .finish(),
         column_comments: BTreeMap::from_iter([
@@ -6528,11 +6498,11 @@ SELECT
     id,
     name,
     dataflow_id,
-    pg_catalog.sum(records) AS records,
-    pg_catalog.sum(batches) AS batches,
-    pg_catalog.sum(size) AS size,
-    pg_catalog.sum(capacity) AS capacity,
-    pg_catalog.sum(allocations) AS allocations
+    SUM(records)::int8 AS records,
+    SUM(batches)::int8 AS batches,
+    SUM(size)::int8 AS size,
+    SUM(capacity)::int8 AS capacity,
+    SUM(allocations)::int8 AS allocations
 FROM mz_introspection.mz_records_per_dataflow_operator_per_worker
 GROUP BY id, name, dataflow_id",
         access: vec![PUBLIC_SELECT],
@@ -6547,41 +6517,11 @@ pub static MZ_RECORDS_PER_DATAFLOW_PER_WORKER: LazyLock<BuiltinView> =
             .with_column("id", ScalarType::UInt64.nullable(false))
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("worker_id", ScalarType::UInt64.nullable(false))
-            .with_column(
-                "records",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "batches",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "size",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "capacity",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
-            .with_column(
-                "allocations",
-                ScalarType::Numeric {
-                    max_scale: Some(NumericMaxScale::ZERO),
-                }
-                .nullable(false),
-            )
+            .with_column("records", ScalarType::Int64.nullable(true))
+            .with_column("batches", ScalarType::Int64.nullable(true))
+            .with_column("size", ScalarType::Int64.nullable(true))
+            .with_column("capacity", ScalarType::Int64.nullable(true))
+            .with_column("allocations", ScalarType::Int64.nullable(true))
             .with_key(vec![0, 1, 2])
             .finish(),
         column_comments: BTreeMap::new(),
@@ -6590,11 +6530,11 @@ SELECT
     rdo.dataflow_id as id,
     dfs.name,
     rdo.worker_id,
-    pg_catalog.SUM(rdo.records) as records,
-    pg_catalog.SUM(rdo.batches) as batches,
-    pg_catalog.SUM(rdo.size) as size,
-    pg_catalog.SUM(rdo.capacity) as capacity,
-    pg_catalog.SUM(rdo.allocations) as allocations
+    SUM(rdo.records)::int8 as records,
+    SUM(rdo.batches)::int8 as batches,
+    SUM(rdo.size)::int8 as size,
+    SUM(rdo.capacity)::int8 as capacity,
+    SUM(rdo.allocations)::int8 as allocations
 FROM
     mz_introspection.mz_records_per_dataflow_operator_per_worker rdo,
     mz_introspection.mz_dataflows_per_worker dfs
@@ -6615,41 +6555,11 @@ pub static MZ_RECORDS_PER_DATAFLOW: LazyLock<BuiltinView> = LazyLock::new(|| Bui
     desc: RelationDesc::builder()
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column(
-            "records",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "batches",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "size",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "capacity",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "allocations",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
+        .with_column("records", ScalarType::Int64.nullable(true))
+        .with_column("batches", ScalarType::Int64.nullable(true))
+        .with_column("size", ScalarType::Int64.nullable(true))
+        .with_column("capacity", ScalarType::Int64.nullable(true))
+        .with_column("allocations", ScalarType::Int64.nullable(true))
         .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -6674,11 +6584,11 @@ pub static MZ_RECORDS_PER_DATAFLOW: LazyLock<BuiltinView> = LazyLock::new(|| Bui
 SELECT
     id,
     name,
-    pg_catalog.SUM(records) as records,
-    pg_catalog.SUM(batches) as batches,
-    pg_catalog.SUM(size) as size,
-    pg_catalog.SUM(capacity) as capacity,
-    pg_catalog.SUM(allocations) as allocations
+    SUM(records)::int8 as records,
+    SUM(batches)::int8 as batches,
+    SUM(size)::int8 as size,
+    SUM(capacity)::int8 as capacity,
+    SUM(allocations)::int8 as allocations
 FROM
     mz_introspection.mz_records_per_dataflow_per_worker
 GROUP BY
@@ -8605,11 +8515,11 @@ pub static MZ_ARRANGEMENT_SIZES_PER_WORKER: LazyLock<BuiltinView> = LazyLock::ne
         desc: RelationDesc::builder()
             .with_column("operator_id", ScalarType::UInt64.nullable(false))
             .with_column("worker_id", ScalarType::UInt64.nullable(false))
-            .with_column("records", ScalarType::Int64.nullable(false))
-            .with_column("batches", ScalarType::Int64.nullable(false))
-            .with_column("size", ScalarType::Int64.nullable(false))
-            .with_column("capacity", ScalarType::Int64.nullable(false))
-            .with_column("allocations", ScalarType::Int64.nullable(false))
+            .with_column("records", ScalarType::Int64.nullable(true))
+            .with_column("batches", ScalarType::Int64.nullable(true))
+            .with_column("size", ScalarType::Int64.nullable(true))
+            .with_column("capacity", ScalarType::Int64.nullable(true))
+            .with_column("allocations", ScalarType::Int64.nullable(true))
             .finish(),
         column_comments: BTreeMap::new(),
         sql: "
@@ -8624,7 +8534,7 @@ batches_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS batches
+        COUNT(*) AS batches
     FROM
         mz_introspection.mz_arrangement_batches_raw
     GROUP BY
@@ -8634,7 +8544,7 @@ records_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS records
+        COUNT(*) AS records
     FROM
         mz_introspection.mz_arrangement_records_raw
     GROUP BY
@@ -8644,7 +8554,7 @@ heap_size_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS size
+        COUNT(*) AS size
     FROM
         mz_introspection.mz_arrangement_heap_size_raw
     GROUP BY
@@ -8654,7 +8564,7 @@ heap_capacity_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS capacity
+        COUNT(*) AS capacity
     FROM
         mz_introspection.mz_arrangement_heap_capacity_raw
     GROUP BY
@@ -8664,7 +8574,7 @@ heap_allocations_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS allocations
+        COUNT(*) AS allocations
     FROM
         mz_introspection.mz_arrangement_heap_allocations_raw
     GROUP BY
@@ -8674,7 +8584,7 @@ batcher_records_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS records
+        COUNT(*) AS records
     FROM
         mz_introspection.mz_arrangement_batcher_records_raw
     GROUP BY
@@ -8684,7 +8594,7 @@ batcher_size_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS size
+        COUNT(*) AS size
     FROM
         mz_introspection.mz_arrangement_batcher_size_raw
     GROUP BY
@@ -8694,7 +8604,7 @@ batcher_capacity_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS capacity
+        COUNT(*) AS capacity
     FROM
         mz_introspection.mz_arrangement_batcher_capacity_raw
     GROUP BY
@@ -8704,7 +8614,7 @@ batcher_allocations_cte AS (
     SELECT
         operator_id,
         worker_id,
-        pg_catalog.count(*) AS allocations
+        COUNT(*) AS allocations
     FROM
         mz_introspection.mz_arrangement_batcher_allocations_raw
     GROUP BY
@@ -8714,11 +8624,23 @@ combined AS (
     SELECT
         opw.operator_id,
         opw.worker_id,
-        COALESCE(records_cte.records, 0) + COALESCE(batcher_records_cte.records, 0) AS records,
-        COALESCE(batches_cte.batches, 0) AS batches,
-        COALESCE(heap_size_cte.size, 0) + COALESCE(batcher_size_cte.size, 0) AS size,
-        COALESCE(heap_capacity_cte.capacity, 0) + COALESCE(batcher_capacity_cte.capacity, 0) AS capacity,
-        COALESCE(heap_allocations_cte.allocations, 0) + COALESCE(batcher_allocations_cte.allocations, 0) AS allocations
+        CASE
+            WHEN records_cte.records IS NULL AND batcher_records_cte.records IS NULL THEN NULL
+            ELSE COALESCE(records_cte.records, 0) + COALESCE(batcher_records_cte.records, 0)
+        END AS records,
+        batches_cte.batches AS batches,
+        CASE
+            WHEN heap_size_cte.size IS NULL AND batcher_size_cte.size IS NULL THEN NULL
+            ELSE COALESCE(heap_size_cte.size, 0) + COALESCE(batcher_size_cte.size, 0)
+        END AS size,
+        CASE
+            WHEN heap_capacity_cte.capacity IS NULL AND batcher_capacity_cte.capacity IS NULL THEN NULL
+            ELSE COALESCE(heap_capacity_cte.capacity, 0) + COALESCE(batcher_capacity_cte.capacity, 0)
+        END AS capacity,
+        CASE
+            WHEN heap_allocations_cte.allocations IS NULL AND batcher_allocations_cte.allocations IS NULL THEN NULL
+            ELSE COALESCE(heap_allocations_cte.allocations, 0) + COALESCE(batcher_allocations_cte.allocations, 0)
+        END AS allocations
     FROM
                     operators_per_worker_cte opw
     LEFT OUTER JOIN batches_cte USING (operator_id, worker_id)
@@ -8751,41 +8673,11 @@ pub static MZ_ARRANGEMENT_SIZES: LazyLock<BuiltinView> = LazyLock::new(|| Builti
     oid: oid::VIEW_MZ_ARRANGEMENT_SIZES_OID,
     desc: RelationDesc::builder()
         .with_column("operator_id", ScalarType::UInt64.nullable(false))
-        .with_column(
-            "records",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "batches",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "size",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "capacity",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
-        .with_column(
-            "allocations",
-            ScalarType::Numeric {
-                max_scale: Some(NumericMaxScale::ZERO),
-            }
-            .nullable(false),
-        )
+        .with_column("records", ScalarType::Int64.nullable(true))
+        .with_column("batches", ScalarType::Int64.nullable(true))
+        .with_column("size", ScalarType::Int64.nullable(true))
+        .with_column("capacity", ScalarType::Int64.nullable(true))
+        .with_column("allocations", ScalarType::Int64.nullable(true))
         .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -8808,11 +8700,11 @@ pub static MZ_ARRANGEMENT_SIZES: LazyLock<BuiltinView> = LazyLock::new(|| Builti
     sql: "
 SELECT
     operator_id,
-    pg_catalog.sum(records) AS records,
-    pg_catalog.sum(batches) AS batches,
-    pg_catalog.sum(size) AS size,
-    pg_catalog.sum(capacity) AS capacity,
-    pg_catalog.sum(allocations) AS allocations
+    SUM(records)::int8 AS records,
+    SUM(batches)::int8 AS batches,
+    SUM(size)::int8 AS size,
+    SUM(capacity)::int8 AS capacity,
+    SUM(allocations)::int8 AS allocations
 FROM mz_introspection.mz_arrangement_sizes_per_worker
 GROUP BY operator_id",
     access: vec![PUBLIC_SELECT],
@@ -9023,26 +8915,11 @@ pub static MZ_DATAFLOW_ARRANGEMENT_SIZES: LazyLock<BuiltinView> = LazyLock::new(
     desc: RelationDesc::builder()
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column(
-            "records",
-            ScalarType::Numeric { max_scale: None }.nullable(false),
-        )
-        .with_column(
-            "batches",
-            ScalarType::Numeric { max_scale: None }.nullable(false),
-        )
-        .with_column(
-            "size",
-            ScalarType::Numeric { max_scale: None }.nullable(false),
-        )
-        .with_column(
-            "capacity",
-            ScalarType::Numeric { max_scale: None }.nullable(false),
-        )
-        .with_column(
-            "allocations",
-            ScalarType::Numeric { max_scale: None }.nullable(false),
-        )
+        .with_column("records", ScalarType::Int64.nullable(true))
+        .with_column("batches", ScalarType::Int64.nullable(true))
+        .with_column("size", ScalarType::Int64.nullable(true))
+        .with_column("capacity", ScalarType::Int64.nullable(true))
+        .with_column("allocations", ScalarType::Int64.nullable(true))
         .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -9073,11 +8950,11 @@ pub static MZ_DATAFLOW_ARRANGEMENT_SIZES: LazyLock<BuiltinView> = LazyLock::new(
 SELECT
     mdod.dataflow_id AS id,
     mdod.dataflow_name AS name,
-    COALESCE(sum(mas.records), 0) AS records,
-    COALESCE(sum(mas.batches), 0) AS batches,
-    COALESCE(sum(mas.size), 0) AS size,
-    COALESCE(sum(mas.capacity), 0) AS capacity,
-    COALESCE(sum(mas.allocations), 0) AS allocations
+    SUM(mas.records)::int8 AS records,
+    SUM(mas.batches::int8) AS batches,
+    SUM(mas.size)::int8 AS size,
+    SUM(mas.capacity)::int8 AS capacity,
+    SUM(mas.allocations)::int8 AS allocations
 FROM mz_introspection.mz_dataflow_operator_dataflows AS mdod
 LEFT JOIN mz_introspection.mz_arrangement_sizes AS mas
     ON mdod.id = mas.operator_id

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -47,11 +47,11 @@ query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sizes' ORDER BY position
 ----
 1  operator_id  uint8
-2  records  numeric
-3  batches  numeric
-4  size  numeric
-5  capacity  numeric
-6  allocations  numeric
+2  records  int8
+3  batches  int8
+4  size  int8
+5  capacity  int8
+6  allocations  int8
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_error_counts' ORDER BY position

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -47,11 +47,11 @@ query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sizes' ORDER BY position
 ----
 1  operator_id  uint8
-2  records  int8
-3  batches  int8
-4  size  int8
-5  capacity  int8
-6  allocations  int8
+2  records  bigint
+3  batches  bigint
+4  size  bigint
+5  capacity  bigint
+6  allocations  bigint
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_error_counts' ORDER BY position
@@ -102,11 +102,11 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND o
 ----
 1  id  uint8
 2  name  text
-3  records  numeric
-4  batches  numeric
-5  size  numeric
-6  capacity  numeric
-7  allocations  numeric
+3  records  bigint
+4  batches  bigint
+5  size  bigint
+6  capacity  bigint
+7  allocations  bigint
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_channels' ORDER BY position
@@ -208,11 +208,11 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND o
 ----
 1  id  uint8
 2  name  text
-3  records  numeric
-4  batches  numeric
-5  size  numeric
-6  capacity  numeric
-7  allocations  numeric
+3  records  bigint
+4  batches  bigint
+5  size  bigint
+6  capacity  bigint
+7  allocations  bigint
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_records_per_dataflow_operator' ORDER BY position
@@ -220,11 +220,11 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND o
 1  id  uint8
 2  name  text
 3  dataflow_id  uint8
-4  records  numeric
-5  batches  numeric
-6  size  numeric
-7  capacity  numeric
-8  allocations  numeric
+4  records  bigint
+5  batches  bigint
+6  size  bigint
+7  capacity  bigint
+8  allocations  bigint
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_scheduling_elapsed' ORDER BY position

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -225,7 +225,7 @@ true true
 > CREATE DEFAULT INDEX ii_empty ON t3
 
 > SELECT records, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
-0 true true
+null true true
 
 # Tests that arrangement sizes are approximate
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -225,7 +225,7 @@ true true
 > CREATE DEFAULT INDEX ii_empty ON t3
 
 > SELECT records, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
-null true true
+<null> true true
 
 # Tests that arrangement sizes are approximate
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -236,7 +236,7 @@ true true
 # We have 16 workers, and only want to ensure that the sizes are not egregious.
 
 > SELECT records, size < 16 * 1024, allocations < 512 FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-0 true true
+<null> true true
 
 > INSERT INTO t4 SELECT 1
 
@@ -263,7 +263,8 @@ true true true true true
 
 > CREATE INDEX vt5_idx ON vt5(a)
 
-> SELECT records, (size/1024/1024)::int FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%vt5_idx'
+# Cast to numeric to get its rounding behavior
+> SELECT records, (size::numeric/1024/1024)::int FROM mz_introspection.mz_dataflow_arrangement_sizes WHERE name LIKE '%vt5_idx'
 10000 1
 
 > DROP TABLE t5 CASCADE


### PR DESCRIPTION
Include all operators that might have a size in the arrangement size tracking. Not ideal because it could be operators without arrangements, but better than what we have now, and I don't want to rework the operator size tracking at this point.

Best viewed with white space hidden.

Related: https://github.com/MaterializeInc/database-issues/issues/9452
