### PR TITLE
Improve some code comments

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -4386,7 +4386,7 @@ pub static MZ_STATEMENT_LIFECYCLE_HISTORY: LazyLock<BuiltinSource> = LazyLock::n
         is_retained_metrics_object: false,
         // TODO[btv]: Maybe this should be public instead of
         // `MONITOR_REDACTED`, but since that would be a backwards-compatible
-        // chagne, we probably don't need to worry about it now.
+        // change, we probably don't need to worry about it now.
         access: vec![
             SUPPORT_SELECT,
             ANALYTICS_SELECT,
@@ -9125,7 +9125,7 @@ pub static MZ_EXPECTED_GROUP_SIZE_ADVICE: LazyLock<BuiltinView> = LazyLock::new(
         -- such pattern, we look for how many levels can be eliminated without hitting a level
         -- that actually substantially filters the input. The advice is constructed so that
         -- setting the hint for the affected region will eliminate these redundant levels of
-        -- the hierachical rendering.
+        -- the hierarchical rendering.
         --
         -- A number of helper CTEs are used for the view definition. The first one, operators,
         -- looks for operator names that comprise arrangements of inputs to each level of a

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1502,8 +1502,8 @@ pub fn memoize_expr(
                     // updated if they reference a column reference themselves.
                     if *col > input_arity {
                         if let MirScalarExpr::Column(col2, _) = memoized_parts[*col - input_arity] {
-                            // We do _not_ propagate column names, since mis-associationg names and column
-                            // references will be very confusing (and possibly bug inducing).
+                            // We do _not_ propagate column names, since mis-associating names and column
+                            // references will be very confusing (and possibly bug-inducing).
                             *col = col2;
                         }
                     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2198,6 +2198,9 @@ fn range_difference<'a>(
     propagates_nulls = true
 )]
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    // SQL equality demands that if either input is null, then the result should be null. However,
+    // we don't need to handle this case here; it is handled when `BinaryFunc::eval` checks
+    // `propagates_nulls`.
     Datum::from(a == b)
 }
 

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -191,7 +191,7 @@ impl ConnectionUuidHandle {
         *self.0.lock().expect("lock poisoned") = Some(conn_uuid);
     }
 
-    /// Returns a displayble that renders a possibly missing connection UUID.
+    /// Returns a displayable that renders a possibly missing connection UUID.
     pub fn display(&self) -> impl fmt::Display {
         self.get().display_or("<unknown>")
     }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4956,6 +4956,7 @@ pub static OP_IMPLS: LazyLock<BTreeMap<&'static str, Func>> = LazyLock::new(|| {
         //   same type in planning. However, it's possible that we will perform
         //   equality on types not listed here (e.g. `Varchar`) due to decisions
         //   made in the optimizer.
+        // - Null inputs are handled by `BinaryFunc::eval` checking `propagates_nulls`.
         "=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Eq => Bool, 1752;
             params!(Bool, Bool) => BinaryFunc::Eq => Bool, 91;

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -236,12 +236,7 @@ pub enum HirScalarExpr {
     /// Given `expr` with arity 1. If expr returns:
     /// * 0 rows, return NULL
     /// * 1 row, return the value of that row
-    /// * >1 rows, the sql spec says we should throw an error but we can't
-    ///   (see <https://github.com/MaterializeInc/database-issues/issues/154>)
-    ///   so instead we return all the rows.
-    ///   If there are multiple `Select` expressions in a single SQL query, the result is that we take the product of all of them.
-    ///   This is counter to the spec, but is consistent with eg postgres' treatment of multiple set-returning-functions
-    ///   (see <https://tapoueh.org/blog/2017/10/set-returning-functions-and-postgresql-10/>).
+    /// * >1 rows, we return an error
     Select(Box<HirRelationExpr>, NameMetadata),
     Windowing(WindowExpr, NameMetadata),
 }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -783,8 +783,6 @@ fn optimize(
     #[allow(deprecated)]
     expr.visit_mut_pre_post(
         &mut |e| {
-            // We should not eagerly memoize `if` branches that might not be taken.
-            // TODO: Memoize expressions in the intersection of `then` and `els`.
             if let MirScalarExpr::If { then, els, .. } = e {
                 Some(vec![then, els])
             } else {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -99,6 +99,10 @@ pub fn optimize_dataflow(
         transform_ctx.df_meta,
     )?;
 
+    // Warning: If you want to add a transform call here, consider it very carefully whether it
+    // could accidentally invalidate information that we already derived above in
+    // `optimize_dataflow_monotonic` or `prune_and_annotate_dataflow_index_imports`.
+
     mz_repr::explain::trace_plan(dataflow);
 
     Ok(())

--- a/src/transform/src/normalize_ops.rs
+++ b/src/transform/src/normalize_ops.rs
@@ -41,7 +41,7 @@ impl crate::Transform for NormalizeOps {
                 crate::canonicalization::TopKElision::action(expr);
                 // (b) Fuse various like-kinded operators. Might enable further canonicalization.
                 crate::fusion::Fusion::action(expr);
-                // (c) Fuse join trees (might lift in-between Filters).
+                // (c) Fuse join trees (might lift in-between MFPs).
                 crate::fusion::join::Join::action(expr)?;
                 // (d) Extract column references in Map as Project.
                 crate::canonicalization::ProjectionExtraction::action(expr);

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -78,7 +78,7 @@ pub enum TypeError<'a> {
         source: &'a MirRelationExpr,
         /// The column types we found (`sub` type)
         got: Vec<ColumnType>,
-        /// The solumn types we expected (`sup` type)
+        /// The column types we expected (`sup` type)
         expected: Vec<ColumnType>,
         /// The difference between these types
         diffs: Vec<RelationTypeDifference>,
@@ -460,7 +460,7 @@ impl Typecheck {
 
     /// New non-transient global IDs will be treated as an error
     ///
-    /// Only turn this on after the context has been appropraitely populated by, e.g., an earlier run
+    /// Only turn this on after the context has been appropriately populated by, e.g., an earlier run
     pub fn disallow_new_globals(mut self) -> Self {
         self.disallow_new_globals = true;
         self

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -434,7 +434,6 @@ INSERT INTO T VALUES ('this is gonna be an invalid regex', '', '\');
 query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
 SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 
-# TODO: multiline literal errors should be printed somehow differently in EXPLAIN
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
 SELECT *, s~'\' FROM t;


### PR DESCRIPTION
This PR improves some code comments:
- fixes some typos
- removes some stale comments
- adds some comments that were missing

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
