### PR TITLE
test: unflake introspection-sources.td

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -45,18 +45,20 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 > CREATE VIEW vv AS SELECT * FROM t
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 1
 
 > CREATE DEFAULT INDEX ON vv
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 2
 
 > SELECT COUNT(*)
@@ -75,34 +77,38 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 > CREATE MATERIALIZED VIEW mvv AS SELECT * FROM vv
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 3
 
 > DROP MATERIALIZED VIEW mvv
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 2
 
 > DROP INDEX vv_primary_idx
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 1
 
 > DROP MATERIALIZED VIEW mv
 
-> SELECT COUNT(*)
-  FROM (SELECT import_frontiers.export_id, import_frontiers.import_id
-        FROM
-            mz_introspection.mz_compute_import_frontiers AS import_frontiers)
+> SELECT COUNT(*) FROM (
+    SELECT import_frontiers.export_id, import_frontiers.import_id
+    FROM mz_introspection.mz_compute_import_frontiers AS import_frontiers
+    WHERE export_id LIKE 'u%'
+  )
 0
 
 # Test that frontiers of introspection sources advance at all.


### PR DESCRIPTION
Some import frontier queries in that file expected to observe only the import frontiers of dataflows for objects they previously installed, but could also observe the import frontiers of the query dataflows. This is fixed by filtering to non-transient dataflows.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9500

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
