### PR TITLE
Fix key terminology around various Index structs

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1760,7 +1760,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
                     .map(|col_name| col_name.to_string())
                     .collect::<Vec<_>>();
 
-                let (p, _) = mz_expr::permutation_for_arrangement(&index.keys, on_desc.arity());
+                let (p, _) = mz_expr::permutation_for_arrangement(&index.key, on_desc.arity());
 
                 // Init ix_names with unknown column names. Unknown columns are
                 // represented as an empty String and rendered as `#c` by the

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1750,7 +1750,7 @@ impl CatalogState {
         let index = CatalogItem::Index(Index {
             global_id,
             on: log_global_id,
-            keys: log
+            key: log
                 .variant
                 .index_by()
                 .into_iter()

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1613,9 +1613,9 @@ impl CatalogState {
             diff,
         ));
 
-        for (i, key) in index.keys.iter().enumerate() {
+        for (i, key_col) in index.key.iter().enumerate() {
             let on_entry = self.get_entry_by_global_id(&index.on);
-            let nullable = key
+            let nullable = key_col
                 .typ(
                     &on_entry
                         .desc(&self.resolve_full_name(on_entry.name(), on_entry.conn_id()))
@@ -1625,15 +1625,15 @@ impl CatalogState {
                 )
                 .nullable;
             let seq_in_index = u64::cast_from(i + 1);
-            let key_sql = key_sqls
+            let key_col_sql = key_sqls
                 .get(i)
                 .expect("missing sql information for index key")
                 .to_ast_string_simple();
-            let (field_number, expression) = match key {
+            let (field_number, expression) = match key_col {
                 MirScalarExpr::Column(col, _) => {
                     (Datum::UInt64(u64::cast_from(*col + 1)), Datum::Null)
                 }
-                _ => (Datum::Null, Datum::String(&key_sql)),
+                _ => (Datum::Null, Datum::String(&key_col_sql)),
             };
             updates.push(BuiltinTableUpdate::row(
                 &*MZ_INDEX_COLUMNS,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1347,7 +1347,7 @@ impl CatalogState {
                 create_sql: index.create_sql,
                 global_id,
                 on: index.on,
-                keys: index.keys.into(),
+                key: index.key.into(),
                 conn_id: None,
                 resolved_ids,
                 cluster_id: index.cluster_id,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2950,7 +2950,7 @@ impl Coordinator {
                                     let index_plan = optimize::index::Index::new(
                                         entry.name().clone(),
                                         idx.on,
-                                        idx.keys.to_vec(),
+                                        idx.key.to_vec(),
                                     );
                                     let global_mir_plan = optimizer.optimize(index_plan)?;
                                     let optimized_plan = global_mir_plan.df_desc().clone();

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -98,7 +98,7 @@ impl IndexOracle for DataflowBuilder<'_> {
     ) -> Box<dyn Iterator<Item = (GlobalId, &[MirScalarExpr])> + '_> {
         Box::new(
             self.indexes_on(id)
-                .map(|(idx_id, idx)| (idx_id, idx.keys.as_ref())),
+                .map(|(idx_id, idx)| (idx_id, idx.key.as_ref())),
         )
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -344,7 +344,7 @@ impl Coordinator {
                     let _dispatch_guard = explain_ctx.dispatch_guard();
 
                     let index_plan =
-                        optimize::index::Index::new(plan.name.clone(), plan.index.on, plan.index.keys.clone());
+                        optimize::index::Index::new(plan.name.clone(), plan.index.on, plan.index.key.clone());
 
                     // MIR ⇒ MIR optimization (global)
                     let global_mir_plan = optimizer.catch_unwind_optimize(index_plan)?;
@@ -423,7 +423,7 @@ impl Coordinator {
                         plan::Index {
                             create_sql,
                             on,
-                            keys,
+                            key,
                             cluster_id,
                             compaction_window,
                         },
@@ -443,7 +443,7 @@ impl Coordinator {
             item: CatalogItem::Index(Index {
                 create_sql,
                 global_id,
-                keys: keys.into(),
+                key: key.into(),
                 on,
                 conn_id: None,
                 resolved_ids,

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -194,7 +194,7 @@ impl<'a> DataflowBuilder<'a> {
                 for (index_id, idx) in valid_indexes {
                     let index_desc = IndexDesc {
                         on_id: *id,
-                        key: idx.keys.to_vec(),
+                        key: idx.key.to_vec(),
                     };
                     let entry = self.catalog.get_entry(id);
                     let desc = entry

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -89,13 +89,13 @@ impl Optimizer {
 pub struct Index {
     name: QualifiedItemName,
     on: GlobalId,
-    keys: Vec<mz_expr::MirScalarExpr>,
+    key: Vec<mz_expr::MirScalarExpr>,
 }
 
 impl Index {
     /// Construct a new [`Index`]. Arguments are recorded as-is.
-    pub fn new(name: QualifiedItemName, on: GlobalId, keys: Vec<mz_expr::MirScalarExpr>) -> Self {
-        Self { name, on, keys }
+    pub fn new(name: QualifiedItemName, on: GlobalId, key: Vec<mz_expr::MirScalarExpr>) -> Self {
+        Self { name, on, key }
     }
 }
 
@@ -159,7 +159,7 @@ impl Optimize<Index> for Optimizer {
 
         let index_desc = IndexDesc {
             on_id: index.on,
-            key: index.keys.clone(),
+            key: index.key.clone(),
         };
         df_desc.export_index(self.exported_index_id, index_desc, on_desc.typ().clone());
 
@@ -189,7 +189,7 @@ impl Optimize<Index> for Optimizer {
         }
 
         // Emit a notice if we are trying to create an empty index.
-        if index.keys.is_empty() {
+        if index.key.is_empty() {
             df_meta.push_optimizer_notice_dedup(IndexKeyEmpty);
         }
 
@@ -197,11 +197,11 @@ impl Optimize<Index> for Optimizer {
         // currently optimizing.
         for (index_id, idx) in df_builder
             .indexes_on(index.on)
-            .filter(|(_id, idx)| idx.keys.as_ref() == &index.keys)
+            .filter(|(_id, idx)| idx.key.as_ref() == &index.key)
         {
             df_meta.push_optimizer_notice_dedup(IndexAlreadyExists {
                 index_id,
-                index_key: idx.keys.to_vec(),
+                index_key: idx.key.to_vec(),
                 index_on_id: idx.on,
                 exported_index_id: self.exported_index_id,
             });

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1416,8 +1416,8 @@ pub struct Index {
     pub global_id: GlobalId,
     /// The [`GlobalId`] this Index is on.
     pub on: GlobalId,
-    /// Keys of the index.
-    pub keys: Arc<[MirScalarExpr]>,
+    /// The key of the index.
+    pub key: Arc<[MirScalarExpr]>,
     /// If created in the `TEMPORARY` schema, the [`ConnectionId`] for that session.
     pub conn_id: Option<ConnectionId>,
     /// Other catalog objects referenced by this index, e.g. the object we're indexing.
@@ -3272,7 +3272,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
     }
 
     fn index_details(&self) -> Option<(&[MirScalarExpr], GlobalId)> {
-        if let CatalogItem::Index(Index { keys, on, .. }) = self.item() {
+        if let CatalogItem::Index(Index { key: keys, on, .. }) = self.item() {
             Some((keys, *on))
         } else {
             None

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1821,7 +1821,7 @@ pub struct Index {
     pub create_sql: String,
     /// Collection this index is on top of.
     pub on: GlobalId,
-    pub keys: Vec<mz_expr::MirScalarExpr>,
+    pub key: Vec<mz_expr::MirScalarExpr>,
     pub compaction_window: Option<CompactionWindow>,
     pub cluster_id: ClusterId,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3969,7 +3969,7 @@ pub fn plan_create_index(
                 .collect()
         }
     };
-    let keys = query::plan_index_exprs(scx, &on_desc, filled_key_parts.clone())?;
+    let key = query::plan_index_exprs(scx, &on_desc, filled_key_parts.clone())?;
 
     let index_name = if let Some(name) = name {
         QualifiedItemName {
@@ -3987,7 +3987,7 @@ pub fn plan_create_index(
         } else {
             // Use PG schema for automatically naming indexes:
             // `<table>_<_-separated indexed expressions>_idx`
-            let index_name_col_suffix = keys
+            let index_name_col_suffix = key
                 .iter()
                 .map(|k| match k {
                     mz_expr::MirScalarExpr::Column(i, name) => {
@@ -4064,7 +4064,7 @@ pub fn plan_create_index(
         index: Index {
             create_sql,
             on: on.global_id(),
-            keys,
+            key,
             cluster_id,
             compaction_window,
         },


### PR DESCRIPTION
We have decided some time ago that
- "keys" should mean multiple (composite) keys, e.g. a `Vec<Vec<MirScalarExpr>>`;
- "key" should mean one (composite) key, e.g., a `Vec<MirScalarExpr>`;
- "key column", "key part", "key field", "key component" or simply "k" (which Frank uses, and is common in the optimizer) should mean one column of a composite key, e.g., a `MirScalarExpr`.

discussion:
https://materializeinc.slack.com/archives/C02PPB50ZHS/p1676473154162599

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
