### PR TITLE
Temporal bucket: pass through data close to frontier

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -426,6 +426,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_server_maintenance_interval",
     "compute_dataflow_max_inflight_bytes_cc",
     "compute_flat_map_fuel",
+    "compute_temporal_bucketing_summary",
     "consolidating_vec_growth_dampener",
     "copy_to_s3_parquet_row_group_file_ratio",
     "copy_to_s3_arrow_builder_buffer_ratio",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -109,7 +109,7 @@ def get_minimal_system_parameters(
         "enable_refresh_every_mvs": "true",
         "enable_cluster_schedule_refresh": "true",
         "enable_statement_lifecycle_logging": "true",
-        "enable_compute_temporal_bucketing": "false",
+        "enable_compute_temporal_bucketing": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1138,6 +1138,7 @@ class FlipFlagsAction(Action):
             "compute_replica_expiration_offset",
             "enable_compute_render_fueled_as_specific_collection",
             "enable_compute_temporal_bucketing",
+            "compute_temporal_bucketing_summary",
             "enable_compute_logical_backpressure",
             "compute_logical_backpressure_max_retained_capabilities",
             "compute_logical_backpressure_inflight_slack",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -42,6 +42,13 @@ pub const ENABLE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
     "Whether to enable temporal bucketing in compute.",
 );
 
+/// The summary to apply to the frontier in temporal bucketing in compute.
+pub const TEMPORAL_BUCKETING_SUMMARY: Config<Duration> = Config::new(
+    "compute_temporal_bucketing_summary",
+    Duration::from_secs(2),
+    "The summary to apply to frontiers in temporal bucketing in compute.",
+);
+
 /// The yielding behavior with which linear joins should be rendered.
 pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
     "linear_join_yielding",
@@ -376,6 +383,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CORRECTION_V2)
         .add(&ENABLE_MV_APPEND_SMEARING)
         .add(&ENABLE_TEMPORAL_BUCKETING)
+        .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)

