### PR TITLE
ci: Fix multiple kinds of test trimming interacting

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -153,6 +153,13 @@ so it is executed.""",
 
     pipeline = yaml.safe_load(raw)
 
+    # This has to run before other cutting steps because it depends on the id numbers
+    print("--- Trim test selection")
+    if test_selection := os.getenv("CI_TEST_IDS"):
+        trim_test_selection_id(pipeline, {int(i) for i in test_selection.split(",")})
+    elif test_selection := os.getenv("CI_TEST_SELECTION"):
+        trim_test_selection_name(pipeline, set(test_selection.split(",")))
+
     if args.pipeline == "test":
         if args.coverage or args.sanitizer != Sanitizer.none:
             print("Coverage/Sanitizer build, not trimming pipeline")
@@ -296,12 +303,6 @@ so it is executed.""",
 
     print("--- Set parallelism name")
     set_parallelism_name(pipeline)
-
-    print("--- Trim test selection")
-    if test_selection := os.getenv("CI_TEST_IDS"):
-        trim_test_selection_id(pipeline, {int(i) for i in test_selection.split(",")})
-    elif test_selection := os.getenv("CI_TEST_SELECTION"):
-        trim_test_selection_name(pipeline, set(test_selection.split(",")))
 
     print("--- Check depends_on")
     check_depends_on(pipeline, args.pipeline)


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
