### PR TITLE
bin/environmentd: Support METDATA_BACKEND_URL properly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,7 @@ build --test_output=all
 #
 # TODO(parkmycar): Switch over to using `env_inherit` on `rust_test` once that's stable.
 # <https://github.com/bazelbuild/rules_rust/pull/2809>
-build --test_env=COCKROACH_URL
+build --test_env=METADATA_BACKEND_URL
 
 # Allows spaces to in filenames, without this Rust Doc tests fail to build.
 build:macos --experimental_inprocess_symlink_creation

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -219,7 +219,7 @@ case "$cmd" in
             --env SCHEMA_REGISTRY_URL
             --env STEP_START_TIMESTAMP_WITH_TZ
             --env POSTGRES_URL
-            --env COCKROACH_URL
+            --env METADATA_BACKEND_URL
             # For ci-closed-issues-detect
             --env GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN
             # For auto_cut_release

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -87,7 +87,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     postgres_url = (
         f"postgres://postgres:postgres@localhost:{c.default_port('postgres')}"
     )
-    cockroach_url = f"postgres://root@localhost:{c.default_port(c.metadata_store())}"
+    metadata_backend_url = (
+        f"postgres://root@localhost:{c.default_port(c.metadata_store())}"
+    )
 
     env = dict(
         os.environ,
@@ -95,12 +97,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         KAFKA_ADDRS="localhost:30123",
         SCHEMA_REGISTRY_URL=f"http://localhost:{c.default_port('schema-registry')}",
         POSTGRES_URL=postgres_url,
-        COCKROACH_URL=cockroach_url,
+        METADATA_BACKEND_URL=metadata_backend_url,
         MZ_SOFT_ASSERTIONS="1",
         MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET="mz-test-persist-1d-lifecycle-delete",
         MZ_S3_UPLOADER_TEST_S3_BUCKET="mz-test-1d-lifecycle-delete",
         MZ_PERSIST_EXTERNAL_STORAGE_TEST_AZURE_CONTAINER="mz-test-azure",
-        MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=cockroach_url,
+        MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=metadata_backend_url,
     )
 
     coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -507,7 +507,7 @@ impl Catalog {
     }
 
     /// Creates a debug catalog from the current
-    /// `COCKROACH_URL` with parameters set appropriately for debug contexts,
+    /// `METADATA_BACKEND_URL` with parameters set appropriately for debug contexts,
     /// like in tests.
     ///
     /// WARNING! This function can arbitrarily fail because it does not make any

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -547,8 +547,8 @@ impl Listeners {
         let scratch_dir = tempfile::tempdir()?;
         let (consensus_uri, timestamp_oracle_url) = {
             let seed = config.seed;
-            let cockroach_url = env::var("COCKROACH_URL")
-                .map_err(|_| anyhow!("COCKROACH_URL environment variable is not set"))?;
+            let cockroach_url = env::var("METADATA_BACKEND_URL")
+                .map_err(|_| anyhow!("METADATA_BACKEND_URL environment variable is not set"))?;
             let (client, conn) = tokio_postgres::connect(&cockroach_url, NoTls).await?;
             mz_ore::task::spawn(|| "startup-postgres-conn", async move {
                 if let Err(err) = conn.await {

--- a/src/timestamp-oracle/src/postgres_oracle.rs
+++ b/src/timestamp-oracle/src/postgres_oracle.rs
@@ -106,7 +106,7 @@ impl From<PostgresTimestampOracleConfig> for PostgresClientConfig {
 }
 
 impl PostgresTimestampOracleConfig {
-    pub(crate) const EXTERNAL_TESTS_POSTGRES_URL: &'static str = "COCKROACH_URL";
+    pub(crate) const EXTERNAL_TESTS_POSTGRES_URL: &'static str = "METADATA_BACKEND_URL";
 
     /// Returns a new instance of [`PostgresTimestampOracleConfig`] with default tuning.
     pub fn new(url: &SensitiveUrl, metrics_registry: &MetricsRegistry) -> Self {
@@ -125,7 +125,7 @@ impl PostgresTimestampOracleConfig {
     ///
     /// By default, postgres oracle tests are no-ops so that `cargo test` works
     /// on new environments without any configuration. To activate the tests for
-    /// [`PostgresTimestampOracle`] set the `COCKROACH_URL` environment variable
+    /// [`PostgresTimestampOracle`] set the `METADATA_BACKEND_URL` environment variable
     /// with a valid connection url [1].
     ///
     /// [1]: https://docs.rs/tokio-postgres/latest/tokio_postgres/config/struct.Config.html#url


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
