### PR TITLE
compute: only initialize replica after successful connection

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -753,7 +753,7 @@ where
         instance.replicas.insert(replica_id);
 
         instance.call(move |i| {
-            i.add_replica(replica_id, replica_config)
+            i.add_replica(replica_id, replica_config, None)
                 .expect("validated")
         });
 

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -291,4 +291,9 @@ where
     pub fn iter(&self) -> impl Iterator<Item = &ComputeCommand<T>> {
         self.commands.iter()
     }
+
+    /// Return whether the history is in reduced form.
+    pub fn is_reduced(&self) -> bool {
+        self.commands.len() == self.reduced_count
+    }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -5688,13 +5688,6 @@ def workflow_test_lgalloc_limiter(c: Composition) -> None:
             user="mz_system",
         )
         setup_workload()
-
-        # Force a reconnect to make sure the replica gets the new config immediately.
-        # TODO(database-issues#9483): make this workaround unnecessary
-        c.up("clusterd1")
-        time.sleep(1)
-        c.kill("clusterd1")
-
         c.up("clusterd1")
 
         c.testdrive("> SELECT count(*) FROM mv\n1000000")
@@ -5807,13 +5800,6 @@ def workflow_test_memory_limiter(c: Composition) -> None:
             user="mz_system",
         )
         setup_workload()
-
-        # Force a reconnect to make sure the replica gets the new config immediately.
-        # TODO(database-issues#9483): make this workaround unnecessary
-        c.up("clusterd1")
-        time.sleep(1)
-        c.kill("clusterd1")
-
         c.up("clusterd1")
 
         c.testdrive("> SELECT count(*) FROM mv\n1000000")


### PR DESCRIPTION
This PR changes the compute controller to defer sending the initialization commands until after a replica connection has been established. Doing so avoids command pileup at the replica task and ensures that commands can be reduced without ever making it to the replica if their dataflows/peeks have been dropped/canceled before the connection succeeded.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9502
Fixes https://github.com/MaterializeInc/database-issues/issues/9413

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/9483

### Tips for reviewer

Ideally we would do the same thing for the storage controller, but there it's harder because the storage controller might decide to install certain sources/sinks only on a single replica. It is not clear how that should interact with sending initialization commands only to connected replicas. Should a source only be scheduled on a replica once the connection succeeds? Should the source be moved to a different replica once the currently active one disconnects? All questions we could answer, but this change seems less important for the storage controller, given that it doesn't have the same risk of (peek) commands piling up that compute has.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
