### PR TITLE
ci: Run docker with host network instead of bridge

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -14,6 +14,7 @@ env:
   CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
   CI_BAZEL_LTO: 1
+  CI_HOST_NETWORK: 1
 
 steps:
   - group: Builds
@@ -254,6 +255,9 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-multi-broker
+        env:
+          # TODO(def-) Investigate
+          CI_HOST_NETWORK: 0
 
       - id: redpanda-resumption
         label: ":panda_face: resumption tests"
@@ -931,6 +935,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-self-managed-upgrade
         label: "Checks Self-Managed upgrade, whole-Mz restart"
@@ -943,6 +949,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFromLatestSelfManaged, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-self-managed-upgrade-previous
         label: "Checks Self-Managed upgrade from previous, whole-Mz restart"
@@ -955,6 +963,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFromPreviousSelfManaged, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
@@ -967,6 +977,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=PreflightCheckRollback, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
@@ -979,6 +991,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
@@ -991,6 +1005,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-0dt-restart-entire-mz-forced-migrations
         label: "Checks 0dt restart of the entire Mz with forced migrations"
@@ -1003,6 +1019,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
@@ -1015,6 +1033,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
@@ -1027,6 +1047,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
@@ -1039,6 +1061,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
+        env:
+          CI_HOST_NETWORK: 0
 
       - id: checks-0dt-bump-version
         label: "Checks 0dt upgrade to a bumped version"
@@ -1046,6 +1070,8 @@ steps:
         timeout_in_minutes: 240
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
+        env:
+          CI_HOST_NETWORK: 0
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -1059,6 +1085,7 @@ steps:
         parallelism: 3
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
+          CI_HOST_NETWORK: 0
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-4cpu-8gb
@@ -1620,6 +1647,8 @@ steps:
           queue: hetzner-aarch64-4cpu-8gb
         env:
           CI_ALLOW_LOCAL_BUILD: true
+          # TODO(def-) Reenable when next version is released
+          CI_HOST_NETWORK: 0
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg
@@ -1665,6 +1694,8 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: crdb-restarts
+    env:
+      CI_HOST_NETWORK: 0
 
   - id: pubsub-disruption
     label: "PubSub disruption"
