### PR TITLE
ci: try disabling jemalloc sampling

### DIFF
--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -26,7 +26,7 @@ use tikv_jemalloc_ctl::{epoch, stats};
 
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:false,prof_active:false,lg_prof_sample:19\0";
 
 #[derive(Copy, Clone, Debug)]
 pub struct JemallocProfMetadata {


### PR DESCRIPTION
Measurements: https://docs.google.com/spreadsheets/d/1nXaKexFOSJ0-1eEIDLPQCJM9LPPmwBacAuKTOMCcwks/edit? gid=2146535294#gid=2146535294 (~20% faster)

But disabling it in CI is not so easy after https://github.com/MaterializeInc/materialize/pull/23231 and https://github.com/MaterializeInc/materialize/pull/25522. I'm wondering if we should bother with getting the option back.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
