### PR TITLE
Speed up builds in CI a bit more

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -182,6 +182,7 @@ case "$cmd" in
             --volume "$(pwd)/target-xcompile:/mnt/build"
             --volume "$(pwd):$(pwd)"
             --workdir "$(pwd)"
+            --env XDG_CACHE_HOME=/mnt/build/cache
             --env AWS_ACCESS_KEY_ID
             --env AWS_DEFAULT_REGION
             --env AWS_SECRET_ACCESS_KEY

--- a/misc/images/jobs/Dockerfile
+++ b/misc/images/jobs/Dockerfile
@@ -9,8 +9,7 @@
 
 MZFROM prod-base
 
-COPY persistcli /usr/local/bin/persistcli
-COPY mz-catalog-debug /usr/local/bin/mz-catalog-debug
+COPY persistcli mz-catalog-debug /usr/local/bin/
 
 # TODO: the intention is for this image to eventually serve as the one-off
 # job launcher for all of materialize, not just for persist. but because of

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -11,13 +11,10 @@ MZFROM ubuntu-base
 
 RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends postgresql-client && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY testdrive /usr/local/bin/
-
 # Install the Protobuf compiler from protobuf-src.
-COPY protobuf-bin /usr/local/bin
+COPY testdrive protobuf-bin /usr/local/bin
 COPY protobuf-include /usr/local/include
 RUN chmod +x /usr/local/bin/protoc
-
 ENV PROTOC /usr/local/bin/protoc
 ENV PROTOC_INCLUDE /usr/local/include
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