@@ -1914,10 +1945,12 @@ steps:
               args: ["--versions-source=git"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          # TODO(def-): Fix up when a new version has been released
+          CI_HOST_NETWORK: 0
 
       - id: legacy-upgrade-docs
         label: "Legacy upgrade tests (last version from docs)"
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 60
         plugins:
@@ -1926,6 +1959,9 @@ steps:
               args: ["--versions-source=docs", "--self-managed-upgrade"]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          # TODO(def-): Fix up when a new version has been released
+          CI_HOST_NETWORK: 0
 
   - group: Cloud tests
     key: cloudtests

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -14,6 +14,7 @@ env:
   CI_BAZEL_BUILD: 1
   CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
   CI_BAZEL_LTO: 1
+  CI_HOST_NETWORK: 1
 
 steps:
   - group: Builds
@@ -225,6 +226,7 @@ steps:
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
+        CI_HOST_NETWORK: 0
 
   - id: nightly-preflight-check-rollback
     label: Nightly with preflight check and rollback
@@ -264,6 +266,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
               args: [ "--mysql-version=8.0.40" ]
+        skip: "Syntax changed"
 
   - group: "Postgres: other versions"
     key: postgres-versions
@@ -279,6 +282,8 @@ steps:
               args: [ "--pg-version=16.6" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          CI_HOST_NETWORK: 0
       - id: pg-cdc-15
         label: "Postgres CDC w/ 15"
         depends_on: build-aarch64
@@ -290,6 +295,8 @@ steps:
               args: [ "--pg-version=15.10" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          CI_HOST_NETWORK: 0
       - id: pg-cdc-14
         label: "Postgres CDC w/ 14"
         depends_on: build-aarch64
@@ -301,6 +308,8 @@ steps:
               args: [ "--pg-version=14.15" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          CI_HOST_NETWORK: 0
       - id: pg-cdc-13
         label: "Postgres CDC w/ 13"
         depends_on: build-aarch64
@@ -312,6 +321,8 @@ steps:
               args: [ "--pg-version=13.18" ]
         agents:
           queue: hetzner-aarch64-4cpu-8gb
+        env:
+          CI_HOST_NETWORK: 0
 
   - group: "Platform checks"
     key: platform-checks
@@ -385,6 +396,8 @@ steps:
         parallelism: 3
         agents:
           queue: hetzner-aarch64-8cpu-16gb
+        env:
+          CI_HOST_NETWORK: 0
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -397,6 +410,8 @@ steps:
         parallelism: 3
         agents:
           queue: hetzner-aarch64-8cpu-16gb
+        env:
+          CI_HOST_NETWORK: 0
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -457,6 +472,8 @@ steps:
         parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
+        env:
+          CI_HOST_NETWORK: 0
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -52,12 +52,12 @@ SERVICES = [
     Minio(
         # We need a stable port exposed to the host since we can't pass any arguments
         # to the .pt files used in the tests.
-        ports=["40109:9000", "40110:9001"],
+        ports=["9000:9000", "9001:9001"],
         allow_host_ports=True,
         additional_directories=["copytos3"],
     ),
     Azurite(
-        ports=["40111:10000"],
+        ports=["10000:10000"],
         allow_host_ports=True,
     ),
     Clusterd(),  # Only to attempt to download the binary

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -18,6 +18,7 @@ env:
   CI_BAZEL_BUILD: 0
   CI_BAZEL_REMOTE_CACHE: $BAZEL_REMOTE_CACHE
   CI_BAZEL_LTO: 0
+  CI_HOST_NETWORK: 1
   CARGO_BUILD_JOBS: "default"
 
 # When resources are constrained, run early since this might be blocking a PR from merging
@@ -425,7 +426,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-rtr
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -494,6 +495,7 @@ steps:
     label: dbt-materialize tests
     depends_on: build-aarch64
     timeout_in_minutes: 30
+    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: dbt-materialize
@@ -527,6 +529,9 @@ steps:
         agents:
           # too slow to run emulated on aarch64, SQL Server's docker image is not yet available for aarch64 natively yet: https://github.com/microsoft/mssql-docker/issues/802
           queue: hetzner-x86-64-4cpu-8gb
+        env:
+          # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9514 is fixed
+          CI_HOST_NETWORK: 0
 
       - id: debezium-mysql
         label: "Debezium MySQL tests"

--- a/misc/dbt-materialize/Dockerfile
+++ b/misc/dbt-materialize/Dockerfile
@@ -11,5 +11,5 @@ FROM python:3.10.14
 
 COPY . dbt-materialize/
 
-RUN pip install pytest
+RUN pip install pytest pytest-split
 RUN pip install ./dbt-materialize[dev]

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -11,6 +11,7 @@
 Basic test for the Data build tool (dbt) integration of Materialize
 """
 
+import os
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Dict, List, Optional
@@ -136,6 +137,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     c.run(
                         "dbt",
                         "pytest",
+                        f"--splits={os.getenv('BUILDKITE_PARALLEL_JOB_COUNT', 1)}",
+                        f"--group={int(os.getenv('BUILDKITE_PARALLEL_JOB', 0)) + 1}",
                         *test_args,
                         env_extra={
                             "DBT_HOST": "materialized",

--- a/misc/images/sshd/setup.sh
+++ b/misc/images/sshd/setup.sh
@@ -14,3 +14,7 @@ set -euo pipefail
 if [[ "${MAX_STARTUPS:-}" ]]; then
     augtool -s <<< "set /files/etc/ssh/sshd_config/MaxStartups $MAX_STARTUPS"
 fi
+
+if [[ "${SSH_PORT:-}" ]]; then
+    augtool -s <<< "set /files/etc/ssh/sshd_config/Port $SSH_PORT"
+fi

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -31,7 +31,7 @@ class SshChange(Enum):
 
 
 # {i} will be replaced later
-SHOW_CONNECTION_SSH_TUNNEL = """materialize.public.ssh_tunnel_{i} "CREATE CONNECTION \\"materialize\\".\\"public\\".\\"ssh_tunnel_{i}\\" TO SSH TUNNEL (HOST = 'ssh-bastion-host', PORT = 22, USER = 'mz')" """
+SHOW_CONNECTION_SSH_TUNNEL = """materialize.public.ssh_tunnel_{i} "CREATE CONNECTION \\"materialize\\".\\"public\\".\\"ssh_tunnel_{i}\\" TO SSH TUNNEL (HOST = 'ssh-bastion-host', PORT = 23, USER = 'mz')" """
 WITH_SSH_SUFFIX = "USING SSH TUNNEL ssh_tunnel_{i}"
 
 

--- a/misc/python/materialize/checks/cloudtest_actions.py
+++ b/misc/python/materialize/checks/cloudtest_actions.py
@@ -69,7 +69,7 @@ class SetupSshTunnels(Action):
                         > CREATE CONNECTION IF NOT EXISTS ssh_tunnel_{i} TO SSH TUNNEL (
                             HOST 'ssh-bastion-host',
                             USER 'mz',
-                            PORT 22
+                            PORT 23
                             );
                         """
                     )

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -47,14 +47,17 @@ class StartMz(MzcomposeAction):
         force_migrations: str | None = None,
         publish: bool | None = None,
     ) -> None:
-        if healthcheck is None:
-            healthcheck = ["CMD", "curl", "-f", "localhost:6878/api/readyz"]
+        self.healthcheck = healthcheck or [
+            "CMD",
+            "curl",
+            "-f",
+            "localhost:6878/api/readyz",
+        ]
         self.tag = tag
         self.environment_extra = environment_extra
         self.system_parameter_defaults = system_parameter_defaults
         self.additional_system_parameter_defaults = additional_system_parameter_defaults
         self.system_parameter_version = system_parameter_version or tag
-        self.healthcheck = healthcheck
         self.mz_service = mz_service
         self.platform = platform
         self.deploy_generation = deploy_generation

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -23,7 +23,7 @@ from materialize.checks.mzcompose_actions import (
 )
 from materialize.checks.scenarios import Scenario
 from materialize.mz_version import MzVersion
-from materialize.mzcompose.services.materialized import LEADER_STATUS_HEALTHCHECK
+from materialize.mzcompose.services.materialized import leader_status_healthcheck
 from materialize.version_list import (
     get_published_minor_mz_versions,
     get_self_managed_versions,
@@ -76,7 +76,7 @@ def start_mz_read_only(
         tag=tag,
         mz_service=mz_service,
         deploy_generation=deploy_generation,
-        healthcheck=LEADER_STATUS_HEALTHCHECK,
+        healthcheck=leader_status_healthcheck(),
         restart="on-failure",
         system_parameter_defaults=system_parameter_defaults,
         system_parameter_version=system_parameter_version,

--- a/misc/python/materialize/cloudtest/k8s/ssh.py
+++ b/misc/python/materialize/cloudtest/k8s/ssh.py
@@ -68,7 +68,7 @@ class SshService(K8sService):
     def __init__(self, namespace: str) -> None:
         super().__init__(namespace)
         ports = [
-            V1ServicePort(name="ssh", port=22),
+            V1ServicePort(name="ssh", port=23, target_port=22),
         ]
 
         self.service = V1Service(

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -20,6 +20,8 @@ from typing import (
     TypedDict,
 )
 
+from materialize import ui
+
 
 class ServiceHealthcheck(TypedDict, total=False):
     """Configuration for a check to determine whether the containers for this
@@ -183,6 +185,10 @@ class Service:
         config: The definition of the service.
     """
 
-    def __init__(self, name: str, config: ServiceConfig) -> None:
+    def __init__(
+        self, name: str, config: ServiceConfig, supports_host_network_mode: bool = True
+    ) -> None:
         self.name = name
         self.config = config
+        if supports_host_network_mode and ui.env_is_truthy("CI_HOST_NETWORK"):
+            self.config["network_mode"] = "host"

--- a/misc/python/materialize/mzcompose/services/balancerd.py
+++ b/misc/python/materialize/mzcompose/services/balancerd.py
@@ -30,9 +30,9 @@ class Balancerd(Service):
         if command is None:
             command = [
                 "service",
-                "--pgwire-listen-addr=0.0.0.0:6875",
-                "--https-listen-addr=0.0.0.0:6876",
-                "--internal-http-listen-addr=0.0.0.0:6878",
+                "--pgwire-listen-addr=0.0.0.0:6575",
+                "--https-listen-addr=0.0.0.0:6576",
+                "--internal-http-listen-addr=0.0.0.0:6578",
                 f"--static-resolver-addr={static_resolver_addr or 'materialized:6875'}",
                 f"--https-resolver-template={https_resolver_template or 'materialized:6876'}",
             ]
@@ -52,7 +52,7 @@ class Balancerd(Service):
         config: ServiceConfig = {
             "mzbuild": mzbuild,
             "command": command,
-            "ports": [6875, 6876, 6877, 6878],
+            "ports": [6575, 6576, 6578],
             "volumes": volumes,
             "depends_on": depends_graph,
         }

--- a/misc/python/materialize/mzcompose/services/cockroach.py
+++ b/misc/python/materialize/mzcompose/services/cockroach.py
@@ -43,7 +43,7 @@ class Cockroach(Service):
             image = f"cockroachdb/cockroach:{Cockroach.DEFAULT_COCKROACH_TAG}"
 
         if command is None:
-            command = ["start-single-node", "--insecure"]
+            command = ["start-single-node", "--insecure", "--http-addr=0.0.0.0:8078"]
 
         if setup_materialize:
             path = os.path.relpath(
@@ -58,7 +58,7 @@ class Cockroach(Service):
         if healthcheck is None:
             healthcheck = {
                 # init_success is a file created by the Cockroach container entrypoint
-                "test": "[ -f init_success ] && curl --fail 'http://localhost:8080/health?ready=1'",
+                "test": "[ -f init_success ] && curl --fail 'http://localhost:8078/health?ready=1'",
                 "interval": "1s",
                 "start_period": "30s",
             }

--- a/misc/python/materialize/mzcompose/services/frontegg.py
+++ b/misc/python/materialize/mzcompose/services/frontegg.py
@@ -20,6 +20,7 @@ class FronteggMock(Service):
         self,
         users: str,
         issuer: str,
+        port: int = 6882,
         encoding_key: str | None = None,
         encoding_key_file: str | None = None,
         decoding_key: str | None = None,
@@ -30,7 +31,7 @@ class FronteggMock(Service):
         depends_on: list[str] = [],
     ) -> None:
         command = [
-            "--listen-addr=0.0.0.0:6880",
+            f"--listen-addr=0.0.0.0:{port}",
             "--users",
             users,
             "--issuer",
@@ -59,7 +60,7 @@ class FronteggMock(Service):
             config={
                 "mzbuild": mzbuild,
                 "command": command,
-                "ports": [6880],
+                "ports": [port],
                 "volumes": volumes,
                 "depends_on": depends_graph,
             },

--- a/misc/python/materialize/mzcompose/services/mysql.py
+++ b/misc/python/materialize/mzcompose/services/mysql.py
@@ -58,6 +58,7 @@ class MySql(Service):
                 ],
                 "command": [
                     "--secure-file-priv=/var/lib/mysql-files",
+                    f"--port={port}",
                     *additional_args,
                 ],
                 "healthcheck": {
@@ -65,6 +66,7 @@ class MySql(Service):
                         "CMD",
                         "mysqladmin",
                         "ping",
+                        f"--port={port}",
                         f"--password={root_password}",
                         "--protocol=TCP",
                     ],

--- a/misc/python/materialize/mzcompose/services/schema_registry.py
+++ b/misc/python/materialize/mzcompose/services/schema_registry.py
@@ -19,13 +19,15 @@ class SchemaRegistry(Service):
         aliases: list[str] = [],
         image: str = "confluentinc/cp-schema-registry",
         tag: str = DEFAULT_CONFLUENT_PLATFORM_VERSION,
-        port: int = 8081,
+        ports: list[int] | None = None,
         kafka_servers: list[tuple[str, str]] = [("kafka", "9092")],
         environment_extra: list[str] = [],
         depends_on_extra: list[str] = [],
         volumes: list[str] = [],
         platform: str | None = None,
     ) -> None:
+        if not ports:
+            ports = [8081]
         bootstrap_servers = ",".join(
             f"PLAINTEXT://{host}:{port}" for host, port in kafka_servers
         )
@@ -39,7 +41,7 @@ class SchemaRegistry(Service):
         ]
         config: ServiceConfig = {
             "image": f"{image}:{tag}",
-            "ports": [port],
+            "ports": ports,
             "networks": {"default": {"aliases": aliases}},
             "environment": environment,
             "depends_on": {
@@ -58,7 +60,7 @@ class SchemaRegistry(Service):
                     # configured to require them.
                     "-fu",
                     "materialize:sekurity",
-                    "localhost:8081",
+                    f"localhost:{ports[0]}",
                 ],
                 "interval": "1s",
                 "start_period": "120s",

--- a/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
+++ b/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
@@ -39,11 +39,12 @@ class SshBastionHost(Service):
             config={
                 "mzbuild": "ssh-bastion-host",
                 "init": True,
-                "ports": ["22"],
+                "ports": ["23"],
                 "environment": [
                     "SSH_USERS=mz:1000:1000",
                     "TCP_FORWARDING=true",
                     *([f"MAX_STARTUPS={max_startups}"] if max_startups else []),
+                    "SSH_PORT=23",
                 ],
                 "volumes": [f"{setup_path}:/etc/entrypoint.d/setup.sh"],
                 "networks": {"default": {"aliases": aliases}},
@@ -65,7 +66,7 @@ def setup_default_ssh_test_connection(
             CREATE CONNECTION IF NOT EXISTS {ssh_tunnel_name} TO SSH TUNNEL (
             HOST 'ssh-bastion-host',
             USER 'mz',
-            PORT 22)
+            PORT 23)
         """,
         service=mz_service,
     )

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -29,6 +29,8 @@ class Testdrive(Service):
         mzbuild: str = "testdrive",
         materialize_url: str = "postgres://materialize@materialized:6875",
         materialize_url_internal: str = "postgres://materialize@materialized:6877",
+        materialize_http_port: int = 6876,
+        materialize_internal_http_port: int = 6878,
         materialize_use_https: bool = False,
         materialize_params: dict[str, str] = {},
         kafka_url: str = "kafka:9092",
@@ -105,6 +107,8 @@ class Testdrive(Service):
                 f"--schema-registry-url={schema_registry_url}",
                 f"--materialize-url={materialize_url}",
                 f"--materialize-internal-url={materialize_url_internal}",
+                f"--materialize-http-port={materialize_http_port}",
+                f"--materialize-internal-http-port={materialize_internal_http_port}",
                 *(["--materialize-use-https"] if materialize_use_https else []),
                 # Faster retries
             ]

--- a/misc/python/materialize/mzcompose/services/zookeeper.py
+++ b/misc/python/materialize/mzcompose/services/zookeeper.py
@@ -22,7 +22,10 @@ class Zookeeper(Service):
         tag: str = DEFAULT_CONFLUENT_PLATFORM_VERSION,
         port: int = 2181,
         volumes: list[str] = [],
-        environment: list[str] = ["ZOOKEEPER_CLIENT_PORT=2181"],
+        environment: list[str] = [
+            "ZOOKEEPER_CLIENT_PORT=2181",
+            "ZOOKEEPER_ADMIN_SERVER_PORT=18080",
+        ],
         platform: str | None = None,
     ) -> None:
         config: ServiceConfig = {

--- a/misc/python/materialize/zippy/backup_and_restore_actions.py
+++ b/misc/python/materialize/zippy/backup_and_restore_actions.py
@@ -32,6 +32,11 @@ class BackupAndRestore(Action):
         with c.override(
             Materialized(
                 name=state.mz_service,
+                ports=(
+                    [16875, 16876, 16877, 16878, 16879]
+                    if state.mz_service == "materialized2"
+                    else [6875, 6876, 6877, 6878, 6879]
+                ),
                 external_blob_store=True,
                 blob_store_is_azure=c.blob_store() == "azurite",
                 external_metadata_store=True,

--- a/src/persist/src/azure.rs
+++ b/src/persist/src/azure.rs
@@ -183,7 +183,7 @@ impl AzureBlobConfig {
             container_name.clone(),
             prefix,
             metrics,
-            Url::parse(&format!("http://localhost:40111/{}", container_name)).expect("valid url"),
+            Url::parse(&format!("http://localhost:10000/{}", container_name)).expect("valid url"),
             Box::new(TestBlobKnobs),
             Arc::new(ConfigSet::default()),
         )?;

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -24,9 +24,9 @@ from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import (
-    LEADER_STATUS_HEALTHCHECK,
     DeploymentStatus,
     Materialized,
+    leader_status_healthcheck,
 )
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.mz import Mz
@@ -61,6 +61,7 @@ SERVICES = [
     ),
     Materialized(
         name="mz_new",
+        ports=[16875, 16876, 16877, 16878, 16879],
         sanity_restart=False,
         deploy_generation=1,
         system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -548,8 +549,10 @@ def workflow_basic(c: Composition) -> None:
     # Verify against new Materialize that it is in read-only mode
     with c.override(
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -710,8 +713,10 @@ def workflow_basic(c: Composition) -> None:
 
     with c.override(
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -785,6 +790,7 @@ def workflow_basic(c: Composition) -> None:
                     or "Can't create a connection to host" in str(e)
                     or "Connection refused" in str(e)
                 ), f"Unexpected error: {e}"
+                break
             except CommandFailureCausedUIError as e:
                 # service "mz_old" is not running
                 assert "running docker compose failed" in str(
@@ -972,6 +978,7 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -980,8 +987,10 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
             default_replication_factor=2,
         ),
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -1122,6 +1131,7 @@ def workflow_kafka_source_rehydration_large_initial(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -1130,8 +1140,10 @@ def workflow_kafka_source_rehydration_large_initial(c: Composition) -> None:
             default_replication_factor=2,
         ),
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -1278,6 +1290,7 @@ def workflow_pg_source_rehydration(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -1286,8 +1299,10 @@ def workflow_pg_source_rehydration(c: Composition) -> None:
             default_replication_factor=2,
         ),
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -1430,6 +1445,7 @@ def workflow_mysql_source_rehydration(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -1438,8 +1454,10 @@ def workflow_mysql_source_rehydration(c: Composition) -> None:
             default_replication_factor=2,
         ),
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -1577,6 +1595,7 @@ def workflow_kafka_source_failpoint(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -1585,8 +1604,10 @@ def workflow_kafka_source_failpoint(c: Composition) -> None:
             default_replication_factor=2,
         ),
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -1676,13 +1697,14 @@ def workflow_builtin_item_migrations(c: Composition) -> None:
     with c.override(
         Materialized(
             name="mz_new",
+            ports=[16875, 16876, 16877, 16878, 16879],
             sanity_restart=False,
             deploy_generation=1,
             system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
             restart="on-failure",
             external_metadata_store=True,
             force_migrations="all",
-            healthcheck=LEADER_STATUS_HEALTHCHECK,
+            healthcheck=leader_status_healthcheck(16878),
             default_replication_factor=2,
         ),
     ):
@@ -1707,24 +1729,20 @@ def workflow_builtin_item_migrations(c: Composition) -> None:
         new_mz_tables_gid = c.sql_query(
             "SELECT id FROM mz_tables WHERE name = 'mz_tables'",
             service="mz_new",
-            reuse_connection=False,
         )[0][0]
         new_mv_gid = c.sql_query(
             "SELECT id FROM mz_materialized_views WHERE name = 'mv'",
             service="mz_new",
-            reuse_connection=False,
         )[0][0]
         assert new_mz_tables_gid == mz_tables_gid
         assert new_mv_gid == mv_gid
         new_mz_tables_shard_id = c.sql_query(
             f"SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '{mz_tables_gid}'",
             service="mz_new",
-            reuse_connection=False,
         )[0][0]
         new_mv_shard_id = c.sql_query(
             f"SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '{mv_gid}'",
             service="mz_new",
-            reuse_connection=False,
         )[0][0]
         assert new_mz_tables_shard_id != mz_tables_shard_id
         assert new_mv_shard_id == mv_shard_id
@@ -1903,6 +1921,11 @@ def workflow_upsert_sources(c: Composition) -> None:
         with c.override(
             Materialized(
                 name=mz2,
+                ports=(
+                    [16875, 16876, 16877, 16878, 16879]
+                    if mz1 == "mz_new"
+                    else [6875, 6876, 6877, 6878, 6879]
+                ),
                 sanity_restart=False,
                 deploy_generation=i,
                 system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
@@ -1911,8 +1934,10 @@ def workflow_upsert_sources(c: Composition) -> None:
                 default_replication_factor=2,
             ),
             Testdrive(
-                materialize_url=f"postgres://materialize@{mz1}:6875",
-                materialize_url_internal=f"postgres://materialize@{mz1}:6877",
+                materialize_url=f"postgres://materialize@{mz1}:{16875 if mz1 == 'mz_new' else 6875}",
+                materialize_url_internal=f"postgres://materialize@{mz1}:{16877 if mz1 == 'mz_new' else 6877}",
+                materialize_http_port=16876 if mz1 == "mz_new" else 6876,
+                materialize_internal_http_port=16878 if mz1 == "mz_new" else 6878,
                 mz_service=mz1,
                 materialize_params={"cluster": "cluster"},
                 no_consistency_checks=True,
@@ -2089,8 +2114,10 @@ def workflow_ddl(c: Composition) -> None:
     # Verify against new Materialize that it is in read-only mode
     with c.override(
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -2259,8 +2286,10 @@ def workflow_ddl(c: Composition) -> None:
 
     with c.override(
         Testdrive(
-            materialize_url="postgres://materialize@mz_new:6875",
-            materialize_url_internal="postgres://materialize@mz_new:6877",
+            materialize_url="postgres://materialize@mz_new:16875",
+            materialize_url_internal="postgres://materialize@mz_new:16877",
+            materialize_http_port=16876,
+            materialize_internal_http_port=16878,
             mz_service="mz_new",
             materialize_params={"cluster": "cluster"},
             no_reset=True,
@@ -2334,6 +2363,7 @@ def workflow_ddl(c: Composition) -> None:
                     or "Can't create a connection to host" in str(e)
                     or "Connection refused" in str(e)
                 ), f"Unexpected error: {e}"
+                break
             except CommandFailureCausedUIError as e:
                 # service "mz_old" is not running
                 assert "running docker compose failed" in str(

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -71,7 +71,7 @@ USERS = {
         "roles": [OTHER_ROLE],
     },
 }
-FRONTEGG_URL = "http://frontegg-mock:6880"
+FRONTEGG_URL = "http://frontegg-mock:6882"
 
 
 def app_password(email: str) -> str:
@@ -83,16 +83,16 @@ def app_password(email: str) -> str:
 SERVICES = [
     TestCerts(),
     Testdrive(
-        materialize_url=f"postgres://{quote(ADMIN_USER)}:{app_password(ADMIN_USER)}@balancerd:6875?sslmode=require",
+        materialize_url=f"postgres://{quote(ADMIN_USER)}:{app_password(ADMIN_USER)}@balancerd:6575?sslmode=require",
         materialize_use_https=True,
         no_reset=True,
     ),
     Balancerd(
         command=[
             "service",
-            "--pgwire-listen-addr=0.0.0.0:6875",
-            "--https-listen-addr=0.0.0.0:6876",
-            "--internal-http-listen-addr=0.0.0.0:6878",
+            "--pgwire-listen-addr=0.0.0.0:6575",
+            "--https-listen-addr=0.0.0.0:6576",
+            "--internal-http-listen-addr=0.0.0.0:6578",
             "--frontegg-resolver-template=materialized:6875",
             "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
             f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
@@ -162,7 +162,7 @@ def assert_metrics(c: Composition, contains: str):
     result = c.exec(
         "materialized",
         "curl",
-        "http://balancerd:6878/metrics",
+        "http://balancerd:6578/metrics",
         "-s",
         capture=True,
     )
@@ -238,9 +238,9 @@ def workflow_plaintext(c: Composition) -> None:
         Balancerd(
             command=[
                 "service",
-                "--pgwire-listen-addr=0.0.0.0:6875",
-                "--https-listen-addr=0.0.0.0:6876",
-                "--internal-http-listen-addr=0.0.0.0:6878",
+                "--pgwire-listen-addr=0.0.0.0:6575",
+                "--https-listen-addr=0.0.0.0:6576",
+                "--internal-http-listen-addr=0.0.0.0:6578",
                 "--frontegg-resolver-template=materialized:6875",
                 "--frontegg-jwk-file=/secrets/frontegg-mock.crt",
                 f"--frontegg-api-token-url={FRONTEGG_URL}/identity/resources/auth/v1/api-token",
@@ -270,7 +270,7 @@ def workflow_http(c: Composition) -> None:
     result = c.exec(
         "materialized",
         "curl",
-        "https://balancerd:6876/api/sql",
+        "https://balancerd:6576/api/sql",
         "-k",
         "-s",
         "--header",
@@ -294,7 +294,7 @@ def workflow_ip_forwarding(c: Composition) -> None:
     # via the balancer come from the current ip
     # and that we can use proxy_protocol when talking to
     # envd directly.
-    balancer_port = c.port("balancerd", 6876)
+    balancer_port = c.port("balancerd", 6576)
     # mz internal (unencrypted port)
     materialize_port = c.port("materialized", 6878)
 
@@ -590,6 +590,7 @@ def workflow_mz_not_running(c: Composition) -> None:
                 "failure in name resolution",
                 "failed to lookup address information",
                 "Name or service not known",
+                "EOF detected",
             ]
         )
     except:

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -127,7 +127,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
             CREATE CONNECTION sshconn TO SSH TUNNEL (
                 HOST 'ssh-bastion-host',
                 USER 'mz',
-                PORT 22
+                PORT 23
             );
             """
         )

--- a/test/cloudtest/test_ssh_tunnels.py
+++ b/test/cloudtest/test_ssh_tunnels.py
@@ -20,7 +20,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
             > CREATE CONNECTION IF NOT EXISTS ssh_conn TO SSH TUNNEL (
                 HOST 'ssh-bastion-host',
                 USER 'mz',
-                PORT 22
+                PORT 23
               );
             """
         )

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -38,10 +38,25 @@ SERVICES = [
         },
         support_external_clusterd=True,
     ),
-    Clusterd(name="clusterd_1_1"),
-    Clusterd(name="clusterd_1_2"),
-    Clusterd(name="clusterd_2_1"),
-    Clusterd(name="clusterd_2_2"),
+    Clusterd(
+        name="clusterd_1_1",
+        processes=[("clusterd_1_1", 2102, 2103), ("clusterd_1_2", 2106, 2107)],
+    ),
+    Clusterd(
+        name="clusterd_1_2",
+        processes=[("clusterd_1_1", 2102, 2103), ("clusterd_1_2", 2106, 2107)],
+        ports=[2104, 2105, 2106, 2107, 6882],
+    ),
+    Clusterd(
+        name="clusterd_2_1",
+        processes=[("clusterd_2_1", 2110, 2111), ("clusterd_2_2", 2114, 2115)],
+        ports=[2108, 2109, 2110, 2111, 6883],
+    ),
+    Clusterd(
+        name="clusterd_2_2",
+        processes=[("clusterd_2_1", 2110, 2111), ("clusterd_2_2", 2114, 2115)],
+        ports=[2112, 2113, 2114, 2115, 6884],
+    ),
     Testdrive(),
 ]
 
@@ -242,23 +257,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             no_reset=True,
             materialize_params={"cluster": "cluster2"},
             seed=id,
-        ),
-        Clusterd(
-            name="clusterd_1_1",
-            process_names=["clusterd_1_1", "clusterd_1_2"],
-        ),
-        Clusterd(
-            name="clusterd_1_2",
-            process_names=["clusterd_1_1", "clusterd_1_2"],
-        ),
-        Clusterd(
-            name="clusterd_2_1",
-            process_names=["clusterd_2_1", "clusterd_2_2"],
-        ),
-        Clusterd(
-            name="clusterd_2_2",
-            process_names=["clusterd_2_1", "clusterd_2_2"],
-        ),
+        )
     ):
         c.up(
             "materialized",
@@ -279,10 +278,10 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             """
             DROP CLUSTER IF EXISTS cluster1 CASCADE;
             CREATE CLUSTER cluster1 REPLICAS (replica1 (
-                STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
-                STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
-                COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
-                COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
+                STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2104'],
+                STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2107'],
+                COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2105'],
+                COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2106']
             ));
             """
         )
@@ -291,10 +290,10 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             """
             DROP CLUSTER IF EXISTS cluster2 CASCADE;
             CREATE CLUSTER cluster2 REPLICAS (replica1 (
-                STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
-                STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
-                COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
-                COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
+                STORAGECTL ADDRESSES ['clusterd_2_1:2108', 'clusterd_2_2:2112'],
+                STORAGE ADDRESSES ['clusterd_2_1:2111', 'clusterd_2_2:2115'],
+                COMPUTECTL ADDRESSES ['clusterd_2_1:2109', 'clusterd_2_2:2113'],
+                COMPUTE ADDRESSES ['clusterd_2_1:2110', 'clusterd_2_2:2114']
             ));
             """
         )

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -19,10 +19,10 @@ ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;
   COMPUTE ADDRESSES ['clusterd1:2102'],
   WORKERS 1))
 > CREATE CLUSTER prod_deploy REPLICAS (replica1 (
-  STORAGECTL ADDRESSES ['clusterd2:2100', 'clusterd3:2100'],
-  STORAGE ADDRESSES ['clusterd2:2103', 'clusterd3:2103'],
-  COMPUTECTL ADDRESSES ['clusterd2:2101', 'clusterd3:2101'],
-  COMPUTE ADDRESSES ['clusterd2:2102', 'clusterd3:2102'],
+  STORAGECTL ADDRESSES ['clusterd2:2104', 'clusterd3:2108'],
+  STORAGE ADDRESSES ['clusterd2:2107', 'clusterd3:2111'],
+  COMPUTECTL ADDRESSES ['clusterd2:2105', 'clusterd3:2109'],
+  COMPUTE ADDRESSES ['clusterd2:2106', 'clusterd3:2110'],
   WORKERS 2))
 > DROP SCHEMA IF EXISTS prod CASCADE
 > DROP SCHEMA IF EXISTS prod_deploy CASCADE

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -24,10 +24,10 @@ one
 
 > CREATE CLUSTER storage_cluster REPLICAS (
     r1 (
-      STORAGECTL ADDRESSES ['clusterd1:2100', 'clusterd2:2100'],
-      STORAGE ADDRESSES ['clusterd1:2103', 'clusterd2:2103'],
-      COMPUTECTL ADDRESSES ['clusterd1:2101', 'clusterd2:2101'],
-      COMPUTE ADDRESSES ['clusterd1:2102', 'clusterd2:2102'],
+      STORAGECTL ADDRESSES ['clusterd1:2100', 'clusterd2:2104'],
+      STORAGE ADDRESSES ['clusterd1:2103', 'clusterd2:2107'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101', 'clusterd2:2105'],
+      COMPUTE ADDRESSES ['clusterd1:2102', 'clusterd2:2106'],
       WORKERS 4
     )
   )

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -113,7 +113,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(
         # Fixed port so that we keep the same port after restarting Mz in disruptions
         Materialized(
-            ports=["16875:6875", "16877:6877"],
+            ports=[6875, 6876, 6877, 6878, 6879],
             external_blob_store=True,
             blob_store_is_azure=args.azurite,
             external_metadata_store=True,
@@ -124,7 +124,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ),
         Materialized(
             name="materialized2",
-            ports=["26875:6875", "26877:6877"],
+            ports=[16875, 16876, 16877, 16878, 16879],
             external_blob_store=True,
             blob_store_is_azure=args.azurite,
             external_metadata_store=True,
@@ -178,7 +178,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         conn.close()
 
         ports = {s: c.default_port(s) for s in services}
-        ports["materialized2"] = 26875
+        ports["materialized2"] = 16875
         mz_service = "materialized"
         deploy_generation = 0
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -181,7 +181,7 @@ def run_one_scenario(
 
         tag = resolve_tag(tag, scenario_class, args.scale)
 
-        entrypoint_host = "balancerd" if balancerd else "materialized"
+        entrypoint_host = "balancerd:6575" if balancerd else "materialized:6875"
 
         c.up({"name": "testdrive", "persistent": True})
 
@@ -235,7 +235,7 @@ def run_one_scenario(
 
         with c.override(
             Testdrive(
-                materialize_url=f"postgres://materialize@{entrypoint_host}:6875",
+                materialize_url=f"postgres://materialize@{entrypoint_host}",
                 default_timeout=default_timeout,
                 materialize_params={"statement_timeout": f"'{default_timeout}'"},
                 metadata_store="cockroach",

--- a/test/feature-flag-consistency/mzcompose.py
+++ b/test/feature-flag-consistency/mzcompose.py
@@ -78,9 +78,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = test.parse_output_consistency_input_args(parser)
 
     port_mz_default_internal, port_mz_system_internal = 6875, 6877
-    port_mz_default_this, port_mz_system_this = 6875, 6877
-    port_mz_default_other, port_mz_system_other = 16875, 16877
-
     configurations = args.configuration
 
     if len(configurations) == 0:
@@ -98,19 +95,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         with c.override(
             Materialized(
                 name="mz_this",
-                ports=[
-                    f"{port_mz_default_this}:{port_mz_default_internal}",
-                    f"{port_mz_system_this}:{port_mz_system_internal}",
-                ],
                 additional_system_parameter_defaults=test.flag_configuration_pair.config1.to_system_params(),
                 use_default_volumes=False,
             ),
             Materialized(
                 name="mz_other",
-                ports=[
-                    f"{port_mz_default_other}:{port_mz_default_internal}",
-                    f"{port_mz_system_other}:{port_mz_system_internal}",
-                ],
+                ports=[16875, 16876, 16877, 16878, 16879],
                 additional_system_parameter_defaults=test.flag_configuration_pair.config2.to_system_params(),
                 use_default_volumes=False,
             ),

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -160,7 +160,7 @@ running
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'text_data_ssh';
 stalled
 
-> ALTER CONNECTION testdrive_no_reset_connections.public.ssh RESET (PORT) WITH (VALIDATE = true);
+> ALTER CONNECTION testdrive_no_reset_connections.public.ssh SET (PORT = 23) WITH (VALIDATE = true);
 
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'text_data_ssh';
 running
@@ -195,7 +195,7 @@ stalled
 $ kafka-ingest topic=text-data format=bytes
 papaya
 
-> ALTER CONNECTION testdrive_no_reset_connections.public.ssh_backup RESET (PORT) WITH (VALIDATE = true);
+> ALTER CONNECTION testdrive_no_reset_connections.public.ssh_backup SET (PORT = 23) WITH (VALIDATE = true);
 
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'text_data_ssh';
 running

--- a/test/kafka-rtr/resumption/mz-setup.td
+++ b/test/kafka-rtr/resumption/mz-setup.td
@@ -17,8 +17,8 @@ $ kafka-create-topic topic=input_2
 $ kafka-ingest topic=input_2 format=bytes repeat=100
 A,B,0
 
-> CREATE CONNECTION IF NOT EXISTS kafka_conn_1 TO KAFKA (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT);
-> CREATE CONNECTION IF NOT EXISTS kafka_conn_2 TO KAFKA (BROKER 'toxiproxy:8092', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn_1 TO KAFKA (BROKER 'toxiproxy:9093', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn_2 TO KAFKA (BROKER 'toxiproxy:8093', SECURITY PROTOCOL PLAINTEXT);
 
 > CREATE SOURCE input_1
   FROM KAFKA CONNECTION kafka_conn_1 (TOPIC 'testdrive-input_1-${testdrive.seed}')

--- a/test/kafka-rtr/resumption/toxiproxy-setup.td
+++ b/test/kafka-rtr/resumption/toxiproxy-setup.td
@@ -10,13 +10,13 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "kafka_1",
-  "listen": "0.0.0.0:9092",
+  "listen": "0.0.0.0:9093",
   "upstream": "kafka:9092"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "kafka_2",
-  "listen": "0.0.0.0:8092",
+  "listen": "0.0.0.0:8093",
   "upstream": "kafka:9092"
 }

--- a/test/kafka-rtr/simple/mz-setup.td
+++ b/test/kafka-rtr/simple/mz-setup.td
@@ -17,8 +17,8 @@ $ kafka-create-topic topic=input_2
 $ kafka-ingest topic=input_2 format=bytes repeat=100
 A,B,0
 
-> CREATE CONNECTION IF NOT EXISTS kafka_conn_1 TO KAFKA (BROKER 'toxiproxy:9092', SECURITY PROTOCOL PLAINTEXT);
-> CREATE CONNECTION IF NOT EXISTS kafka_conn_2 TO KAFKA (BROKER 'toxiproxy:8092', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn_1 TO KAFKA (BROKER 'toxiproxy:9093', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn_2 TO KAFKA (BROKER 'toxiproxy:8093', SECURITY PROTOCOL PLAINTEXT);
 
 > CREATE SOURCE input_1
   FROM KAFKA CONNECTION kafka_conn_1 (TOPIC 'testdrive-input_1-${testdrive.seed}')

--- a/test/kafka-rtr/simple/toxiproxy-setup.td
+++ b/test/kafka-rtr/simple/toxiproxy-setup.td
@@ -10,14 +10,14 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "kafka_1",
-  "listen": "0.0.0.0:9092",
+  "listen": "0.0.0.0:9093",
   "upstream": "kafka:9092"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "kafka_2",
-  "listen": "0.0.0.0:8092",
+  "listen": "0.0.0.0:8093",
   "upstream": "kafka:9092"
 }
 

--- a/test/mysql-cdc-resumption-old-syntax/alter-source-connection.td
+++ b/test/mysql-cdc-resumption-old-syntax/alter-source-connection.td
@@ -12,4 +12,4 @@
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
 stalled
 
-> ALTER CONNECTION mysql_conn SET (HOST = '${arg.mysql-source-host}');
+> ALTER CONNECTION mysql_conn SET (HOST = '${arg.mysql-source-host}:${arg.mysql-source-port}');

--- a/test/mysql-cdc-resumption-old-syntax/alter-table-fix.td
+++ b/test/mysql-cdc-resumption-old-syntax/alter-table-fix.td
@@ -10,7 +10,7 @@
 # This test "reverts" a schema change that causes a subsource to
 # enter a failed state.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/alter-table.td
+++ b/test/mysql-cdc-resumption-old-syntax/alter-table.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/configure-mysql.td
+++ b/test/mysql-cdc-resumption-old-syntax/configure-mysql.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;

--- a/test/mysql-cdc-resumption-old-syntax/configure-replica-with-delay.td
+++ b/test/mysql-cdc-resumption-old-syntax/configure-replica-with-delay.td
@@ -7,9 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 STOP REPLICA;
-CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=3306, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1, MASTER_DELAY=${arg.mysql-replica-delay-in-sec};
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=${arg.mysql-replication-master-port}, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1, MASTER_DELAY=${arg.mysql-replica-delay-in-sec};
 START REPLICA;

--- a/test/mysql-cdc-resumption-old-syntax/configure-replica.td
+++ b/test/mysql-cdc-resumption-old-syntax/configure-replica.td
@@ -7,9 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 STOP REPLICA;
-CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=3306, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1;
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=${arg.mysql-replication-master-port}, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1;
 START REPLICA;

--- a/test/mysql-cdc-resumption-old-syntax/configure-toxiproxy.td
+++ b/test/mysql-cdc-resumption-old-syntax/configure-toxiproxy.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }

--- a/test/mysql-cdc-resumption-old-syntax/create-source.td
+++ b/test/mysql-cdc-resumption-old-syntax/create-source.td
@@ -13,6 +13,7 @@
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 > CREATE CONNECTION mysql_conn TO MYSQL (
     HOST "${arg.mysql-source-host}",
+    PORT ${arg.mysql-source-port},
     USER root,
     PASSWORD SECRET mysqlpass
   )

--- a/test/mysql-cdc-resumption-old-syntax/delete-rows-t1.td
+++ b/test/mysql-cdc-resumption-old-syntax/delete-rows-t1.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/delete-rows-t2.td
+++ b/test/mysql-cdc-resumption-old-syntax/delete-rows-t2.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/mysql-disable-select-permission.td
+++ b/test/mysql-cdc-resumption-old-syntax/mysql-disable-select-permission.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 REVOKE SELECT ON public.* FROM materialize;

--- a/test/mysql-cdc-resumption-old-syntax/mzcompose.py
+++ b/test/mysql-cdc-resumption-old-syntax/mzcompose.py
@@ -17,7 +17,7 @@ import time
 from typing import Any
 
 import pymysql
-from pg8000 import Cursor
+from psycopg import Cursor
 
 from materialize import buildkite
 from materialize.mzcompose.composition import Composition
@@ -35,11 +35,13 @@ SERVICES = [
     MySql(),
     MySql(
         name="mysql-replica-1",
+        port=3308,
         version=MySql.DEFAULT_VERSION,
         additional_args=create_mysql_server_args(server_id="2", is_master=False),
     ),
     MySql(
         name="mysql-replica-2",
+        port=3309,
         version=MySql.DEFAULT_VERSION,
         additional_args=create_mysql_server_args(server_id="3", is_master=False),
     ),
@@ -189,11 +191,13 @@ def workflow_master_changes(c: Composition) -> None:
         Materialized(sanity_restart=False, default_replication_factor=2),
         MySql(
             name="mysql-replica-1",
+            port=3308,
             version=MySql.DEFAULT_VERSION,
             additional_args=create_mysql_server_args(server_id="2", is_master=False),
         ),
         MySql(
             name="mysql-replica-2",
+            port=3309,
             version=MySql.DEFAULT_VERSION,
             additional_args=create_mysql_server_args(server_id="3", is_master=False),
         ),
@@ -201,7 +205,9 @@ def workflow_master_changes(c: Composition) -> None:
         initialize(c, create_source=False)
 
         host_data_master = "mysql"
+        port_data_master = 3306
         host_for_mz_source = "mysql-replica-2"
+        port_for_mz_source = 3309
 
         c.up("mysql-replica-1", "mysql-replica-2")
 
@@ -209,27 +215,33 @@ def workflow_master_changes(c: Composition) -> None:
         run_testdrive_files(
             c,
             f"--var=mysql-replication-master-host={host_data_master}",
+            f"--var=mysql-replication-master-port={port_data_master}",
             "configure-replica.td",
             mysql_host="mysql-replica-1",
+            mysql_port=3308,
         )
         # configure mysql-replica-2 to replicate mysql
         run_testdrive_files(
             c,
             f"--var=mysql-replication-master-host={host_data_master}",
+            f"--var=mysql-replication-master-port={port_data_master}",
             "configure-replica.td",
             mysql_host="mysql-replica-2",
+            mysql_port=3309,
         )
         # wait for mysql-replica-2 to replicate the current state
         time.sleep(15)
         run_testdrive_files(
             c,
             f"--var=mysql-source-host={host_for_mz_source}",
+            f"--var=mysql-source-port={port_for_mz_source}",
             "verify-mysql-source-select-all.td",
         )
         # create source pointing to mysql-replica-2
         run_testdrive_files(
             c,
             f"--var=mysql-source-host={host_for_mz_source}",
+            f"--var=mysql-source-port={port_for_mz_source}",
             "create-source.td",
         )
 
@@ -240,13 +252,16 @@ def workflow_master_changes(c: Composition) -> None:
 
         c.kill("mysql")
         host_data_master = "mysql-replica-1"
+        port_data_master = 3308
 
         # let mysql-replica-2 replicate from mysql-replica-1
         run_testdrive_files(
             c,
             f"--var=mysql-replication-master-host={host_data_master}",
+            f"--var=mysql-replication-master-port={port_data_master}",
             "configure-replica.td",
             mysql_host=host_for_mz_source,
+            mysql_port=port_for_mz_source,
         )
 
         run_testdrive_files(
@@ -255,7 +270,12 @@ def workflow_master_changes(c: Composition) -> None:
         )
 
         # delete rows in mysql-replica-1
-        run_testdrive_files(c, "delete-rows-t1.td", mysql_host=host_data_master)
+        run_testdrive_files(
+            c,
+            "delete-rows-t1.td",
+            mysql_host=host_data_master,
+            mysql_port=port_data_master,
+        )
 
         # It may take some time until mysql-replica-2 catches up.
         time.sleep(15)
@@ -276,6 +296,7 @@ def workflow_switch_to_replica_and_kill_master(c: Composition) -> None:
         Materialized(sanity_restart=False, default_replication_factor=2),
         MySql(
             name="mysql-replica-1",
+            port=3308,
             version=MySql.DEFAULT_VERSION,
             additional_args=create_mysql_server_args(server_id="2", is_master=False),
         ),
@@ -283,7 +304,9 @@ def workflow_switch_to_replica_and_kill_master(c: Composition) -> None:
         initialize(c)
 
         host_data_master = "mysql"
+        port_data_master = 3306
         host_for_mz_source = "mysql"
+        port_for_mz_source = 3306
 
         c.up("mysql-replica-1")
 
@@ -291,8 +314,10 @@ def workflow_switch_to_replica_and_kill_master(c: Composition) -> None:
         run_testdrive_files(
             c,
             f"--var=mysql-replication-master-host={host_data_master}",
+            f"--var=mysql-replication-master-port={port_data_master}",
             "configure-replica.td",
             mysql_host="mysql-replica-1",
+            mysql_port=3308,
         )
 
         # give the replica some time to replicate the current state
@@ -306,9 +331,11 @@ def workflow_switch_to_replica_and_kill_master(c: Composition) -> None:
 
         # change connection to replica
         host_for_mz_source = "mysql-replica-1"
+        port_for_mz_source = 3308
         run_testdrive_files(
             c,
             f"--var=mysql-source-host={host_for_mz_source}",
+            f"--var=mysql-source-port={port_for_mz_source}",
             "alter-source-connection.td",
         )
 
@@ -342,6 +369,7 @@ def initialize(c: Composition, create_source: bool = True) -> None:
         run_testdrive_files(
             c,
             "--var=mysql-source-host=toxiproxy",
+            "--var=mysql-source-port=3307",
             "create-source.td",
         )
 
@@ -644,6 +672,7 @@ def create_source_after_logs_expiration(
     run_testdrive_files(
         c,
         "--var=mysql-source-host=toxiproxy",
+        "--var=mysql-source-port=3307",
         "create-source.td",
     )
 
@@ -658,6 +687,7 @@ def logs_expiration_while_mz_down(
     run_testdrive_files(
         c,
         "--var=mysql-source-host=toxiproxy",
+        "--var=mysql-source-port=3307",
         "create-source.td",
     )
 
@@ -687,10 +717,13 @@ def logs_expiration_while_mz_down(
     run_testdrive_files(c, "verify-source-stalled.td")
 
 
-def run_testdrive_files(c: Composition, *files: str, mysql_host: str = "mysql") -> None:
+def run_testdrive_files(
+    c: Composition, *files: str, mysql_host: str = "mysql", mysql_port: int = 3306
+) -> None:
     c.run_testdrive_files(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         f"--var=mysql-host={mysql_host}",
+        f"--var=mysql-port={mysql_port}",
         *files,
     )
 

--- a/test/mysql-cdc-resumption-old-syntax/populate-table-t3.td
+++ b/test/mysql-cdc-resumption-old-syntax/populate-table-t3.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/populate-tables.td
+++ b/test/mysql-cdc-resumption-old-syntax/populate-tables.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption-old-syntax/reset-master.td
+++ b/test/mysql-cdc-resumption-old-syntax/reset-master.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 RESET BINARY LOGS AND GTIDS;

--- a/test/mysql-cdc-resumption-old-syntax/toxiproxy-close-connection.td
+++ b/test/mysql-cdc-resumption-old-syntax/toxiproxy-close-connection.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": false
 }

--- a/test/mysql-cdc-resumption-old-syntax/toxiproxy-restore-connection.td
+++ b/test/mysql-cdc-resumption-old-syntax/toxiproxy-restore-connection.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }

--- a/test/mysql-cdc-resumption-old-syntax/verify-mysql-select.td
+++ b/test/mysql-cdc-resumption-old-syntax/verify-mysql-select.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/alter-source-connection.td
+++ b/test/mysql-cdc-resumption/alter-source-connection.td
@@ -12,4 +12,4 @@
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
 stalled
 
-> ALTER CONNECTION mysql_conn SET (HOST = '${arg.mysql-source-host}');
+> ALTER CONNECTION mysql_conn SET (HOST = '${arg.mysql-source-host}:${arg.mysql-source-port}');

--- a/test/mysql-cdc-resumption/alter-table-fix.td
+++ b/test/mysql-cdc-resumption/alter-table-fix.td
@@ -10,7 +10,7 @@
 # This test "reverts" a schema change that causes a subsource to
 # enter a failed state.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/alter-table.td
+++ b/test/mysql-cdc-resumption/alter-table.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/configure-mysql.td
+++ b/test/mysql-cdc-resumption/configure-mysql.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;

--- a/test/mysql-cdc-resumption/configure-replica-with-delay.td
+++ b/test/mysql-cdc-resumption/configure-replica-with-delay.td
@@ -7,9 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 STOP REPLICA;
-CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=3306, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1, MASTER_DELAY=${arg.mysql-replica-delay-in-sec};
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=${arg.mysql-replication-master-port}, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1, MASTER_DELAY=${arg.mysql-replica-delay-in-sec};
 START REPLICA;

--- a/test/mysql-cdc-resumption/configure-replica.td
+++ b/test/mysql-cdc-resumption/configure-replica.td
@@ -7,9 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 STOP REPLICA;
-CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=3306, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1;
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='${arg.mysql-replication-master-host}', SOURCE_PORT=${arg.mysql-replication-master-port}, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1;
 START REPLICA;

--- a/test/mysql-cdc-resumption/configure-toxiproxy.td
+++ b/test/mysql-cdc-resumption/configure-toxiproxy.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }

--- a/test/mysql-cdc-resumption/create-source.td
+++ b/test/mysql-cdc-resumption/create-source.td
@@ -13,6 +13,7 @@
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 > CREATE CONNECTION mysql_conn TO MYSQL (
     HOST "${arg.mysql-source-host}",
+    PORT ${arg.mysql-source-port},
     USER root,
     PASSWORD SECRET mysqlpass
   )

--- a/test/mysql-cdc-resumption/delete-rows-t1.td
+++ b/test/mysql-cdc-resumption/delete-rows-t1.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/delete-rows-t2.td
+++ b/test/mysql-cdc-resumption/delete-rows-t2.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/mysql-disable-select-permission.td
+++ b/test/mysql-cdc-resumption/mysql-disable-select-permission.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 REVOKE SELECT ON public.* FROM materialize;

--- a/test/mysql-cdc-resumption/populate-table-t3.td
+++ b/test/mysql-cdc-resumption/populate-table-t3.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/populate-tables.td
+++ b/test/mysql-cdc-resumption/populate-tables.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc-resumption/reset-master.td
+++ b/test/mysql-cdc-resumption/reset-master.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 RESET BINARY LOGS AND GTIDS;

--- a/test/mysql-cdc-resumption/toxiproxy-close-connection.td
+++ b/test/mysql-cdc-resumption/toxiproxy-close-connection.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": false
 }

--- a/test/mysql-cdc-resumption/toxiproxy-restore-connection.td
+++ b/test/mysql-cdc-resumption/toxiproxy-restore-connection.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }

--- a/test/mysql-cdc-resumption/verify-mysql-select.td
+++ b/test/mysql-cdc-resumption/verify-mysql-select.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host}:${arg.mysql-port} password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE public;

--- a/test/mysql-cdc/proxied/connect_timeout.td
+++ b/test/mysql-cdc/proxied/connect_timeout.td
@@ -21,7 +21,7 @@ ALTER SYSTEM SET mysql_source_connect_timeout = '3s';
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }
@@ -35,6 +35,7 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql/toxics conten
 > CREATE SECRET mysql_pass AS '${arg.mysql-root-password}';
 ! CREATE CONNECTION mysql_conn TO MYSQL (
     HOST "toxiproxy",
+    PORT 3307,
     USER root,
     PASSWORD SECRET mysql_pass
   );

--- a/test/mysql-cdc/proxied/connect_timeout_latency.td
+++ b/test/mysql-cdc/proxied/connect_timeout_latency.td
@@ -21,7 +21,7 @@ ALTER SYSTEM SET mysql_source_connect_timeout = '2s';
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306",
   "enabled": true
 }
@@ -35,6 +35,7 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql/toxics conten
 > CREATE SECRET mysql_pass AS '${arg.mysql-root-password}';
 ! CREATE CONNECTION mysql_conn TO MYSQL (
     HOST "toxiproxy",
+    PORT 3307,
     USER root,
     PASSWORD SECRET mysql_pass
   );
@@ -47,6 +48,7 @@ ALTER SYSTEM SET mysql_source_connect_timeout = '30s';
 
 > CREATE CONNECTION mysql_conn TO MYSQL (
     HOST "toxiproxy",
+    PORT 3307,
     USER root,
     PASSWORD SECRET mysql_pass
   );

--- a/test/mysql-rtr-old-syntax/rtr/mz-setup.td
+++ b/test/mysql-rtr-old-syntax/rtr/mz-setup.td
@@ -27,14 +27,14 @@ INSERT INTO table_b SELECT 1,2 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT
 
 > CREATE CONNECTION mysql_conn_1 TO MYSQL (
     HOST toxiproxy,
-    PORT 3306,
+    PORT 3307,
     USER root,
     PASSWORD SECRET mysqlpass
   )
 
 > CREATE CONNECTION mysql_conn_2 TO MYSQL (
     HOST toxiproxy,
-    PORT 2306,
+    PORT 2307,
     USER root,
     PASSWORD SECRET mysqlpass
   )

--- a/test/mysql-rtr-old-syntax/rtr/toxiproxy-setup.td
+++ b/test/mysql-rtr-old-syntax/rtr/toxiproxy-setup.td
@@ -10,14 +10,14 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql_1",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql_2",
-  "listen": "0.0.0.0:2306",
+  "listen": "0.0.0.0:2307",
   "upstream": "mysql:3306"
 }
 

--- a/test/mysql-rtr/rtr/mz-setup.td
+++ b/test/mysql-rtr/rtr/mz-setup.td
@@ -27,14 +27,14 @@ INSERT INTO table_b SELECT 1,2 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT
 
 > CREATE CONNECTION mysql_conn_1 TO MYSQL (
     HOST toxiproxy,
-    PORT 3306,
+    PORT 3307,
     USER root,
     PASSWORD SECRET mysqlpass
   )
 
 > CREATE CONNECTION mysql_conn_2 TO MYSQL (
     HOST toxiproxy,
-    PORT 2306,
+    PORT 2307,
     USER root,
     PASSWORD SECRET mysqlpass
   )

--- a/test/mysql-rtr/rtr/toxiproxy-setup.td
+++ b/test/mysql-rtr/rtr/toxiproxy-setup.td
@@ -10,14 +10,14 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql_1",
-  "listen": "0.0.0.0:3306",
+  "listen": "0.0.0.0:3307",
   "upstream": "mysql:3306"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "mysql_2",
-  "listen": "0.0.0.0:2306",
+  "listen": "0.0.0.0:2307",
   "upstream": "mysql:3306"
 }
 

--- a/test/mz-debug/mzcompose.py
+++ b/test/mz-debug/mzcompose.py
@@ -20,12 +20,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz_debug import MzDebug
 
 SERVICES = [
-    Materialized(
-        ports=[
-            "6875:6875",
-            "6877:6877",
-        ]
-    ),
+    Materialized(supports_host_network_mode=False),
     MzDebug(),
 ]
 
@@ -80,6 +75,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "--docker-container-id",
             container_id,
             "--mz-connection-url",
-            "postgres://mz_system@localhost:6877/materialize",
+            f"postgres://mz_system@localhost:{c.port('materialized', 6877)}/materialize",
         ]
     )

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -52,7 +52,11 @@ SERVICES = [
     Azurite(),
     Mc(),
     Materialized(default_replication_factor=2),
-    Materialized(name="materialized2", default_replication_factor=2),
+    Materialized(
+        name="materialized2",
+        default_replication_factor=2,
+        ports=[16875, 16876, 16877, 16878, 16879],
+    ),
     Service("sqlsmith", {"mzbuild": "sqlsmith"}),
     Service(
         name="persistcli",
@@ -89,10 +93,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             # TODO: Retry with toxiproxy on azurite
             external_blob_store=True,
             blob_store_is_azure=args.azurite,
-            external_metadata_store="toxiproxy",
-            ports=["6975:6875", "6976:6876", "6977:6877"],
-            sanity_restart=sanity_restart,
+            external_metadata_store="toxiproxy:26258",
             metadata_store="cockroach",
+            sanity_restart=sanity_restart,
             default_replication_factor=2,
         ),
         Toxiproxy(seed=random.randrange(2**63)),
@@ -154,7 +157,7 @@ def toxiproxy_start(c: Composition) -> None:
         f"http://localhost:{port}/proxies",
         json={
             "name": "cockroach",
-            "listen": "0.0.0.0:26257",
+            "listen": "0.0.0.0:26258",
             "upstream": "cockroach:26257",
             "enabled": True,
         },
@@ -164,7 +167,7 @@ def toxiproxy_start(c: Composition) -> None:
         f"http://localhost:{port}/proxies",
         json={
             "name": "minio",
-            "listen": "0.0.0.0:9000",
+            "listen": "0.0.0.0:9002",
             "upstream": "minio:9000",
             "enabled": True,
         },
@@ -174,7 +177,7 @@ def toxiproxy_start(c: Composition) -> None:
         f"http://localhost:{port}/proxies",
         json={
             "name": "azurite",
-            "listen": "0.0.0.0:10000",
+            "listen": "0.0.0.0:10001",
             "upstream": "azurite:10000",
             "enabled": True,
         },

--- a/test/pg-cdc-old-syntax/status/01-setup.td
+++ b/test/pg-cdc-old-syntax/status/01-setup.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }
@@ -19,6 +19,7 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
 
 > CREATE CONNECTION pg TO POSTGRES (
     HOST toxiproxy,
+    PORT 5433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass

--- a/test/pg-cdc-old-syntax/status/03-toxiproxy-interrupt.td
+++ b/test/pg-cdc-old-syntax/status/03-toxiproxy-interrupt.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": false
 }
@@ -32,7 +32,7 @@ t                   ceased
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-cdc-resumption-old-syntax/configure-materialize.td
+++ b/test/pg-cdc-resumption-old-syntax/configure-materialize.td
@@ -13,6 +13,7 @@
 > CREATE SECRET pgpass AS 'materialize'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST toxiproxy,
+    PORT 5433,
     DATABASE postgres,
     USER materialize,
     PASSWORD SECRET pgpass

--- a/test/pg-cdc-resumption-old-syntax/configure-toxiproxy.td
+++ b/test/pg-cdc-resumption-old-syntax/configure-toxiproxy.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-cdc-resumption-old-syntax/toxiproxy-close-connection.td
+++ b/test/pg-cdc-resumption-old-syntax/toxiproxy-close-connection.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": false
 }

--- a/test/pg-cdc-resumption-old-syntax/toxiproxy-restore-connection.td
+++ b/test/pg-cdc-resumption-old-syntax/toxiproxy-restore-connection.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-cdc-resumption/configure-materialize.td
+++ b/test/pg-cdc-resumption/configure-materialize.td
@@ -13,6 +13,7 @@
 > CREATE SECRET pgpass AS 'materialize'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST toxiproxy,
+    PORT 5433,
     DATABASE postgres,
     USER materialize,
     PASSWORD SECRET pgpass

--- a/test/pg-cdc-resumption/configure-toxiproxy.td
+++ b/test/pg-cdc-resumption/configure-toxiproxy.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-cdc-resumption/toxiproxy-close-connection.td
+++ b/test/pg-cdc-resumption/toxiproxy-close-connection.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": false
 }

--- a/test/pg-cdc-resumption/toxiproxy-restore-connection.td
+++ b/test/pg-cdc-resumption/toxiproxy-restore-connection.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-cdc/status/01-setup.td
+++ b/test/pg-cdc/status/01-setup.td
@@ -10,7 +10,7 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }
@@ -19,6 +19,7 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
 
 > CREATE CONNECTION pg TO POSTGRES (
     HOST toxiproxy,
+    PORT 5433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass

--- a/test/pg-cdc/status/03-toxiproxy-interrupt.td
+++ b/test/pg-cdc/status/03-toxiproxy-interrupt.td
@@ -15,7 +15,7 @@ true
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": false
 }
@@ -32,7 +32,7 @@ t                   ceased
 $ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
 {
   "name": "postgres",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432",
   "enabled": true
 }

--- a/test/pg-rtr-old-syntax/rtr/mz-setup.td
+++ b/test/pg-rtr-old-syntax/rtr/mz-setup.td
@@ -32,7 +32,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE CONNECTION pg_conn_1 TO POSTGRES (
     HOST toxiproxy,
-    PORT 5432,
+    PORT 5433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
@@ -40,7 +40,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE CONNECTION pg_conn_2 TO POSTGRES (
     HOST toxiproxy,
-    PORT 4432,
+    PORT 4433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass

--- a/test/pg-rtr-old-syntax/rtr/toxiproxy-setup.td
+++ b/test/pg-rtr-old-syntax/rtr/toxiproxy-setup.td
@@ -10,14 +10,14 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "pg_1",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "pg_2",
-  "listen": "0.0.0.0:4432",
+  "listen": "0.0.0.0:4433",
   "upstream": "postgres:5432"
 }
 

--- a/test/pg-rtr/rtr/mz-setup.td
+++ b/test/pg-rtr/rtr/mz-setup.td
@@ -32,7 +32,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE CONNECTION pg_conn_1 TO POSTGRES (
     HOST toxiproxy,
-    PORT 5432,
+    PORT 5433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
@@ -40,7 +40,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE CONNECTION pg_conn_2 TO POSTGRES (
     HOST toxiproxy,
-    PORT 4432,
+    PORT 4433,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass

--- a/test/pg-rtr/rtr/toxiproxy-setup.td
+++ b/test/pg-rtr/rtr/toxiproxy-setup.td
@@ -10,14 +10,14 @@
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "pg_1",
-  "listen": "0.0.0.0:5432",
+  "listen": "0.0.0.0:5433",
   "upstream": "postgres:5432"
 }
 
 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
 {
   "name": "pg_2",
-  "listen": "0.0.0.0:4432",
+  "listen": "0.0.0.0:4433",
   "upstream": "postgres:5432"
 }
 

--- a/test/pgtest-mz/copy-to.pt
+++ b/test/pgtest-mz/copy-to.pt
@@ -12,7 +12,7 @@ ReadyForQuery {"status":"I"}
 
 # Create aws connection to be used
 send
-Query {"query": "CREATE CONNECTION aws_conn TO AWS (ACCESS KEY ID = 'minioadmin', SECRET ACCESS KEY = SECRET aws_secret_access_key, REGION = 'us-east-1', ENDPOINT = 'http://localhost:40109')"}
+Query {"query": "CREATE CONNECTION aws_conn TO AWS (ACCESS KEY ID = 'minioadmin', SECRET ACCESS KEY = SECRET aws_secret_access_key, REGION = 'us-east-1', ENDPOINT = 'http://localhost:9000')"}
 ----
 
 until

--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -23,7 +23,7 @@ from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.util import selected_by_name
 
 SERVICES = [
-    Materialized(options=["--persist-pubsub-url=http://toxiproxy:6879"]),
+    Materialized(options=["--persist-pubsub-url=http://toxiproxy:6880"]),
     Redpanda(),
     Toxiproxy(),
     Testdrive(no_reset=True, seed=1, default_timeout="60s"),
@@ -191,7 +191,7 @@ def toxiproxy_start(c: Composition) -> None:
                 $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
                 {
                    "name": "pubsub",
-                   "listen": "0.0.0.0:6879",
+                   "listen": "0.0.0.0:6880",
                    "upstream": "materialized:6879",
                    "enabled": true
                 }

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -43,9 +43,9 @@ SERVICES = [
         support_external_clusterd=True,
     ),
     Clusterd(name="clusterd_1_1"),
-    Clusterd(name="clusterd_1_2"),
-    Clusterd(name="clusterd_2_1"),
-    Clusterd(name="clusterd_2_2"),
+    Clusterd(name="clusterd_1_2", ports=[2104, 2105, 2106, 2107, 6882]),
+    Clusterd(name="clusterd_2_1", ports=[2108, 2109, 2110, 2111, 6883]),
+    Clusterd(name="clusterd_2_2", ports=[2112, 2113, 2114, 2115, 6884]),
     Testdrive(),
 ]
 
@@ -253,10 +253,10 @@ def drop_create_replica(c: Composition) -> None:
             """
             > DROP CLUSTER REPLICA cluster1.replica1
             > CREATE CLUSTER REPLICA cluster1.replica3
-              STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
-              STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
-              COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
-              COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
+              STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2104'],
+              STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2107'],
+              COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2105'],
+              COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2106']
             """
         )
     )
@@ -455,19 +455,22 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         ),
         Clusterd(
             name="clusterd_1_1",
-            process_names=["clusterd_1_1", "clusterd_1_2"],
+            processes=[("clusterd_1_1", 2102, 2103), ("clusterd_1_2", 2106, 2107)],
         ),
         Clusterd(
             name="clusterd_1_2",
-            process_names=["clusterd_1_1", "clusterd_1_2"],
+            processes=[("clusterd_1_1", 2102, 2103), ("clusterd_1_2", 2106, 2107)],
+            ports=[2104, 2105, 2106, 2107, 6882],
         ),
         Clusterd(
             name="clusterd_2_1",
-            process_names=["clusterd_2_1", "clusterd_2_2"],
+            processes=[("clusterd_2_1", 2110, 2111), ("clusterd_2_2", 2114, 2115)],
+            ports=[2108, 2109, 2110, 2111, 6883],
         ),
         Clusterd(
             name="clusterd_2_2",
-            process_names=["clusterd_2_1", "clusterd_2_2"],
+            processes=[("clusterd_2_1", 2110, 2111), ("clusterd_2_2", 2114, 2115)],
+            ports=[2112, 2113, 2114, 2115, 6884],
         ),
     ):
         c.up(
@@ -508,16 +511,16 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 replica1 (
-                    STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
-                    STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
-                    COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
+                    STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2104'],
+                    STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2107'],
+                    COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2105'],
+                    COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2106']
                 ),
                 replica2 (
-                    STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
-                    STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
-                    COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
+                    STORAGECTL ADDRESSES ['clusterd_2_1:2108', 'clusterd_2_2:2112'],
+                    STORAGE ADDRESSES ['clusterd_2_1:2111', 'clusterd_2_2:2115'],
+                    COMPUTECTL ADDRESSES ['clusterd_2_1:2109', 'clusterd_2_2:2113'],
+                    COMPUTE ADDRESSES ['clusterd_2_1:2110', 'clusterd_2_2:2114']
                 )
             )
             """

--- a/test/ssh-connection/setup.td
+++ b/test/ssh-connection/setup.td
@@ -17,7 +17,7 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true
 > CREATE CONNECTION IF NOT EXISTS thancred TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'mz',
-    PORT 22
+    PORT 23
   );
 
 # We don't authorize this connection's keys, so we
@@ -25,5 +25,5 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true
 > CREATE CONNECTION IF NOT EXISTS keyless TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'mz',
-    PORT 22
+    PORT 23
   );

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -19,7 +19,7 @@ id public_key_1 public_key_2
 ! CREATE CONNECTION louisoix TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'louisoix',
-    PORT 22,
+    PORT 23,
     PUBLIC KEY 1 = 'bad'
   );
 contains:the PUBLIC KEY 1 option cannot be explicitly specified
@@ -27,7 +27,7 @@ contains:the PUBLIC KEY 1 option cannot be explicitly specified
 ! CREATE CONNECTION louisoix TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'louisoix',
-    PORT 22,
+    PORT 23,
     PUBLIC KEY 2 = 'bad'
   );
 contains:the PUBLIC KEY 2 option cannot be explicitly specified
@@ -35,7 +35,7 @@ contains:the PUBLIC KEY 2 option cannot be explicitly specified
 > CREATE CONNECTION louisoix TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'louisoix',
-    PORT 22
+    PORT 23
   );
 
 # mz_ssh_tunnel_connections is properly populated, and SSH public keys look like keys
