### PR TITLE
Allow invalid clippy paths for tokio Builder::spawn* methods.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -31,16 +31,17 @@ disallowed-methods = [
     { path = "tokio::task::JoinSet::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
 
     # These are banned because we want to ensure people don't forget to use .name(...), so we require the use of `mz_ore`
-    { path = "tokio::task::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::Builder::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::Builder::spawn_blocking_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::join_set::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::join_set::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    # We allow invalid because these paths only exist with tokio_unstable and feature tracing.
+    { path = "tokio::task::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::Builder::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::Builder::spawn_blocking_on", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::join_set::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::join_set::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
 
     { path = "rdkafka::config::ClientConfig::new", reason = "use the `client::create_new_client_config` wrapper in `kafka_util` instead" },
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -32,6 +32,8 @@ disallowed-methods = [
 
     # These are banned because we want to ensure people don't forget to use .name(...), so we require the use of `mz_ore`
     # We allow invalid because these paths only exist with tokio_unstable and feature tracing.
+    # When these features are disabled, clippy warns about the path not existing. We don't use tokio_unstable in the cloud
+    # repo, so clippy gives erroneous warnings about the path not referring to an existing function.
     { path = "tokio::task::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
     { path = "tokio::task::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },
     { path = "tokio::task::Builder::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead", allow-invalid = true },


### PR DESCRIPTION
Allow invalid clippy paths for tokio Builder::spawn* methods.

### Motivation

  * This PR fixes a previously unreported bug.
The cloud repo inherits lints from here, and we don't use tokio_unstable, so clippy complains about invalid paths.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
