### PR TITLE
cargo test: Prevent smoke_test_metrics_future_ext from being CPU-starved

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -109,6 +109,11 @@ priority = 60
 filter = "package(mz-repr) and test(row_packing_roundtrips_single_valued)"
 priority = 60
 
+[[profile.default.overrides]]
+filter = "package(mz-ore) and test(smoke_test_metrics_future_ext)"
+threads-required = 8
+priority = 50
+
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false


### PR DESCRIPTION
Seen flaking in https://buildkite.com/materialize/test/builds/107051
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
