### PR TITLE
Add webhook sources to the list of unretryable commands

### DIFF
--- a/src/persist/src/azure.rs
+++ b/src/persist/src/azure.rs
@@ -208,8 +208,11 @@ impl AzureBlob {
             // TODO: we could move this logic into the test harness.
             // it's currently here because it's surprisingly annoying to
             // create the container out-of-band
-            if let Err(e) = config.client.create().await {
-                warn!("Failed to create container: {e}");
+            if let Err(error) = config.client.create().await {
+                info!(
+                    ?error,
+                    "failed to create emulator container; this is expected on repeat runs"
+                );
             }
         }
 

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -61,6 +61,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFl
         | CreateDatabase(_)
         | CreateSchema(_)
         | CreateSource(_)
+        | CreateWebhookSource(_)
         | CreateSink(_)
         | CreateMaterializedView(_)
         | CreateView(_)


### PR DESCRIPTION
And make a warning when re-creating the emulator container less scary.

### Motivation

https://github.com/MaterializeInc/database-issues/issues/9503