### PR TITLE
ci: Speed up cargo test further using optimized build and reducing one test scope

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -41,7 +41,3 @@ rustflags = [
 # Always reserve at least one core so Cargo doesn't pin our CPU
 jobs = -1
 rustflags = ["--cfg=tokio_unstable"]
-
-[profile.ci]
-inherits = "dev"
-debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,6 +304,11 @@ lto = "off"
 debug = 1
 incremental = true
 
+[profile.ci]
+inherits = "optimized"
+debug = "line-tables-only"
+debug-assertions = true
+
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a
 # feature/patch branch (e.g., "fix-thing" or "pr-1234"). Feature/patch branches

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3257,6 +3257,8 @@ mod tests {
                 "avg_internal_v1",
                 "bool_and",
                 "bool_or",
+                "has_table_privilege", // > 3 s each
+                "has_type_privilege",  // > 3 s each
                 "mod",
                 "mz_panic",
                 "mz_sleep",


### PR DESCRIPTION
Build time is similar as with debug build. Test time goes down to < 80s for each of the runs:
```
Summary [  76.276s] 199 tests run: 199 passed, 4 skipped
Summary [  66.871s] 1662 tests run: 1662 passed, 11 skipped
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
