### PR TITLE
optimizer: add flagged off term graph

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,6 @@
+- use smallvec 3
+- algorithm is basically just 
+- hash conjing key the op by the hash of the operands
+- the overall process:
+  - reduce
+  - 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3461,7 +3461,7 @@ mod tests {
                         // Check that `MirScalarExpr::reduce` yields the same result
                         // as the real evaluation.
                         let mut reduced = mir.clone();
-                        reduced.reduce(&[]);
+                        reduced.reduce(&[], false);
                         match reduced {
                             MirScalarExpr::Literal(reduce_result, ctyp) => {
                                 match reduce_result {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -85,7 +85,7 @@ pub fn canonicalize_equivalences<'a, I>(
                         expressions_rewritten = true;
                     }
                 });
-                popped_expr.reduce(&column_types);
+                popped_expr.reduce(&column_types, false);
                 new_equivalence.push((rank_complexity(&popped_expr), popped_expr));
             }
             new_equivalence.sort();
@@ -223,7 +223,9 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types
     );
 
     // 1) Reduce each individual predicate.
-    predicates.iter_mut().for_each(|p| p.reduce(column_types));
+    predicates
+        .iter_mut()
+        .for_each(|p| p.reduce(column_types, false));
 
     // 2) Split "A and B" into two predicates: "A" and "B"
     // Relies on the `reduce` above having flattened nested ANDs.
@@ -431,7 +433,7 @@ fn replace_subexpr_and_reduce(
         },
     );
     if changed {
-        predicate.reduce(column_types);
+        predicate.reduce(column_types, false);
     }
     changed
 }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2539,7 +2539,7 @@ mod term_graph {
             done.pop().unwrap()
         }
 
-        pub fn reduce(&mut self) {}
+        pub fn reduce(&self) {}
     }
 }
 
