### PR TITLE
Add tests for `coalesce`'s error semantics

### DIFF
--- a/test/sqllogictest/error_semantics.slt
+++ b/test/sqllogictest/error_semantics.slt
@@ -1,0 +1,95 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This file is for error semantics and evaluation order/short-circuiting, see
+# https://github.com/MaterializeInc/database-issues/issues/4972
+#
+
+########################################################################################################################
+# NOTE: THESE EXPECTED RESULTS ARE NOT SET IN STONE! The results, together with occasional comments above them, are our
+# current best guess of what our error semantics will be, but it's ok to change this for now as we learn more.
+########################################################################################################################
+
+statement ok
+create table test (a int, b int);
+
+statement ok
+insert into test values (1, 0);
+
+query I
+select coalesce(a, 1/b) from test;
+----
+1
+
+# Postgres errors on it, which we consider to be a bug in Postgres, because Postgres' coalesce docs say it should
+# short-circuit: https://www.postgresql.org/docs/current/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL
+query I
+select coalesce(a, 1/0) from test;
+----
+1
+
+query I
+select coalesce(a, 1/b) from test where b = 0;
+----
+1
+
+query I
+select coalesce(7, 1/b) from test;
+----
+7
+
+query I
+select coalesce(7, 1/0) from test;
+----
+7
+
+statement ok
+create table test_nonnull (a int not null, b int);
+
+statement ok
+insert into test_nonnull values (1, 0);
+
+query I
+select coalesce(a, 1/b) from test_nonnull;
+----
+1
+
+# Postgres errors, which we consider to be a bug in Postgres
+query I
+select coalesce(a, 1/0) from test_nonnull;
+----
+1
+
+query I
+select coalesce(a, 1/b) from test_nonnull where b = 0;
+----
+1
+
+query I
+select coalesce(7, 1/b) from test_nonnull;
+----
+7
+
+query I
+select coalesce(7, 1/0) from test_nonnull;
+----
+7
+
+# MFP CSE, see https://github.com/MaterializeInc/materialize/pull/33109
+query I
+select coalesce(a, a/b + 1, a/b + 2) from test;
+----
+1
+
+# The following two results are probably wrong (but depends on what error semantics we agree on later).
+query error db error: ERROR: Evaluation error: division by zero
+select coalesce(a, (select a/b from test)) from test;
+
+query error db error: ERROR: Evaluation error: division by zero
+select *, case when a = 5 then (select a/b from test) else 7 end from test;

--- a/test/sqllogictest/planning_errors.slt
+++ b/test/sqllogictest/planning_errors.slt
@@ -7,8 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# This file is for SQL planning errors only. Parse errors should live in the
-# sql-parser test suite!
+# This file is for SQL planning errors only.
+# - Parse errors should live in the sql-parser test suite!
+# - Error semantics issues due to evaluation order live in `error_semantics.slt`
 
 query error VALUES expression in FROM clause must be surrounded by parentheses
 SELECT * FROM VALUES (1)


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/33103 and https://github.com/MaterializeInc/materialize/pull/33109, adding tests that show the current behavior.

Note that these tests are not meant to set the current behavior in stone. They are just there to
- let us know if our behavior changes (although we might easily accept changes to it, but it's still better to know about them than to not know about them).
- These tests (together with their comments) are my best guess of what the error semantics specification will mandate for these queries, so writing them down in tests might help in working towards a specification.

(We can incrementally add more tests in this file while we work on error semantics.)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
