### PR TITLE
ci: Fix bazel_lto check in mkpipeline

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -117,7 +117,7 @@ so it is executed.""",
     pipeline = yaml.safe_load(raw)
 
     bazel = pipeline.get("env", {}).get("CI_BAZEL_BUILD", 1) == 1
-    bazel_lto = pipeline.get("env", {}).get("CI_BAZEL_LTO", 1) == 1
+    bazel_lto = pipeline.get("env", {}).get("CI_BAZEL_LTO", 0) == 1
 
     hash_check: dict[Arch, tuple[str, bool]] = {}
 


### PR DESCRIPTION
Should default to 0, not 1
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
