### PR TITLE
Don't run view inlining with `fast_path_optimizer`

### DIFF
--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -325,6 +325,8 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
         // whole optimizer pipeline, but just a tiny subset of it. (But we'll need to run
         // `create_fast_path_plan` later again, because, e.g., running `LiteralConstraints` is still
         // ahead of us.)
+        // Note: One limitation of this is that view inlining hasn't happened yet, hiding some fast
+        // path opportunities.
         let use_fast_path_optimizer = match create_fast_path_plan(
             &mut df_desc,
             self.select_id,

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -48,9 +48,6 @@ pub fn optimize_dataflow(
     transform_ctx: &mut TransformCtx,
     fast_path_optimizer: bool,
 ) -> Result<(), TransformError> {
-    // Inline views that are used in only one other view.
-    inline_views(dataflow)?;
-
     if fast_path_optimizer {
         optimize_dataflow_relations(
             dataflow,
@@ -58,6 +55,9 @@ pub fn optimize_dataflow(
             transform_ctx,
         )?;
     } else {
+        // Inline views that are used in only one other view.
+        inline_views(dataflow)?;
+
         // Logical optimization pass after view inlining
         optimize_dataflow_relations(
             dataflow,

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1414,3 +1414,33 @@ LIMIT 3 OFFSET 1;
 2  l2
 1  a
 1  l1
+
+# Should get fast path after view inlining. (No `fast_path_optimizer` though.)
+statement ok
+CREATE VIEW v1 AS
+SELECT *, a*a FROM t1;
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR
+SELECT *
+FROM v1
+WHERE a = 3;
+----
+Explained Query (fast path):
+  Project (#0{a}, #1{b}, #3)
+    Map (9)
+      ReadIndex on=materialize.public.t1 idx_t1_a=[lookup value=(3)]
+
+Used Indexes:
+  - materialize.public.idx_t1_a (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+query ITI
+SELECT *
+FROM v1
+WHERE a = 3;
+----
+3  l3  9


### PR DESCRIPTION
This moves the `inline_views` call in `optimize_dataflow` into the non-`fast_path_optimizer` branch. The `fast_path_optimizer` bool can only be set if `create_fast_path_plan` already recognized a fast path opportunity before inlining, in which case not inlining is needed.

There should be no behavior change from this, only a slight speedup for fast path queries.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
