### PR TITLE
tests: Disable two very flaky tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -363,6 +363,7 @@ steps:
       #
       # See: <https://github.com/microsoft/mssql-docker/issues/864>
       queue: hetzner-x86-64-4cpu-8gb
+    skip: "database-issues#9519 and database-issues#9514"
 
   - group: "Connection tests"
     key: connection-tests

--- a/test/mysql-cdc-old-syntax/alter-table-after-source.td
+++ b/test/mysql-cdc-old-syntax/alter-table-after-source.td
@@ -7,8 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-sql-timeout duration=1s
 $ set-sql-timeout duration=60s
+
+# TODO(def-) Reenable when database-issues#7900 is fixed
+$ skip-if
+SELECT true
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created

--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -7,8 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-sql-timeout duration=1s
 $ set-sql-timeout duration=60s
+
+# TODO(def-) Reenable when database-issues#7900 is fixed
+$ skip-if
+SELECT true
 
 #
 # Test ALTER TABLE -- source will error out for tables which existed when the source was created


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
