### PR TITLE
Short circuit at LIMIT+OFFSET in peek stash

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1543,10 +1543,7 @@ impl IndexPeek {
         // `order_by` field. Further limiting will happen when the results
         // are collected, so we don't need to have exactly this many results,
         // just at least those results that would have been returned.
-        let max_results = peek
-            .finishing
-            .limit
-            .map(|l| usize::cast_from(u64::from(l)) + peek.finishing.offset);
+        let max_results = peek.finishing.num_rows_needed();
 
         let mut l_datum_vec = DatumVec::new();
         let mut r_datum_vec = DatumVec::new();

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3698,6 +3698,18 @@ impl<L> RowSetFinishing<L> {
     }
 }
 
+impl RowSetFinishing<NonNeg<i64>, usize> {
+    /// The number of rows needed from before the finishing to evaluate the finishing:
+    /// offset + limit.
+    ///
+    /// If it returns None, then we need all the rows.
+    pub fn num_rows_needed(&self) -> Option<usize> {
+        self.limit
+            .as_ref()
+            .map(|l| usize::cast_from(u64::from(l.clone())) + self.offset)
+    }
+}
+
 impl RowSetFinishing {
     /// Applies finishing actions to a [`RowCollection`], and reports the total
     /// time it took to run.


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9511 as discussed with @aljoscha here: https://materializeinc.slack.com/archives/C08JWHM837U/p1753437243688499?thread_ts=1753369592.747059&cid=C08JWHM837U

I've tested this by setting a low `PEEK_RESPONSE_STASH_THRESHOLD_BYTES` and running all slts like that. [Plus I think Nightly also tests with setting `PEEK_RESPONSE_STASH_THRESHOLD_BYTES` to 0.](https://github.com/MaterializeInc/materialize/blob/a048f88ed6cbd5601febe1a4ad23b40b8eef53e9/misc/python/materialize/mzcompose/__init__.py#L183) Nightly: https://buildkite.com/materialize/nightly/builds/12684

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9511

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
