### PR TITLE
ci: Fix check in mkpipeline.py

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -500,7 +500,7 @@ def switch_jobs_to_aws(pipeline: Any, priority: int) -> None:
                 config["agents"]["queue"] = "linux-aarch64-medium"
 
         elif agent == "hetzner-aarch64-16cpu-32gb":
-            if "hetzner-aarch64-16cpu-32gb" not in stuck:
+            if "hetzner-x86-64-16cpu-32gb" not in stuck:
                 config["agents"]["queue"] = "hetzner-x86-64-16cpu-32gb"
                 if config.get("depends_on") == "build-aarch64":
                     config["depends_on"] = "build-x86_64"


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/32990

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
