### PR TITLE
ci: Fix annotation problems

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -57,7 +57,7 @@ from .deploy.deploy_util import rust_version
 # err on the side of including too much rather than too little. (For example,
 # bin/resync-submodules is not presently used by CI, but it's just not worth
 # trying to capture that.)
-CI_GLUE_GLOBS = ["bin", "ci"]
+CI_GLUE_GLOBS = ["bin", "ci", "misc/python/materialize/cli/ci_annotate_errors.py"]
 
 DEFAULT_AGENT = "hetzner-aarch64-4cpu-8gb"
 


### PR DESCRIPTION
All found while investigating https://materializeinc.slack.com/archives/C01LKF361MZ/p1752695001558709

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
