### PR TITLE
Correct replica expiration test

### DIFF
--- a/test/testdrive/replica-expiration.td
+++ b/test/testdrive/replica-expiration.td
@@ -23,10 +23,12 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d'
   FROM events
   WHERE mz_now() <= event_ts + INTERVAL '20 days';
 > CREATE DEFAULT INDEX ON events_view;
-> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
-> SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
+> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000000) AS x;
+# We expect to have at least 1 million records in the arrangement, and 1 million future retractions.
+# Some of the future retractions may still be buffered and don't show up in the arrangement size.
+> SELECT records BETWEEN 1000001 AND 2000000 FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-2000
+true
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 
@@ -44,10 +46,10 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '20d'
   FROM events
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 > CREATE DEFAULT INDEX ON events_view;
-> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
+> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000000) AS x;
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-1000
+1000000
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 
@@ -211,10 +213,10 @@ ALTER SYSTEM SET compute_replica_expiration_offset = 0;
   FROM events
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 > CREATE DEFAULT INDEX ON events_view;
-> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
-> SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
+> INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000000) AS x;
+> SELECT records BETWEEN 1000001 AND 2000000 FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-2000
+true
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 

--- a/test/testdrive/replica-expiration.td
+++ b/test/testdrive/replica-expiration.td
@@ -24,13 +24,9 @@ ALTER SYSTEM SET compute_replica_expiration_offset = '30d'
   WHERE mz_now() <= event_ts + INTERVAL '20 days';
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
-# TODO: The following query should return 2000, but it returns 1000 because the
-# arrangement sizes does not account for the temporal bucket. It is part of
-# a different operator, and we only reveal counts associated with arrangement
-# operators.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-1000
+2000
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 
@@ -216,12 +212,9 @@ ALTER SYSTEM SET compute_replica_expiration_offset = 0;
   WHERE mz_now() <= event_ts + INTERVAL '30 days';
 > CREATE DEFAULT INDEX ON events_view;
 > INSERT INTO events SELECT x::text, now() FROM generate_series(1, 1000) AS x;
-# TODO: The following query should return 2000, but it returns 1000 because the
-# arrangement sizes does not account for the temporal bucket. It is part of
-# a different operator.
 > SELECT records FROM mz_introspection.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%events_view_primary_idx';
-1000
+2000
 > DROP TABLE events CASCADE;
 > DROP CLUSTER test;
 


### PR DESCRIPTION
Correct the replica expiration test such that it again tests what it is supposed to test. We achieve this by increasing the amount of data to process.

The test ensures that replica expiration drops data that's further out than the replica expiration. It stopped doing so after introducing (and enabling) temporal bucketing. Temporal bucketing serves as another merge batcher. The merge batcher first stages data in a chunker, and when full, inserts the data in a chain.

We had so little data that it would remain in the chunker, causing us to never reveal it in the operator/arrangement size tracking. Increasing the data volume surfaces the data that we weren't tracking.
