### PR TITLE
ci-builder: Only bootstrap once, use concurrency group

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -33,6 +33,7 @@ Commands:
     run         run a command in the ci-builder image
     build       build the ci-builder image locally
     exists      reports via the exit code whether the ci-builder image exists
+    tag         reports the tag for the ci-builder image
     root-shell  open a root shell to the most recently started ci-builder container
 
 For details, consult ci/builder/README.md."
@@ -140,6 +141,9 @@ case "$cmd" in
         ;;
     exists)
         docker manifest inspect materialize/ci-builder:"$tag" &> /dev/null
+        ;;
+    tag)
+        echo "$tag"
         ;;
     push)
         build "$@"

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -39,9 +39,12 @@ while IFS=: read -r arch flavor; do
     if [[ $arch == aarch64 ]]; then
         queue=builder-linux-aarch64-mem
     fi
+    tag=$(MZ_DEV_CI_BUILDER_ARCH=$arch bin/ci-builder tag "$flavor")
     bootstrap_steps+="
   - label: bootstrap $flavor $arch
-    command: bin/ci-builder push $flavor
+    command: bin/ci-builder exists $flavor || bin/ci-builder push $flavor
+    concurrency: 1
+    concurrency_group: \"ci-builder:$tag\"
     agents:
       queue: $queue
 "


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