@@ -49,7 +49,7 @@ louisoix true  true
 > CREATE CONNECTION omega TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'omega',
-    PORT 22
+    PORT 23
   );
 
 > SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
@@ -92,7 +92,7 @@ name     pkey1 pkey2
 > CREATE CONNECTION phoenix TO SSH TUNNEL (
     HOST 'light.example.com',
     USER 'phoenix',
-    PORT 22
+    PORT 23
   );
 
 > CREATE CONNECTION yshtola TO POSTGRES (
@@ -143,7 +143,7 @@ ALTER SYSTEM SET storage_enforce_external_addresses = true
 > CREATE CONNECTION omega TO SSH TUNNEL (
     HOST 'chaos.example.com',
     USER 'omega',
-    PORT 22
+    PORT 23
   );
 
 # error is not consistent
@@ -153,7 +153,7 @@ contains:failed to
 > CREATE CONNECTION local TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'omega',
-    PORT 22
+    PORT 23
   );
 
 ! VALIDATE CONNECTION local;

--- a/test/ssh-connection/validate-failures.td
+++ b/test/ssh-connection/validate-failures.td
@@ -10,21 +10,21 @@
 ! CREATE CONNECTION IF NOT EXISTS invalid_host TO SSH TUNNEL (
     HOST 'invalid-ssh-bastion-host',
     USER 'mz',
-    PORT 22
+    PORT 23
   ) WITH (VALIDATE);
 contains:failed to lookup address information
 
 ! CREATE CONNECTION IF NOT EXISTS invalid_port TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'mz',
