### PR TITLE
ci: Use incremental cached Cargo builder instead of Bazel for test pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ debug = 2
 [profile.optimized]
 inherits = "release"
 lto = "off"
-debug = false
+debug = 1
 incremental = true
 
 # IMPORTANT: when patching a dependency, you should only depend on "main",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -28,7 +28,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: l-builder-linux-x86_64
+          queue: builder-linux-x86_64
 
       - id: build-aarch64
         label: ":bazel: Build aarch64"
@@ -39,7 +39,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: l-builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
 
       - id: build-x86_64-asan
         label: ":bazel: Build x86_64 (ASan)"
@@ -50,7 +50,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: l-builder-linux-x86_64
+          queue: builder-linux-x86_64
         env:
           CI_SANITIZER: address
         sanitizer: skip
@@ -65,7 +65,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 60
         agents:
-          queue: l-builder-linux-aarch64
+          queue: builder-linux-aarch64-mem
         env:
           CI_SANITIZER: address
         sanitizer: skip

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -15,11 +15,9 @@
 dag: true
 
 env:
-  CI_BAZEL_BUILD: 1
+  CI_BAZEL_BUILD: 0
   CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
-  # Note: In .cargo/config we set the default build jobs to -1 so on developer machines we keep
-  # a single core open when compiling. But we want to use all of CI's resources, hence setting the
-  # build jobs to "default" which will use all cores.
+  CI_BAZEL_LTO: 0
   CARGO_BUILD_JOBS: "default"
 
 # When resources are constrained, run early since this might be blocking a PR from merging
@@ -30,9 +28,9 @@ steps:
     key: builds
     steps:
       - id: build-x86_64
-        label: ":bazel: Build x86_64"
+        label: ":rust: Build x86_64"
         env:
-        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
         inputs:
           - "*"
         artifact_paths: bazel-explain.log
@@ -42,9 +40,9 @@ steps:
           queue: l-builder-linux-x86_64
 
       - id: build-aarch64
-        label: ":bazel: Build aarch64"
+        label: ":rust: Build aarch64"
         env:
-        command: bin/ci-builder run min bin/pyactivate -m ci.test.build
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
         inputs:
           - "*"
         artifact_paths: bazel-explain.log

--- a/src/balancerd/ci/mzbuild.yml
+++ b/src/balancerd/ci/mzbuild.yml
@@ -11,6 +11,6 @@ name: balancerd
 description: Ingress balancer.
 pre-image:
   - type: cargo-build
-    bin: [balancerd]
+    bin: balancerd
     bazel-bin: "@//src/balancerd:balancerd"
     split_debuginfo: true


### PR DESCRIPTION
Much faster incremental recompilation: 45s vs 4min with Bazel (doesn't support incremental)

Example run: https://buildkite.com/materialize/test/builds/106761 incremental build + tests in 8 min total:
<img width="1667" height="175" alt="Screenshot 2025-07-23 at 19 54 57" src="https://github.com/user-attachments/assets/6f31a975-c8db-4f68-b20d-4ccc408e3918" />
Larger build with tests in 11 min: https://buildkite.com/materialize/test/builds/106768
Builds for actual releases are still switched over to Bazel + LTO, example build: https://buildkite.com/materialize/test/builds/106769

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
