### PR TITLE
adapter: Fix error msg for `InvalidSchemaName`

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -414,15 +414,15 @@ impl PlanError {
                 None
             }
             Self::InvalidOptionValue { err, .. } => err.hint(),
-            Self::UnknownFunction { ..} => Some("No function matches the given name and argument types. You might need to add explicit type casts.".into()),
+            Self::UnknownFunction { ..} => Some("No function matches the given name and argument types.  You might need to add explicit type casts.".into()),
             Self::IndistinctFunction {..} => {
-                Some("Could not choose a best candidate function. You might need to add explicit type casts.".into())
+                Some("Could not choose a best candidate function.  You might need to add explicit type casts.".into())
             }
             Self::UnknownOperator {..} => {
-                Some("No operator matches the given name and argument types. You might need to add explicit type casts.".into())
+                Some("No operator matches the given name and argument types.  You might need to add explicit type casts.".into())
             }
             Self::IndistinctOperator {..} => {
-                Some("Could not choose a best candidate operator. You might need to add explicit type casts.".into())
+                Some("Could not choose a best candidate operator.  You might need to add explicit type casts.".into())
             },
             Self::InvalidPrivatelinkAvailabilityZone { supported_azs, ..} => {
                 let supported_azs_str = supported_azs.iter().join("\n  ");
@@ -481,7 +481,10 @@ impl PlanError {
                 Some("Use ALTER SYSTEM SET 'network_policy' to change the default network policy.".into())
             }
             Self::WrongParameterType(_, _, _) => {
-                Some("EXECUTE automatically inserts only such casts that are allowed in an assignment cast context. Try adding an explicit cast.".into())
+                Some("EXECUTE automatically inserts only such casts that are allowed in an assignment cast context.  Try adding an explicit cast.".into())
+            }
+            Self::InvalidSchemaName => {
+                Some("Use SET schema = name to select a schema.  Use SHOW SCHEMAS to list available schemas.  Use SHOW search_path to show the schema names that we looked for, but none of them existed.".into())
             }
             _ => None,
         }
@@ -705,7 +708,7 @@ impl fmt::Display for PlanError {
             },
             Self::InvalidPrivatelinkAvailabilityZone { name, ..} => write!(f, "invalid AWS PrivateLink availability zone {}", name.quoted()),
             Self::DuplicatePrivatelinkAvailabilityZone {..} =>   write!(f, "connection cannot contain duplicate availability zones"),
-            Self::InvalidSchemaName => write!(f, "no schema has been selected to create in"),
+            Self::InvalidSchemaName => write!(f, "no valid schema selected"),
             Self::ItemAlreadyExists { name, item_type } => write!(f, "{item_type} {} already exists", name.quoted()),
             Self::ManagedCluster {cluster_name} => write!(f, "cannot modify managed cluster {cluster_name}"),
             Self::InvalidKeysInSubscribeEnvelopeUpsert => {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1975,7 +1975,7 @@ const INCONSISTENT_VIEW_OUTCOME_WARNING_REGEXPS: [&str; 9] = [
     "SHOW commands are not allowed in views",
     "cannot create view with unstable dependencies",
     "cannot use wildcard expansions or NATURAL JOINs in a view that depends on system objects",
-    "no schema has been selected to create in",
+    "no valid schema selected",
     r#"system schema '\w+' cannot be modified"#,
     r#"permission denied for (SCHEMA|CLUSTER) "(\w+\.)?\w+""#,
     // NOTE(vmarcos): Column ambiguity that could not be eliminated by our

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -817,7 +817,7 @@ simple
 SELECT regexp_matches(bar, '(b[^b]+)(b[^b]+)(b[^b]+)', 'ig') FROM foo2;
 ----
 db error: ERROR: function regexp_matches(smallint, unknown, unknown) does not exist
-HINT: No function matches the given name and argument types. You might need to add explicit type casts.
+HINT: No function matches the given name and argument types.  You might need to add explicit type casts.
 
 statement ok
 DROP CLUSTER multiprocess;

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -77,8 +77,17 @@ SELECT current_schemas(true)
 statement ok
 SET cluster = quickstart
 
-statement error no schema has been selected to create in
+statement error no valid schema selected
 CREATE TABLE t (i INT)
+
+statement error no valid schema selected
+SHOW SOURCES;
+
+statement error no valid schema selected
+SHOW SINKS;
+
+statement error no valid schema selected
+SHOW INDEXES;
 
 statement ok
 CREATE SCHEMA foo


### PR DESCRIPTION
[As reported by](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1752205511184339) @jubrad: `InvalidSchemaName`'s error msg no longer fits its usage. It says

> no schema has been selected to create in

but it's currently also used for various statement types other than CREATEs. This PR fixes the error msg, and also adds a hint.

### Motivation

  * This PR fixes a recognized bug: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1752205511184339

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
