### PR TITLE
Guard subquery size with a TableFunc

### DIFF
--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -202,5 +202,6 @@ message ProtoTableFunc {
     google.protobuf.Empty mz_acl_explode = 17;
     mz_repr.relation_and_scalar.ProtoScalarType unnest_map = 18;
     google.protobuf.Empty regexp_matches = 19;
+    mz_repr.relation_and_scalar.ProtoScalarType guard_subquery_size = 20;
   }
 }

--- a/src/transform/src/canonicalization.rs
+++ b/src/transform/src/canonicalization.rs
@@ -18,7 +18,7 @@ mod flatmap_to_map;
 mod projection_extraction;
 mod topk_elision;
 
-pub use flatmap_to_map::FlatMapToMap;
+pub use flatmap_to_map::FlatMapElimination;
 pub use projection_extraction::ProjectionExtraction;
 pub use topk_elision::TopKElision;
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -611,7 +611,7 @@ impl Default for FuseAndCollapse {
                 Box::new(canonicalization::ProjectionExtraction),
                 Box::new(movement::ProjectionLifting::default()),
                 Box::new(fusion::Fusion),
-                Box::new(canonicalization::FlatMapToMap),
+                Box::new(canonicalization::FlatMapElimination),
                 Box::new(fusion::join::Join),
                 Box::new(NormalizeLets::new(false)),
                 Box::new(fusion::reduce::Reduce),

--- a/src/transform/src/normalize_ops.rs
+++ b/src/transform/src/normalize_ops.rs
@@ -37,7 +37,7 @@ impl crate::Transform for NormalizeOps {
         relation.try_visit_mut_post::<_, crate::TransformError>(
             &mut |expr: &mut MirRelationExpr| {
                 // (a) Might enable fusion in the next step.
-                crate::canonicalization::FlatMapToMap::action(expr);
+                crate::canonicalization::FlatMapElimination::action(expr);
                 crate::canonicalization::TopKElision::action(expr);
                 // (b) Fuse various like-kinded operators. Might enable further canonicalization.
                 crate::fusion::Fusion::action(expr);

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -287,7 +287,9 @@ mod tests {
             "FoldConstants" => Ok(Box::new(mz_transform::fold_constants::FoldConstants {
                 limit: None,
             })),
-            "FlatMapToMap" => Ok(Box::new(mz_transform::canonicalization::FlatMapToMap)),
+            "FlatMapElimination" => {
+                Ok(Box::new(mz_transform::canonicalization::FlatMapElimination))
+            }
             "JoinFusion" => Ok(Box::new(mz_transform::fusion::join::Join)),
             "LiteralLifting" => Ok(Box::new(
                 mz_transform::literal_lifting::LiteralLifting::default(),

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -167,8 +167,8 @@ fn handle_apply(
             apply_transform(transform, catalog, input)
         }
         "flatmap_to_map" => {
-            use mz_transform::canonicalization::FlatMapToMap;
-            let transform = FlatMapToMap;
+            use mz_transform::canonicalization::FlatMapElimination;
+            let transform = FlatMapElimination;
             apply_transform(transform, catalog, input)
         }
         "fold_constants" => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
