### PR TITLE
revert: Compact command history when client connects

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1043,7 +1043,7 @@ where
             log_sources.insert(log, id);
         }
 
-        let history = ComputeCommandHistory::new(Some(metrics.for_history()));
+        let history = ComputeCommandHistory::new(metrics.for_history());
 
         let send_count = metrics.response_send_count.clone();
         let recv_count = metrics.response_recv_count.clone();

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -203,7 +203,7 @@ impl ComputeState {
         context: ComputeInstanceContext,
     ) -> Self {
         let traces = TraceManager::new(metrics.clone());
-        let command_history = ComputeCommandHistory::new(Some(metrics.for_history()));
+        let command_history = ComputeCommandHistory::new(metrics.for_history());
         let (hydration_tx, hydration_rx) = mpsc::channel();
 
         // We always initialize as read_only=true. Only when we're explicitly

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -729,7 +729,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         // Overwrite `self.command_history` to reflect `new_commands`.
         // It is possible that there still isn't a compute state yet.
         if let Some(compute_state) = &mut self.compute_state {
-            let mut command_history = ComputeCommandHistory::new(Some(self.metrics.for_history()));
+            let mut command_history = ComputeCommandHistory::new(self.metrics.for_history());
             for command in new_commands.iter() {
                 command_history.push(command.clone());
             }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -5728,8 +5728,6 @@ def workflow_test_lgalloc_limiter(c: Composition) -> None:
         else:
             raise RuntimeError("replica did not exit with code 167")
 
-        c.kill("clusterd1")
-
         # Test 3: The MV should be able to hydrate with a disk limit of 10 MiB
         # and a burst budget of 10 GiB-seconds.
         c.sql(
@@ -5741,6 +5739,13 @@ def workflow_test_lgalloc_limiter(c: Composition) -> None:
             user="mz_system",
         )
         setup_workload()
+
+        # Force a reconnect to make sure the replica gets the new config immediately.
+        # TODO(database-issues#9483): make this workaround unnecessary
+        c.up("clusterd1")
+        time.sleep(1)
+        c.kill("clusterd1")
+
         c.up("clusterd1")
 
         c.testdrive("> SELECT count(*) FROM mv\n1000000")
@@ -5853,9 +5858,14 @@ def workflow_test_memory_limiter(c: Composition) -> None:
             port=6877,
             user="mz_system",
         )
+        setup_workload()
+
+        # Force a reconnect to make sure the replica gets the new config immediately.
+        # TODO(database-issues#9483): make this workaround unnecessary
+        c.up("clusterd1")
+        time.sleep(1)
         c.kill("clusterd1")
 
-        setup_workload()
         c.up("clusterd1")
 
         c.testdrive("> SELECT count(*) FROM mv\n1000000")


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/32959 introduced an optimization where after a replica connection was made, the ReplicaTask would first reduce the received commands as much as possible, before sending them on to the replica. Unfortunately, this broke frontier tracking in the controller because the ReplicaTask could reduce away dataflow creations, without sending back the expected "drop command".

The proper fix is https://github.com/MaterializeInc/database-issues/issues/9483, but putting out a revert here first so we can backport it into the release.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9471
Fixes https://github.com/MaterializeInc/database-issues/issues/9477

### Tips for reviewers

This requires an ugly workaround for the memory limiter tests. We can remove that as soon as https://github.com/MaterializeInc/database-issues/issues/9483 is implemented.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