-    PORT 23
+    PORT 24
   ) WITH (VALIDATE);
-regex:failed to connect to the remote host: connect to host .* port 23: Connection refused
+regex:failed to connect to the remote host: connect to host .* port 24: Connection refused
 
 > CREATE CONNECTION IF NOT EXISTS invalid_user TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'invalid',
-    PORT 22
+    PORT 23
   );
 
 ! VALIDATE CONNECTION invalid_user;

--- a/test/testdrive/connection-validation.td
+++ b/test/testdrive/connection-validation.td
@@ -34,7 +34,7 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true
 
 > DROP CONNECTION kafka_conn
 
-> CREATE CONNECTION invalid_tunnel TO SSH TUNNEL (HOST 'invalid', USER 'invalid', PORT 22)
+> CREATE CONNECTION invalid_tunnel TO SSH TUNNEL (HOST 'invalid', USER 'invalid', PORT 23)
 
 ! CREATE CONNECTION invalid_kafka_conn TO KAFKA (BROKERS ('${testdrive.kafka-addr}' USING SSH TUNNEL invalid_tunnel), SECURITY PROTOCOL PLAINTEXT)
 contains:failed to lookup address information

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -14,6 +14,8 @@
 # sources. This also serves to verify that logging is correctly cleaned up under
 # active dataflow cancellation.
 
