### PR TITLE
testdrive: Faster retries

### DIFF
--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -65,6 +65,7 @@ class Testdrive(Service):
         cluster_replica_size: dict[str, dict[str, Any]] | None = None,
         network_mode: str | None = None,
         set_persist_urls: bool = True,
+        backoff_factor: float = 1.0,
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {}
 
@@ -107,7 +108,10 @@ class Testdrive(Service):
                 f"--materialize-url={materialize_url}",
                 f"--materialize-internal-url={materialize_url_internal}",
                 *(["--materialize-use-https"] if materialize_use_https else []),
+                # Faster retries
             ]
+
+        entrypoint.append(f"--backoff-factor={backoff_factor}")
 
         if aws_region:
             entrypoint.append(f"--aws-region={aws_region}")

--- a/test/mysql-cdc-old-syntax/15-create-source.td
+++ b/test/mysql-cdc-old-syntax/15-create-source.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=3
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 

--- a/test/mysql-cdc-old-syntax/alter-column-irrelevant.td
+++ b/test/mysql-cdc-old-syntax/alter-column-irrelevant.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/alter-table-after-source.td
+++ b/test/mysql-cdc-old-syntax/alter-table-after-source.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created

--- a/test/mysql-cdc-old-syntax/alter-table-irrelevant.td
+++ b/test/mysql-cdc-old-syntax/alter-table-irrelevant.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/constraints.td
+++ b/test/mysql-cdc-old-syntax/constraints.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc-old-syntax/correctness-property-2.td
+++ b/test/mysql-cdc-old-syntax/correctness-property-2.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true

--- a/test/mysql-cdc-old-syntax/create-views-from-source-in-schema.td
+++ b/test/mysql-cdc-old-syntax/create-views-from-source-in-schema.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/data-utf8.td
+++ b/test/mysql-cdc-old-syntax/data-utf8.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/empty-table.td
+++ b/test/mysql-cdc-old-syntax/empty-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/generated-columns.td
+++ b/test/mysql-cdc-old-syntax/generated-columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/gh-10981.td
+++ b/test/mysql-cdc-old-syntax/gh-10981.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/invisible-columns.td
+++ b/test/mysql-cdc-old-syntax/invisible-columns.td
@@ -11,7 +11,6 @@ $ skip-if
 SELECT mz_version_num() < 13300;
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/move-table.td
+++ b/test/mysql-cdc-old-syntax/move-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/mysql-cdc-ssl.td
+++ b/test/mysql-cdc-old-syntax/mysql-cdc-ssl.td
@@ -11,7 +11,6 @@
 # (part of the CREATE SOURCE statement).
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET ssl_ca AS '${arg.ssl-ca}'

--- a/test/mysql-cdc-old-syntax/mysql-cdc.td
+++ b/test/mysql-cdc-old-syntax/mysql-cdc.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc-old-syntax/override/10-replica-connection.td
+++ b/test/mysql-cdc-old-syntax/override/10-replica-connection.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-max-tries max-tries=20
-
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 

--- a/test/mysql-cdc-old-syntax/privileges.td
+++ b/test/mysql-cdc-old-syntax/privileges.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}

--- a/test/mysql-cdc-old-syntax/subsource-names.td
+++ b/test/mysql-cdc-old-syntax/subsource-names.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/subsource-resolution-duplicates.td
+++ b/test/mysql-cdc-old-syntax/subsource-resolution-duplicates.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc-old-syntax/support-multiple-materializations.td
+++ b/test/mysql-cdc-old-syntax/support-multiple-materializations.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/table-in-mysql-schema.td
+++ b/test/mysql-cdc-old-syntax/table-in-mysql-schema.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/temporary-tables.td
+++ b/test/mysql-cdc-old-syntax/temporary-tables.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/toast-columns.td
+++ b/test/mysql-cdc-old-syntax/toast-columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/transactions-multi-conn.td
+++ b/test/mysql-cdc-old-syntax/transactions-multi-conn.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/transactions.td
+++ b/test/mysql-cdc-old-syntax/transactions.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/truncate-table.td
+++ b/test/mysql-cdc-old-syntax/truncate-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/two-destination-schemas.td
+++ b/test/mysql-cdc-old-syntax/two-destination-schemas.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/two-publications-one-table.td
+++ b/test/mysql-cdc-old-syntax/two-publications-one-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/two-source-schemas.td
+++ b/test/mysql-cdc-old-syntax/two-source-schemas.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/two-sources-one-publication.td
+++ b/test/mysql-cdc-old-syntax/two-sources-one-publication.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-binary.td
+++ b/test/mysql-cdc-old-syntax/types-binary.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-blob.td
+++ b/test/mysql-cdc-old-syntax/types-blob.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-boolean.td
+++ b/test/mysql-cdc-old-syntax/types-boolean.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-character.td
+++ b/test/mysql-cdc-old-syntax/types-character.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-double.td
+++ b/test/mysql-cdc-old-syntax/types-double.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 

