### PR TITLE
Mention in testdrive.md that `--rewrite-results` is currently buggy

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -211,11 +211,11 @@ Schema registry URL [default: http://localhost:8081]
 
 ## Resource sharing and reuse across tests
 
-By default, `testdrive` will clean up the environment and Mz prior to running each test. In certain situations, two or more testdrive invocations need to run consequtively while being able to operate on the same database objects. The options below help to ensure successful cooperation.
+By default, `testdrive` will clean up the environment and Mz prior to running each test. In certain situations, two or more testdrive invocations need to run consecutively while being able to operate on the same database objects. The options below help to ensure successful cooperation.
 
 #### `--no-reset`
 
-By default, `testdrive` will clean up its environment as much as it can before the start of the test, which includes Mz databases, etc. If two consequtive invocations of `testdrive` need to be able to operate on the same objects, e.g. database tables, the second invocation needs to run with `--no-reset`
+By default, `testdrive` will clean up its environment as much as it can before the start of the test, which includes Mz databases, etc. If two consecutive invocations of `testdrive` need to be able to operate on the same objects, e.g. database tables, the second invocation needs to run with `--no-reset`
 
 #### `--seed <seed>`
 
@@ -223,7 +223,7 @@ Unless specified, each `testdrive` invocation will use random names for certain 
 
 #### `--temp-dir <temp-dir>`
 
-Force the use of the specfied temporary directory rather than creating one with a random name. This allows multiple `testdrive` instances to be able to find the same files at the same location.
+Force the use of the specified temporary directory rather than creating one with a random name. This allows multiple `testdrive` instances to be able to find the same files at the same location.
 
 ## Controlling test suite execution
 
@@ -242,6 +242,8 @@ Max number of tests to run before terminating. This is useful in conjunction wit
 Shuffle the list of tests before running them (using the value from --seed, if any). This is useful when attempting to use `testdrive` in randomized scenarios or when applying background workload to the database.
 
 #### `--rewrite-results`
+
+Note that this option is currently buggy!
 
 Automatically rewrite the testdrive file with the correct results when they are not as expected. Consider setting a lower `--default-max-tries` value too to get a result faster.
 


### PR DESCRIPTION
This is to prevent people from thinking that they are doing something wrong, see
https://materializeinc.slack.com/archives/C08AXPDBPH7/p1752158187078249
"Spent 30 minutes trying to figure out why --rewrite-results in testdrive wasn’t working. Maybe we should remove it from our testdrive readme?"

cc @SangJunBak 

(Also, fix some typos that were highlighted by my IDE.)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
