### PR TITLE
Add a watcher timeout to orchestrator-kubernetes

### DIFF
--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -119,52 +119,55 @@ impl CloudResourceController for KubernetesOrchestrator {
     }
 
     async fn watch_vpc_endpoints(&self) -> BoxStream<'static, VpcEndpointEvent> {
-        let stream = watcher(self.vpc_endpoint_api.clone(), watcher::Config::default())
-            .touched_objects()
-            .filter_map(|object| async move {
-                match object {
-                    Ok(vpce) => {
-                        let connection_id =
-                            mz_cloud_resources::id_from_vpc_endpoint_name(&vpce.name_any())?;
+        let stream = watcher(
+            self.vpc_endpoint_api.clone(),
+            // This watcher timeout must be shorter than the client read timeout.
+            watcher::Config::default().timeout(59),
+        )
+        .touched_objects()
+        .filter_map(|object| async move {
+            match object {
+                Ok(vpce) => {
+                    let connection_id =
+                        mz_cloud_resources::id_from_vpc_endpoint_name(&vpce.name_any())?;
 
-                        if let Some(state) = vpce.status.as_ref().and_then(|st| st.state.to_owned())
-                        {
-                            Some(VpcEndpointEvent {
-                                connection_id,
-                                status: state,
-                                // Use the 'Available' Condition on the VPCE Status to set the event-time, falling back
-                                // to now if it's not set
-                                time: vpce
-                                    .status
-                                    .unwrap()
-                                    .conditions
-                                    .and_then(|c| c.into_iter().find(|c| &c.type_ == "Available"))
-                                    .and_then(|condition| Some(condition.last_transition_time.0))
-                                    .unwrap_or_else(Utc::now),
-                            })
-                        } else {
-                            // The Status/State is not yet populated on the VpcEndpoint, which means it was just
-                            // initialized and hasn't yet been reconciled by the environment-controller
-                            // We return an event with an 'unknown' state so that watchers know the VpcEndpoint was created
-                            // even if we don't yet have an accurate status
-                            Some(VpcEndpointEvent {
-                                connection_id,
-                                status: VpcEndpointState::Unknown,
-                                time: vpce.creation_timestamp()?.0,
-                            })
-                        }
-                        // TODO: Should we also check for the deletion_timestamp on the vpce? That would indicate that the
-                        // resource is about to be deleted; however there is already a 'deleted' enum val on VpcEndpointState
-                        // which refers to the state of the customer's VPC Endpoint Service, so we'd need to introduce a new state val
+                    if let Some(state) = vpce.status.as_ref().and_then(|st| st.state.to_owned()) {
+                        Some(VpcEndpointEvent {
+                            connection_id,
+                            status: state,
+                            // Use the 'Available' Condition on the VPCE Status to set the event-time, falling back
+                            // to now if it's not set
+                            time: vpce
+                                .status
+                                .unwrap()
+                                .conditions
+                                .and_then(|c| c.into_iter().find(|c| &c.type_ == "Available"))
+                                .and_then(|condition| Some(condition.last_transition_time.0))
+                                .unwrap_or_else(Utc::now),
+                        })
+                    } else {
+                        // The Status/State is not yet populated on the VpcEndpoint, which means it was just
+                        // initialized and hasn't yet been reconciled by the environment-controller
+                        // We return an event with an 'unknown' state so that watchers know the VpcEndpoint was created
+                        // even if we don't yet have an accurate status
+                        Some(VpcEndpointEvent {
+                            connection_id,
+                            status: VpcEndpointState::Unknown,
+                            time: vpce.creation_timestamp()?.0,
+                        })
                     }
-                    Err(error) => {
-                        // We assume that errors returned by Kubernetes are usually transient, so we
-                        // just log a warning and ignore them otherwise.
-                        tracing::warn!("vpc endpoint watch error: {error}");
-                        None
-                    }
+                    // TODO: Should we also check for the deletion_timestamp on the vpce? That would indicate that the
+                    // resource is about to be deleted; however there is already a 'deleted' enum val on VpcEndpointState
+                    // which refers to the state of the customer's VPC Endpoint Service, so we'd need to introduce a new state val
                 }
-            });
+                Err(error) => {
+                    // We assume that errors returned by Kubernetes are usually transient, so we
+                    // just log a warning and ignore them otherwise.
+                    tracing::warn!("vpc endpoint watch error: {error}");
+                    None
+                }
+            }
+        });
         Box::pin(stream)
     }
 

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -379,7 +379,8 @@ impl NamespacedKubernetesOrchestrator {
             "environmentd.materialize.cloud/namespace={}",
             self.namespace
         );
-        watcher::Config::default().labels(&ns_selector)
+        // This watcher timeout must be shorter than the client read timeout.
+        watcher::Config::default().timeout(59).labels(&ns_selector)
     }
 
     /// Convert a higher-level label key to the actual one we


### PR DESCRIPTION
Add a watcher timeout to orchestrator-kubernetes.

### Motivation

  * This PR fixes a previously unreported bug.
When a watcher lives longer than the Kube client read timeout, it throws errors.
We recently changed the timeouts in our Kube client in https://github.com/MaterializeInc/materialize/pull/29499

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