@@ -3595,7 +3595,7 @@ mod tests {
 
         for tc in test_cases {
             let mut actual = tc.input.clone();
-            actual.reduce(&relation_type);
+            actual.reduce(&relation_type, false);
             assert!(
                 actual == tc.output,
                 "input: {}\nactual: {}\nexpected: {}",

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -24,7 +24,7 @@ mod test {
         let mut scalar: MirScalarExpr = deserialize(&mut input_stream, "MirScalarExpr", &mut ctx)?;
         let typ: Vec<ColumnType> = deserialize(&mut input_stream, "Vec<ColumnType> ", &mut ctx)?;
         let before = scalar.typ(&typ);
-        scalar.reduce(&typ);
+        scalar.reduce(&typ, false);
         let after = scalar.typ(&typ);
         // Verify that `reduce` did not change the type of the scalar.
         if before.scalar_type != after.scalar_type {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1541,7 +1541,7 @@ impl WebhookValidation {
         let reduce_task = mz_ore::task::spawn_blocking(
             || "webhook-validation-reduce",
             move || {
-                expression_.reduce(&desc_.typ().column_types);
+                expression_.reduce(&desc_.typ().column_types, false);
                 expression_
             },
         );

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -3454,7 +3454,7 @@ impl HirScalarExpr {
     /// - a window function call
     fn simplify_to_literal(self) -> Option<Row> {
         let mut expr = self.lower_uncorrelated().ok()?;
-        expr.reduce(&[]);
+        expr.reduce(&[], false);
         match expr {
             mz_expr::MirScalarExpr::Literal(Ok(row), _) => Some(row),
             _ => None,
@@ -3477,7 +3477,7 @@ impl HirScalarExpr {
         let mut expr = self.lower_uncorrelated().map_err(|err| {
             PlanError::ConstantExpressionSimplificationFailed(err.to_string_with_causes())
         })?;
-        expr.reduce(&[]);
+        expr.reduce(&[], false);
         match expr {
             mz_expr::MirScalarExpr::Literal(Ok(row), _) => Ok(row),
             mz_expr::MirScalarExpr::Literal(Err(err), _) => Err(

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1389,7 +1389,7 @@ pub fn plan_index_exprs<'a>(
         transform_ast::transform(scx, &mut expr)?;
         let expr = plan_expr_or_col_index(ecx, &expr)?;
         let mut expr = expr.lower_uncorrelated()?;
-        expr.reduce(&on_desc.typ().column_types);
+        expr.reduce(&on_desc.typ().column_types, false);
         out.push(expr);
     }
     Ok(out)

--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -848,7 +848,7 @@ impl EquivalenceClasses {
                 self.remap.reduce_child(expr);
                 if let Some(columns) = columns {
                     let orig_expr = expr.clone();
-                    expr.reduce(columns);
+                    expr.reduce(columns, false);
                     if expr.contains_err() {
                         // Rollback to the original expression if it contains an error.
                         *expr = orig_expr;

--- a/src/transform/src/canonicalization.rs
+++ b/src/transform/src/canonicalization.rs
@@ -75,7 +75,7 @@ impl crate::Transform for ReduceScalars {
                         .as_ref()
                         .unwrap();
                     for predicate in predicates.iter_mut() {
-                        predicate.reduce(input_type);
+                        predicate.reduce(input_type, false);
                     }
                     predicates.retain(|p| !p.is_literal_true());
                 }
@@ -87,7 +87,7 @@ impl crate::Transform for ReduceScalars {
                         .as_ref()
                         .unwrap();
                     for expr in exprs.iter_mut() {
-                        expr.reduce(input_type);
+                        expr.reduce(input_type, false);
                     }
                 }
                 MirRelationExpr::Map { scalars, .. } => {
@@ -99,7 +99,7 @@ impl crate::Transform for ReduceScalars {
                         .unwrap();
                     let input_arity = output_type.len() - scalars.len();
                     for (index, scalar) in scalars.iter_mut().enumerate() {
-                        scalar.reduce(&output_type[..input_arity + index]);
+                        scalar.reduce(&output_type[..input_arity + index], false);
                     }
                 }
                 MirRelationExpr::Join { equivalences, .. } => {
@@ -119,7 +119,7 @@ impl crate::Transform for ReduceScalars {
 
                     for class in equivalences.iter_mut() {
                         for expr in class.iter_mut() {
-                            expr.reduce(&input_types[..]);
+                            expr.reduce(&input_types[..], false);
                         }
                         class.sort();
                         class.dedup();
@@ -140,10 +140,10 @@ impl crate::Transform for ReduceScalars {
                         .as_ref()
                         .unwrap();
                     for key in group_key.iter_mut() {
-                        key.reduce(input_type);
+                        key.reduce(input_type, false);
                     }
                     for aggregate in aggregates.iter_mut() {
-                        aggregate.expr.reduce(input_type);
+                        aggregate.expr.reduce(input_type, false);
                     }
                 }
                 MirRelationExpr::TopK { limit, .. } => {
@@ -154,7 +154,7 @@ impl crate::Transform for ReduceScalars {
                         .as_ref()
                         .unwrap();
                     if let Some(limit) = limit {
-                        limit.reduce(input_type);
+                        limit.reduce(input_type, false);
                     }
                 }
             }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -805,7 +805,7 @@ fn optimize(
                 MirScalarExpr::CallUnary { func, expr: _ } => {
                     let knowledge = knowledge_stack.pop().unwrap();
                     if matches!(&knowledge, DatumKnowledge::Lit { .. }) {
-                        e.reduce(column_types);
+                        e.reduce(column_types, false);
                     } else if func == &UnaryFunc::IsNull(func::IsNull) && !knowledge.nullable() {
                         *e = MirScalarExpr::literal_false();
                     };
@@ -822,7 +822,7 @@ fn optimize(
                         matches!(knowledge1, DatumKnowledge::Lit { .. }),
                         matches!(knowledge2, DatumKnowledge::Lit { .. }),
                     ] {
-                        e.reduce(column_types);
+                        e.reduce(column_types, false);
                     }
                     DatumKnowledge::from(&*e)
                 }
@@ -833,7 +833,7 @@ fn optimize(
                         .drain(knowledge_stack.len() - exprs.len()..)
                         .any(|k| matches!(k, DatumKnowledge::Lit { .. }))
                     {
-                        e.reduce(column_types);
+                        e.reduce(column_types, false);
                     }
                     DatumKnowledge::from(&*e)
                 }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -283,7 +283,7 @@ impl EquivalencePropagation {
                         };
                         let changed = reducer.reduce_expr(expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(&input_types[..(input_arity + index)]);
+                            expr.reduce(&input_types[..(input_arity + index)], false);
                         }
                         if !ctx.features.enable_dequadratic_eqprop_map {
                             // Unfortunately, we had to stop doing the following, because it
@@ -338,7 +338,7 @@ impl EquivalencePropagation {
                     for expr in exprs.iter_mut() {
                         let changed = reducer.reduce_expr(expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types.as_ref().unwrap());
+                            expr.reduce(input_types.as_ref().unwrap(), false);
                         }
                     }
                     let input_arity = *derived
@@ -372,7 +372,7 @@ impl EquivalencePropagation {
                     for expr in predicates.iter_mut() {
                         let changed = reducer.reduce_expr(expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types.as_ref().unwrap());
+                            expr.reduce(input_types.as_ref().unwrap(), false);
                         }
                     }
                     // Incorporate `predicates` into `outer_equivalences`.
@@ -480,7 +480,7 @@ impl EquivalencePropagation {
                             let changed = reducer.reduce_expr(expr);
                             let acceptable_sub = literal_domination(&old, expr);
                             if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                                expr.reduce(input_types.as_ref().unwrap());
+                                expr.reduce(input_types.as_ref().unwrap(), false);
                             }
                             if !acceptable_sub && !literal_domination(&old, expr)
                                 || expr.contains_err()
@@ -566,7 +566,7 @@ impl EquivalencePropagation {
                         let changed = reducer.reduce_expr(key);
                         let acceptable_sub = literal_domination(&old_key, key);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            key.reduce(input_type.as_ref().unwrap());
+                            key.reduce(input_type.as_ref().unwrap(), false);
                         }
                         if !acceptable_sub && !literal_domination(&old_key, key) {
                             key.clone_from(&old_key);
@@ -575,7 +575,7 @@ impl EquivalencePropagation {
                     for aggr in aggregates.iter_mut() {
                         let changed = reducer.reduce_expr(&mut aggr.expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            aggr.expr.reduce(input_type.as_ref().unwrap());
+                            aggr.expr.reduce(input_type.as_ref().unwrap(), false);
                         }
                         // A count expression over a non-null expression can discard the expression.
                         if aggr.func == mz_expr::AggregateFunc::Count && !aggr.distinct {
@@ -639,7 +639,7 @@ impl EquivalencePropagation {
                         let changed = reducer.reduce_expr(expr);
                         let acceptable_sub = literal_domination(&old_expr, expr);
                         if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types.as_ref().unwrap());
+                            expr.reduce(input_types.as_ref().unwrap(), false);
                         }
                         if !acceptable_sub && !literal_domination(&old_expr, expr) {
                             expr.clone_from(&old_expr);

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -163,7 +163,7 @@ impl PredicatePushdown {
                     // whether they are literal errors before working with them.
                     let input_type = input.typ();
                     for predicate in predicates.iter_mut() {
-                        predicate.reduce(&input_type.column_types);
+                        predicate.reduce(&input_type.column_types, false);
                     }
 
                     // It can be helpful to know if there are any non-literal errors,
@@ -1201,7 +1201,7 @@ impl PredicatePushdown {
         mut s: MirScalarExpr,
         column_types: &[ColumnType],
     ) -> Vec<MirScalarExpr> {
-        s.reduce(column_types);
+        s.reduce(column_types, false);
 
         if let MirScalarExpr::CallVariadic {
             func: VariadicFunc::And,


### PR DESCRIPTION
https://www.notion.so/materialize/Notes-Equivalence-Relations-for-MSE-reduce-22b13f48d37b80658786d05a993307ed?source=copy_link#22b13f48d37b807ca4b9dd0c9ce495cc

this was all taken from: https://github.com/MaterializeInc/materialize/pull/32963

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
