### PR TITLE
sql_server: add checking permissions for all instances and tables in one query

### DIFF
--- a/src/sql-server-util/src/lib.rs
+++ b/src/sql-server-util/src/lib.rs
@@ -638,9 +638,6 @@ impl Connection {
                 let result = client.execute(query, &params[..]).await?;
 
                 match result.rows_affected() {
-                    [] => Err(SqlServerError::InvariantViolated(
-                        "got empty response".into(),
-                    )),
                     rows_affected => {
                         let response = Response::Execute {
                             rows_affected: rows_affected.into(),
@@ -854,6 +851,13 @@ pub enum SqlServerError {
     Generic(#[from] anyhow::Error),
     #[error("programming error! {0}")]
     ProgrammingError(String),
+    #[error(
+        "insufficient permissions for tables [{tables}] or capture instances [{capture_instances}]"
+    )]
+    AuthorizationError {
+        tables: String,
+        capture_instances: String,
+    },
 }
 
 /// Errors returned from decoding SQL Server rows.

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -147,8 +147,6 @@ pub(super) async fn purify_source_exports(
         }
     }
 
-    // TODO(sql_server2): Validate permissions on upstream tables.
-
     let capture_instances: BTreeMap<_, _> = requested_exports
         .iter()
         .map(|requested| {
@@ -164,6 +162,12 @@ pub(super) async fn purify_source_exports(
             (table.qualified_name(), Arc::clone(capture_instance))
         })
         .collect();
+
+    mz_sql_server_util::inspect::validate_source_privileges(
+        client,
+        capture_instances.values().map(|instance| instance.as_ref()),
+    )
+    .await?;
 
     // If CDC is freshly enabled for a table, it has been observed that
     // the `start_lsn`` from `cdc.change_tables` can be ahead of the LSN

--- a/test/sql-server-cdc/20-column-options.td
+++ b/test/sql-server-cdc/20-column-options.td
@@ -29,7 +29,6 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't2_columns'
 
 INSERT INTO t2_columns VALUES ('invisible');
 
-
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
 > CREATE CONNECTION sql_server_columns_connection TO SQL SERVER (
@@ -73,11 +72,11 @@ INSERT INTO t1_columns VALUES (2.000001, '01:59:32.99901', '$0.89', 0x1122AABBCC
 2.0000010000 01:59:32.999010 ESKqu8wA3Q==
 <null> <null> <null>
 
+> DROP SOURCE t1_columns_sql_server CASCADE;
+
 ! CREATE SOURCE t2_columns_sql_server
   FROM SQL SERVER CONNECTION sql_server_columns_connection (
     EXCLUDE COLUMNS (dbo.t2_columns.c1)
   )
   FOR TABLES (dbo.t2_columns);
 contains:Table t2_columns had all columns excluded
-
-> DROP SOURCE t1_columns_sql_server CASCADE;

--- a/test/sql-server-cdc/21-privileges.td
+++ b/test/sql-server-cdc/21-privileges.td
@@ -1,0 +1,82 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup SQL Server state.
+#
+# Create a table that has CDC enabled.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+USE test;
+CREATE TABLE t1_privileges (c1 int, c2 int);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_privileges', @role_name = 'SA', @supports_net_changes = 0;
+
+CREATE LOGIN authorization_user_column_perms WITH PASSWORD = '${arg.default-sql-server-password}';
+CREATE USER authorization_user_column_perms FOR LOGIN authorization_user_column_perms;
+ALTER ROLE db_datareader ADD MEMBER authorization_user_column_perms;
+
+DENY SELECT ON OBJECT::dbo.t1_privileges(c2) TO authorization_user_column_perms;
+
+CREATE LOGIN authorization_user_column_perms_capture_instance WITH PASSWORD = '${arg.default-sql-server-password}';
+CREATE USER authorization_user_column_perms_capture_instance FOR LOGIN authorization_user_column_perms_capture_instance;
+ALTER ROLE db_datareader ADD MEMBER authorization_user_column_perms_capture_instance;
+
+DENY SELECT ON OBJECT::cdc.dbo_t1_privileges_ct(__$start_lsn) TO authorization_user_column_perms_capture_instance;
+
+CREATE LOGIN authorization_user_table_perms WITH PASSWORD = '${arg.default-sql-server-password}';
+CREATE USER authorization_user_table_perms FOR LOGIN authorization_user_table_perms;
+ALTER ROLE db_datareader ADD MEMBER authorization_user_table_perms;
+
+DENY SELECT ON OBJECT::dbo.t1_privileges TO authorization_user_table_perms;
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+> CREATE CONNECTION sql_server_privileges_connection_table TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER 'authorization_user_table_perms',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+! CREATE SOURCE t1_privileges_sql_server_failure
+  FROM SQL SERVER CONNECTION sql_server_privileges_connection_table
+  FOR TABLES (dbo.t1_privileges);
+contains:reference to dbo.t1_privileges not found in source
+
+> CREATE CONNECTION sql_server_privileges_connection_column TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER 'authorization_user_column_perms',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+# Column exclusion has no effect on rejection for column level permissions.
+! CREATE SOURCE t1_privileges_sql_server_failure
+  FROM SQL SERVER CONNECTION sql_server_privileges_connection_column (
+    EXCLUDE COLUMNS (dbo.t1_privileges.c2)
+  )
+  FOR TABLES (dbo.t1_privileges);
+contains:insufficient permissions for tables [dbo.t1_privileges] or capture instances []
+
+> CREATE CONNECTION sql_server_privileges_connection_capture_instance TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER 'authorization_user_column_perms_capture_instance',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+! CREATE SOURCE t1_privileges_sql_server_failure
+  FROM SQL SERVER CONNECTION sql_server_privileges_connection_capture_instance
+  FOR TABLES (dbo.t1_privileges);
+contains:insufficient permissions for tables [] or capture instances [dbo_t1_privileges]


### PR DESCRIPTION


### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/database-issues/issues/9208

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
