### PR TITLE
[persist] Run fewer background threads in tests

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -444,7 +444,7 @@ impl Service for TransactorService {
             Arc::new(UnreliableConsensus::new(consensus, unreliable));
 
         // Wire up the TransactorService.
-        let isolated_runtime = Arc::new(IsolatedRuntime::default());
+        let isolated_runtime = Arc::new(IsolatedRuntime::new_for_tests());
         let pubsub_sender = PubSubClientConnection::noop().sender;
         let shared_states = Arc::new(StateCache::new(
             &config,

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -667,7 +667,7 @@ impl Service for TransactorService {
             Arc::new(UnreliableConsensus::new(consensus, unreliable));
 
         // Wire up the TransactorService.
-        let isolated_runtime = Arc::new(IsolatedRuntime::default());
+        let isolated_runtime = Arc::new(IsolatedRuntime::new_for_tests());
         let pubsub_sender = PubSubClientConnection::noop().sender;
         let shared_states = Arc::new(StateCache::new(
             &config,

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -106,7 +106,7 @@ fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
     let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
     let consensus = Arc::new(MemConsensus::default());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::default());
+    let isolated_runtime = Arc::new(IsolatedRuntime::new_for_tests());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,
@@ -138,7 +138,7 @@ async fn create_file_pg_client()
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::default());
+    let isolated_runtime = Arc::new(IsolatedRuntime::new_for_tests());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,
@@ -173,7 +173,7 @@ async fn create_s3_pg_client()
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::default());
+    let isolated_runtime = Arc::new(IsolatedRuntime::new_for_tests());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,

--- a/src/persist-client/src/async_runtime.rs
+++ b/src/persist-client/src/async_runtime.rs
@@ -16,6 +16,12 @@ use mz_ore::metrics::{MetricsRegistry, register_runtime_metrics};
 use mz_ore::task::{JoinHandle, RuntimeExt};
 use tokio::runtime::{Builder, Runtime};
 
+/// A reasonable number of threads to use in tests: enough to reproduce nontrivial
+/// orderings if necessary and avoid blocking, but not too many.
+// This was done as a workaround for https://sourceware.org/bugzilla/show_bug.cgi?id=19951
+// in tests, but seems useful in general.
+pub const TEST_THREADS: usize = 4;
+
 /// An isolated runtime for asynchronous tasks, particularly work
 /// that may be CPU intensive such as encoding/decoding and shard
 /// maintenance.
@@ -66,7 +72,7 @@ impl IsolatedRuntime {
 
     /// Create an isolated runtime with appropriate values for tests.
     pub fn new_for_tests() -> Self {
-        IsolatedRuntime::new(&MetricsRegistry::new(), None)
+        IsolatedRuntime::new(&MetricsRegistry::new(), Some(TEST_THREADS))
     }
 
     /// Spawns a task onto this runtime.

--- a/src/persist-client/src/async_runtime.rs
+++ b/src/persist-client/src/async_runtime.rs
@@ -64,6 +64,11 @@ impl IsolatedRuntime {
         }
     }
 
+    /// Create an isolated runtime with appropriate values for tests.
+    pub fn new_for_tests() -> Self {
+        IsolatedRuntime::new(&MetricsRegistry::new(), None)
+    }
+
     /// Spawns a task onto this runtime.
     ///
     /// Note: We purposefully do not use the [`tokio::task::spawn_blocking`] API here, see the doc
@@ -79,12 +84,6 @@ impl IsolatedRuntime {
             .as_ref()
             .expect("exists until drop")
             .spawn_named(name, fut)
-    }
-}
-
-impl Default for IsolatedRuntime {
-    fn default() -> Self {
-        IsolatedRuntime::new(&MetricsRegistry::new(), None)
     }
 }
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -27,6 +27,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
+use crate::async_runtime;
 use crate::internal::machine::{
     NEXT_LISTEN_BATCH_RETRYER_CLAMP, NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF,
     NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER,
@@ -263,6 +264,7 @@ impl PersistConfig {
 
         let mut cfg = Self::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
         cfg.hostname = "tests".into();
+        cfg.isolated_runtime_worker_threads = async_runtime::TEST_THREADS;
         cfg
     }
 }

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -494,7 +494,10 @@ where
                 Arc::clone(&blob),
                 Arc::clone(&metrics),
                 Arc::clone(&machine.applier.shard_metrics),
-                Arc::new(IsolatedRuntime::default()),
+                Arc::new(IsolatedRuntime::new(
+                    metrics_registry,
+                    Some(cfg.isolated_runtime_worker_threads),
+                )),
                 req,
                 schemas,
             )
@@ -631,7 +634,10 @@ where
         state_versions,
         Arc::new(StateCache::new(cfg, metrics, Arc::new(NoopPubSubSender))),
         Arc::new(NoopPubSubSender),
-        Arc::new(IsolatedRuntime::default()),
+        Arc::new(IsolatedRuntime::new(
+            &MetricsRegistry::new(),
+            Some(cfg.isolated_runtime_worker_threads),
+        )),
         Diagnostics::from_purpose("admin"),
     )
     .await?;

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1053,7 +1053,7 @@ mod tests {
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
             write.metrics.shards.shard(&write.machine.shard_id(), ""),
-            Arc::new(IsolatedRuntime::default()),
+            Arc::new(IsolatedRuntime::new_for_tests()),
             req.clone(),
             schemas.clone(),
         )

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -4290,7 +4290,6 @@ pub(crate) mod tests {
 
     #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    #[ignore] // TODO: Reenable when database-issues#9472 is fixed
     async fn sneaky_downgrades(dyncfgs: ConfigUpdates) {
         let mut clients = new_test_client_cache(&dyncfgs);
         let shard_id = ShardId::new();

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1616,7 +1616,7 @@ mod tests {
             blob,
             consensus,
             metrics,
-            Arc::new(IsolatedRuntime::default()),
+            Arc::new(IsolatedRuntime::new_for_tests()),
             Arc::new(StateCache::new_no_metrics()),
             pubsub_sender,
         )

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -735,7 +735,6 @@ mod tests {
 
     #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    #[ignore] // TODO: Reenable when database-issues#9472 is fixed
     async fn size(dyncfgs: ConfigUpdates) {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),


### PR DESCRIPTION
### Motivation

We believe this is a contributing factor to https://github.com/MaterializeInc/database-issues/issues/9472, by way of https://sourceware.org/bugzilla/show_bug.cgi?id=19951.

Based on that upstream report, we believe that spawning fewer threads will make this issue less likely - both because having fewer threads means fewer chances to observe the issue, and because we may be less likely to fill the cache and trigger the issue in the first place.

It's also unnecessary to spawn so many threads in a test, especially since nextest will generally run many tests concurrently...

### Tips for reviewer

We also discussed adding a timeout to shutdown, but it turns out that the timeout only applies to the blocking thread pool, and the isolated runtime interface doesn't allow spawning blocking threads... so we wouldn't expect this config to have any effect here unfortunately.

https://github.com/tokio-rs/tokio/blob/0a3fe460862720d005b8fa39cdde30575a063785/tokio/src/runtime/runtime.rs#L430-L432

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
