### PR TITLE
add bounded buffer for balancer bidi stream

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -479,6 +479,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "balancerd_log_filter_defaults",
     "balancerd_opentelemetry_filter_defaults",
     "balancerd_sentry_filters",
+    "balancerd_max_copy_buffer_size",
     "persist_enable_s3_lgalloc_cc_sizes",
     "persist_enable_arrow_lgalloc_cc_sizes",
     "controller_past_generation_replica_cleanup_retry_interval",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1208,6 +1208,7 @@ class FlipFlagsAction(Action):
             "balancerd_log_filter_defaults",
             "balancerd_opentelemetry_filter_defaults",
             "balancerd_sentry_filters",
+            "balancerd_max_copy_buffer_size",
             "persist_enable_s3_lgalloc_cc_sizes",
             "persist_enable_s3_lgalloc_noncc_sizes",
             "persist_enable_arrow_lgalloc_cc_sizes",

--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -43,6 +43,13 @@ pub const INJECT_PROXY_PROTOCOL_HEADER_HTTP: Config<bool> = Config::new(
     "Whether to inject tcp proxy protocol headers to downstream http servers.",
 );
 
+/// Maximum buffer size per connection for bidirectional copying to limit memory usage.
+pub const MAX_COPY_BUFFER_SIZE: Config<usize> = Config::new(
+    "balancerd_max_copy_buffer_size",
+    64 * 1024, // 64KB default
+    "Maximum buffer size per connection for bidirectional copying to limit memory usage.",
+);
+
 /// Sets the filter to apply to stderr logging.
 pub const LOGGING_FILTER: Config<&str> = Config::new(
     "balancerd_log_filter",
@@ -98,6 +105,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&SIGTERM_CONNECTION_WAIT)
         .add(&SIGTERM_LISTEN_WAIT)
         .add(&INJECT_PROXY_PROTOCOL_HEADER_HTTP)
+        .add(&MAX_COPY_BUFFER_SIZE)
         .add(&LOGGING_FILTER)
         .add(&OPENTELEMETRY_FILTER)
         .add(&LOGGING_FILTER_DEFAULTS)


### PR DESCRIPTION
use copy_bidirectional_with_sizes to set an internal buffer size
- memory for bidirectional copy for balancer.
- introduces new dyncfg for balancer MAX_COPY_BUFFER_SIZE


This was largely generated by cursor just to see if it  could do it. I had to give it some hints on copy_bidirectional_with_sizes, but it largely did the rest. 


This PR was mostly created due to the TODO requesting limiting the total memory right above the copy_bidirectional... 
```
// Now blindly shuffle bytes back and forth until closed.
// TODO: Limit total memory use.
```
That function should use bounded memory via 8k internal buffers, this PR would only allow us to alter the size of the internal buffers.

I'm not sure what the intent of the original TODO is.


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
