### PR TITLE
storage/upsert: use RocksDB in memory

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -398,20 +398,18 @@ impl StorageInstanceContext {
         scratch_directory: Option<PathBuf>,
         cluster_memory_limit: Option<usize>,
     ) -> Result<Self, anyhow::Error> {
+        // If no file system is available, fall back to running RocksDB in memory.
+        let rocksdb_env = if scratch_directory.is_some() {
+            rocksdb::Env::new()?
+        } else {
+            rocksdb::Env::mem_env()?
+        };
+
         Ok(Self {
             scratch_directory,
-            rocksdb_env: rocksdb::Env::new()?,
+            rocksdb_env,
             cluster_memory_limit,
         })
-    }
-
-    /// Constructs a new connection context for usage in tests.
-    pub fn for_tests(rocksdb_env: rocksdb::Env) -> Self {
-        Self {
-            scratch_directory: None,
-            rocksdb_env,
-            cluster_memory_limit: None,
-        }
     }
 }
 


### PR DESCRIPTION
This PR changes the upsert operator to use a RocksDB MemEnv when no file system is available, instead of falling back to `InMemoryHashMap`. Testing suggests that this results in significantly reduced memory usage, due to RocksDB's compression support.

This vastly improves the performance of upsert sources on replicas that don't get a scratch fs, like swap replicas. Based on our limited experience so far, upsert sources using MemEnv on swap replicas have roughly the same resource requirements as upsert sources using disk directly. [See Slack thread.](https://materializeinc.slack.com/archives/C08A7H11KP0/p1752782229619859)

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/9480

### Tips for reviewer

The diff has a bunch of indentation changes, much easier to review with whitespace disabled.

The `InMemoryHashMap` backend is still used in tests so I didn't attempt to remove it. There is an opportunity for a larger refactor here where we remove the `UpsertStateBackend` abstraction, given that there is only a single used backend now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
