### PR TITLE
De-flake `pgtest-mz/desc.pt`

### DIFF
--- a/test/pgtest-mz/desc.pt
+++ b/test/pgtest-mz/desc.pt
@@ -39,10 +39,10 @@ Bind {"statement": "q", "portal": "p"}
 ----
 
 # Unfortunately we cannot wait for BindComplete because it doesn't show up
-# until Sync, so this is probably a bit racey. But since this will initiate a
-# new connection, seems likely that the Bind always gets processed before this
-# connection is ready.
+# until Sync, so this is probably a bit racey. We need the bind to get processed before the `DROP TABLE`. We sleep first
+# to increase the chances of this.
 send conn=writer
+Query {"query": "SELECT mz_unsafe.mz_sleep(1)"}
 Query {"query": "DROP TABLE t"}
 Query {"query": "CREATE TABLE t (c INT, b INT)"}
 Query {"query": "INSERT INTO t VALUES (1, 2)"}
@@ -52,7 +52,12 @@ until conn=writer
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
+ReadyForQuery
 ----
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["NULL"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"DROP TABLE"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"CREATE TABLE"}


### PR DESCRIPTION
This hopefully fixes the https://github.com/MaterializeInc/database-issues/issues/9481 flake. Unfortunately, I didn't find a better way than to put a sleep in the test's second connection.

As an experiment, I tried putting various sleeps in protocol.rs's handling of these pgwire messages, which allowed me to repro the reported flake. The flake went away with the PR's sleep.

### Motivation

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
