### PR TITLE
adapter: Fix the name of `PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -546,7 +546,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "enable_0dt_caught_up_check",
     "with_0dt_caught_up_check_allowed_lag",
     "with_0dt_caught_up_check_cutoff",
-    "plan_insights_notice fast_path_clusters_optimize_duration",
+    "plan_insights_notice_fast_path_clusters_optimize_duration",
     "enable_continual_task_builtins",
     "enable_expression_cache",
     "enable_password_auth",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1281,7 +1281,7 @@ class FlipFlagsAction(Action):
             "with_0dt_caught_up_check_cutoff",
             "enable_statement_lifecycle_logging",
             "enable_introspection_subscribes",
-            "plan_insights_notice fast_path_clusters_optimize_duration",
+            "plan_insights_notice_fast_path_clusters_optimize_duration",
             "enable_continual_task_builtins",
             "enable_expression_cache",
             "enable_multi_replica_sources",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -87,7 +87,7 @@ pub const ENABLE_INTROSPECTION_SUBSCRIBES: Config<bool> = Config::new(
 
 /// The plan insights notice will not investigate fast path clusters if plan optimization took longer than this.
 pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Duration> = Config::new(
-    "plan_insights_notice fast_path_clusters_optimize_duration",
+    "plan_insights_notice_fast_path_clusters_optimize_duration",
     // Looking at production values of the mz_optimizer_e2e_optimization_time_seconds metric, most
     // optimizations run faster than 10ms, so this should still work well for most queries. We want
     // to avoid the case where an optimization took just under this value and there are lots of


### PR DESCRIPTION
The old name had a space, which means that we can't toggle the flag (neither through LD, nor through ALTER SYSTEM SET). https://materializeinc.slack.com/archives/C04DJT084KA/p1752581301959399?thread_ts=1752524062.165129&cid=C04DJT084KA

Full Nightly: https://buildkite.com/materialize/nightly/builds/12608 (I'm a slightly bit worried about upgrade paths when changing a flag name, so especially interested in what the upgrade tests will say.)

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
