### PR TITLE
doc fix for b/g deployments

### DIFF
--- a/doc/user/content/manage/dbt/blue-green-deployments.md
+++ b/doc/user/content/manage/dbt/blue-green-deployments.md
@@ -42,7 +42,7 @@ If your dbt project includes [sinks](/manage/dbt/get-started/#sinks), you
 Unlike other objects, sinks must not be recreated in the process of a blue/green
 deployment, and must instead cut over to the new definition of their upstream
 dependencies after the environment swap. The schema and cluster for your sinks should be
-included in the dbt_project definition as well. 
+included in the dbt_project definition as well.
 {{</ warning >}}
 
 In a blue/green deployment, you first deploy your code changes to a deployment
@@ -53,9 +53,9 @@ These environments are later swapped transparently.
 <br>
 
 1. In `dbt_project.yml`, use the `deployment` variable to specify the cluster(s)
-   and schema(s) that contain the changes you want to deploy. If you have sinks that 
-   should be altered to point to the new green environment, their schemas and clusters 
-   should be included as well. 
+   and schema(s) that contain the changes you want to deploy. If you have sinks that
+   should be altered to point to the new green environment, their schemas and clusters
+   should be included as well.
 
     ```yaml
     vars:

--- a/doc/user/content/manage/dbt/blue-green-deployments.md
+++ b/doc/user/content/manage/dbt/blue-green-deployments.md
@@ -41,7 +41,8 @@ If your dbt project includes [sinks](/manage/dbt/get-started/#sinks), you
 **must** ensure that these are created in a **dedicated schema and cluster**.
 Unlike other objects, sinks must not be recreated in the process of a blue/green
 deployment, and must instead cut over to the new definition of their upstream
-dependencies after the environment swap.
+dependencies after the environment swap. The schema and cluster for your sinks should be
+included in the dbt_project definition as well. 
 {{</ warning >}}
 
 In a blue/green deployment, you first deploy your code changes to a deployment
@@ -52,7 +53,9 @@ These environments are later swapped transparently.
 <br>
 
 1. In `dbt_project.yml`, use the `deployment` variable to specify the cluster(s)
-   and schema(s) that contain the changes you want to deploy.
+   and schema(s) that contain the changes you want to deploy. If you have sinks that 
+   should be altered to point to the new green environment, their schemas and clusters 
+   should be included as well. 
 
     ```yaml
     vars:


### PR DESCRIPTION
<!--
update b/g deployment docs to include details of how to handle sink schemas and clusters
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
