### PR TITLE
ore/netio: always set `TCP_NODELAY`

### DIFF
--- a/src/cluster/src/communication.rs
+++ b/src/cluster/src/communication.rs
@@ -344,9 +344,6 @@ async fn connect_lower(
         address: &str,
     ) -> anyhow::Result<(Epoch, Stream)> {
         let mut s = Stream::connect(address).await?;
-        if let Stream::Tcp(tcp) = &s {
-            tcp.set_nodelay(true)?;
-        }
 
         // Make sure all network calls have timeouts, so we don't get stuck when the peer goes
         // away. Writes are buffered, so they probably don't need timeouts, but we're adding them
@@ -424,9 +421,6 @@ async fn accept_higher(
 
     async fn accept(listener: &Listener) -> anyhow::Result<(usize, Stream)> {
         let (mut s, _) = listener.accept().await?;
-        if let Stream::Tcp(tcp) = &s {
-            tcp.set_nodelay(true)?;
-        }
 
         // Make sure all network calls have timeouts, so we don't get stuck when the peer goes
         // away.

--- a/src/ore/src/netio/socket.rs
+++ b/src/ore/src/netio/socket.rs
@@ -340,6 +340,9 @@ impl Listener {
     }
 
     /// Accepts a new incoming connection to this listener.
+    ///
+    /// If the connection protocol is TCP, the returned stream has `TCP_NODELAY` set, making it
+    /// suitable for low-latency communication by default.
     pub async fn accept(&self) -> Result<(Stream, SocketAddr), io::Error> {
         match self {
             Listener::Tcp(listener) => {
@@ -421,6 +424,9 @@ pub enum Stream {
 
 impl Stream {
     /// Opens a connection to the specified socket address.
+    ///
+    /// If the connection protocol is TCP, the returned stream has `TCP_NODELAY` set, making it
+    /// suitable for low-latency communication by default.
     pub async fn connect<A>(addr: A) -> Result<Stream, io::Error>
     where
         A: ToSocketAddrs,
@@ -444,6 +450,7 @@ impl Stream {
         match addr {
             SocketAddr::Inet(addr) => {
                 let stream = TcpStream::connect(addr).await?;
+                stream.set_nodelay(true)?;
                 Ok(Stream::Tcp(stream))
             }
             SocketAddr::Unix(UnixSocketAddr { path: Some(path) }) => {


### PR DESCRIPTION
This PR changes `mz_ore::netio::socket` to always set `TCP_NODELAY`, disabling Nagle's algorithm, when a TCP stream is created. Previously, it would only do this for server-side streams, but not client-side streams.

[Disabling Nagle's algorithm seems to be the correct default for modern distributed systems.](https://brooker.co.za/blog/2024/05/09/nagle.html) Doing it in `mz_ore` removes one source of performance pitfalls when writing new networking code.

### Motivation

   * This PR refactors existing code.

I stumbled over this while working on a new cluster protocol. Not enabling `TCP_NODELAY` causes significant regressions  in our feature benchmarks, which don't reproduce when running `bin/environmentd` locally because that uses UDS instead of TCP 🙃 I'd like to avoid having to deal with this in the future.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
