### PR TITLE
mzbuild: Mirror ssh-bastion-host from quay.io to Dockerhub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,20 @@ updates:
       update-types:
         - minor
         - patch
+- package-ecosystem: docker
+  directory: /test
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "22:00"
+  open-pull-requests-limit: 50
+  labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: pip
   directory: /ci/builder
   schedule:

--- a/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
+++ b/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
@@ -37,7 +37,7 @@ class SshBastionHost(Service):
         super().__init__(
             name=name,
             config={
-                "image": "quay.io/panubo/sshd:1.7.1",
+                "mzbuild": "ssh-bastion-host",
                 "init": True,
                 "ports": ["22"],
                 "environment": [

--- a/test/ssh-bastion-host/Dockerfile
+++ b/test/ssh-bastion-host/Dockerfile
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Mirrored so it's available on DockerHub when quay.io is down
+FROM quay.io/panubo/sshd:1.7.1

--- a/test/ssh-bastion-host/mzbuild.yml
+++ b/test/ssh-bastion-host/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: ssh-bastion-host


### PR DESCRIPTION
https://materializeinc.slack.com/archives/C01LKF361MZ/p1753461350615199

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
