### PR TITLE
adapter/controller: for controller_ready metrics, differentiate between controllers

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -61,7 +61,7 @@ impl Coordinator {
                 span.in_scope(|| otel_ctx.attach_as_parent());
                 self.message_command(cmd).instrument(span).await
             }
-            Message::ControllerReady => {
+            Message::ControllerReady { controller: _ } => {
                 let Coordinator {
                     controller,
                     catalog,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -130,7 +130,7 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
 /// Whether one of the underlying controllers is ready for their `process`
 /// method to be called.
 #[derive(Debug, Default)]
-enum Readiness<T> {
+pub enum Readiness<T> {
     /// No underlying controllers are ready.
     #[default]
     NotReady,
@@ -364,6 +364,11 @@ where
                 }
             }
         }
+    }
+
+    /// Returns the [Readiness] status of this controller.
+    pub fn get_readiness(&self) -> &Readiness<T> {
+        &self.readiness
     }
 
     /// Install a _watch set_ in the controller.


### PR DESCRIPTION
This is so we can attribute better where time on the coordinator main loop is going.