+$ set-sql-timeout duration=60s
+
 # Introspection subscribes add noise to the introspection sources, so disable them.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false

--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -54,7 +54,7 @@ source          subsource
 > CREATE CONNECTION ssh_conn TO SSH TUNNEL (
     HOST 'unused',
     USER 'mz',
-    PORT 22
+    PORT 23
   );
 > CREATE CONNECTION pg_conn TO POSTGRES (
     HOST unused,

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -155,7 +155,7 @@ def workflow_basic(c: Composition) -> None:
 
 def workflow_clusterd(c: Composition) -> None:
     c.up("materialized", "clusterd")
-    port = c.port("clusterd", 6878)
+    port = c.port("clusterd", 6881)
 
     c.sql(
         "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -185,6 +185,11 @@ def run_workload(c: Composition, workload: Workload, args: argparse.Namespace) -
         *[
             Materialized(
                 name=mz_name,
+                ports=(
+                    [6875, 6876, 6877, 6878, 6879]
+                    if mz_name == "mz_first"
+                    else [16875, 16876, 16877, 16878, 16879]
+                ),
                 external_metadata_store=True,
                 external_blob_store=True,
                 blob_store_is_azure=args.azurite,
@@ -253,7 +258,7 @@ def run_workload(c: Composition, workload: Workload, args: argparse.Namespace) -
         )
 
         print("+++ Verifying committed transactions ...")
-        cursor = c.sql_cursor(service="mz_second")
+        cursor = c.sql_cursor(port=16875, service="mz_second")
         for commit in commits:
             if commit is None:
                 continue

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -15,6 +15,7 @@ Test Kafka Upsert sources using Testdrive.
 """
 
 import os
+import time
 from textwrap import dedent
 
 from materialize import ci_util
@@ -676,10 +677,12 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
             )
 
         num_rows = 100_000  # out of disk with 200_000 rows
-        batch_size = 10_000
+        batch_size = 1_000
         for i in range(0, num_rows, batch_size):
             batch_num = min(batch_size, num_rows - i)
             make_inserts(c, i, batch_num)
+            # Kafka is too slow, queue full
+            time.sleep(10)
 
         c.testdrive(
             args=["--no-reset"],

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -83,8 +83,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = test.parse_output_consistency_input_args(parser)
 
     port_mz_default_internal, port_mz_system_internal = 6875, 6877
-    port_mz_default_this, port_mz_system_this = 6875, 6877
-    port_mz_default_other, port_mz_system_other = 16875, 16877
     tag_mz_other = resolve_tag(args.other_tag)
 
     print(f"Using {tag_mz_other} as tag for other mz version")
@@ -93,19 +91,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         Materialized(
             name="mz_this",
             image=None,
-            ports=[
-                f"{port_mz_default_this}:{port_mz_default_internal}",
-                f"{port_mz_system_this}:{port_mz_system_internal}",
-            ],
             use_default_volumes=False,
         ),
         Materialized(
             name="mz_other",
             image=f"materialize/materialized:{tag_mz_other}",
-            ports=[
-                f"{port_mz_default_other}:{port_mz_default_internal}",
-                f"{port_mz_system_other}:{port_mz_system_internal}",
-            ],
+            ports=[16875, 16876, 16877, 16878, 16879],
             use_default_volumes=False,
         ),
     ):

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -52,6 +52,11 @@ def create_mzs(
     return [
         Materialized(
             name=mz_name,
+            ports=(
+                [16875, 16876, 16877, 16878, 16879]
+                if mz_name == "materialized2"
+                else [6875, 6876, 6877, 6878, 6879]
+            ),
             external_blob_store=True,
             blob_store_is_azure=azurite,
             external_metadata_store=True,
@@ -64,7 +69,7 @@ def create_mzs(
         for mz_name in ["materialized", "materialized2"]
     ] + [
         Testdrive(
-            materialize_url="postgres://materialize@balancerd:6875",
+            materialize_url="postgres://materialize@balancerd:6575",
             no_reset=True,
             seed=1,
             # Timeout increased since Large Zippy occasionally runs into them


### PR DESCRIPTION
Only for CI, not locally. Some tests run twice as fast. Individual benchmarks are interesting to see how it affects some individual actions: https://docs.google.com/spreadsheets/d/1L-mAGsB5tcrIpqJDhGC13JRMP8TGw4nE6QYA-jbKt5s/edit?gid=2146535294#gid=2146535294
Impressive changes:
- ManySmallUpdates 18.6s -> 0.7s (27 times faster)
- SubscribeParallelTable: 58.5 s -> 2.7 s (21 times faster)
- StartupLoaded 3.7 s -> 1.7 s (2.1 times faster)
- PgCdcInitialLoad 1.2 s -> 0.7 s (1.8 times faster)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
