### PR TITLE
mz_join: efficient linear scan through times

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -105,6 +105,7 @@ def get_minimal_system_parameters(
         "enable_logical_compaction_window": "true",
         "enable_multi_worker_storage_persist_sink": "true",
         "enable_multi_replica_sources": "true",
+        "enable_mz_join_core_v2": "true",
         "enable_rbac_checks": "true",
         "enable_reduce_mfp_fusion": "true",
         "enable_refresh_every_mvs": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1303,6 +1303,7 @@ class FlipFlagsAction(Action):
             "storage_statistics_retention_duration",
             "enable_ctp_cluster_protocols",
             "enable_paused_cluster_readhold_downgrade",
+            "enable_mz_join_core_v2",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -21,6 +21,14 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
      linear joins.",
 );
 
+/// Whether rendering should use `mz_join_core_v2` rather than DD's `JoinCore::join_core`.
+pub const ENABLE_MZ_JOIN_CORE_V2: Config<bool> = Config::new(
+    "enable_mz_join_core_v2",
+    false,
+    "Whether compute should use `mz_join_core_v2` rather than DD's `JoinCore::join_core` to render \
+     linear joins.",
+);
+
 /// Whether rendering should use the new MV sink correction buffer implementation.
 pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "enable_compute_correction_v2",
@@ -380,6 +388,7 @@ pub const PEEK_STASH_BATCH_SIZE: Config<usize> = Config::new(
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&ENABLE_MZ_JOIN_CORE_V2)
         .add(&ENABLE_CORRECTION_V2)
         .add(&ENABLE_MV_APPEND_SMEARING)
         .add(&ENABLE_TEMPORAL_BUCKETING)

--- a/src/compute/src/render/join.rs
+++ b/src/compute/src/render/join.rs
@@ -14,5 +14,6 @@
 mod delta_join;
 mod linear_join;
 mod mz_join_core;
