### PR TITLE
[sql_server] refactor disable cdc cleanup as requires db_owner permissions

### DIFF
--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -55,7 +55,7 @@ pub const CDC_POLL_INTERVAL: Config<Duration> = Config::new(
 
 pub const CDC_CLEANUP_CHANGE_TABLE: Config<bool> = Config::new(
     "sql_server_cdc_cleanup_change_table",
-    true,
+    false,
     "When enabled we'll notify SQL Server that it can cleanup the change tables \
     as the source makes progress and commits data.",
 );


### PR DESCRIPTION
https://github.com/MaterializeInc/database-issues/issues/9491

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
