### PR TITLE
Fix indentation in `peek_optimize`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -14,6 +14,8 @@ use std::sync::Arc;
 use http::Uri;
 use itertools::Either;
 use maplit::btreemap;
+use mz_adapter_types::dyncfgs::PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION;
+use mz_catalog::memory::objects::CatalogItem;
 use mz_compute_types::sinks::ComputeSinkConnection;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
@@ -25,7 +27,6 @@ use mz_repr::{Datum, GlobalId, RowArena, Timestamp};
 use mz_sql::ast::{ExplainStage, Statement};
 use mz_sql::catalog::CatalogCluster;
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
-use mz_catalog::memory::objects::CatalogItem;
 use mz_sql::plan::QueryWhen;
 use mz_sql::plan::{self, HirScalarExpr};
 use mz_sql::session::metadata::SessionMetadata;
@@ -596,35 +597,36 @@ impl Coordinator {
                     let stage = match pipeline_result {
                         Ok(Either::Left(global_lir_plan)) => {
                             let optimizer = optimizer.unwrap_left();
-                        // Enable fast path cluster calculation for slow path plans.
-                        let needs_plan_insights = explain_ctx.needs_plan_insights();
-                        // Disable anything that uses the optimizer if we only want the notice and
-                        // plan optimization took longer than the threshold. This is to prevent a
-                        // situation where optimizing takes a while and there a lots of clusters,
-                        // which would delay peek execution by the product of those.
-                        let opt_limit = mz_adapter_types::dyncfgs::PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION.get(catalog.system_config().dyncfgs());
-                        let target_instance = catalog
-                            .get_cluster(optimizer.cluster_id())
-                            .name
-                            .clone();
-                        let enable_re_optimize =
-                            !(matches!(explain_ctx, ExplainContext::PlanInsightsNotice(_))
-                                && optimizer.duration() > opt_limit);
-                        let insights_ctx = needs_plan_insights.then(|| PlanInsightsContext {
-                            stmt: plan.select.as_deref().map(Clone::clone).map(Statement::Select),
-                            raw_expr: plan.source.clone(),
-                            catalog,
-                            compute_instances,
-                            target_instance,
-                            metrics: optimizer.metrics().clone(),
-                            finishing: optimizer.finishing().clone(),
-                            optimizer_config: optimizer.config().clone(),
-                            session,
-                            timestamp_context,
-                            view_id: optimizer.select_id(),
-                            index_id: optimizer.index_id(),
-                            enable_re_optimize,
-                        }).map(Box::new);
+                            // Enable fast path cluster calculation for slow path plans.
+                            let needs_plan_insights = explain_ctx.needs_plan_insights();
+                            // Disable anything that uses the optimizer if we only want the notice and
+                            // plan optimization took longer than the threshold. This is to prevent a
+                            // situation where optimizing takes a while and there a lots of clusters,
+                            // which would delay peek execution by the product of those.
+                            let opt_limit = PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION
+                                .get(catalog.system_config().dyncfgs());
+                            let target_instance = catalog
+                                .get_cluster(optimizer.cluster_id())
+                                .name
+                                .clone();
+                            let enable_re_optimize =
+                                !(matches!(explain_ctx, ExplainContext::PlanInsightsNotice(_))
+                                    && optimizer.duration() > opt_limit);
+                            let insights_ctx = needs_plan_insights.then(|| PlanInsightsContext {
+                                stmt: plan.select.as_deref().map(Clone::clone).map(Statement::Select),
+                                raw_expr: plan.source.clone(),
+                                catalog,
+                                compute_instances,
+                                target_instance,
+                                metrics: optimizer.metrics().clone(),
+                                finishing: optimizer.finishing().clone(),
+                                optimizer_config: optimizer.config().clone(),
+                                session,
+                                timestamp_context,
+                                view_id: optimizer.select_id(),
+                                index_id: optimizer.index_id(),
+                                enable_re_optimize,
+                            }).map(Box::new);
                             match explain_ctx {
                                 ExplainContext::Plan(explain_ctx) => {
                                     let (_, df_meta, _) = global_lir_plan.unapply();
@@ -724,7 +726,7 @@ impl Coordinator {
                                     df_meta: Default::default(),
                                     explain_ctx,
                                     insights_ctx: None,
-                            })
+                                })
                             } else {
                                 // In regular `EXPLAIN` contexts, immediately retire
                                 // the execution with the error.


### PR DESCRIPTION
It's not clear to me why `cargo fmt` was not fixing this automatically. It might be because of the long line involving `PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION`, but even if I further shorten that line by choosing a shorter name for the `let`, `cargo fmt` still refuses to deal with this.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
