### PR TITLE
test: avoid flakes caused by reconciliation of introspection subscribes

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1713,7 +1713,10 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
         c.up("materialized", "clusterd1", "clusterd2")
 
         c.sql(
-            "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
+            """
+            ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;
+            ALTER SYSTEM SET enable_introspection_subscribes = false;
+            """,
             port=6877,
             user="mz_system",
         )
@@ -1864,7 +1867,10 @@ def workflow_test_compute_reconciliation_replace(c: Composition) -> None:
         c.up("materialized", "clusterd1")
 
         c.sql(
-            "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
+            """
+            ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;
+            ALTER SYSTEM SET enable_introspection_subscribes = false;
+            """,
             port=6877,
             user="mz_system",
         )


### PR DESCRIPTION
Introspection subscribes can confuse the compute reconciliation tests because they always need to be replaced. Avoid that by disabling introspection subscribes for these tests.

### Motivation

   * This PR unflakes tests.

Flake observed in https://buildkite.com/materialize/test/builds/106806.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
