### PR TITLE
docker: Speed up startup of the materialized container

### DIFF
--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -19,21 +19,18 @@ FROM materialize/console:25.2.3 AS console
 
 MZFROM ubuntu-base
 
-RUN groupadd --system --gid=999 materialize \
-    && useradd --system --gid=999 --uid=999 --create-home materialize
-
 ARG CI_SANITIZER=none
 
-RUN apt-get update \
+RUN groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize \
+    && apt-get update \
     && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends \
-        ca-certificates \
         curl \
         gettext-base \
         nginx \
         postgresql \
-        postgresql-contrib \
-        tini \
         ssh \
+        tini \
     && if [ "$CI_SANITIZER" != "none" ]; then \
         TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends llvm; \
        fi \
@@ -57,7 +54,3 @@ RUN MZ_ENDPOINT=http://localhost:6876 \
     && rm /etc/nginx/templates/default.conf.template
 
 USER materialize
-
-RUN pg_ctlcluster 16 main start \
-    && psql -U postgres -c "CREATE ROLE root WITH LOGIN PASSWORD 'root'" \
-    && psql -U postgres -c "CREATE DATABASE root OWNER root"

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -114,6 +114,7 @@ class Materialized(Service):
 
         environment = [
             "MZ_NO_TELEMETRY=1",
+            "MZ_NO_BUILTIN_CONSOLE=1",
             "MZ_TEST_ONLY_DUMMY_SEGMENT_CLIENT=true",
             f"MZ_SOFT_ASSERTIONS={int(soft_assertions)}",
             # The following settings can not be baked in the default image, as they

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -15,6 +15,16 @@ COPY materialized entrypoint.sh /usr/local/bin/
 USER root
 RUN ln -s /usr/local/bin/materialized /usr/local/bin/environmentd \
   && ln -s /usr/local/bin/materialized /usr/local/bin/clusterd
+
 USER materialize
+
+RUN bash -c '\
+  set -euo pipefail; \
+  tini -- entrypoint.sh & \
+  tini_pid=$!; \
+  until curl -sf localhost:6878/api/readyz; do sleep 0.1; done; \
+  kill -TERM "$tini_pid"; \
+  wait "$tini_pid" || true; \
+  pg_ctlcluster 16 main stop --mode=fast --force'
 
 ENTRYPOINT ["tini", "--", "entrypoint.sh"]

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -430,7 +430,7 @@ SHOW optimizer_oneshot_stats_timeout;
 COMPLETE 1
 
 statement ok
-SELECT mz_unsafe.mz_sleep(2)
+SELECT mz_unsafe.mz_sleep(3)
 
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(join implementations, humanized expressions) AS VERBOSE TEXT FOR SELECT * FROM t JOIN t2 ON t.x = t2.x JOIN t3 ON t.x = t3.x JOIN t4 ON t.x = t4.x JOIN t5 ON t.x = t5.x JOIN t6 ON t.x = t6.x JOIN t7 ON t.x = t7.x JOIN t8 ON t.x = t8.x JOIN t9 ON t.x = t9.x JOIN t10 ON t.x = t10.x;


### PR DESCRIPTION
Local run with `bin/mzcompose --find testdrive down && bin/mzcompose --find testdrive run default`. Before:
```
 ✔ Container testdrive-materialized-1          Healthy    61.3s
```
With this PR
```
 ✔ Container testdrive-materialized-1          Healthy    10.7s
```
Another example: `bin/mzcompose --find balancerd down && bin/mzcompose --find balancerd run default`. Before:
```
✔ Container balancerd-materialized-1   Healthy  39.6s
```
After:
```
✔ Container balancerd-materialized-1   Healthy   5.6s
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