+mod mz_join_core_v2;
 
 pub use linear_join::LinearJoinSpec;

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -113,8 +113,7 @@ impl LinearJoinSpec {
             + Clone
             + 'static,
         L: FnMut(Tr1::Key<'_>, Tr1::Val<'_>, Tr2::Val<'_>) -> I + 'static,
-        I: IntoIterator,
-        I::Item: Data,
+        I: IntoIterator<Item: Data> + 'static,
     {
         use LinearJoinImpl::*;
 

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -18,7 +18,9 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::{AsCollection, Collection, Data};
-use mz_compute_types::dyncfgs::{ENABLE_MZ_JOIN_CORE, LINEAR_JOIN_YIELDING};
+use mz_compute_types::dyncfgs::{
+    ENABLE_MZ_JOIN_CORE, ENABLE_MZ_JOIN_CORE_V2, LINEAR_JOIN_YIELDING,
+};
 use mz_compute_types::plan::join::JoinClosure;
 use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
 use mz_dyncfg::ConfigSet;
@@ -37,6 +39,7 @@ use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context, ShutdownProbe};
 use crate::render::join::mz_join_core::mz_join_core;
+use crate::render::join::mz_join_core_v2::mz_join_core as mz_join_core_v2;
 use crate::row_spine::{RowRowBuilder, RowRowSpine};
 use crate::typedefs::{MzTimestamp, RowRowAgent, RowRowEnter};
 
@@ -46,6 +49,7 @@ use crate::typedefs::{MzTimestamp, RowRowAgent, RowRowEnter};
 #[derive(Clone, Copy)]
 enum LinearJoinImpl {
     Materialize,
+    MaterializeV2,
     DifferentialDataflow,
 }
 
@@ -73,9 +77,12 @@ impl Default for LinearJoinSpec {
 impl LinearJoinSpec {
     /// Create a `LinearJoinSpec` based on the given config.
     pub fn from_config(config: &ConfigSet) -> Self {
-        let implementation = match ENABLE_MZ_JOIN_CORE.get(config) {
-            true => LinearJoinImpl::Materialize,
-            false => LinearJoinImpl::DifferentialDataflow,
+        let implementation = if ENABLE_MZ_JOIN_CORE_V2.get(config) {
+            LinearJoinImpl::MaterializeV2
+        } else if ENABLE_MZ_JOIN_CORE.get(config) {
+            LinearJoinImpl::Materialize
+        } else {
+            LinearJoinImpl::DifferentialDataflow
         };
 
         let yielding_raw = LINEAR_JOIN_YIELDING.get(config);
@@ -133,6 +140,27 @@ impl LinearJoinSpec {
             (Materialize, None, None) => {
                 let yield_fn = |_start, _work| false;
                 mz_join_core(arranged1, arranged2, shutdown_probe, result, yield_fn).as_collection()
+            }
+            (MaterializeV2, Some(work_limit), Some(time_limit)) => {
+                let yield_fn =
+                    move |start: Instant, work| work >= work_limit || start.elapsed() >= time_limit;
+                mz_join_core_v2(arranged1, arranged2, shutdown_probe, result, yield_fn)
+                    .as_collection()
+            }
+            (MaterializeV2, Some(work_limit), None) => {
+                let yield_fn = move |_start, work| work >= work_limit;
+                mz_join_core_v2(arranged1, arranged2, shutdown_probe, result, yield_fn)
+                    .as_collection()
+            }
+            (MaterializeV2, None, Some(time_limit)) => {
+                let yield_fn = move |start: Instant, _work| start.elapsed() >= time_limit;
+                mz_join_core_v2(arranged1, arranged2, shutdown_probe, result, yield_fn)
+                    .as_collection()
+            }
+            (MaterializeV2, None, None) => {
+                let yield_fn = |_start, _work| false;
+                mz_join_core_v2(arranged1, arranged2, shutdown_probe, result, yield_fn)
+                    .as_collection()
             }
         }
     }

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -13,28 +13,24 @@
 //!
 //!  * Differential's `JoinCore::join_core`
 //!  * A Materialize fork thereof, called `mz_join_core`
+//!  * Another Materialize fork thereof, called `mz_join_core_v2`
 //!
 //! `mz_join_core` exists to solve a responsiveness problem with the DD implementation.
 //! DD's join is only able to yield between keys. When computing a large cross-join or a highly
 //! skewed join, this can result in loss of interactivity when the join operator refuses to yield
 //! control for multiple seconds or longer, which in turn causes degraded user experience.
 //!
-//! `mz_join_core` currently fixes the yielding issue by omitting the merge-join matching strategy
-//! implemented in DD's join implementation. This leaves only the nested loop strategy for which it
+//! `mz_join_core` currently fixes the yielding issue by omitting the linear scan through times
+//! implemented in DD's join implementation. This leaves only the quadratic strategy for which it
 //! is easy to implement yielding within keys.
 //!
-//! While `mz_join_core` retains responsiveness in the face of cross-joins it is also, due to its
-//! sole reliance on nested-loop matching, significantly slower than DD's join for workloads that
-//! have a large amount of edits at different times. We consider these niche workloads for
-//! Materialize today, due to the way source ingestion works, but that might change in the future.
+//! While `mz_join_core` retains responsiveness in the face of cross-joins it is also significantly
+//! slower than DD's join for workloads that have a large amount of edits at different times.
+//! `mz_join_core_v2` resolves this by adding support for the DD join's linear scan through times.
 //!
-//! For the moment, we keep both implementations around, selectable through a feature flag.
-//! We expect `mz_join_core` to be more useful in Materialize today, but being able to fall back to
-//! DD's implementation provides a safety net in case that assumption is wrong.
-//!
-//! In the mid-term, we want to arrive at a single join implementation that is as efficient as DD's
-//! join and as responsive as `mz_join_core`. Whether that means adding merge-join matching to
-//! `mz_join_core` or adding better fueling to DD's join implementation is still TBD.
+//! For the moment, we keep all three implementations around, selectable through feature flags.
+//! Eventually, we hope that `mz_join_core_v2` proves itself sufficiently to become the only join
+//! implementation.
 
 use std::cmp::Ordering;
 use std::collections::VecDeque;

--- a/src/compute/src/render/join/mz_join_core_v2.rs
+++ b/src/compute/src/render/join/mz_join_core_v2.rs
@@ -9,32 +9,24 @@
 
 //! A fork of DD's `JoinCore::join_core`.
 //!
-//! Currently, compute rendering knows two implementations for linear joins:
+//! Currently, compute rendering knows three implementations for linear joins:
 //!
 //!  * Differential's `JoinCore::join_core`
 //!  * A Materialize fork thereof, called `mz_join_core`
+//!  * Another Materialize fork thereof, called `mz_join_core_v2`
 //!
 //! `mz_join_core` exists to solve a responsiveness problem with the DD implementation.
 //! DD's join is only able to yield between keys. When computing a large cross-join or a highly
 //! skewed join, this can result in loss of interactivity when the join operator refuses to yield
 //! control for multiple seconds or longer, which in turn causes degraded user experience.
 //!
-//! `mz_join_core` currently fixes the yielding issue by omitting the merge-join matching strategy
-//! implemented in DD's join implementation. This leaves only the nested loop strategy for which it
-//! is easy to implement yielding within keys.
+//! `mz_join_core` resolves the yielding issue but compromises by being quadratic over the number
+//! of distinct times in the input. `mz_join_core_v2` is an attempt to replace the quadratic
+//! behavior by using a linear scan through times, copied from the DD implementation.
 //!
-//! While `mz_join_core` retains responsiveness in the face of cross-joins it is also, due to its
-//! sole reliance on nested-loop matching, significantly slower than DD's join for workloads that
-//! have a large amount of edits at different times. We consider these niche workloads for
-//! Materialize today, due to the way source ingestion works, but that might change in the future.
-//!
-//! For the moment, we keep both implementations around, selectable through a feature flag.
-//! We expect `mz_join_core` to be more useful in Materialize today, but being able to fall back to
-//! DD's implementation provides a safety net in case that assumption is wrong.
-//!
-//! In the mid-term, we want to arrive at a single join implementation that is as efficient as DD's
-//! join and as responsive as `mz_join_core`. Whether that means adding merge-join matching to
-//! `mz_join_core` or adding better fueling to DD's join implementation is still TBD.
+//! For the moment, we keep all three implementations around, selectable through feature flags.
+//! Eventually, we hope that `mz_join_core_v2` proves itself sufficiently to become the only join
+//! implementation.
 
 use std::cmp::Ordering;
 use std::collections::VecDeque;

--- a/src/compute/src/render/join/mz_join_core_v2.rs
+++ b/src/compute/src/render/join/mz_join_core_v2.rs
@@ -1,0 +1,685 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A fork of DD's `JoinCore::join_core`.
+//!
+//! Currently, compute rendering knows two implementations for linear joins:
+//!
+//!  * Differential's `JoinCore::join_core`
+//!  * A Materialize fork thereof, called `mz_join_core`
+//!
+//! `mz_join_core` exists to solve a responsiveness problem with the DD implementation.
+//! DD's join is only able to yield between keys. When computing a large cross-join or a highly
+//! skewed join, this can result in loss of interactivity when the join operator refuses to yield
+//! control for multiple seconds or longer, which in turn causes degraded user experience.
+//!
+//! `mz_join_core` currently fixes the yielding issue by omitting the merge-join matching strategy
+//! implemented in DD's join implementation. This leaves only the nested loop strategy for which it
+//! is easy to implement yielding within keys.
+//!
+//! While `mz_join_core` retains responsiveness in the face of cross-joins it is also, due to its
+//! sole reliance on nested-loop matching, significantly slower than DD's join for workloads that
+//! have a large amount of edits at different times. We consider these niche workloads for
+//! Materialize today, due to the way source ingestion works, but that might change in the future.
+//!
+//! For the moment, we keep both implementations around, selectable through a feature flag.
+//! We expect `mz_join_core` to be more useful in Materialize today, but being able to fall back to
+//! DD's implementation provides a safety net in case that assumption is wrong.
+//!
+//! In the mid-term, we want to arrive at a single join implementation that is as efficient as DD's
+//! join and as responsive as `mz_join_core`. Whether that means adding merge-join matching to
+//! `mz_join_core` or adding better fueling to DD's join implementation is still TBD.
+
+use std::cmp::Ordering;
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use differential_dataflow::Data;
+use differential_dataflow::consolidation::{consolidate, consolidate_updates};
+use differential_dataflow::difference::Multiply;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::arrangement::Arranged;
+use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
+use mz_repr::Diff;
+use timely::PartialOrder;
+use timely::container::{CapacityContainerBuilder, PushInto, SizableContainer};
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::channels::pushers::Tee;
+use timely::dataflow::channels::pushers::buffer::Session;
+use timely::dataflow::operators::generic::OutputHandleCore;
+use timely::dataflow::operators::{Capability, Operator};
+use timely::dataflow::{Scope, StreamCore};
+use timely::progress::timestamp::Timestamp;
+use tracing::trace;
+
+use crate::render::context::ShutdownProbe;
+
+/// Joins two arranged collections with the same key type.
+///
+/// Each matching pair of records `(key, val1)` and `(key, val2)` are subjected to the `result` function,
+/// which produces something implementing `IntoIterator`, where the output collection will have an entry for
+/// every value returned by the iterator.
+pub(super) fn mz_join_core<G, Tr1, Tr2, L, I, YFn, C>(
+    arranged1: &Arranged<G, Tr1>,
+    arranged2: &Arranged<G, Tr2>,
+    shutdown_probe: ShutdownProbe,
+    mut result: L,
+    yield_fn: YFn,
+) -> StreamCore<G, C>
+where
+    G: Scope,
+    G::Timestamp: Lattice,
+    Tr1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
+    Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
+        + Clone
+        + 'static,
+    L: FnMut(Tr1::Key<'_>, Tr1::Val<'_>, Tr2::Val<'_>) -> I + 'static,
+    I: IntoIterator,
+    I::Item: Data,
+    YFn: Fn(Instant, usize) -> bool + 'static,
+    C: SizableContainer + PushInto<(I::Item, G::Timestamp, Diff)> + Data,
+{
+    let mut trace1 = arranged1.trace.clone();
+    let mut trace2 = arranged2.trace.clone();
+
+    arranged1.stream.binary_frontier(
+        &arranged2.stream,
+        Pipeline,
+        Pipeline,
+        "Join",
+        move |capability, info| {
+            let operator_id = info.global_id;
+
+            // Acquire an activator to reschedule the operator when it has unfinished work.
+            let activator = arranged1.stream.scope().activator_for(info.address);
+
+            // Our initial invariants are that for each trace, physical compaction is less or equal the trace's upper bound.
+            // These invariants ensure that we can reference observed batch frontiers from `_start_upper` onward, as long as
+            // we maintain our physical compaction capabilities appropriately. These assertions are tested as we load up the
+            // initial work for the two traces, and before the operator is constructed.
+
+            // Acknowledged frontier for each input.
+            // These two are used exclusively to track batch boundaries on which we may want/need to call `cursor_through`.
+            // They will drive our physical compaction of each trace, and we want to maintain at all times that each is beyond
+            // the physical compaction frontier of their corresponding trace.
+            // Should we ever *drop* a trace, these are 1. much harder to maintain correctly, but 2. no longer used.
+            use timely::progress::frontier::Antichain;
+            let mut acknowledged1 = Antichain::from_elem(<G::Timestamp>::minimum());
+            let mut acknowledged2 = Antichain::from_elem(<G::Timestamp>::minimum());
+
+            // deferred work of batches from each input.
+            let mut todo1 = VecDeque::new();
+            let mut todo2 = VecDeque::new();
+
+            // We'll unload the initial batches here, to put ourselves in a less non-deterministic state to start.
+            trace1.map_batches(|batch1| {
+                trace!(
+                    operator_id,
+                    input = 1,
+                    lower = ?batch1.lower().elements(),
+                    upper = ?batch1.upper().elements(),
+                    size = batch1.len(),
+                    "pre-loading batch",
+                );
+
+                acknowledged1.clone_from(batch1.upper());
+                // No `todo1` work here, because we haven't accepted anything into `batches2` yet.
+                // It is effectively "empty", because we choose to drain `trace1` before `trace2`.
+                // Once we start streaming batches in, we will need to respond to new batches from
+                // `input1` with logic that would have otherwise been here. Check out the next loop
+                // for the structure.
+            });
+            // At this point, `ack1` should exactly equal `trace1.read_upper()`, as they are both determined by
+            // iterating through batches and capturing the upper bound. This is a great moment to assert that
+            // `trace1`'s physical compaction frontier is before the frontier of completed times in `trace1`.
+            // TODO: in the case that this does not hold, instead "upgrade" the physical compaction frontier.
+            assert!(PartialOrder::less_equal(
+                &trace1.get_physical_compaction(),
+                &acknowledged1.borrow()
+            ));
+
+            trace!(
+                operator_id,
+                input = 1,
+                acknowledged1 = ?acknowledged1.elements(),
+                "pre-loading finished",
+            );
+
+            // We capture batch2 cursors first and establish work second to avoid taking a `RefCell` lock
+            // on both traces at the same time, as they could be the same trace and this would panic.
+            let mut batch2_cursors = Vec::new();
+            trace2.map_batches(|batch2| {
+                trace!(
+                    operator_id,
+                    input = 2,
+                    lower = ?batch2.lower().elements(),
+                    upper = ?batch2.upper().elements(),
+                    size = batch2.len(),
+                    "pre-loading batch",
+                );
+
+                acknowledged2.clone_from(batch2.upper());
+                batch2_cursors.push((batch2.cursor(), batch2.clone()));
+            });
+            // At this point, `ack2` should exactly equal `trace2.read_upper()`, as they are both determined by
+            // iterating through batches and capturing the upper bound. This is a great moment to assert that
+            // `trace2`'s physical compaction frontier is before the frontier of completed times in `trace2`.
+            // TODO: in the case that this does not hold, instead "upgrade" the physical compaction frontier.
+            assert!(PartialOrder::less_equal(
+                &trace2.get_physical_compaction(),
+                &acknowledged2.borrow()
+            ));
+
+            // Load up deferred work using trace2 cursors and batches captured just above.
+            for (batch2_cursor, batch2) in batch2_cursors.into_iter() {
+                trace!(
+                    operator_id,
+                    input = 2,
+                    acknowledged1 = ?acknowledged1.elements(),
+                    "deferring work for batch",
+                );
+
+                // It is safe to ask for `ack1` because we have confirmed it to be in advance of `distinguish_since`.
+                let (trace1_cursor, trace1_storage) =
+                    trace1.cursor_through(acknowledged1.borrow()).unwrap();
+                // We could downgrade the capability here, but doing so is a bit complicated mathematically.
+                // TODO: downgrade the capability by searching out the one time in `batch2.lower()` and not
+                // in `batch2.upper()`. Only necessary for non-empty batches, as empty batches may not have
+                // that property.
+                todo2.push_back(Deferred::new(
+                    trace1_cursor,
+                    trace1_storage,
+                    batch2_cursor,
+                    batch2.clone(),
+                    capability.clone(),
+                ));
+            }
+
+            trace!(
+                operator_id,
+                input = 2,
+                acknowledged2 = ?acknowledged2.elements(),
+                "pre-loading finished",
+            );
+
+            // Droppable handles to shared trace data structures.
+            let mut trace1_option = Some(trace1);
+            let mut trace2_option = Some(trace2);
+
+            move |input1, input2, output| {
+                // If the dataflow is shutting down, discard all existing and future work.
+                if shutdown_probe.in_shutdown() {
+                    trace!(operator_id, "shutting down");
+
+                    // Discard data at the inputs.
+                    input1.for_each(|_cap, _data| ());
+                    input2.for_each(|_cap, _data| ());
+
+                    // Discard queued work.
+                    todo1 = Default::default();
+                    todo2 = Default::default();
+
+                    // Stop holding on to input traces.
+                    trace1_option = None;
+                    trace2_option = None;
+
+                    return;
+                }
+
+                // 1. Consuming input.
+                //
+                // The join computation repeatedly accepts batches of updates from each of its inputs.
+                //
+                // For each accepted batch, it prepares a work-item to join the batch against previously "accepted"
+                // updates from its other input. It is important to track which updates have been accepted, because
+                // we use a shared trace and there may be updates present that are in advance of this accepted bound.
+                //
+                // Batches are accepted: 1. in bulk at start-up (above), 2. as we observe them in the input stream,
+                // and 3. if the trace can confirm a region of empty space directly following our accepted bound.
+                // This last case is a consequence of our inability to transmit empty batches, as they may be formed
+                // in the absence of timely dataflow capabilities.
+
+                // Drain input 1, prepare work.
+                input1.for_each(|capability, data| {
+                    let trace2 = trace2_option
+                        .as_mut()
+                        .expect("we only drop a trace in response to the other input emptying");
+                    let capability = capability.retain();
+                    for batch1 in data.drain(..) {
+                        // Ignore any pre-loaded data.
+                        if PartialOrder::less_equal(&acknowledged1, batch1.lower()) {
+                            trace!(
+                                operator_id,
+                                input = 1,
+                                lower = ?batch1.lower().elements(),
+                                upper = ?batch1.upper().elements(),
+                                size = batch1.len(),
+                                "loading batch",
+                            );
+
+                            if !batch1.is_empty() {
+                                trace!(
+                                    operator_id,
+                                    input = 1,
+                                    acknowledged2 = ?acknowledged2.elements(),
+                                    "deferring work for batch",
+                                );
+
+                                // It is safe to ask for `ack2` as we validated that it was at least `get_physical_compaction()`
+                                // at start-up, and have held back physical compaction ever since.
+                                let (trace2_cursor, trace2_storage) =
+                                    trace2.cursor_through(acknowledged2.borrow()).unwrap();
+                                let batch1_cursor = batch1.cursor();
+                                todo1.push_back(Deferred::new(
+                                    batch1_cursor,
+                                    batch1.clone(),
+                                    trace2_cursor,
+                                    trace2_storage,
+                                    capability.clone(),
+                                ));
+                            }
+
+                            // To update `acknowledged1` we might presume that `batch1.lower` should equal it, but we
+                            // may have skipped over empty batches. Still, the batches are in-order, and we should be
+                            // able to just assume the most recent `batch1.upper`
+                            debug_assert!(PartialOrder::less_equal(&acknowledged1, batch1.upper()));
+                            acknowledged1.clone_from(batch1.upper());
+
+                            trace!(
+                                operator_id,
+                                input = 1,
+                                acknowledged1 = ?acknowledged1.elements(),
+                                "batch acknowledged",
+                            );
+                        }
+                    }
+                });
+
+                // Drain input 2, prepare work.
+                input2.for_each(|capability, data| {
+                    let trace1 = trace1_option
+                        .as_mut()
+                        .expect("we only drop a trace in response to the other input emptying");
+                    let capability = capability.retain();
+                    for batch2 in data.drain(..) {
+                        // Ignore any pre-loaded data.
+                        if PartialOrder::less_equal(&acknowledged2, batch2.lower()) {
+                            trace!(
+                                operator_id,
+                                input = 2,
+                                lower = ?batch2.lower().elements(),
+                                upper = ?batch2.upper().elements(),
+                                size = batch2.len(),
+                                "loading batch",
+                            );
+
+                            if !batch2.is_empty() {
+                                trace!(
+                                    operator_id,
+                                    input = 2,
+                                    acknowledged1 = ?acknowledged1.elements(),
+                                    "deferring work for batch",
+                                );
+
+                                // It is safe to ask for `ack1` as we validated that it was at least `get_physical_compaction()`
+                                // at start-up, and have held back physical compaction ever since.
+                                let (trace1_cursor, trace1_storage) =
+                                    trace1.cursor_through(acknowledged1.borrow()).unwrap();
+                                let batch2_cursor = batch2.cursor();
+                                todo2.push_back(Deferred::new(
+                                    trace1_cursor,
+                                    trace1_storage,
+                                    batch2_cursor,
+                                    batch2.clone(),
+                                    capability.clone(),
+                                ));
+                            }
+
+                            // To update `acknowledged2` we might presume that `batch2.lower` should equal it, but we
+                            // may have skipped over empty batches. Still, the batches are in-order, and we should be
+                            // able to just assume the most recent `batch2.upper`
+                            debug_assert!(PartialOrder::less_equal(&acknowledged2, batch2.upper()));
+                            acknowledged2.clone_from(batch2.upper());
+
+                            trace!(
+                                operator_id,
+                                input = 2,
+                                acknowledged2 = ?acknowledged2.elements(),
+                                "batch acknowledged",
+                            );
+                        }
+                    }
+                });
+
+                // Advance acknowledged frontiers through any empty regions that we may not receive as batches.
+                if let Some(trace1) = trace1_option.as_mut() {
+                    trace!(
+                        operator_id,
+                        input = 1,
+                        acknowledged1 = ?acknowledged1.elements(),
+                        "advancing trace upper",
+                    );
+                    trace1.advance_upper(&mut acknowledged1);
+                }
+                if let Some(trace2) = trace2_option.as_mut() {
+                    trace!(
+                        operator_id,
+                        input = 2,
+                        acknowledged2 = ?acknowledged2.elements(),
+                        "advancing trace upper",
+                    );
+                    trace2.advance_upper(&mut acknowledged2);
+                }
+
+                // 2. Join computation.
+                //
+                // For each of the inputs, we do some amount of work (measured in terms of number
+                // of output records produced). This is meant to yield control to allow downstream
+                // operators to consume and reduce the output, but it it also means to provide some
+                // degree of responsiveness. There is a potential risk here that if we fall behind
+                // then the increasing queues hold back physical compaction of the underlying traces
+                // which results in unintentionally quadratic processing time (each batch of either
+                // input must scan all batches from the other input).
+
+                // Perform some amount of outstanding work.
+                trace!(
+                    operator_id,
+                    input = 1,
+                    work_left = todo1.len(),
+                    "starting work",
+                );
+
+                let start_time = Instant::now();
+                let mut work = 0;
+                while !todo1.is_empty() && !yield_fn(start_time, work) {
+                    todo1.front_mut().unwrap().work(
+                        output,
+                        &mut result,
+                        |w| yield_fn(start_time, w),
+                        &mut work,
+                    );
+                    if !todo1.front().unwrap().work_remains() {
+                        todo1.pop_front();
+                    }
+                }
+
+                trace!(
+                    operator_id,
+                    input = 1,
+                    work_left = todo1.len(),
+                    work_done = work,
+                    elapsed = ?start_time.elapsed(),
+                    "ceasing work",
+                );
+
+                // Perform some amount of outstanding work.
+                trace!(
+                    operator_id,
+                    input = 2,
+                    work_left = todo2.len(),
+                    "starting work",
+                );
+
+                let start_time = Instant::now();
+                let mut work = 0;
+                while !todo2.is_empty() && !yield_fn(start_time, work) {
+                    todo2.front_mut().unwrap().work(
+                        output,
+                        &mut result,
+                        |w| yield_fn(start_time, w),
+                        &mut work,
+                    );
+                    if !todo2.front().unwrap().work_remains() {
+                        todo2.pop_front();
+                    }
+                }
+
+                trace!(
+                    operator_id,
+                    input = 2,
+                    work_left = todo2.len(),
+                    work_done = work,
+                    elapsed = ?start_time.elapsed(),
+                    "ceasing work",
+                );
+
+                // Re-activate operator if work remains.
+                if !todo1.is_empty() || !todo2.is_empty() {
+                    activator.activate();
+                }
+
+                // 3. Trace maintenance.
+                //
+                // Importantly, we use `input.frontier()` here rather than `acknowledged` to track
+                // the progress of an input, because should we ever drop one of the traces we will
+                // lose the ability to extract information from anything other than the input.
+                // For example, if we dropped `trace2` we would not be able to use `advance_upper`
+                // to keep `acknowledged2` up to date wrt empty batches, and would hold back logical
+                // compaction of `trace1`.
+
+                // Maintain `trace1`. Drop if `input2` is empty, or advance based on future needs.
+                if let Some(trace1) = trace1_option.as_mut() {
+                    if input2.frontier().is_empty() {
+                        trace!(operator_id, input = 1, "dropping trace handle");
+                        trace1_option = None;
+                    } else {
+                        trace!(
+                            operator_id,
+                            input = 1,
+                            logical = ?*input2.frontier().frontier(),
+                            physical = ?acknowledged1.elements(),
+                            "advancing trace compaction",
+                        );
+
+                        // Allow `trace1` to compact logically up to the frontier we may yet receive,
+                        // in the opposing input (`input2`). All `input2` times will be beyond this
+                        // frontier, and joined times only need to be accurate when advanced to it.
+                        trace1.set_logical_compaction(input2.frontier().frontier());
+                        // Allow `trace1` to compact physically up to the upper bound of batches we
+                        // have received in its input (`input1`). We will not require a cursor that
+                        // is not beyond this bound.
+                        trace1.set_physical_compaction(acknowledged1.borrow());
+                    }
+                }
+
+                // Maintain `trace2`. Drop if `input1` is empty, or advance based on future needs.
+                if let Some(trace2) = trace2_option.as_mut() {
+                    if input1.frontier().is_empty() {
+                        trace!(operator_id, input = 2, "dropping trace handle");
+                        trace2_option = None;
+                    } else {
+                        trace!(
+                            operator_id,
+                            input = 2,
+                            logical = ?*input1.frontier().frontier(),
+                            physical = ?acknowledged2.elements(),
+                            "advancing trace compaction",
+                        );
+
+                        // Allow `trace2` to compact logically up to the frontier we may yet receive,
+                        // in the opposing input (`input1`). All `input1` times will be beyond this
+                        // frontier, and joined times only need to be accurate when advanced to it.
+                        trace2.set_logical_compaction(input1.frontier().frontier());
+                        // Allow `trace2` to compact physically up to the upper bound of batches we
+                        // have received in its input (`input2`). We will not require a cursor that
+                        // is not beyond this bound.
+                        trace2.set_physical_compaction(acknowledged2.borrow());
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Deferred join computation.
+///
+/// The structure wraps cursors which allow us to play out join computation at whatever rate we like.
+/// This allows us to avoid producing and buffering massive amounts of data, without giving the timely
+/// dataflow system a chance to run operators that can consume and aggregate the data.
+struct Deferred<C1, C2, D>
+where
+    C1: Cursor<Diff = Diff>,
+    C2: for<'a> Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time, Diff = Diff>,
+{
+    cursor1: C1,
+    storage1: C1::Storage,
+    cursor2: C2,
+    storage2: C2::Storage,
+    capability: Capability<C1::Time>,
+    done: bool,
+    temp: Vec<(D, C1::Time, Diff)>,
+}
+
+impl<C1, C2, D> Deferred<C1, C2, D>
+where
+    C1: Cursor<Diff = Diff>,
+    C2: for<'a> Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time, Diff = Diff>,
+    D: Data,
+{
+    fn new(
+        cursor1: C1,
+        storage1: C1::Storage,
+        cursor2: C2,
+        storage2: C2::Storage,
+        capability: Capability<C1::Time>,
+    ) -> Self {
+        Deferred {
+            cursor1,
+            storage1,
+            cursor2,
+            storage2,
+            capability,
+            done: false,
+            temp: Vec::new(),
+        }
+    }
+
+    fn work_remains(&self) -> bool {
+        !self.done
+    }
+
+    /// Process keys until at least `fuel` output tuples produced, or the work is exhausted.
+    fn work<L, I, YFn, C>(
+        &mut self,
+        output: &mut OutputHandleCore<C1::Time, CapacityContainerBuilder<C>, Tee<C1::Time, C>>,
+        mut logic: L,
+        yield_fn: YFn,
+        work: &mut usize,
+    ) where
+        I: IntoIterator<Item = D>,
+        L: FnMut(C1::Key<'_>, C1::Val<'_>, C2::Val<'_>) -> I,
+        YFn: Fn(usize) -> bool,
+        C: SizableContainer + PushInto<(D, C1::Time, Diff)> + Data,
+    {
+        let meet = self.capability.time();
+
+        let mut session = output.session(&self.capability);
+
+        let storage1 = &self.storage1;
+        let storage2 = &self.storage2;
+
+        let cursor1 = &mut self.cursor1;
+        let cursor2 = &mut self.cursor2;
+
+        let temp = &mut self.temp;
+
+        let flush = |data: &mut Vec<_>, session: &mut Session<_, _, _>| {
+            let old_len = data.len();
+            // Consolidating here is important when the join closure produces data that
+            // consolidates well, for example when projecting columns.
+            consolidate_updates(data);
+            let recovered = old_len - data.len();
+            session.give_iterator(data.drain(..));
+            recovered
+        };
+
+        assert_eq!(temp.len(), 0);
+
+        let mut buffer = Vec::default();
+
+        while cursor1.key_valid(storage1) && cursor2.key_valid(storage2) {
+            match cursor1.key(storage1).cmp(&cursor2.key(storage2)) {
+                Ordering::Less => cursor1.seek_key(storage1, cursor2.key(storage2)),
+                Ordering::Greater => cursor2.seek_key(storage2, cursor1.key(storage1)),
+                Ordering::Equal => {
+                    // Populate `temp` with the results, until we should yield.
+                    let key = cursor2.key(storage2);
+                    while let Some(val1) = cursor1.get_val(storage1) {
+                        while let Some(val2) = cursor2.get_val(storage2) {
+                            // Evaluate logic on `key, val1, val2`. Note the absence of time and diff.
+                            let mut result = logic(key, val1, val2).into_iter().peekable();
+
+                            // We can only produce output if the result return something.
+                            if let Some(first) = result.next() {
+                                // Join times.
+                                cursor1.map_times(storage1, |time1, diff1| {
+                                    let mut time1 = C1::owned_time(time1);
+                                    time1.join_assign(meet);
+                                    let diff1 = C1::owned_diff(diff1);
+                                    cursor2.map_times(storage2, |time2, diff2| {
+                                        let mut time2 = C2::owned_time(time2);
+                                        time2.join_assign(&time1);
+                                        let diff = diff1.multiply(&C2::owned_diff(diff2));
+                                        buffer.push((time2, diff));
+                                    });
+                                });
+                                consolidate(&mut buffer);
+
+                                // Special case no results, one result, and potentially many results
+                                match (result.peek().is_some(), buffer.len()) {
+                                    // Certainly no output
+                                    (_, 0) => {}
+                                    // Single element, single time
+                                    (false, 1) => {
+                                        let (time, diff) = buffer.pop().unwrap();
+                                        temp.push((first, time, diff));
+                                    }
+                                    // Multiple elements or multiple times
+                                    (_, _) => {
+                                        for d in std::iter::once(first).chain(result) {
+                                            temp.extend(buffer.iter().map(|(time, diff)| {
+                                                (d.clone(), time.clone(), diff.clone())
+                                            }))
+                                        }
+                                    }
+                                }
+                                buffer.clear();
+                            }
+                            cursor2.step_val(storage2);
+                        }
+                        cursor1.step_val(storage1);
+                        cursor2.rewind_vals(storage2);
+
+                        *work = work.saturating_add(temp.len());
+
+                        if yield_fn(*work) {
+                            // Returning here is only allowed because we leave the cursors in a
+                            // state that will let us pick up the work correctly on the next
+                            // invocation.
+                            *work -= flush(temp, &mut session);
+                            if yield_fn(*work) {
+                                return;
+                            }
+                        }
+                    }
+
+                    cursor1.step_key(storage1);
+                    cursor2.step_key(storage2);
+                }
+            }
+        }
+
+        if !temp.is_empty() {
+            *work -= flush(temp, &mut session);
+        }
+
+        // We only get here after having iterated through all keys.
+        self.done = true;
+    }
+}

--- a/src/compute/src/render/join/mz_join_core_v2.rs
+++ b/src/compute/src/render/join/mz_join_core_v2.rs
@@ -28,8 +28,10 @@
 //! Eventually, we hope that `mz_join_core_v2` proves itself sufficiently to become the only join
 //! implementation.
 
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
+use std::rc::Rc;
 use std::time::Instant;
 
 use differential_dataflow::Data;
@@ -61,7 +63,7 @@ pub(super) fn mz_join_core<G, Tr1, Tr2, L, I, YFn, C>(
     arranged1: &Arranged<G, Tr1>,
     arranged2: &Arranged<G, Tr2>,
     shutdown_probe: ShutdownProbe,
-    mut result: L,
+    result: L,
     yield_fn: YFn,
 ) -> StreamCore<G, C>
 where
@@ -106,8 +108,12 @@ where
             let mut acknowledged2 = Antichain::from_elem(<G::Timestamp>::minimum());
 
             // deferred work of batches from each input.
-            let mut todo1 = VecDeque::new();
-            let mut todo2 = VecDeque::new();
+            let result_fn = Rc::new(RefCell::new(result));
+            let mut todo1 = Work::<<Tr1::Batch as BatchReader>::Cursor, Tr2::Cursor, _, _>::new(
+                Rc::clone(&result_fn),
+            );
+            let mut todo2 =
+                Work::<Tr1::Cursor, <Tr2::Batch as BatchReader>::Cursor, _, _>::new(result_fn);
 
             // We'll unload the initial batches here, to put ourselves in a less non-deterministic state to start.
             trace1.map_batches(|batch1| {
@@ -184,13 +190,13 @@ where
                 // TODO: downgrade the capability by searching out the one time in `batch2.lower()` and not
                 // in `batch2.upper()`. Only necessary for non-empty batches, as empty batches may not have
                 // that property.
-                todo2.push_back(Deferred::new(
+                todo2.push(
                     trace1_cursor,
                     trace1_storage,
                     batch2_cursor,
                     batch2.clone(),
                     capability.clone(),
-                ));
+                );
             }
 
             trace!(
@@ -214,8 +220,8 @@ where
                     input2.for_each(|_cap, _data| ());
 
                     // Discard queued work.
-                    todo1 = Default::default();
-                    todo2 = Default::default();
+                    todo1.discard();
+                    todo2.discard();
 
                     // Stop holding on to input traces.
                     trace1_option = None;
@@ -268,13 +274,13 @@ where
                                 let (trace2_cursor, trace2_storage) =
                                     trace2.cursor_through(acknowledged2.borrow()).unwrap();
                                 let batch1_cursor = batch1.cursor();
-                                todo1.push_back(Deferred::new(
+                                todo1.push(
                                     batch1_cursor,
                                     batch1.clone(),
                                     trace2_cursor,
                                     trace2_storage,
                                     capability.clone(),
-                                ));
+                                );
                             }
 
                             // To update `acknowledged1` we might presume that `batch1.lower` should equal it, but we
@@ -324,13 +330,13 @@ where
                                 let (trace1_cursor, trace1_storage) =
                                     trace1.cursor_through(acknowledged1.borrow()).unwrap();
                                 let batch2_cursor = batch2.cursor();
-                                todo2.push_back(Deferred::new(
+                                todo2.push(
                                     trace1_cursor,
                                     trace1_storage,
                                     batch2_cursor,
                                     batch2.clone(),
                                     capability.clone(),
-                                ));
+                                );
                             }
 
                             // To update `acknowledged2` we might presume that `batch2.lower` should equal it, but we
@@ -379,65 +385,33 @@ where
                 // which results in unintentionally quadratic processing time (each batch of either
                 // input must scan all batches from the other input).
 
-                // Perform some amount of outstanding work.
+                // Perform some amount of outstanding work for input 1.
                 trace!(
                     operator_id,
                     input = 1,
-                    work_left = todo1.len(),
-                    "starting work",
+                    work_left = todo1.remaining(),
+                    "starting work"
                 );
-
-                let start_time = Instant::now();
-                let mut work = 0;
-                while !todo1.is_empty() && !yield_fn(start_time, work) {
-                    todo1.front_mut().unwrap().work(
-                        output,
-                        &mut result,
-                        |w| yield_fn(start_time, w),
-                        &mut work,
-                    );
-                    if !todo1.front().unwrap().work_remains() {
-                        todo1.pop_front();
-                    }
-                }
-
+                todo1.process(output, &yield_fn);
                 trace!(
                     operator_id,
                     input = 1,
-                    work_left = todo1.len(),
-                    work_done = work,
-                    elapsed = ?start_time.elapsed(),
+                    work_left = todo1.remaining(),
                     "ceasing work",
                 );
 
-                // Perform some amount of outstanding work.
+                // Perform some amount of outstanding work for input 2.
                 trace!(
                     operator_id,
                     input = 2,
-                    work_left = todo2.len(),
-                    "starting work",
+                    work_left = todo2.remaining(),
+                    "starting work"
                 );
-
-                let start_time = Instant::now();
-                let mut work = 0;
-                while !todo2.is_empty() && !yield_fn(start_time, work) {
-                    todo2.front_mut().unwrap().work(
-                        output,
-                        &mut result,
-                        |w| yield_fn(start_time, w),
-                        &mut work,
-                    );
-                    if !todo2.front().unwrap().work_remains() {
-                        todo2.pop_front();
-                    }
-                }
-
+                todo2.process(output, &yield_fn);
                 trace!(
                     operator_id,
                     input = 2,
-                    work_left = todo2.len(),
-                    work_done = work,
-                    elapsed = ?start_time.elapsed(),
+                    work_left = todo2.remaining(),
                     "ceasing work",
                 );
 
@@ -509,6 +483,103 @@ where
     )
 }
 
+/// Work collected by the join operator.
+///
+/// The join operator enqueues new work here first, and then processes it at a controlled rate,
+/// potentially yielding control to the Timely runtime in between. This allows it to avoid OOMs,
+/// caused by buffering massive amounts of data at the output, and loss of interactivity.
+///
+/// Collected work can be reduced by calling the `process` method.
+struct Work<C1, C2, D, L>
+where
+    C1: Cursor,
+    C2: Cursor,
+{
+    /// Pending work.
+    todo: VecDeque<Deferred<C1, C2, D>>,
+    /// A function that transforms raw join matches into join results.
+    result_fn: Rc<RefCell<L>>,
+}
+
+impl<C1, C2, D, L, I> Work<C1, C2, D, L>
+where
+    C1: Cursor<Diff = Diff>,
+    C2: for<'a> Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time, Diff = Diff>,
+    D: Data,
+    L: FnMut(C1::Key<'_>, C1::Val<'_>, C2::Val<'_>) -> I,
+    I: IntoIterator<Item = D>,
+{
+    fn new(result_fn: Rc<RefCell<L>>) -> Self {
+        Self {
+            todo: Default::default(),
+            result_fn,
+        }
+    }
+
+    /// Return the amount of remaining work chunks.
+    fn remaining(&self) -> usize {
+        self.todo.len()
+    }
+
+    /// Return whether there is any work pending.
+    fn is_empty(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    /// Append some pending work.
+    fn push(
+        &mut self,
+        cursor1: C1,
+        storage1: C1::Storage,
+        cursor2: C2,
+        storage2: C2::Storage,
+        capability: Capability<C1::Time>,
+    ) {
+        self.todo.push_back(Deferred {
+            cursor1,
+            storage1,
+            cursor2,
+            storage2,
+            capability,
+            done: false,
+            temp: Default::default(),
+        });
+    }
+
+    /// Discard all pending work.
+    fn discard(&mut self) {
+        self.todo = Default::default();
+    }
+
+    /// Process pending work until none is remaining or `yield_fn` requests a yield.
+    fn process<C, YFn>(
+        &mut self,
+        output: &mut OutputHandleCore<C1::Time, CapacityContainerBuilder<C>, Tee<C1::Time, C>>,
+        yield_fn: YFn,
+    ) where
+        C: SizableContainer + PushInto<(D, C1::Time, Diff)> + Data,
+        YFn: Fn(Instant, usize) -> bool,
+    {
+        let start_time = Instant::now();
+        let mut produced = 0;
+
+        while !yield_fn(start_time, produced)
+            && let Some(mut deferred) = self.todo.pop_front()
+        {
+            deferred.work(
+                output,
+                &mut *self.result_fn.borrow_mut(),
+                |w| yield_fn(start_time, w),
+                &mut produced,
+            );
+
+            if !deferred.done {
+                self.todo.push_front(deferred);
+            }
+        }
+    }
+}
+
 /// Deferred join computation.
 ///
 /// The structure wraps cursors which allow us to play out join computation at whatever rate we like.
@@ -516,8 +587,8 @@ where
 /// dataflow system a chance to run operators that can consume and aggregate the data.
 struct Deferred<C1, C2, D>
 where
-    C1: Cursor<Diff = Diff>,
-    C2: for<'a> Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time, Diff = Diff>,
+    C1: Cursor,
+    C2: Cursor,
 {
     cursor1: C1,
     storage1: C1::Storage,
@@ -534,35 +605,13 @@ where
     C2: for<'a> Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time, Diff = Diff>,
     D: Data,
 {
-    fn new(
-        cursor1: C1,
-        storage1: C1::Storage,
-        cursor2: C2,
-        storage2: C2::Storage,
-        capability: Capability<C1::Time>,
-    ) -> Self {
-        Deferred {
-            cursor1,
-            storage1,
-            cursor2,
-            storage2,
-            capability,
-            done: false,
-            temp: Vec::new(),
-        }
-    }
-
-    fn work_remains(&self) -> bool {
-        !self.done
-    }
-
     /// Process keys until at least `fuel` output tuples produced, or the work is exhausted.
     fn work<L, I, YFn, C>(
         &mut self,
         output: &mut OutputHandleCore<C1::Time, CapacityContainerBuilder<C>, Tee<C1::Time, C>>,
         mut logic: L,
         yield_fn: YFn,
-        work: &mut usize,
+        produced: &mut usize,
     ) where
         I: IntoIterator<Item = D>,
         L: FnMut(C1::Key<'_>, C1::Val<'_>, C2::Val<'_>) -> I,
@@ -648,14 +697,14 @@ where
                         cursor1.step_val(storage1);
                         cursor2.rewind_vals(storage2);
 
-                        *work = work.saturating_add(temp.len());
+                        *produced = produced.saturating_add(temp.len());
 
-                        if yield_fn(*work) {
+                        if yield_fn(*produced) {
                             // Returning here is only allowed because we leave the cursors in a
                             // state that will let us pick up the work correctly on the next
                             // invocation.
-                            *work -= flush(temp, &mut session);
-                            if yield_fn(*work) {
+                            *produced -= flush(temp, &mut session);
+                            if yield_fn(*produced) {
                                 return;
                             }
                         }
@@ -668,7 +717,7 @@ where
         }
 
         if !temp.is_empty() {
-            *work -= flush(temp, &mut session);
+            *produced -= flush(temp, &mut session);
         }
 
         // We only get here after having iterated through all keys.


### PR DESCRIPTION
This PR introduces `mz_join_core_v2`, an evolution of `mz_join_core` that's meant to resolve a long-standing performance issue around processing input batches with a large number of distinct times. `mz_join_core`'s match generation is quadratic in the number of distinct times, which often causes dataflows to struggle when they are expected to join collections with deep histories.

DD's join implements a more efficient match generation strategy that's linear in the number of distinct times. The reason `mz_join_core` doesn't employ that too is that `mz_join_core` wants to yield often to ensure responsiveness, which would require keeping self-referential state between operator invocations, a thing that's notoriously difficult to do in Rust.

`mz_join_core_v2` extends `mz_join_core` by DD's the linear scan strategy. It solves the issue of self-referential state by wrapping the match generation logic into an `async fn`, which produces self-referential `Future`s we can store in the operator state. The operator can then poll these futures to advance the pending work, until it determines the need to yield control.

We implement `mz_join_core_v2` as a new join variant, to enable a slow rollout. Once we are confident that it behaves correctly and doesn't cause performance regressions, we can remove `mz_join_core`.

### Motivation

  * This PR implements a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/6777

### Tips for reviewers

The diff is large, but the upper parts of `mz_join_core_v2.rs` can mostly be skipped because they just copy `mz_join_core.rs`. The first commit verbatim copies the latter into the former, so to see what parts actually changed, you can exclude the first commit from the diff.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