--- a/src/compute/src/extensions/temporal_bucket.rs
+++ b/src/compute/src/extensions/temporal_bucket.rs
@@ -69,20 +69,28 @@ where
             let mut cap = Some(cap);
             let mut buffer = Vec::new();
             move |input, output| {
+                let (mut inputs, mut stashed, mut passed, mut peeled_count) = (0, 0, 0, 0);
                 let frontier =
                     if PartialOrder::less_than(&input.frontier().frontier(), &as_of.borrow()) {
-                        input.frontier().frontier()
-                    } else {
                         as_of.borrow()
+                    } else {
+                        input.frontier().frontier()
                     };
                 let threshold: Antichain<_> = frontier
                     .iter()
                     .flat_map(|f| threshold.results_in(f))
                     .collect();
+
+                let mut times = std::collections::BTreeSet::new();
+
                 while let Some((time, data)) = input.next() {
+                    inputs += data.len();
                     // Skip data that is about to be revealed.
-                    let extracted = data.extract_if(.., |(_, t, _)| !threshold.less_than(t));
+                    let before = data.len();
+                    let extracted = data.extract_if(.., |(_, t, _)| !threshold.less_equal(t));
                     output.session_with_builder(&time).give_iterator(extracted);
+                    passed += before - data.len();
+                    stashed += data.len();
 
                     // Sort data by time, then drain it into a buffer that contains data for a
                     // single bucket.
@@ -91,6 +99,7 @@ where
                     let mut range = None;
 
                     for (datum, time, diff) in data.drain(..) {
+                        times.insert(time.clone());
                         // If we have a range, check if the time is not within it.
                         if let Some((start, end)) = &range
                             && (time < *start || time >= *end)
@@ -118,10 +127,11 @@ where
                 }
 
                 // Check for data that is ready to be revealed.
-                let peeled = chain.peel(input.frontier().frontier());
+                let peeled = chain.peel(threshold.borrow());
                 if let Some(cap) = cap.as_ref() {
                     let mut session = output.session_with_builder(cap);
                     for stack in peeled.into_iter().flat_map(|x| x.done()) {
+                        peeled_count += stack.len();
                         // TODO: If we have a columnar merge batcher, cloning won't be necessary.
                         session.give_iterator(stack.iter().cloned());
                     }
@@ -135,10 +145,10 @@ where
                 }
 
                 // Downgrade the cap to the current input frontier.
-                if input.frontier().is_empty() {
+                if input.frontier().is_empty() || threshold.is_empty() {
                     cap = None;
                 } else if let Some(cap) = cap.as_mut() {
-                    cap.downgrade(&input.frontier().frontier()[0]);
+                    cap.downgrade(&threshold[0]);
                 }
 
                 // Maintain the bucket chain by restoring it with fuel.
@@ -147,6 +157,22 @@ where
                 if fuel <= 0 {
                     // If we run out of fuel, we activate the operator to continue processing.
                     activator.activate();
+                }
+
+                if inputs > 0 || peeled_count > 0 {
+                    println!(
+                        "[{}] frontier: {:?}, as-of: {:?} threshold: {:?}\tinputs: {}, stashed: {}, passed: {}, peeled: {}\ttimes: {:?}",
+                        info.global_id,
+                        &*input.frontier().frontier(),
+                        &*as_of.borrow(),
+                        &*threshold.borrow(),
+                        inputs,
+                        stashed,
+                        passed,
+                        peeled_count,
+                        times,
+                    );
+
                 }
             }
         })

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -462,7 +462,13 @@ pub fn build_compute_dataflow<A: Allocate>(
                 for (id, (oks, errs)) in imported_sources.into_iter() {
                     let oks = if ENABLE_TEMPORAL_BUCKETING.get(&compute_state.worker_config) {
                         oks.inner
-                            .bucket::<CapacityContainerBuilder<_>>(2000.into())
+                            .bucket::<CapacityContainerBuilder<_>>(
+                                dataflow
+                                    .as_of
+                                    .clone()
+                                    .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum())),
+                                2000.into(),
+                            )
                             .as_collection()
                     } else {
                         oks

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -462,7 +462,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                 for (id, (oks, errs)) in imported_sources.into_iter() {
                     let oks = if ENABLE_TEMPORAL_BUCKETING.get(&compute_state.worker_config) {
                         oks.inner
-                            .bucket::<CapacityContainerBuilder<_>>()
+                            .bucket::<CapacityContainerBuilder<_>>(2000.into())
                             .as_collection()
                     } else {
                         oks

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -122,7 +122,7 @@ use mz_compute_types::dataflows::{DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::{
     COMPUTE_APPLY_COLUMN_DEMANDS, COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK,
     COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES, ENABLE_COMPUTE_LOGICAL_BACKPRESSURE,
-    ENABLE_TEMPORAL_BUCKETING,
+    ENABLE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::LirId;
 use mz_compute_types::plan::render_plan::{
@@ -461,14 +461,13 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
                     let oks = if ENABLE_TEMPORAL_BUCKETING.get(&compute_state.worker_config) {
+                        let as_of = context.as_of_frontier.clone();
+                        let summary = TEMPORAL_BUCKETING_SUMMARY
+                            .get(&compute_state.worker_config)
+                            .try_into()
+                            .expect("must fit");
                         oks.inner
-                            .bucket::<CapacityContainerBuilder<_>>(
-                                dataflow
-                                    .as_of
-                                    .clone()
-                                    .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum())),
-                                2000.into(),
-                            )
+                            .bucket::<CapacityContainerBuilder<_>>(as_of, summary)
                             .as_collection()
                     } else {
                         oks

--- a/test/testdrive/replica-expiration.td
+++ b/test/testdrive/replica-expiration.td
@@ -24,9 +24,13 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d'
   WHERE mz_now() <= event_ts + INTERVAL '20 days';
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
+# TODO: The following query should return 2000, but it returns 1000 because the
+# the arrangement sizes does not account for the temporal bucket. It is part of
+# a different operator, and we only reveal counts associated with arrangement
+# operators.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-2000
+1000
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 
@@ -212,9 +216,12 @@ ALTER SYSTEM SET compute_replica_expiration_offset = 0;
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
+# TODO: The following query should return 2000, but it returns 1000 because the
+# the arrangement sizes does not account for the temporal bucket. It is part of
+# a different operator.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-2000
+1000
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 

--- a/test/testdrive/replica-expiration.td
+++ b/test/testdrive/replica-expiration.td
@@ -25,7 +25,7 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d'
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
 # TODO: The following query should return 2000, but it returns 1000 because the
-# the arrangement sizes does not account for the temporal bucket. It is part of
+# arrangement sizes does not account for the temporal bucket. It is part of
 # a different operator, and we only reveal counts associated with arrangement
 # operators.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
@@ -217,7 +217,7 @@ ALTER SYSTEM SET compute_replica_expiration_offset = 0;
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
 # TODO: The following query should return 2000, but it returns 1000 because the
-# the arrangement sizes does not account for the temporal bucket. It is part of
+# arrangement sizes does not account for the temporal bucket. It is part of
 # a different operator.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';


### PR DESCRIPTION
Updates the temporal bucketing logic to only store data in the bucket chain that is likely not to be revealed soon, as far as it's possible to determine this locally. The condition we implement determines a upper frontier based on the as-of of the dataflow, the current input frontier, and a summary. It computes the join of the input frontier and the as-of, and applies the summary to the result. The summary is configurable and defaults to the equivalent of two seconds.

This results in a frontier that is always ahead of the input frontier, causing the operator to release and pass through a configurable amount of future updates, saving the cost associated with inserting and extracting the data from the bucket chain.

This addresses the performance concerns for dataflows without future retractions: most of the data will never enter the bucket chain. The initial snapshot is within the 2s summary of the as-of, so it'll be forwarded verbatim. Only if there are future updates, we'll store them in the bucket chain.

There is a new cost associated with inserting data into the bucket chain, but we hope to amortize this cost with the CPU savings associated with having fewer outstanding updates in the merge batcher. We reduce the cost from once every frontier tick to once for inserting and extracting the data in the bucket chain, plus the maintenance of data in the chain.
