### PR TITLE
ci: Implement ci-location for ci-regexp

### DIFF
--- a/doc/developer/ci-regexp.md
+++ b/doc/developer/ci-regexp.md
@@ -20,4 +20,13 @@ ci-apply-to: SQLsmith
 ci-apply-to: sqlsmith explain
 ```
 
+Use `ci-location` to specify the file or test fragment in which a test failure occurs. When the Buildkite annotation says `Unknown error in test-read-frontier-advancement`, then `test-read-frontier-advancement` is the location. When it says `Unknown error in services.log`, then `services.log` is the location.
+
+Examples:
+
+```
+ci-location: test-read-frontier-advancement
+ci-location: services.log
+```
+
 When a test issue is discovered and the GitHub issue is still open, you may want the failure to not cause a test failure, so that CI does not become flaky, but still add an annotation and record the failure into https://ci-failures.dev.materialize.com. You can use `ci-ignore-failure: true` for that.

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -569,8 +569,10 @@ def annotate_logged_errors(
             if match and issue.info["state"] == "open":
                 if issue.apply_to and issue.apply_to not in (
                     step_key.lower(),
-                    buildkite_label.lower(),
+                    buildkite_label.lower().rstrip("01234567889 "),
                 ):
+                    continue
+                if issue.location and issue.location != location:
                     continue
 
                 if issue.info["number"] not in already_reported_issue_numbers:


### PR DESCRIPTION
Required for https://github.com/MaterializeInc/database-issues/issues/9470 to not match too many kinds of assertions

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