--- a/test/mysql-cdc-old-syntax/types-enum.td
+++ b/test/mysql-cdc-old-syntax/types-enum.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-integer.td
+++ b/test/mysql-cdc-old-syntax/types-integer.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-json.td
+++ b/test/mysql-cdc-old-syntax/types-json.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-serial.td
+++ b/test/mysql-cdc-old-syntax/types-serial.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-set.td
+++ b/test/mysql-cdc-old-syntax/types-set.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-spatial.td
+++ b/test/mysql-cdc-old-syntax/types-spatial.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-temporal-2.td
+++ b/test/mysql-cdc-old-syntax/types-temporal-2.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-temporal-with-tz.td
+++ b/test/mysql-cdc-old-syntax/types-temporal-with-tz.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/types-temporal.td
+++ b/test/mysql-cdc-old-syntax/types-temporal.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc-old-syntax/views.td
+++ b/test/mysql-cdc-old-syntax/views.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/15-create-source.td
+++ b/test/mysql-cdc/15-create-source.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=3
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 

--- a/test/mysql-cdc/alter-column-irrelevant.td
+++ b/test/mysql-cdc/alter-column-irrelevant.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created

--- a/test/mysql-cdc/alter-table-irrelevant.td
+++ b/test/mysql-cdc/alter-table-irrelevant.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/constraints.td
+++ b/test/mysql-cdc/constraints.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc/correctness-property-2.td
+++ b/test/mysql-cdc/correctness-property-2.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true

--- a/test/mysql-cdc/create-views-from-source-in-schema.td
+++ b/test/mysql-cdc/create-views-from-source-in-schema.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/data-utf8.td
+++ b/test/mysql-cdc/data-utf8.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/empty-table.td
+++ b/test/mysql-cdc/empty-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/generated-columns.td
+++ b/test/mysql-cdc/generated-columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/gh-10981.td
+++ b/test/mysql-cdc/gh-10981.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/invisible-columns.td
+++ b/test/mysql-cdc/invisible-columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/move-table.td
+++ b/test/mysql-cdc/move-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/mysql-cdc-ssl.td
+++ b/test/mysql-cdc/mysql-cdc-ssl.td
@@ -11,7 +11,6 @@
 # (part of the CREATE SOURCE statement).
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET ssl_ca AS '${arg.ssl-ca}'

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc/override/10-replica-connection.td
+++ b/test/mysql-cdc/override/10-replica-connection.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-max-tries max-tries=20
-
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 

--- a/test/mysql-cdc/privileges.td
+++ b/test/mysql-cdc/privileges.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}

--- a/test/mysql-cdc/subsource-names.td
+++ b/test/mysql-cdc/subsource-names.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/subsource-resolution-duplicates.td
+++ b/test/mysql-cdc/subsource-resolution-duplicates.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'

--- a/test/mysql-cdc/support-multiple-materializations.td
+++ b/test/mysql-cdc/support-multiple-materializations.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/table-in-mysql-schema.td
+++ b/test/mysql-cdc/table-in-mysql-schema.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/temporary-tables.td
+++ b/test/mysql-cdc/temporary-tables.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/toast-columns.td
+++ b/test/mysql-cdc/toast-columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/transactions-multi-conn.td
+++ b/test/mysql-cdc/transactions-multi-conn.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/transactions.td
+++ b/test/mysql-cdc/transactions.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/truncate-table.td
+++ b/test/mysql-cdc/truncate-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/two-destination-schemas.td
+++ b/test/mysql-cdc/two-destination-schemas.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/two-publications-one-table.td
+++ b/test/mysql-cdc/two-publications-one-table.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/two-source-schemas.td
+++ b/test/mysql-cdc/two-source-schemas.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/two-sources-one-publication.td
+++ b/test/mysql-cdc/two-sources-one-publication.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-binary.td
+++ b/test/mysql-cdc/types-binary.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-bit.td
+++ b/test/mysql-cdc/types-bit.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-blob.td
+++ b/test/mysql-cdc/types-blob.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-boolean.td
+++ b/test/mysql-cdc/types-boolean.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-character.td
+++ b/test/mysql-cdc/types-character.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-double.td
+++ b/test/mysql-cdc/types-double.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 

--- a/test/mysql-cdc/types-enum.td
+++ b/test/mysql-cdc/types-enum.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-integer.td
+++ b/test/mysql-cdc/types-integer.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-json.td
+++ b/test/mysql-cdc/types-json.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-serial.td
+++ b/test/mysql-cdc/types-serial.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-set.td
+++ b/test/mysql-cdc/types-set.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-spatial.td
+++ b/test/mysql-cdc/types-spatial.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-temporal-2.td
+++ b/test/mysql-cdc/types-temporal-2.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-temporal-with-tz.td
+++ b/test/mysql-cdc/types-temporal-with-tz.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/types-temporal.td
+++ b/test/mysql-cdc/types-temporal.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/mysql-cdc/views.td
+++ b/test/mysql-cdc/views.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
 
 
 #

--- a/test/testdrive-old-kafka-src-syntax/indexes.td
+++ b/test/testdrive-old-kafka-src-syntax/indexes.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
-$ set-max-tries max-tries=5
 
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -409,7 +409,7 @@ true
 4
 
 # Seems to take a while in k8s
-$ set-max-tries max-tries=50
+$ set-max-tries max-tries=5000
 
 # The cluster should be turned off at some point.
 > SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster';


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
