### PR TITLE
SLT: Parallelize on each CI agent, remove some slow and useless junit uploads

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2056,9 +2056,8 @@ steps:
     label: ":bulb: SQL logic tests (4 replicas)"
     depends_on: build-aarch64
     timeout_in_minutes: 480
-    parallelism: 10
+    parallelism: 4
     agents:
-      # Runs faster/more consistently on larger agent
       queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -268,8 +268,8 @@ steps:
     label: "Fast SQL logic tests"
     depends_on: build-aarch64
     timeout_in_minutes: 30
-    parallelism: 8
     inputs: [test/sqllogictest]
+    parallelism: 3
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -770,10 +770,6 @@ class Composition:
             capture_and_print: Print during execution and capture the
                 stdout+stderr of the `docker compose` invocation.
         """
-        # Restart any dependencies whose definitions have changed. The trick,
-        # taken from Buildkite's Docker Compose plugin, is to run an `up`
-        # command that requests zero instances of the requested service.
-        self.up("--scale", f"{service}=0", service, wait=False)
         return self.invoke(
             "run",
             *(["--entrypoint", entrypoint] if entrypoint else []),

--- a/misc/python/materialize/mzcompose/services/sql_logic_test.py
+++ b/misc/python/materialize/mzcompose/services/sql_logic_test.py
@@ -14,7 +14,6 @@ from materialize.mzcompose import (
 from materialize.mzcompose.service import (
     Service,
 )
-from materialize.mzcompose.services.postgres import METADATA_STORE
 
 
 class SqlLogicTest(Service):
@@ -22,12 +21,13 @@ class SqlLogicTest(Service):
         self,
         name: str = "sqllogictest",
         mzbuild: str = "sqllogictest",
-        environment: list[str] = [
-            "MZ_SOFT_ASSERTIONS=1",
-        ],
+        environment: list[str] | None = None,
         volumes: list[str] = ["../..:/workdir"],
-        depends_on: list[str] = [METADATA_STORE],
     ) -> None:
+        if environment is None:
+            environment = [
+                "MZ_SOFT_ASSERTIONS=1",
+            ]
         environment += [
             "MZ_SYSTEM_PARAMETER_DEFAULT="
             + ";".join(
@@ -46,7 +46,6 @@ class SqlLogicTest(Service):
                 "environment": environment,
                 "volumes": volumes,
                 "tmpfs": ["/tmp"],
-                "depends_on": depends_on,
                 "propagate_uid_gid": True,
                 "init": True,
             },

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -56,6 +56,9 @@ struct Args {
     /// PostgreSQL connection URL to use for `persist` consensus.
     #[clap(long)]
     postgres_url: String,
+    /// PostgreSQL prefix for this SLT run
+    #[clap(long)]
+    prefix: String,
     /// Path to sqllogictest script to run.
     #[clap(value_name = "PATH", required = true)]
     paths: Vec<String>,
@@ -175,6 +178,7 @@ async fn main() -> ExitCode {
         stderr: &OutputStream::new(io::stderr(), args.timestamps),
         verbosity: args.verbosity,
         postgres_url: args.postgres_url.clone(),
+        prefix: args.prefix.clone(),
         no_fail: args.no_fail,
         fail_fast: args.fail_fast,
         auto_index_tables: args.auto_index_tables,

--- a/test/testdrive-old-kafka-src-syntax/mzcompose.py
+++ b/test/testdrive-old-kafka-src-syntax/mzcompose.py
@@ -13,6 +13,7 @@ the expected-result/actual-result (aka golden testing) paradigm. A query is
 retried until it produces the desired result.
 """
 import glob
+import os
 
 from materialize import MZ_ROOT, ci_util, spawn
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -231,6 +232,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 file,
                 persistent=False,
             )
+            # Uploading successful junit files wastes time and contains no useful information
+            os.remove(f"test/testdrive-old-kafka-src-syntax/{junit_report}")
 
         c.test_parts(args.files, process)
         c.sanity_restart_mz()

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -14,6 +14,7 @@ retried until it produces the desired result.
 """
 
 import glob
+import os
 
 from materialize import MZ_ROOT, buildkite, ci_util
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -225,6 +226,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 *passthrough_args,
                 file,
             )
+            # Uploading successful junit files wastes time and contains no useful information
+            os.remove(f"test/testdrive/{junit_report}")
 
         files = buildkite.shard_list(
             [

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -14,6 +14,7 @@
 Test Kafka Upsert sources using Testdrive.
 """
 
+import os
 from textwrap import dedent
 
 from materialize import ci_util
@@ -147,6 +148,8 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
                 f"--var=default-storage-size={materialized.default_storage_size}",
                 file,
             )
+            # Uploading successful junit files wastes time and contains no useful information
+            os.remove(f"test/upsert/{junit_report}")
 
         c.test_parts(args.files, process)
         c.sanity_restart_mz()


### PR DESCRIPTION
Test pipeline: [8 agents took 9 min](https://buildkite.com/materialize/test/builds/106318#01981387-f0e4-4fbc-9b73-a4d477b97716) -> [3 agents take 5 min](https://buildkite.com/materialize/test/builds/106329#01981421-2250-4631-a39e-44bf62f62f01)
Nightly pipeline: [10 agents took 1h 26 min](https://buildkite.com/materialize/nightly/builds/12618#0198106c-e6a8-45b6-a176-346195ec1afe) -> [4 agents take 48 min](https://buildkite.com/materialize/nightly/builds/12628#019813d6-9302-4fc8-af3a-c92a3de23c23)
Proof that this works fine when a test fails: https://buildkite.com/materialize/test/builds/106368
<img width="1688" height="537" alt="Screenshot 2025-07-17 at 12 57 28" src="https://github.com/user-attachments/assets/0013b229-6593-4d21-923e-c6f7a158eb20" />

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
