### PR TITLE
allow overriding the kubernetes api endpoint when calling kubectl

### DIFF
--- a/misc/python/materialize/cloudtest/util/wait.py
+++ b/misc/python/materialize/cloudtest/util/wait.py
@@ -26,6 +26,7 @@ def wait(
     *,
     label: str | None = None,
     namespace: str | None = None,
+    server: str | None = None,
 ) -> None:
     cmd = [
         "kubectl",
@@ -44,6 +45,9 @@ def wait(
 
     if namespace is not None:
         cmd.extend(["--namespace", namespace])
+
+    if server is not None:
+        cmd.extend(["--server", server])
 
     ui.progress(f'waiting for {" ".join(cmd)} ... ')
 


### PR DESCRIPTION
### Motivation

this is necessary if we want to use a local kind kubeconfig from within a docker container, since the kubeconfig written by kind will point at localhost, but localhost won't be accessible inside the container

this is used in the cloud e2e test suite

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
