### PR TITLE
mysql: fix allow for cdc replication of 0 value enum variants

### DIFF
--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -153,6 +153,7 @@ fn pack_val_as_datum(
 
                                 // If mysql strict mode is disabled when an invalid entry is inserted
                                 // then the entry will be replicated as a 0. Outside the 1 indexed enum.
+                                // https://dev.mysql.com/doc/refman/8.4/en/enum.html#enum-indexes
                                 if enum_int == 0 {
                                     packer.push(Datum::String(""));
                                 } else {

--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -149,17 +149,25 @@ fn pack_val_as_datum(
                                 packer.push(Datum::String(data));
                             }
                             Value::Int(val) => {
-                                // Enum types are provided as 1-indexed integers in the replication
-                                // stream, so we need to find the string value from the enum meta
-                                let enum_val =
-                                    e.values.get(usize::try_from(val)? - 1).ok_or_else(|| {
+                                let enum_int = usize::try_from(val)?;
+
+                                // If mysql strict mode is disabled when an invalid entry is inserted
+                                // then the entry will be replicated as a 0. Outside the 1 indexed enum.
+                                if enum_int == 0 {
+                                    packer.push(Datum::String(""));
+                                } else {
+                                    // Enum types are provided as 1-indexed integers in the replication
+                                    // stream, so we need to find the string value from the enum meta
+                                    let enum_val = e.values.get(enum_int - 1).ok_or_else(|| {
                                         anyhow::anyhow!(
                                             "received invalid enum value: {} for column {}",
                                             val,
                                             col_desc.name
                                         )
                                     })?;
-                                packer.push(Datum::String(enum_val));
+
+                                    packer.push(Datum::String(enum_val));
+                                }
                             }
                             _ => Err(anyhow::anyhow!(
                                 "received unexpected value for enum type: {:?}",

--- a/test/mysql-cdc/20-source-replication.td
+++ b/test/mysql-cdc/20-source-replication.td
@@ -21,25 +21,36 @@ $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-pass
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
+SET SESSION sql_mode='';
 USE public;
-CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
-INSERT INTO dummy VALUES (123, "dummy data");
-INSERT INTO dummy VALUES (234, "moar dummy");
+CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128), size ENUM('x-small', 'small', 'medium', 'large', 'x-large'));
+INSERT INTO dummy VALUES (123, "dummy data", 'not-present');
+INSERT INTO dummy VALUES (234, "moar dummy", 'small');
 COMMIT;
 
 > CREATE SOURCE foo FROM MYSQL CONNECTION mysq;
-> CREATE TABLE dummy FROM SOURCE foo (REFERENCE public.dummy);
+> CREATE TABLE dummy FROM SOURCE foo (REFERENCE public.dummy) WITH (TEXT COLUMNS (size));
 
 > SELECT * FROM dummy;
-123 "dummy data"
-234 "moar dummy"
+123 "dummy data" ""
+234 "moar dummy" small
 
 $ mysql-execute name=mysql
 USE public;
-INSERT INTO dummy VALUES (145, "next row");
+INSERT INTO dummy VALUES (145, "next row", NULL);
 COMMIT;
 
 > SELECT * FROM dummy;
-123 "dummy data"
-234 "moar dummy"
-145 "next row"
+123 "dummy data" ""
+234 "moar dummy" small
+145 "next row" <null>
+
+$ mysql-execute name=mysql
+USE public;
+UPDATE dummy SET size = 'medium' WHERE size IS NULL OR size = '';
+COMMIT;
+
+> SELECT * FROM dummy;
+123 "dummy data" medium
+234 "moar dummy" small
+145 "next row" medium

--- a/test/mysql-cdc/20-source-replication.td
+++ b/test/mysql-cdc/20-source-replication.td
@@ -21,36 +21,25 @@ $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-pass
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
-SET SESSION sql_mode='';
 USE public;
-CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128), size ENUM('x-small', 'small', 'medium', 'large', 'x-large'));
-INSERT INTO dummy VALUES (123, "dummy data", 'not-present');
-INSERT INTO dummy VALUES (234, "moar dummy", 'small');
+CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
+INSERT INTO dummy VALUES (123, "dummy data");
+INSERT INTO dummy VALUES (234, "moar dummy");
 COMMIT;
 
 > CREATE SOURCE foo FROM MYSQL CONNECTION mysq;
-> CREATE TABLE dummy FROM SOURCE foo (REFERENCE public.dummy) WITH (TEXT COLUMNS (size));
+> CREATE TABLE dummy FROM SOURCE foo (REFERENCE public.dummy);
 
 > SELECT * FROM dummy;
-123 "dummy data" ""
-234 "moar dummy" small
+123 "dummy data"
+234 "moar dummy"
 
 $ mysql-execute name=mysql
 USE public;
-INSERT INTO dummy VALUES (145, "next row", NULL);
+INSERT INTO dummy VALUES (145, "next row");
 COMMIT;
 
 > SELECT * FROM dummy;
-123 "dummy data" ""
-234 "moar dummy" small
-145 "next row" <null>
-
-$ mysql-execute name=mysql
-USE public;
-UPDATE dummy SET size = 'medium' WHERE size IS NULL OR size = '';
-COMMIT;
-
-> SELECT * FROM dummy;
-123 "dummy data" medium
-234 "moar dummy" small
-145 "next row" medium
+123 "dummy data"
+234 "moar dummy"
+145 "next row"

--- a/test/mysql-cdc/types-enum.td
+++ b/test/mysql-cdc/types-enum.td
@@ -26,10 +26,11 @@ $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-pass
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
+SET SESSION sql_mode='';
 USE public;
 
 CREATE TABLE enum_type (f1 ENUM ('val1', 'val2'), f2 TEXT);
-INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2');
+INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'val2');
 
 > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
@@ -42,6 +43,7 @@ contains:referenced tables use unsupported types
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
+"" val2
 
 # Add an additional enum value type
 $ mysql-execute name=mysql
@@ -51,6 +53,7 @@ INSERT INTO enum_type VALUES ('val1', 'val1');
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
+"" val2
 val1 val1
 
 $ mysql-execute name=mysql
@@ -65,7 +68,35 @@ DELETE FROM enum_type WHERE f1 = 'val3';
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
+"" val2
 val1 val1
+
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO enum_type VALUES (NULL, 'val1');
+INSERT INTO enum_type VALUES ('not-present', 'val1');
+COMMIT;
+
+> SELECT * FROM enum_type;
+val1 val1
+val2 val2
+"" val2
+val1 val1
+<null> val1
+"" val1
+
+$ mysql-execute name=mysql
+USE public;
+UPDATE enum_type SET f1 = 'val2' WHERE f1 IS NULL OR f1 = '';
+COMMIT;
+
+> SELECT * FROM enum_type;
+val1 val1
+val2 val2
+val2 val2
+val1 val1
+val2 val1
+val2 val1
 
 # Add an additional enum value type and change the ordering
 $ mysql-execute name=mysql


### PR DESCRIPTION


### Motivation

https://github.com/MaterializeInc/database-issues/issues/9528

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
