### PR TITLE
Correctly bundle py files into build

### DIFF
--- a/misc/mcp-materialize/pyproject.toml
+++ b/misc/mcp-materialize/pyproject.toml
@@ -15,7 +15,7 @@
 
 [project]
 name = "mcp-materialize"
-version = "0.3.0"
+version = "0.3.1"
 description = "A server that exposes Materialize indexes as tools over the Model Context Protocol (MCP)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -46,9 +46,6 @@ build-backend = "hatchling.build"
 packages = ["mcp_materialize"]
 
 [tool.hatch.build]
-include = [
-    "mcp_materialize/sql/*.sql"
-]
 
 [dependency-groups]
 dev = [

--- a/misc/mcp-materialize/uv.lock
+++ b/misc/mcp-materialize/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "mcp-materialize"
-version = "0.2.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION

### Motivation

The build script mistankenly only included the SQL file and so no python files were being uploaded to pypi. Manually verified this has been resolved. Not really sure how to test for this going forward, but the build script really shouldn't be modified that often. 

```
mcp_materialize-0.3.1/Dockerfile
mcp_materialize-0.3.1/mzbuild.yml
mcp_materialize-0.3.1/mzcompose
mcp_materialize-0.3.1/mzcompose.py
mcp_materialize-0.3.1/uv.lock
mcp_materialize-0.3.1/.idea/workspace.xml
mcp_materialize-0.3.1/mcp_materialize/__init__.py
mcp_materialize-0.3.1/mcp_materialize/config.py
mcp_materialize-0.3.1/mcp_materialize/mz_client.py
mcp_materialize-0.3.1/mcp_materialize/transports.py
mcp_materialize-0.3.1/mcp_materialize/sql/tools.sql
mcp_materialize-0.3.1/tests/integration/test_mcp.py
mcp_materialize-0.3.1/.gitignore
mcp_materialize-0.3.1/README.md
mcp_materialize-0.3.1/pyproject.toml
mcp_materialize-0.3.1/PKG-INFO
```

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
