### PR TITLE
envd/ws: fix reception of initial websocket message

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -884,8 +884,8 @@ async fn init_ws(
     let authenticator = authenticator_rx.clone().await.expect("sender not dropped");
     // TODO: Add a timeout here to prevent resource leaks by clients that
     // connect then never send a message.
-    let init_msg = ws.recv().await.ok_or_else(|| anyhow::anyhow!("closed"))??;
     let ws_auth: WebSocketAuth = loop {
+        let init_msg = ws.recv().await.ok_or_else(|| anyhow::anyhow!("closed"))??;
         match init_msg {
             Message::Text(data) => break serde_json::from_str(&data)?,
             Message::Binary(data) => break serde_json::from_slice(&data)?,


### PR DESCRIPTION
This PR fixes a bug in the `init_ws` logic where we would wait for an initial authentication message in the loop, skipping over ping messages, but forgetting to actually read a new message on each loop iteration. As a result, if the first received message was a ping message, we would busy-loop forever, potentially stalling out the entire process by blocking the tokio runtime.

### Motivation

  * This PR fixes a previously unreported bug.
 
See [incident-659](https://materializeinc.slack.com/archives/C0981AETN69).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
