### PR TITLE
testdrive: Lower default timeout to 20s

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -124,6 +124,7 @@ class SinkUpsert(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
@@ -251,6 +252,7 @@ class SinkTables(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 $ schema-registry-verify schema-type=avro subject=testdrive-sink-large-transaction-sink-${testdrive.seed}-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"f1","type":"int"},{"name":"f2","type":["null","string"]}]}]},{"name":"after","type":["null","row"]}]}
 
@@ -391,6 +393,7 @@ class SinkNullDefaults(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 $ schema-registry-verify schema-type=avro subject=sink-sink-null1-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"l_k","type":"string"},{"name":"l_v1","type":["null","string"],"default":null},{"name":"l_v2","type":["null","long"],"default":null},{"name":"c","type":"long"}]}],"default":null},{"name":"after","type":["null","row"],"default":null}]}
 
@@ -653,6 +656,7 @@ class SinkComments(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 $ schema-registry-verify schema-type=avro subject=sink-sink-comments1-key
                 {"type":"record","name":"row","doc":"comment on view sink_source_comments_view","fields":[{"name":"l_v2","type":["null","long"],"default":null,"doc":"key doc on l_v2"}]}
 
@@ -878,6 +882,7 @@ class SinkAutoCreatedTopicConfig(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 $ kafka-verify-topic sink=materialize.public.sink_config1 partition-count=1 topic-config={"cleanup.policy": "compact"}
 
                 $ kafka-verify-topic sink=materialize.public.sink_config2 partition-count=1 topic-config={"cleanup.policy": "compact"}
@@ -964,6 +969,7 @@ class AlterSink(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 # We check the contents of the sink topics by re-ingesting them.
 
                 > CREATE SOURCE sink_alter_source_src
@@ -1047,6 +1053,7 @@ class AlterSinkMv(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 > CREATE SOURCE sink_alter_mv_source_src
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-alter-mv')
                 > CREATE TABLE sink_alter_mv_source FROM SOURCE sink_alter_mv_source_src (REFERENCE "sink-alter-mv")
@@ -1118,6 +1125,7 @@ class AlterSinkLGSource(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 > CREATE SOURCE sink_alter_lg_source_src
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-alter-lg')
                 > CREATE TABLE sink_alter_lg_source FROM SOURCE sink_alter_lg_source_src (REFERENCE "sink-alter-lg")
@@ -1243,6 +1251,7 @@ class AlterSinkPgSource(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 > CREATE SOURCE sink_alter_pg_source_src
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-alter-pg')
                 > CREATE TABLE sink_alter_pg_source FROM SOURCE sink_alter_pg_source_src (REFERENCE "sink-alter-pg")
@@ -1404,6 +1413,7 @@ class AlterSinkOrder(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 # We check the contents of the sink topics by re-ingesting them.
 
                 > CREATE SOURCE sink_alter_order_source_src
@@ -1469,6 +1479,7 @@ class SinkFormat(Check):
         return Testdrive(
             dedent(
                 """
+                $ set-sql-timeout duration=60s
                 # We check the contents of the sink topics by re-ingesting them.
                 > CREATE SOURCE sink_format_source_src
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-format-sink-${testdrive.seed}')

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -135,7 +135,7 @@ class Testdrive(Service):
             entrypoint.append(f"--materialize-param={k}={v}")
 
         if default_timeout is None:
-            default_timeout = "360s"
+            default_timeout = "20s"
         entrypoint.append(f"--default-timeout={default_timeout}")
 
         if kafka_default_partitions:

--- a/test/kafka-auth/mzcompose.py
+++ b/test/kafka-auth/mzcompose.py
@@ -167,6 +167,7 @@ SERVICES = [
     ),
     Testdrive(
         volumes_extra=["secrets:/share/secrets"],
+        default_timeout="30s",
     ),
     Mz(app_password=""),
 ]

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -14,6 +14,7 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true
 # ==> Set up. <==
 
 $ set-from-file ca-crt=/share/secrets/ca.crt
+$ set-sql-timeout duration=60s
 
 > CREATE SECRET password AS 'sekurity'
 > CREATE SECRET password_wrong AS 'wrong'

--- a/test/mysql-cdc-old-syntax/alter-source.td
+++ b/test/mysql-cdc-old-syntax/alter-source.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 > CREATE CONNECTION mysql_conn TO MYSQL (

--- a/test/mysql-cdc-old-syntax/alter-table-after-source.td
+++ b/test/mysql-cdc-old-syntax/alter-table-after-source.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
+$ set-sql-timeout duration=60s
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 > CREATE CONNECTION mysql_conn TO MYSQL (

--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ set-sql-timeout duration=1s
+$ set-sql-timeout duration=60s
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created

--- a/test/pg-cdc-old-syntax/alter-source.td
+++ b/test/pg-cdc-old-syntax/alter-source.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 # IMPORTANT: The Postgres server has a custom pg_hba.conf that only
 # accepts connections from specific users. You will have to update
 # pg_hba.conf if you modify the existing user names or add new ones.

--- a/test/pg-cdc-old-syntax/alter-table-after-source.td
+++ b/test/pg-cdc-old-syntax/alter-table-after-source.td
@@ -11,6 +11,8 @@
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created
 #
 
+$ set-sql-timeout duration=60s
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET pg_schema_validation_interval = '2s';
 

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 # IMPORTANT: The Postgres server has a custom pg_hba.conf that only
 # accepts connections from specific users. You will have to update
 # pg_hba.conf if you modify the existing user names or add new ones.

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -11,6 +11,8 @@
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created
 #
 
+$ set-sql-timeout duration=60s
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET pg_schema_validation_interval = '2s';
 

--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -26,7 +26,7 @@ SERVICES = [
     Materialized(options=["--persist-pubsub-url=http://toxiproxy:6879"]),
     Redpanda(),
     Toxiproxy(),
-    Testdrive(no_reset=True, seed=1),
+    Testdrive(no_reset=True, seed=1, default_timeout="60s"),
 ]
 
 SCHEMA = dedent(

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -121,6 +121,7 @@ class KafkaTransactionLogGreaterThan1:
         c.testdrive(
             dedent(
                 f"""
+                $ set-sql-timeout duration=60s
                 > SELECT bool_or(error ~* '{error}'), bool_or(details::json#>>'{{hints,0}}' ~* '{hint}')
                   FROM mz_internal.mz_sink_status_history
                   JOIN mz_sinks ON mz_sinks.id = sink_id
@@ -214,6 +215,7 @@ class KafkaDisruption:
         c.testdrive(
             dedent(
                 f"""
+                $ set-sql-timeout duration=60s
                 > SELECT status, error ~* '{error}'
                   FROM mz_internal.mz_source_statuses
                   WHERE name = 'source1'
@@ -320,6 +322,7 @@ class KafkaSinkDisruption:
         c.testdrive(
             dedent(
                 f"""
+                $ set-sql-timeout duration=60s
                 # Sinks generally halt after receiving an error, which means that they may alternate
                 # between `stalled` and `starting`. Instead of relying on the current status, we
                 # check that there is a stalled status with the expected error.
@@ -412,6 +415,7 @@ class PgDisruption:
         c.testdrive(
             dedent(
                 f"""
+                $ set-sql-timeout duration=60s
                 # Postgres sources may halt after receiving an error, which means that they may alternate
                 # between `stalled` and `starting`. Instead of relying on the current status, we
                 # check that the latest stall has the error we expect.

--- a/test/ssh-connection/kafka-sink-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-sink-after-ssh-failure.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # This test script runs after the SSH bastion host has been terminated.
+$ set-sql-timeout duration=300s
 
 # Ensure they all are marked as broken for ssh reasons. Sinks continuously restart, so we
 # instead check the history

--- a/test/ssh-connection/kafka-source-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # This test script runs after the SSH bastion host has been terminated.
+$ set-sql-timeout duration=60s
 
 # Ensure they all are marked as broken for ssh reasons
 > SELECT status FROM mz_internal.mz_source_statuses st

--- a/test/testdrive-old-kafka-src-syntax/connection-alter.td
+++ b/test/testdrive-old-kafka-src-syntax/connection-alter.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default single-replica-cluster=quickstart
 #
 # Test basic connection functionality

--- a/test/testdrive-old-kafka-src-syntax/github-7242.td
+++ b/test/testdrive-old-kafka-src-syntax/github-7242.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default single-replica-cluster=quickstart
 
 > CREATE SOURCE tpch

--- a/test/testdrive-old-kafka-src-syntax/kafka-source-errors.td
+++ b/test/testdrive-old-kafka-src-syntax/kafka-source-errors.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ set-arg-default single-replica-cluster=quickstart
+$ set-sql-timeout duration=60s
 
 # Test that Kafka sources with no format are disallowed.
 

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default single-replica-cluster=quickstart
 #
 # Test basic connection functionality

--- a/test/testdrive/github-6335.td
+++ b/test/testdrive/github-6335.td
@@ -16,6 +16,7 @@
 # introspection sources that take a while to update.
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+$ set-sql-timeout duration=60s
 
 # This test uses introspection queries that need to be targeted to a replica
 > SET cluster_replica = r1

--- a/test/testdrive/github-7242.td
+++ b/test/testdrive/github-7242.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default single-replica-cluster=quickstart
 
 > CREATE SOURCE tpch

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=120s
 $ set-arg-default default-replica-size=1
 
 # Test for a subset of the information returned by introspection sources.
@@ -16,6 +17,7 @@ $ set-arg-default default-replica-size=1
 
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
+$ set-sql-timeout duration=60s
 
 # Introspection subscribes add noise to the introspection sources, so disable them.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ set-arg-default single-replica-cluster=quickstart
+$ set-sql-timeout duration=60s
 
 # Test that Kafka sources with no format are disallowed.
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_refresh_every_mvs = true
 ALTER SYSTEM SET enable_cluster_schedule_refresh = true

--- a/test/testdrive/metrics-cluster.td
+++ b/test/testdrive/metrics-cluster.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=300s
+
 > CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (SIZE '2-2'))
 > CREATE CLUSTER bar REPLICAS ()
 > CREATE CLUSTER xyzzy REPLICAS (size_4 (SIZE '4'))

--- a/test/testdrive/mz-sinks.td
+++ b/test/testdrive/mz-sinks.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default single-replica-cluster=quickstart
 
 # Verify that envelope types are correctly reported in mz_sinks

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -10,6 +10,8 @@
 # This test verifies the Quickstart page works: https://materialize.com/docs/get-started/quickstart/
 # Uses shared compute+storage cluster
 
+$ set-sql-timeout duration=60s
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_table_from_source = true
 

--- a/test/yugabyte-cdc/yugabyte-cdc.td
+++ b/test/yugabyte-cdc/yugabyte-cdc.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_yugabyte_connection = true;
 


### PR DESCRIPTION
As suggested by @ggevay , I tried first with 10s, fixed all the failures in the CI runs, and then increased the limit to 20s. Hopefully this will not cause further CI flakiness. The advantage of this PR is that we will get results faster if a test fails instead of having to wait 6 minutes for the result to converge.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
