### PR TITLE
adapter: add metric around catalog_snapshot

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -47,6 +47,7 @@ pub struct Metrics {
     pub pgwire_message_processing_seconds: HistogramVec,
     pub result_rows_first_to_last_byte_seconds: HistogramVec,
     pub pgwire_ensure_transaction_seconds: HistogramVec,
+    pub catalog_snapshot_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -205,6 +206,12 @@ impl Metrics {
                 name: "mz_pgwire_ensure_transaction_seconds",
                 help: "The time it takes to run `ensure_transactions` when processing pgwire messages.",
                 var_labels: ["message_type"],
+                buckets: histogram_seconds_buckets(0.001, 512.0),
+            )),
+            catalog_snapshot_seconds: registry.register(metric!(
+                name: "mz_catalog_snapshot_seconds",
+                help: "The time it takes to run `catalog_snapshot` when fetching the catalog.",
+                var_labels: ["context"],
                 buckets: histogram_seconds_buckets(0.001, 512.0),
             ))
         }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -232,7 +232,7 @@ async fn handle_promsql_query(
         return;
     }
 
-    let catalog = client.client.catalog_snapshot().await;
+    let catalog = client.client.catalog_snapshot("handle_promsql_query").await;
     let clusters: Vec<&Cluster> = catalog.clusters().collect();
 
     for cluster in clusters {


### PR DESCRIPTION
There have been cases where `bind`/`parse` in the protocol take surprisingly long. The suspicion is that it is ultimately down to `catalog_snapshot`, which has to go through the coordinator main loop.
