### PR TITLE
doc: fix sql server clunky language on SSH tunnels

### DIFF
--- a/doc/user/content/ingest-data/sql-server/self-hosted.md
+++ b/doc/user/content/ingest-data/sql-server/self-hosted.md
@@ -11,7 +11,7 @@ aliases:
 ---
 
 This page shows you how to stream data from a self-hosted SQL Server database
-to Materialize using the [SQL Server source](/sql/create-source/sql-server/).
+to Materialize using the [SQL Server Source](/sql/create-source/sql-server/).
 
 {{< tip >}}
 {{< guided-tour-blurb-for-ingest-data >}}
@@ -128,6 +128,10 @@ networking configuration, so start by selecting the relevant option.
 {{< tabs >}}
 
 {{< tab "Allow Materialize IPs">}}
+{{% sql-server-direct/ingesting-data/allow-materialize-ips %}}
+{{< /tab >}}
+
+{{< tab "Use an SSH tunnel">}}
 {{% sql-server-direct/ingesting-data/allow-materialize-ips %}}
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/sql-server/self-hosted.md
+++ b/doc/user/content/ingest-data/sql-server/self-hosted.md
@@ -132,7 +132,7 @@ networking configuration, so start by selecting the relevant option.
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
-{{% sql-server-direct/ingesting-data/allow-materialize-ips %}}
+{{% sql-server-direct/ingesting-data/use-ssh-tunnel %}}
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
@@ -37,7 +37,7 @@
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` SQL Server user you already created:
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` SQL Server user [you created](#1-create-a-materialize-user-in-sql-server):
 
     ```mzsql
     CREATE SECRET sql_server_pass AS '<PASSWORD>';

--- a/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
@@ -37,7 +37,7 @@
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` SQL Server user you created [earlier](/sql-server-direct/ingesting-data/enable-cdc):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` SQL Server user you already created:
 
     ```mzsql
     CREATE SECRET sql_server_pass AS '<PASSWORD>';

--- a/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
@@ -1,0 +1,79 @@
+
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
+   command to create an SSH tunnel connection:
+
+    ```mzsql
+    CREATE CONNECTION ssh_connection TO SSH TUNNEL (
+        HOST '<SSH_BASTION_HOST>',
+        PORT <SSH_BASTION_PORT>,
+        USER '<SSH_BASTION_USER>'
+    );
+    ```
+
+    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP address and port of the SSH bastion host you created [earlier](#b-optional-configure-network-security).
+
+    - Replace `<SSH_BASTION_USER>` with the username for the key pair you created for your SSH bastion host.
+
+1. Get Materialize's public keys for the SSH tunnel connection:
+
+    ```mzsql
+    SELECT * FROM mz_ssh_tunnel_connections;
+    ```
+
+1. Log in to your SSH bastion host and add Materialize's public keys to the `authorized_keys` file, for example:
+
+    ```sh
+    # Command for Linux
+    echo "ssh-ed25519 AAAA...76RH materialize" >> ~/.ssh/authorized_keys
+    echo "ssh-ed25519 AAAA...hLYV materialize" >> ~/.ssh/authorized_keys
+    ```
+
+1. Back in the SQL client connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+
+    ```mzsql
+    VALIDATE CONNECTION ssh_connection;
+    ```
+
+    If no validation error is returned, move to the next step.
+
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` SQL Server user you created [earlier](/sql-server-direct/ingesting-data/enable-cdc):
+
+    ```mzsql
+    CREATE SECRET sql_server_pass AS '<PASSWORD>';
+    ```
+
+    For AWS IAM authentication, you must create a connection to AWS.  See the [`CREATE CONNECTION`](/sql/create-connection/#aws) command for details.
+
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+
+    ```mzsql
+    CREATE CONNECTION sql_server_connection TO SQL SERVER (
+    HOST '<host>',
+    SSH TUNNEL ssh_connection
+    );
+    ```
+
+    - Replace `<host>` with your MySQL endpoint.
+
+  AWS IAM authentication is also available, see the [`CREATE CONNECTION`](/sql/create-connection/#mysql)
+  command for details.
+
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your MySQL instance and start ingesting data:
+
+    ```mzsql
+    CREATE SOURCE mz_source
+      FROM SQL SERVER CONNECTION sql_server_connection
+      FOR ALL TABLES;
+    ```
+
+    - By default, the source will be created in the active cluster; to use a
+      different cluster, use the `IN CLUSTER` clause.
+
+    - To ingest data from specific schemas or tables, use the `FOR SCHEMAS
+      (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` options
+      instead of `FOR ALL TABLES`.
+
+    - To handle unsupported data types, use the `TEXT COLUMNS` or `IGNORE
+      COLUMNS` options. Check out the [reference documentation](/sql/create-source/sql-server/#supported-types)
+      for guidance.

--- a/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/sql-server-direct/ingesting-data/use-ssh-tunnel.html
@@ -54,12 +54,9 @@
     );
     ```
 
-    - Replace `<host>` with your MySQL endpoint.
+    - Replace `<host>` with your SQL Server endpoint.
 
-  AWS IAM authentication is also available, see the [`CREATE CONNECTION`](/sql/create-connection/#mysql)
-  command for details.
-
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your MySQL instance and start ingesting data:
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your SQL Server instance and start ingesting data:
 
     ```mzsql
     CREATE SOURCE mz_source


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9409

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
