### PR TITLE
Rename `ExprPrepStyle::Index`, because we are using it for MVs and subscribes too

### DIFF
--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -164,7 +164,7 @@ impl Optimize<Index> for Optimizer {
         df_desc.export_index(self.exported_index_id, index_desc, on_desc.typ().clone());
 
         // Prepare expressions in the assembled dataflow.
-        let style = ExprPrepStyle::Index;
+        let style = ExprPrepStyle::Maintained;
         df_desc.visit_children(
             |r| prep_relation_expr(r, style),
             |s| prep_scalar_expr(s, style),

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -274,7 +274,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
         df_desc.export_sink(self.sink_id, sink_description);
 
         // Prepare expressions in the assembled dataflow.
-        let style = ExprPrepStyle::Index;
+        let style = ExprPrepStyle::Maintained;
         df_desc.visit_children(
             |r| prep_relation_expr(r, style),
             |s| prep_scalar_expr(s, style),

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -260,7 +260,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
         };
 
         // Prepare expressions in the assembled dataflow.
-        let style = ExprPrepStyle::Index;
+        let style = ExprPrepStyle::Maintained;
         df_desc.visit_children(
             |r| prep_relation_expr(r, style),
             |s| prep_scalar_expr(s, style),


### PR DESCRIPTION
MVs and subscribes need the same expression preparation as indexes. This PR makes the name cover these as well.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
