### PR TITLE
Disabling rbac checks for console tests 

### DIFF
--- a/test/console/mzcompose.py
+++ b/test/console/mzcompose.py
@@ -19,7 +19,7 @@ SERVICES = [
     Postgres(),
     MySql(),
     Testdrive(),
-    Materialized(),
+    Materialized(system_parameter_defaults={"enable_rbac_checks": "false"}),
 ]
 
 


### PR DESCRIPTION

This PR disables rbac checks for the console test drive so we don't see these permission errors when testing sql queries in the console PR infrastructure
<img width="2662" height="934" alt="image" src="https://github.com/user-attachments/assets/ea63ada8-b446-4fb3-95e6-9874ea6e3f7f" />

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
