### PR TITLE
Eliminate one of the `instance_snapshot` calls from peek sequencing

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -296,9 +296,6 @@ impl Coordinator {
         let optimizer = match copy_to_ctx {
             None => {
                 // Collect optimizer parameters specific to the peek::Optimizer.
-                let compute_instance = self
-                    .instance_snapshot(cluster.id())
-                    .expect("compute instance does not exist");
                 let (_, view_id) = self.allocate_transient_id();
                 let (_, index_id) = self.allocate_transient_id();
 


### PR DESCRIPTION
This is a potentially expensive operation, as it enumerates all collections in the cluster.

The second call, which this PR deletes, should give the same result as the first: The controllers are driven by the coordinator main task, so nothing could have happened in the compute controller between the two calls. (`peek_validate` happens on the main task.)

(Btw. if we really wanted to, we might be able to eliminate also the other `instance_snapshot` call. It has some trivial usages, which just ask for the `instance_id`, and there is only one non-trivial usage: https://github.com/MaterializeInc/materialize/blob/235d12a7d910c486122caa172142e5dfd061d5cf/src/adapter/src/coord/indexes.rs#L89 This seems to be mostly shadowed by the filtering that is inside the `get_indexes_on` call just above it, except that it can happen that multiple objects are added to the catalog at the same time, in which case we can use only those that have been already actually created in the controller. If we could ensure that the creation order in the controller is the same as the GlobalId order, then we could replace the `contains_collection` call with just a check on the ids, similar to the `replan` check.)

### Motivation

  * This PR slightly improves QPS.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
