### PR TITLE
ci: Don't upload junit reports to test analytics

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -744,8 +744,7 @@ To see the available workflows, run:
 
             if self.shall_generate_junit_report(args.find):
                 junit_suite = self.generate_junit_suite(composition)
-                junit_xml_file_path = self.write_junit_report_to_file(junit_suite)
-                ci_util.upload_junit_report("mzcompose", junit_xml_file_path)
+                self.write_junit_report_to_file(junit_suite)
 
             if any(
                 not result.is_successful()

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -19,7 +19,7 @@ import argparse
 from argparse import Namespace
 from pathlib import Path
 
-from materialize import MZ_ROOT, buildkite, ci_util, file_util
+from materialize import buildkite, ci_util, file_util
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
@@ -114,7 +114,6 @@ def run_sqllogictest(
             try:
                 c.run(container_name, *cmd)
             except:
-                ci_util.upload_junit_report(c.name, MZ_ROOT / junit_report_path)
                 j += 1
                 raise
 

--- a/test/testdrive-old-kafka-src-syntax/mzcompose.py
+++ b/test/testdrive-old-kafka-src-syntax/mzcompose.py
@@ -13,7 +13,6 @@ the expected-result/actual-result (aka golden testing) paradigm. A query is
 retried until it produces the desired result.
 """
 import glob
-from pathlib import Path
 
 from materialize import MZ_ROOT, ci_util, spawn
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -216,31 +215,24 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             )
 
         junit_report = ci_util.junit_report_filename(c.name)
+        print(f"Passing through arguments to testdrive {passthrough_args}\n")
 
-        try:
-            junit_report = ci_util.junit_report_filename(c.name)
-            print(f"Passing through arguments to testdrive {passthrough_args}\n")
-
-            # do not set default args, they should be set in the td file using set-arg-default to easen the execution
-            # without mzcompose
-            def process(file: str) -> None:
-                c.run_testdrive_files(
-                    (
-                        "--rewrite-results"
-                        if args.rewrite_results
-                        else f"--junit-report={junit_report}"
-                    ),
-                    *non_default_testdrive_vars,
-                    *passthrough_args,
-                    file,
-                )
-
-            c.test_parts(args.files, process)
-            c.sanity_restart_mz()
-        finally:
-            ci_util.upload_junit_report(
-                "testdrive", Path(__file__).parent / junit_report
+        # do not set default args, they should be set in the td file using set-arg-default to easen the execution
+        # without mzcompose
+        def process(file: str) -> None:
+            c.run_testdrive_files(
+                (
+                    "--rewrite-results"
+                    if args.rewrite_results
+                    else f"--junit-report={junit_report}"
+                ),
+                *non_default_testdrive_vars,
+                *passthrough_args,
+                file,
             )
+
+        c.test_parts(args.files, process)
+        c.sanity_restart_mz()
 
 
 def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -14,7 +14,6 @@ retried until it produces the desired result.
 """
 
 import glob
-from pathlib import Path
 
 from materialize import MZ_ROOT, buildkite, ci_util
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -215,21 +214,16 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ):
                 return
             junit_report = ci_util.junit_report_filename(f"{c.name}_{file}")
-            try:
-                c.run_testdrive_files(
-                    (
-                        "--rewrite-results"
-                        if args.rewrite_results
-                        else f"--junit-report={junit_report}"
-                    ),
-                    *non_default_testdrive_vars,
-                    *passthrough_args,
-                    file,
-                )
-            finally:
-                ci_util.upload_junit_report(
-                    "testdrive", Path(__file__).parent / junit_report
-                )
+            c.run_testdrive_files(
+                (
+                    "--rewrite-results"
+                    if args.rewrite_results
+                    else f"--junit-report={junit_report}"
+                ),
+                *non_default_testdrive_vars,
+                *passthrough_args,
+                file,
+            )
 
         files = buildkite.shard_list(
             [

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -14,7 +14,6 @@
 Test Kafka Upsert sources using Testdrive.
 """
 
-from pathlib import Path
 from textwrap import dedent
 
 from materialize import ci_util
@@ -139,24 +138,17 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         junit_report = ci_util.junit_report_filename(c.name)
 
-        try:
-            junit_report = ci_util.junit_report_filename(c.name)
-
-            def process(file: str) -> None:
-                c.run_testdrive_files(
-                    f"--junit-report={junit_report}",
-                    f"--var=replicas={args.replicas}",
-                    f"--var=default-replica-size={materialized.default_replica_size}",
-                    f"--var=default-storage-size={materialized.default_storage_size}",
-                    file,
-                )
-
-            c.test_parts(args.files, process)
-            c.sanity_restart_mz()
-        finally:
-            ci_util.upload_junit_report(
-                "testdrive", Path(__file__).parent / junit_report
+        def process(file: str) -> None:
+            c.run_testdrive_files(
+                f"--junit-report={junit_report}",
+                f"--var=replicas={args.replicas}",
+                f"--var=default-replica-size={materialized.default_replica_size}",
+                f"--var=default-storage-size={materialized.default_storage_size}",
+                file,
             )
+
+        c.test_parts(args.files, process)
+        c.sanity_restart_mz()
 
 
 def workflow_rehydration(c: Composition) -> None:


### PR DESCRIPTION
Can take up to a minute, and we are not using it at all. We instead use ci-annotations to parse the junit reports

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
