### PR TITLE
trufflehog: Exclude another detector

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -162,7 +162,7 @@ cleanup() {
   mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\n"; find . -name 'junit_*.xml')
 
   {
-    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
   } &
   artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -173,7 +173,7 @@ cleanup() {
 
   echo "--- Running trufflehog to scan artifacts for secrets & uploading artifacts"
   {
-    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
   } &
 
   unset CI_EXTRA_ARGS # We don't want extra args for the annotation


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/105830#0197ef0f-734f-463a-99f2-639c009a76d9

This approach is not ideal. If we generate too many random strings we'll keep running into issues like this.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
