### PR TITLE
optimizer: Make `compute_fast_path_clusters` use `fast_path_optimizer`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -311,6 +311,7 @@ impl Coordinator {
                     index_id,
                     optimizer_config,
                     self.optimizer_metrics(),
+                    false,
                 ))
             }
             Some(mut copy_to_ctx) => {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -531,6 +531,9 @@ impl AdapterError {
                 // This should be handled by peek optimization, so it's an internal error if it
                 // reaches the user.
                 OptimizerError::UnsafeMfpPlan => SqlState::INTERNAL_ERROR,
+                // This should be caught by `compute_fast_path_clusters`, so it's an internal error
+                // if it reaches the user.
+                OptimizerError::NonFastPathPlan => SqlState::INTERNAL_ERROR,
             },
             AdapterError::UnallowedOnCluster { .. } => {
                 SqlState::S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -106,6 +106,7 @@ impl PlanInsights {
                     ctx.index_id,
                     ctx.optimizer_config.clone(),
                     ctx.metrics.clone(),
+                    true,
                 );
                 mz_ore::task::spawn_blocking(
                     || "compute fast path clusters",

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -290,6 +290,8 @@ pub enum OptimizerError {
     },
     #[error("MfpPlan couldn't be converted into SafeMfpPlan")]
     UnsafeMfpPlan,
+    #[error("the optimizer was asked to produce a fast path plan, but the plan is too complicated")]
+    NonFastPathPlan,
     #[error("internal optimizer error: {0}")]
     Internal(String),
 }


### PR DESCRIPTION
`fast_path_optimizer` didn't exist when `compute_fast_path_clusters` was written, so it uses the full optimizer on each of the other clusters. This can be very slow despite `PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION` being set to 10ms, because it might happen that optimization for the originally targeted clsuter is fast due to a useful index, but optimizations for any other cluster is slow, due to not having useful indexes. We suspect that this happened yesterday [here](https://materializeinc.slack.com/archives/C04DJT084KA/p1752580039351319?thread_ts=1752524062.165129&cid=C04DJT084KA).

testing: There is an existing test: https://github.com/MaterializeInc/materialize/blob/605dea965ae61514e0ff41fd95caca7b2d5584e1/test/sqllogictest/explain/plan_insights.slt#L794-L807

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
