### PR TITLE
ci: Fixes for nightly (2025-07-17)

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -866,7 +866,7 @@ def remove_dependencies_on_prs(
     """On PRs in test pipeline remove dependencies on the build, start up tests immediately, they keep retrying for the Docker image"""
     if pipeline_name != "test":
         return
-    if not os.getenv("BUILDKITE_PULL_REQUEST"):
+    if not ui.env_is_truthy("BUILDKITE_PULL_REQUEST"):
         return
     for step in steps(pipeline):
         if step.get("id") in (

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1309,7 +1309,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: cloud-canary
-      branches: "main v*.*"
+      branches: "main v*.* *cloud*"
 
     - id: mz-e2e
       label: "Mz E2E Test"

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -64,6 +64,15 @@ from materialize.ui import (
     UIError,
 )
 
+SECRETS = [
+    "mzp_",
+    "-----BEGIN PRIVATE KEY-----",
+    "confluent-api-key=",
+    "confluent-api-secret=",
+    "aws-access-key-id=",
+    "aws-secret-access-key=",
+]
+
 
 class UnknownCompositionError(UIError):
     """The specified composition was unknown."""
@@ -302,11 +311,7 @@ class Composition:
         if not self.silent and not silent:
             # Don't print out secrets in test logs
             filtered_args = [
-                (
-                    "[REDACTED]"
-                    if "mzp_" in arg or "-----BEGIN PRIVATE KEY-----" in arg
-                    else arg
-                )
+                "[REDACTED]" if any(secret in arg for secret in SECRETS) else arg
                 for arg in args
             ]
             print(f"$ docker compose {' '.join(filtered_args)}", file=sys.stderr)

--- a/misc/python/stubs/junit_xml.pyi
+++ b/misc/python/stubs/junit_xml.pyi
@@ -10,6 +10,9 @@
 from typing import TextIO
 
 class TestCase:
+    errors: list[dict]
+    failures: list[dict]
+    skipped: list[dict]
     def __init__(
         self,
         name: str,

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -52,7 +52,7 @@ pub struct Args {
     tracing: TracingCliArgs,
 
     #[clap(long, hide = true, value_parser(parse_crd_columns))]
-    additional_crd_columns: std::vec::Vec<CustomResourceColumnDefinition>,
+    additional_crd_columns: Option<std::vec::Vec<CustomResourceColumnDefinition>>,
 }
 
 fn parse_crd_columns(val: &str) -> Result<Vec<CustomResourceColumnDefinition>, serde_json::Error> {
@@ -88,7 +88,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let metrics = Arc::new(Metrics::register_into(&metrics_registry));
 
     let (client, namespace) = create_client(args.kubernetes_context.clone()).await?;
-    register_crds(client.clone(), args.additional_crd_columns).await?;
+    register_crds(
+        client.clone(),
+        args.additional_crd_columns.unwrap_or_default(),
+    )
+    .await?;
 
     {
         let router = mz_prof_http::router(&BUILD_INFO);


### PR DESCRIPTION
All based on https://buildkite.com/materialize/nightly/builds/12630

The orchestratord change is a follow-up to https://github.com/MaterializeInc/materialize/pull/32850 @alex-hunt-materialize Is it fine to make the new `--additional-crd-columns` optional?
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
