### PR TITLE
ci: Start up tests immediately so they can prepare before build is available

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -233,6 +233,7 @@ case "$cmd" in
             # For self managed docs
             --env BUILDKITE_BRANCH
             --env BUILDKITE_ORGANIZATION_SLUG
+            --env BUILDKITE_PULL_REQUEST
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -919,6 +919,12 @@ class Composition:
                 service["command"] = []
             self.files = {}
 
+        if (
+            os.getenv("BUILDKITE_PULL_REQUEST")
+            and os.getenv("BUILDKITE_PIPELINE_SLUG") == "test"
+        ):
+            max_tries = 300
+
         self.capture_logs()
         self.invoke(
             "up",


### PR DESCRIPTION
Test run here: https://buildkite.com/materialize/test/builds/106253

We can remove some i2 code in return: https://github.com/MaterializeInc/i2/pull/2694

This will speed up the test pipeline in PRs by 1-4 minutes when a build has to happen.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
