### PR TITLE
ci: Remove git restore-mtime & mzcompose: Add local cache for docker availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ flake.lock
 
 /src/testdrive/ci/protobuf-bin
 /src/testdrive/ci/protobuf-include
+/known-docker-images.txt

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -234,6 +234,8 @@ case "$cmd" in
             --env BUILDKITE_BRANCH
             --env BUILDKITE_ORGANIZATION_SLUG
             --env BUILDKITE_PULL_REQUEST
+            --env DOCKERHUB_USERNAME
+            --env DOCKERHUB_ACCESS_TOKEN
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -342,11 +342,6 @@ RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linu
     && chmod +x yq \
     && mv yq /usr/local/bin
 
-RUN curl -fsSL https://raw.githubusercontent.com/MestreLion/git-tools/refs/tags/v2022.12/git-restore-mtime > git-restore-mtime \
-  && echo 'c4a276017e29b68b5513b200cc15b717070856470db56d41517386159b333276 git-restore-mtime' |sha256sum --check \
-  && chmod +x git-restore-mtime \
-  && mv git-restore-mtime /usr/local/bin
-
 # Hardcode some known SSH hosts, or else SSH will ask whether the host is
 # trustworthy on the first connection.
 

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -660,7 +660,6 @@ def trim_test_selection_id(pipeline: Any, step_ids_to_run: set[int]) -> None:
                 "build-aarch64",
                 "build-x86_64-lto",
                 "build-aarch64-lto",
-                "build-wasm",
             )
             and not step.get("async")
         ):
@@ -683,7 +682,6 @@ def trim_test_selection_name(pipeline: Any, steps_to_run: set[str]) -> None:
                 "build-aarch64",
                 "build-x86_64-lto",
                 "build-aarch64-lto",
-                "build-wasm",
             )
             and not step.get("async")
         ):

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -63,7 +63,7 @@ steps:
     command: bin/ci-builder run min bin/pyactivate -m ci.mkpipeline $pipeline $@
     priority: 200
     agents:
-      queue: hetzner-x86-64-4cpu-8gb
+      queue: hetzner-x86-64-4cpu-8gb-mkpipeline
     retry:
       automatic:
         - exit_status: -1

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -224,11 +224,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     ],
                 )
             else:
-                try:
-                    spawn.runv(["git", "restore-mtime"])
-                except subprocess.CalledProcessError:
-                    pass  # Used in CI, but don't fail locally
-
                 assert (
                     buildkite.get_parallelism_count() <= 2
                 ), "Special handling of parallelism, only 1 and 2 supported"

--- a/ci/test/check-merge-with-target.sh
+++ b/ci/test/check-merge-with-target.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 
 fetch_pr_target_branch
 merge_pr_target_branch
-bin/ci-builder run stable git restore-mtime || true # Used in CI, but don't fail locally
 
 ci_collapsed_heading "Conduct checks"
 bin/ci-builder run stable cargo check --all-targets

--- a/ci/test/lint-clippy.sh
+++ b/ci/test/lint-clippy.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-git restore-mtime || true # Used in CI, but don't fail locally
 try cargo clippy --all-targets -- -D warnings
 
 try_status_report

--- a/ci/test/lint-doc.sh
+++ b/ci/test/lint-doc.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-git restore-mtime || true # Used in CI, but don't fail locally
 try bin/doc --document-private-items
 
 try bin/ci-closed-issues-detect --changed-lines-only

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -11,5 +11,4 @@
 #
 # lint-fast.sh — fast linters that don't require building any code.
 
-git restore-mtime || true # Used in CI, but don't fail locally
 bin/lint --verbose

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -109,7 +109,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner-x86-64-16cpu-32gb-merge-skew
+          queue: hetzner2-x86-64-16cpu-32gb-merge-skew
         if: "build.pull_request.id != null"
         coverage: skip
         sanitizer: skip
@@ -144,7 +144,7 @@ steps:
         timeout_in_minutes: 20
         agents:
           # TODO: Revert to aarch64 when https://github.com/trufflesecurity/trufflehog/issues/4229 is solved
-          queue: hetzner-x86-64-16cpu-32gb-lint-rustfmt
+          queue: hetzner2-x86-64-16cpu-32gb-lint-rustfmt
         coverage: skip
         sanitizer: skip
 
@@ -159,7 +159,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-x86-64-16cpu-32gb-clippy
+          queue: hetzner2-x86-64-16cpu-32gb-clippy
         coverage: skip
         sanitizer: skip
 
@@ -175,7 +175,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 40
         agents:
-          queue: hetzner-x86-64-16cpu-32gb-doctests
+          queue: hetzner2-x86-64-16cpu-32gb-doctests
         coverage: skip
         sanitizer: skip
 
@@ -237,7 +237,7 @@ steps:
           composition: cargo-test
           ci-builder: stable
     agents:
-      queue: hetzner-x86-64-dedi-32cpu-128gb-cargo-test
+      queue: hetzner2-x86-64-dedi-32cpu-128gb-cargo-test
 
   - id: testdrive
     label: "Testdrive"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -109,7 +109,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 45
         agents:
-          queue: hetzner2-x86-64-16cpu-32gb-merge-skew
+          queue: hetzner-x86-64-16cpu-32gb-merge-skew
         if: "build.pull_request.id != null"
         coverage: skip
         sanitizer: skip
@@ -144,7 +144,7 @@ steps:
         timeout_in_minutes: 20
         agents:
           # TODO: Revert to aarch64 when https://github.com/trufflesecurity/trufflehog/issues/4229 is solved
-          queue: hetzner2-x86-64-16cpu-32gb-lint-rustfmt
+          queue: hetzner-x86-64-16cpu-32gb-lint-rustfmt
         coverage: skip
         sanitizer: skip
 
@@ -159,7 +159,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 40
         agents:
-          queue: hetzner2-x86-64-16cpu-32gb-clippy
+          queue: hetzner-x86-64-16cpu-32gb-clippy
         coverage: skip
         sanitizer: skip
 
@@ -175,7 +175,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 40
         agents:
-          queue: hetzner2-x86-64-16cpu-32gb-doctests
+          queue: hetzner-x86-64-16cpu-32gb-doctests
         coverage: skip
         sanitizer: skip
 
@@ -237,7 +237,7 @@ steps:
           composition: cargo-test
           ci-builder: stable
     agents:
-      queue: hetzner2-x86-64-dedi-32cpu-128gb-cargo-test
+      queue: hetzner-x86-64-dedi-32cpu-128gb-cargo-test
 
   - id: testdrive
     label: "Testdrive"


### PR DESCRIPTION
Works together with https://github.com/MaterializeInc/i2/pull/2699

`git restore-mtime` turned out not to be a sane approach, since cargo seems to only use the modification time and not check hashes at all!
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
