### PR TITLE
Fix testdrive's Dockerfile

### DIFF
--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -12,7 +12,7 @@ MZFROM ubuntu-base
 RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends postgresql-client && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install the Protobuf compiler from protobuf-src.
-COPY testdrive protobuf-bin /usr/local/bin
+COPY testdrive protobuf-bin /usr/local/bin/
 COPY protobuf-include /usr/local/include
 RUN chmod +x /usr/local/bin/protoc
 ENV PROTOC /usr/local/bin/protoc


### PR DESCRIPTION
I was trying to execute
```
bin/mzcompose --dev --find cluster run test-refresh-mv-restart
```
locally, but was getting the following error:
```
Step 3/12 : COPY testdrive protobuf-bin /usr/local/bin
When using COPY with more than one source file, the destination must be a directory and end with a /
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/gabor/materialize/misc/python/materialize/cli/mzcompose.py", line 935, in <module>
    main(sys.argv[1:])
  File "/home/gabor/materialize/misc/python/materialize/cli/mzcompose.py", line 157, in main
    args.command.invoke(args)
  File "/home/gabor/materialize/misc/python/materialize/cli/mzcompose.py", line 253, in invoke
    self.run(args)
  File "/home/gabor/materialize/misc/python/materialize/cli/mzcompose.py", line 697, in run
    super().run(args)
  File "/home/gabor/materialize/misc/python/materialize/cli/mzcompose.py", line 592, in run
    composition.dependencies.acquire()
  File "/home/gabor/materialize/misc/python/materialize/mzbuild.py", line 1217, in acquire
    dep.build(prep)
  File "/home/gabor/materialize/misc/python/materialize/mzbuild.py", line 980, in build
    spawn.runv(cmd, stdin=f, stdout=sys.stderr.buffer)
  File "/home/gabor/materialize/misc/python/materialize/spawn.py", line 75, in runv
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "/home/gabor/.pyenv/versions/3.11.3/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'build', '-f', '-', '--build-arg=ARCH_GCC=x86_64', '--build-arg=ARCH_GO=amd64', '--build-arg=CI_SANITIZER=none', '-t', 'materialize/testdrive:mzbuild-BIZ6O7K5P5UNPPY3LSZZ6CN5WJUYDCHQ', '--platform=linux/amd64', '/home/gabor/materialize/src/testdrive/ci']' returned non-zero exit status 1.
```
This PR fixes the path to end with a `/` as requested by the error msg. (I'm not sure why CI was not running into the same error. Maybe there is a different docker version or something. My docker is 28.3.2, and my Docker Compose is 2.39.1.)

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
