### PR TITLE
Fix memory limiter build on macOS and bring back macOS clippy

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -194,7 +194,6 @@ steps:
           queue: mac
         coverage: skip
         sanitizer: skip
-        branches: "main v*.* self-managed/v*"
 
       - id: lint-deps
         label: Lint dependencies

--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -181,10 +181,10 @@ impl LimiterTask {
                 Err(err)
             }
             #[cfg(not(target_os = "linux"))]
-            Err(_err) => ProcStatus {
+            Err(_err) => Ok(ProcStatus {
                 vm_rss: 0,
                 vm_swap: 0,
-            },
+            }),
         }
     }
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/105909#0197f3c0-31e9-483e-bee5-b03c2cea4f23

Follow-up to https://github.com/MaterializeInc/materialize/pull/32939
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
