### PR TITLE
cluster: don't panic when dropping `TimelyContainer`

### DIFF
--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -72,12 +72,6 @@ impl<C: ClusterSpec> TimelyContainer<C> {
     }
 }
 
-impl<C: ClusterSpec> Drop for TimelyContainer<C> {
-    fn drop(&mut self) {
-        panic!("Timely container must never drop");
-    }
-}
-
 impl<C> ClusterClient<C>
 where
     C: ClusterSpec,


### PR DESCRIPTION
The panic was originally added to alert us to concurrency bugs where we would accidentally drop the Timely runtime while trying to switch between controller connections. The surrounding code has been simplified a lot since, so the panic isn't as important as a safeguard anymore.

More importantly though, since the Timely runtime is now initialized before we start serving controller connections, it is now actually possible to drop the `TimelyContainer` without any bugs present:

 * Timely runtime is initialized, yielding a `TimelyContainer`.
 * The `TimelyContainer` is passed to `GrpcServer::serve`, which starts to listen for controller connections.
 * The listen fails, for example because the listen port is already in use.
 * `GrpcServer::serve` returns with an error, dropping the `TimelyContainer`.

In this scenario, the process exits anyway, so dropping the `TimelyContainer` is fine and we shouldn't panic. The easiest fix is to simply remove the panic.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9527

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
