### PR TITLE
Add feature flag for `compute_fast_path_clusters`

### DIFF
--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -85,6 +85,12 @@ impl PlanInsights {
         humanizer: &dyn ExprHumanizer,
         ctx: Box<PlanInsightsContext>,
     ) {
+        // Warning: This function is currently dangerous, because it does optimizer work
+        // proportional to the number of clusters, and does so on the main coordinator task.
+        // see https://github.com/MaterializeInc/database-issues/issues/9492
+        if !ctx.optimizer_config.features.enable_fast_path_plan_insights {
+            return;
+        }
         let session: Arc<dyn SessionMetadata + Send> = Arc::new(ctx.session);
         let tasks = ctx
             .compute_instances

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -130,6 +130,7 @@ optimizer_feature_flags!({
     enable_less_reduce_in_eqprop: bool,
     // See the feature flag of the same name.
     enable_dequadratic_eqprop_map: bool,
+    enable_fast_path_plan_insights: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4776,6 +4776,7 @@ pub fn unplan_create_cluster(
                 enable_less_reduce_in_eqprop: _,
                 enable_dequadratic_eqprop_map: _,
                 enable_eq_classes_withholding_errors: _,
+                enable_fast_path_plan_insights: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -558,6 +558,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_less_reduce_in_eqprop: Default::default(),
                 enable_dequadratic_eqprop_map: Default::default(),
                 enable_eq_classes_withholding_errors: Default::default(),
+                enable_fast_path_plan_insights: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2221,6 +2221,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_fast_path_plan_insights,
+        desc: "Enables those plan insight notices that help with getting fast path queries. Don't turn on before #9492 is fixed!",
+        default: false,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2243,6 +2249,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
             enable_dequadratic_eqprop_map: vars.enable_dequadratic_eqprop_map(),
             enable_eq_classes_withholding_errors: vars.enable_eq_classes_withholding_errors(),
+            enable_fast_path_plan_insights: vars.enable_fast_path_plan_insights(),
         }
     }
 }

--- a/test/sqllogictest/explain/plan_insights.slt
+++ b/test/sqllogictest/explain/plan_insights.slt
@@ -15,6 +15,107 @@ mode cockroach
 statement ok
 CREATE TABLE t (a int)
 
+# No fast_path_clusters and fast_path_limit when the feature flag is off.
+query T multiline
+EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t
+----
+{
+  "plans": {
+    "raw": {
+      "text": "Get materialize.public.t\n\nTarget cluster: quickstart\n",
+      "json": {
+        "Get": {
+          "id": {
+            "Global": {
+              "User": 1
+            }
+          },
+          "typ": {
+            "column_types": [
+              {
+                "scalar_type": "Int32",
+                "nullable": true
+              }
+            ],
+            "keys": []
+          }
+        }
+      }
+    },
+    "optimized": {
+      "global": {
+        "text": "Explained Query:\n  ReadStorage materialize.public.t\n\nSource materialize.public.t\n\nTarget cluster: quickstart\n",
+        "json": {
+          "plans": [
+            {
+              "id": "Explained Query",
+              "plan": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "typ": {
+                    "column_types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ],
+                    "keys": []
+                  },
+                  "access_strategy": "Persist"
+                }
+              }
+            }
+          ],
+          "sources": [
+            {
+              "id": {
+                "User": 1
+              },
+              "op": null
+            }
+          ]
+        }
+      },
+      "fast_path": {
+        "text": "<unknown>",
+        "json": null
+      }
+    }
+  },
+  "insights": {
+    "imports": {
+      "u1": {
+        "name": {
+          "database": "materialize",
+          "schema": "public",
+          "item": "t"
+        },
+        "type": "storage"
+      }
+    },
+    "fast_path_clusters": {},
+    "fast_path_limit": null,
+    "persist_count": []
+  },
+  "cluster": {
+    "name": "quickstart",
+    "id": {
+      "User": 1
+    }
+  },
+  "redacted_sql": "SELECT * FROM [u1 AS materialize.public.t]"
+}
+EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_fast_path_plan_insights TO true;
+----
+COMPLETE 0
+
 # Assert fast_path_limit is true. This must be done before adding the index.
 query T multiline
 EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t


### PR DESCRIPTION
[As discussed on slack](https://materializeinc.slack.com/archives/C08A62E0751/p1752773251219519?thread_ts=1752669414.112509&cid=C08A62E0751), this PR just adds a feature flag to have a more targeted mitigation for #incident-646. Currently, it's being mitigated by turning off all plan insight notices for the affected user. After the PR, we can turn off only the problematic notices. (In fact, it will be turned off by default for all users, not just the affected user, which is what we want, because the problem might strike other users, albeit with a lower chance, because the affected user has much more clusters than other users.)

(I've opened an issue for properly fixing `compute_fast_path_clusters`, https://github.com/MaterializeInc/database-issues/issues/9492, and have put it in backlog, as agreed on slack.)

cc @SangJunBak, @aljoscha 

### Motivation


### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
