### PR TITLE
Docs - remove references to DROP SUBSOURCE

### DIFF
--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -326,8 +326,8 @@ start by selecting the relevant option.
     ALL TABLES`.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+   for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
+   and [`DROP SOURCE`](/sql/drop-source) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -327,7 +327,7 @@ start by selecting the relevant option.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
    for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
-   and [`DROP SOURCE`](/sql/drop-source) syntax.
+   and [`DROP SOURCE`](/sql/alter-source/#dropping-subsources) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres/amazon-rds.md
@@ -368,7 +368,7 @@ start by selecting the relevant option.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
    for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
-   and [`DROP SOURCE`](/sql/drop-source) syntax.
+   and [`DROP SOURCE`](/sql/alter-source/#dropping-subsources) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres/amazon-rds.md
@@ -367,8 +367,8 @@ start by selecting the relevant option.
     ALL TABLES`.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+   for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
+   and [`DROP SOURCE`](/sql/drop-source) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/azure-db.md
+++ b/doc/user/content/ingest-data/postgres/azure-db.md
@@ -182,8 +182,8 @@ created [earlier](#2-create-a-publication-and-a-replication-user):
     ALL TABLES`.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+   for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
+   and [`DROP SOURCE`](/sql/drop-source) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/azure-db.md
+++ b/doc/user/content/ingest-data/postgres/azure-db.md
@@ -183,7 +183,7 @@ created [earlier](#2-create-a-publication-and-a-replication-user):
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
    for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
-   and [`DROP SOURCE`](/sql/drop-source) syntax.
+   and [`DROP SOURCE`](/sql/alter-source/#dropping-subsources) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/neon.md
+++ b/doc/user/content/ingest-data/postgres/neon.md
@@ -294,9 +294,9 @@ ingesting data.
     (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
     ALL TABLES`.
 
-4. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
+   for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
+   and [`DROP SOURCE`](/sql/drop-source) syntax.
 
 ### 3. Monitor the ingestion status
 

--- a/doc/user/content/ingest-data/postgres/neon.md
+++ b/doc/user/content/ingest-data/postgres/neon.md
@@ -296,7 +296,7 @@ ingesting data.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
    for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
-   and [`DROP SOURCE`](/sql/drop-source) syntax.
+   and [`DROP SOURCE`](/sql/alter-source/#dropping-subsources) syntax.
 
 ### 3. Monitor the ingestion status
 

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -422,7 +422,7 @@ start by selecting the relevant option.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
    for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
-   and [`DROP SOURCE`](/sql/drop-source) syntax.
+   and [`DROP SOURCE`](/sql/alter-source/#dropping-subsources) syntax.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -421,8 +421,8 @@ start by selecting the relevant option.
     ALL TABLES`.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+   for specific replicated tables using the [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context)
+   and [`DROP SOURCE`](/sql/drop-source) syntax.
 
 {{< /tab >}}
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR cleans up a few lingering references to deprecated syntax `DROP SUBSOURCE`.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
