### PR TITLE
allow overriding individual helm chart values

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -49,6 +49,7 @@ def main():
     parser_run.add_argument("--dev", action="store_true")
     parser_run.add_argument("--namespace", default="materialize")
     parser_run.add_argument("--values")
+    parser_run.add_argument("--set", action="append")
     parser_run.set_defaults(func=run)
 
     parser_reset = subparsers.add_parser("reset")
@@ -106,6 +107,8 @@ def run(args: argparse.Namespace):
     ]
     if args.values is not None:
         helm_args.extend(["--values", args.values])
+    if args.set is not None:
+        helm_args.extend([f"--set={v}" for v in args.set])
     subprocess.check_call(helm_args)
 
 


### PR DESCRIPTION
### Motivation

make it a bit easier to override things without needing to create an entirely separate values file

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
