### PR TITLE
mzcompose: Change format for c.up

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -15,7 +15,11 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Dict, List, Optional
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.dbt import Dbt
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.redpanda import Redpanda
@@ -56,7 +60,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("-s", action="store_true", help="don't suppress output")
     args = parser.parse_args()
 
-    c.up({"name": "dbt", "persistent": True})
+    c.up(Service("dbt", idle=True))
 
     for test_case in test_cases:
         if args.filter in test_case.name:
@@ -82,7 +86,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     c.up(
                         "redpanda",
                         "materialized",
-                        {"name": "testdrive", "persistent": True},
+                        Service("testdrive", idle=True),
                     )
 
                     # Create a topic that some tests rely on

--- a/misc/monitoring/mzcompose.py
+++ b/misc/monitoring/mzcompose.py
@@ -8,7 +8,8 @@
 # by the Apache License, Version 2.0.
 
 from materialize import MZ_ROOT
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 
 SERVICES = [
     Service(

--- a/misc/python/materialize/mysql_util.py
+++ b/misc/python/materialize/mysql_util.py
@@ -9,7 +9,7 @@
 
 from dataclasses import dataclass
 
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 
 
 @dataclass
@@ -40,7 +40,7 @@ def retrieve_ssl_context_for_mysql(c: Composition) -> MySqlSslContext:
 
 def retrieve_invalid_ssl_context_for_mysql(c: Composition) -> MySqlSslContext:
     # Use the TestCert service to obtain a wrong CA and client cert/key:
-    c.up({"name": "test-certs", "persistent": True})
+    c.up(Service("test-certs", idle=True))
     ssl_wrong_ca = c.run("test-certs", "cat", "/secrets/ca.crt", capture=True).stdout
     ssl_wrong_client_cert = c.run(
         "test-certs", "cat", "/secrets/certuser.crt", capture=True

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -21,7 +21,7 @@ from psycopg.errors import OperationalError
 
 from materialize import buildkite
 from materialize.mzcompose import get_default_system_parameters
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import (
     LEADER_STATUS_HEALTHCHECK,
@@ -103,7 +103,7 @@ def workflow_read_only(c: Composition) -> None:
         "postgres",
         "mysql",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     # Make sure cluster is owned by the system so it doesn't get dropped
@@ -402,7 +402,7 @@ def workflow_basic(c: Composition) -> None:
         "postgres",
         "mysql",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     # Make sure cluster is owned by the system so it doesn't get dropped
@@ -557,7 +557,7 @@ def workflow_basic(c: Composition) -> None:
             default_timeout=DEFAULT_TIMEOUT,
         )
     ):
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
         c.testdrive(
             dedent(
                 f"""
@@ -634,7 +634,7 @@ def workflow_basic(c: Composition) -> None:
         )
 
     # But the old Materialize can still run writes
-    c.up({"name": "testdrive", "persistent": True})
+    c.up(Service("testdrive", idle=True))
     c.testdrive(
         dedent(
             f"""
@@ -719,7 +719,7 @@ def workflow_basic(c: Composition) -> None:
             default_timeout=DEFAULT_TIMEOUT,
         )
     ):
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
         c.testdrive(
             dedent(
                 """
@@ -904,7 +904,7 @@ def workflow_kafka_source_rehydration(c: Composition) -> None:
         "kafka",
         "schema-registry",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     count = 1000000
@@ -1051,7 +1051,7 @@ def workflow_kafka_source_rehydration_large_initial(c: Composition) -> None:
         "kafka",
         "schema-registry",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     count = 1000000
@@ -1196,7 +1196,7 @@ def workflow_kafka_source_rehydration_large_initial(c: Composition) -> None:
 def workflow_pg_source_rehydration(c: Composition) -> None:
     """Verify Postgres source rehydration in 0dt deployment"""
     c.down(destroy_volumes=True)
-    c.up("postgres", "mz_old", {"name": "testdrive", "persistent": True})
+    c.up("postgres", "mz_old", Service("testdrive", idle=True))
 
     count = 1000000
     repeats = 100
@@ -1347,7 +1347,7 @@ def workflow_pg_source_rehydration(c: Composition) -> None:
 def workflow_mysql_source_rehydration(c: Composition) -> None:
     """Verify Postgres source rehydration in 0dt deployment"""
     c.down(destroy_volumes=True)
-    c.up("mysql", "mz_old", {"name": "testdrive", "persistent": True})
+    c.up("mysql", "mz_old", Service("testdrive", idle=True))
 
     count = 1000000
     repeats = 100
@@ -1513,7 +1513,7 @@ def workflow_kafka_source_failpoint(c: Composition) -> None:
         "zookeeper",
         "kafka",
         "schema-registry",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     # Start the original Materialized instance with the failpoint enabled.
@@ -1822,7 +1822,7 @@ def workflow_upsert_sources(c: Composition) -> None:
         "postgres",
         "mysql",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
     num_threads = 50
 
@@ -1943,7 +1943,7 @@ def workflow_ddl(c: Composition) -> None:
         "postgres",
         "mysql",
         "mz_old",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     # Make sure cluster is owned by the system so it doesn't get dropped
@@ -2098,7 +2098,7 @@ def workflow_ddl(c: Composition) -> None:
             default_timeout=DEFAULT_TIMEOUT,
         )
     ):
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
         c.testdrive(
             dedent(
                 f"""
@@ -2175,7 +2175,7 @@ def workflow_ddl(c: Composition) -> None:
         )
 
     # Run DDLs against the old Materialize, which should restart the new one
-    c.up({"name": "testdrive", "persistent": True})
+    c.up(Service("testdrive", idle=True))
     c.testdrive(
         dedent(
             f"""
@@ -2268,7 +2268,7 @@ def workflow_ddl(c: Composition) -> None:
             default_timeout=DEFAULT_TIMEOUT,
         )
     ):
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
         c.testdrive(
             dedent(
                 """

--- a/test/backup-restore-postgres/mzcompose.py
+++ b/test/backup-restore-postgres/mzcompose.py
@@ -13,7 +13,7 @@ Basic Backup & Restore test with a table
 
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.persistcli import Persistcli
@@ -42,7 +42,7 @@ def workflow_default(c: Composition) -> None:
     c.enable_minio_versioning()
 
     # Start Materialize, and set up some basic state in it
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
     c.testdrive(
         dedent(
             """

--- a/test/backup-restore/mzcompose.py
+++ b/test/backup-restore/mzcompose.py
@@ -13,7 +13,7 @@ Basic Backup & Restore test with a table
 
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
@@ -42,7 +42,7 @@ def workflow_default(c: Composition) -> None:
     c.enable_minio_versioning()
 
     # Start Materialize, and set up some basic state in it
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
     c.testdrive(
         dedent(
             """

--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -30,7 +30,7 @@ from psycopg import Cursor
 from psycopg.errors import OperationalError, ProgramLimitExceeded, ProgrammingError
 
 from materialize import MZ_ROOT
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.frontegg import FronteggMock
 from materialize.mzcompose.services.materialized import Materialized
@@ -647,7 +647,7 @@ def workflow_webhook(c: Composition) -> None:
         "balancerd",
         "frontegg-mock",
         "materialized",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     grant_all_admin_user(c)

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -19,7 +19,11 @@ from textwrap import dedent
 
 from materialize import buildkite
 from materialize.buildkite import shard_list
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
@@ -1498,7 +1502,7 @@ def run_scenario(
             "postgres",
             "mysql",
             "clusterd",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         c.sql(

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -13,7 +13,11 @@ from urllib.parse import quote
 
 import psycopg
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.dbt import Dbt
 from materialize.mzcompose.services.testdrive import Testdrive
 
@@ -80,7 +84,7 @@ MYSQL_RANGE_FUNCTION = (
 
 
 def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.up({"name": "dbt", "persistent": True}, {"name": "testdrive", "persistent": True})
+    c.up(Service("dbt", idle=True), Service("testdrive", idle=True))
 
     assert MATERIALIZE_PROD_SANDBOX_USERNAME is not None
     assert MATERIALIZE_PROD_SANDBOX_APP_PASSWORD is not None
@@ -215,7 +219,7 @@ def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 
 def workflow_test(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.up({"name": "dbt", "persistent": True})
+    c.up(Service("dbt", idle=True))
 
     con = psycopg.connect(
         host=MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME,

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -22,7 +22,11 @@ from requests.exceptions import ConnectionError, ReadTimeout
 
 from materialize.cloudtest.util.jwt_key import fetch_jwt
 from materialize.mz_env_util import get_cloud_hostname
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.test_result import (
@@ -63,7 +67,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             default_timeout="1200s",
         ),
     ):
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         failures: list[TestFailureDetails] = []
 

--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -11,9 +11,9 @@ import requests
 
 from materialize.mzcompose.composition import (
     Composition,
-    Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.debezium import Debezium
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -15,7 +15,11 @@ then making sure that cluster2 continues to operate properly
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
@@ -266,7 +270,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             "clusterd_1_2",
             "clusterd_2_1",
             "clusterd_2_2",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         c.sql(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -34,7 +34,11 @@ from psycopg.errors import (
 )
 
 from materialize import buildkite, ui
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack
@@ -534,7 +538,7 @@ def workflow_test_github_4587(c: Composition) -> None:
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -636,7 +640,7 @@ def workflow_test_github_4433(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -706,7 +710,7 @@ def workflow_test_github_4966(c: Composition) -> None:
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -782,7 +786,7 @@ def workflow_test_github_5087(c: Composition) -> None:
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -941,7 +945,7 @@ def workflow_test_github_5086(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -1033,7 +1037,7 @@ def workflow_test_github_5831(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -1139,7 +1143,7 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true;",
@@ -1436,7 +1440,7 @@ def workflow_test_system_table_indexes(c: Composition) -> None:
         Testdrive(),
         Materialized(),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
         c.testdrive(
             input=dedent(
                 """
@@ -1467,7 +1471,7 @@ def workflow_test_system_table_indexes(c: Composition) -> None:
         Testdrive(no_reset=True),
         Materialized(),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
         c.testdrive(
             input=dedent(
                 """
@@ -2018,7 +2022,7 @@ def workflow_test_drop_during_reconciliation(c: Composition) -> None:
             "materialized",
             "clusterd1",
             "toxiproxy",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         # Set up toxi-proxies for clusterd GRPC endpoints.
@@ -2279,7 +2283,7 @@ def workflow_test_clusterd_death_detection(c: Composition) -> None:
             "materialized",
             "clusterd1",
             "toxiproxy",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         c.testdrive(
@@ -2607,7 +2611,7 @@ def workflow_test_replica_metrics(c: Composition) -> None:
 def workflow_test_compute_controller_metrics(c: Composition) -> None:
     """Test metrics exposed by the compute controller."""
 
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
 
     def fetch_metrics() -> Metrics:
         resp = c.exec(
@@ -2795,7 +2799,7 @@ def workflow_test_storage_controller_metrics(c: Composition) -> None:
         "materialized",
         "kafka",
         "schema-registry",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     def fetch_metrics() -> Metrics:
@@ -2993,7 +2997,7 @@ def workflow_test_pgwire_metrics(c: Composition) -> None:
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         c.sql(
             """
@@ -3634,7 +3638,7 @@ def workflow_test_github_7000(c: Composition, parser: WorkflowArgumentParser) ->
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # Create an MV reading from an index. Make sure it doesn't produce its
         # snapshot by installing it in a cluster without replicas.
@@ -3801,7 +3805,7 @@ def workflow_test_subscribe_hydration_status(
 ) -> None:
     """Test that hydration status tracking works for subscribe dataflows."""
 
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
 
     # Start a subscribe.
     cursor = c.sql_cursor()
@@ -3919,7 +3923,7 @@ def workflow_test_refresh_mv_warmup(
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         c.testdrive(
             input=dedent(
@@ -4272,7 +4276,7 @@ def workflow_test_refresh_mv_restart(
             """
         )
 
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # 1. (quick restart)
         c.testdrive(input=before_restart)
@@ -4285,7 +4289,7 @@ def workflow_test_refresh_mv_restart(
         check_introspection()
 
         # Reset the testing context.
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # 2. (slow restart)
         c.testdrive(input=before_restart)
@@ -4299,7 +4303,7 @@ def workflow_test_refresh_mv_restart(
         check_introspection()
 
         # Reset the testing context.
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # 3.
         c.testdrive(
@@ -4478,7 +4482,7 @@ def workflow_test_github_8734(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # Create a REFRESH MV and wait for it to refresh once, then take down
         # its cluster.
@@ -4559,7 +4563,7 @@ def workflow_test_github_7798(c: Composition, parser: WorkflowArgumentParser) ->
                 )
             )
 
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         # Create an unmanaged cluster that isn't restarted together with materialized,
         # and therein a source with subsources.
@@ -4860,7 +4864,7 @@ def workflow_test_mz_introspection_cluster_compat(
     with c.override(
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         # Setting variables through `SET <variable>`.
         c.testdrive(
@@ -4963,7 +4967,7 @@ def workflow_test_unified_introspection_during_replica_disconnect(c: Composition
             default_timeout="10s",
         ),
     ):
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
 
         # Set up an unorchestrated replica with a couple dataflows.
         c.sql(
@@ -5063,7 +5067,7 @@ def workflow_test_zero_downtime_reconfigure(
             "zookeeper",
             "kafka",
             "schema-registry",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
         c.testdrive(
             dedent(
@@ -5354,7 +5358,7 @@ def workflow_replica_expiration_creates_retraction_diffs_after_panic(
         Clusterd(name="clusterd1", restart="on-failure"),
     ):
 
-        c.up("materialized", "clusterd1", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "clusterd1", Service("testdrive", idle=True))
         c.testdrive(
             dedent(
                 """
@@ -5417,7 +5421,7 @@ def workflow_test_constant_sink(c: Composition) -> None:
             "zookeeper",
             "kafka",
             "schema-registry",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         c.testdrive(
@@ -5502,7 +5506,7 @@ def workflow_test_lgalloc_limiter(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         c.sql(
             """
@@ -5620,7 +5624,7 @@ def workflow_test_memory_limiter(c: Composition) -> None:
         ),
         Testdrive(no_reset=True),
     ):
-        c.up("materialized", {"name": "testdrive", "persistent": True})
+        c.up("materialized", Service("testdrive", idle=True))
 
         c.sql(
             """

--- a/test/console/mzcompose.py
+++ b/test/console/mzcompose.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres
@@ -29,5 +29,5 @@ def workflow_default(c: Composition) -> None:
         "postgres",
         "mysql",
         "materialized",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )

--- a/test/copy-to-s3/mzcompose.py
+++ b/test/copy-to-s3/mzcompose.py
@@ -21,7 +21,11 @@ from io import BytesIO, StringIO
 import pyarrow.parquet  #
 from minio import Minio
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc
 from materialize.mzcompose.services.minio import Minio as MinioService
@@ -182,8 +186,7 @@ def workflow_ci(c: Composition, _parser: WorkflowArgumentParser) -> None:
 
 
 def workflow_auth(c: Composition) -> None:
-    c.up({"name": "mc", "persistent": True})
-    c.up("materialized", "minio")
+    c.up(Service("mc", idle=True), "materialized", "minio")
 
     # Set up IAM credentials for 3 users with different permissions levels to S3:
     # User 'readwritedelete': PutObject, ListBucket, DeleteObject

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -15,7 +15,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.service import ServiceHealthcheck
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -171,7 +175,7 @@ def run_disruption(c: Composition, d: CrdbDisruption) -> None:
     ]:
         c.exec("cockroach0", "cockroach", "sql", "--insecure", "-e", query)
 
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
 
     # We expect the testdrive fragment to complete within Testdrive's default_timeout
     # This will indicate that Mz has not hung for a prolonged period of time

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -83,7 +83,11 @@ from materialize.feature_benchmark.termination import (
     RunAtMost,
     TerminationCondition,
 )
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.clusterd import Clusterd
@@ -183,7 +187,7 @@ def run_one_scenario(
 
         entrypoint_host = "balancerd" if balancerd else "materialized"
 
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         additional_system_parameter_defaults = (
             ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from psycopg import Cursor
 
 from materialize import buildkite
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
@@ -158,7 +158,7 @@ def workflow_multithreaded(c: Composition) -> None:
         "kafka",
         "schema-registry",
         "materialized",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     value = [201]

--- a/test/lang/csharp/mzcompose.py
+++ b/test/lang/csharp/mzcompose.py
@@ -11,7 +11,8 @@
 Basic test for Postgres-compatible connections from C# programming language.
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/lang/java/mzcompose.py
+++ b/test/lang/java/mzcompose.py
@@ -11,7 +11,8 @@
 Basic test for Postgres-compatible connections from Java programming language.
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/lang/js/mzcompose.py
+++ b/test/lang/js/mzcompose.py
@@ -11,7 +11,8 @@
 Basic test for Postgres-compatible connections from JavaScript programming language.
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/lang/python/mzcompose.py
+++ b/test/lang/python/mzcompose.py
@@ -11,7 +11,8 @@
 Basic test for Postgres-compatible connections from Python programming language.
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/lang/ruby/mzcompose.py
+++ b/test/lang/ruby/mzcompose.py
@@ -11,7 +11,8 @@
 Basic test for Postgres-compatible connections from Ruby programming language.
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -31,7 +31,7 @@ from launchdarkly_api.model.patch_with_comment import PatchWithComment  # type: 
 from launchdarkly_api.model.variation import Variation  # type: ignore
 
 from materialize.mzcompose import DEFAULT_MZ_ENVIRONMENT_ID, DEFAULT_ORG_ID
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -86,7 +86,7 @@ def workflow_default(c: Composition) -> None:
     )
 
     try:
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         # Assert that the default max_result_size is served when sync is disabled.
         with c.override(Materialized(external_metadata_store=True)):

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -24,7 +24,11 @@ from textwrap import dedent
 from urllib.parse import quote
 
 from materialize import MZ_ROOT, buildkite
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -2051,7 +2055,7 @@ def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:
 def run_scenarios(
     c: Composition, scenarios: list[type[Generator]], find_limit: bool, workers: int
 ):
-    c.up({"name": "testdrive", "persistent": True})
+    c.up(Service("testdrive", idle=True))
 
     setup(c, workers)
 
@@ -2219,7 +2223,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
         "materialized",
         "balancerd",
         "frontegg-mock",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     # Construct the requied Clusterd instances and peer them into clusters

--- a/test/metabase/mzcompose.py
+++ b/test/metabase/mzcompose.py
@@ -11,7 +11,8 @@
 Smoketest that Metabase can connect to Materialize
 """
 
-from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.metabase import Metabase
 

--- a/test/mysql-cdc-old-syntax/mzcompose.py
+++ b/test/mysql-cdc-old-syntax/mzcompose.py
@@ -20,7 +20,11 @@ from materialize.mysql_util import (
     retrieve_invalid_ssl_context_for_mysql,
     retrieve_ssl_context_for_mysql,
 )
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mysql import MySql
@@ -214,7 +218,7 @@ def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> Non
     """
     mysql_version = get_targeted_mysql_version(parser)
     with c.override(create_mysql(mysql_version)):
-        c.up("materialized", "mysql", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "mysql", Service("testdrive", idle=True))
 
         # Records to before creating the source.
         (initial_sql, initial_records) = _make_inserts(txns=1, txn_size=1_000_000)

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -20,7 +20,11 @@ from materialize.mysql_util import (
     retrieve_invalid_ssl_context_for_mysql,
     retrieve_ssl_context_for_mysql,
 )
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.mz import Mz
@@ -203,7 +207,7 @@ def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> Non
     """
     mysql_version = get_targeted_mysql_version(parser)
     with c.override(create_mysql(mysql_version)):
-        c.up("materialized", "mysql", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "mysql", Service("testdrive", idle=True))
 
         # Records to before creating the source.
         (initial_sql, initial_records) = _make_inserts(txns=1, txn_size=1_000_000)
@@ -291,7 +295,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
     """
     mysql_version = get_targeted_mysql_version(parser)
     with c.override(create_mysql(mysql_version)):
-        c.up("materialized", "mysql", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "mysql", Service("testdrive", idle=True))
 
         # Set up the MySQL server with the initial records, set up the connection to
         # the MySQL server in Materialize.

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -24,7 +24,11 @@ from matplotlib.markers import MarkerStyle
 from materialize import MZ_ROOT, buildkite
 from materialize.mz_env_util import get_cloud_hostname
 from materialize.mzcompose import ADDITIONAL_BENCHMARKING_SYSTEM_PARAMETERS
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -464,7 +468,7 @@ def run_once(
     with c.override(*overrides):
         for scenario_class in scenarios:
             if target:
-                c.up({"name": "testdrive", "persistent": True})
+                c.up(Service("testdrive", idle=True))
                 conn_infos = {"materialized": target}
                 conn = target.connect()
                 with conn.cursor() as cur:
@@ -478,7 +482,7 @@ def run_once(
                 mz_string = f"{mz_version} ({target.host})"
             else:
                 print("~~~ Starting up services")
-                c.up(*service_names, {"name": "testdrive", "persistent": True})
+                c.up(*service_names, Service("testdrive", idle=True))
 
                 mz_version = c.query_mz_version()
                 mz_string = f"{mz_version} (docker)"

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -18,8 +18,12 @@ import random
 
 import requests
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
-from materialize.mzcompose.service import Service
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
+from materialize.mzcompose.service import Service as MzComposeService
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
@@ -53,8 +57,8 @@ SERVICES = [
     Mc(),
     Materialized(default_replication_factor=2),
     Materialized(name="materialized2", default_replication_factor=2),
-    Service("sqlsmith", {"mzbuild": "sqlsmith"}),
-    Service(
+    MzComposeService("sqlsmith", {"mzbuild": "sqlsmith"}),
+    MzComposeService(
         name="persistcli",
         config={"mzbuild": "jobs"},
     ),
@@ -100,7 +104,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         toxiproxy_start(c)
         c.up(*service_names)
 
-        c.up({"name": "mc", "persistent": True})
+        c.up(Service("mc", idle=True))
         c.exec(
             "mc",
             "mc",

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -15,9 +15,9 @@ import argparse
 
 from materialize.mzcompose.composition import (
     Composition,
-    Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.postgres import PostgresMetadata
 

--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -18,8 +18,13 @@ import pg8000
 from pg8000 import Connection
 
 from materialize import MZ_ROOT, buildkite
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
-from materialize.mzcompose.service import Service, ServiceConfig
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
+from materialize.mzcompose.service import Service as MzComposeService
+from materialize.mzcompose.service import ServiceConfig
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.mz import Mz
@@ -41,7 +46,7 @@ from materialize.source_table_migration import (
 DEFAULT_PG_EXTRA_COMMAND = ["-c", "max_slot_wal_keep_size=10"]
 
 
-class PostgresRecvlogical(Service):
+class PostgresRecvlogical(MzComposeService):
     """
     Command to start a replication.
     """
@@ -314,7 +319,7 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     print(f"Files: {sharded_files}")
 
-    c.up({"name": "test-certs", "persistent": True})
+    c.up(Service("test-certs", idle=True))
     ssl_ca = c.run("test-certs", "cat", "/secrets/ca.crt", capture=True).stdout
     ssl_cert = c.run("test-certs", "cat", "/secrets/certuser.crt", capture=True).stdout
     ssl_key = c.run("test-certs", "cat", "/secrets/certuser.key", capture=True).stdout
@@ -397,7 +402,7 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     print(f"Files: {sharded_files}")
 
-    c.up({"name": "test-certs", "persistent": True})
+    c.up(Service("test-certs", idle=True))
     ssl_ca = c.run("test-certs", "cat", "/secrets/ca.crt", capture=True).stdout
     ssl_cert = c.run("test-certs", "cat", "/secrets/certuser.crt", capture=True).stdout
     ssl_key = c.run("test-certs", "cat", "/secrets/certuser.key", capture=True).stdout

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -26,7 +26,11 @@ from materialize.checks.scenarios import Scenario, SystemVarChange
 from materialize.checks.scenarios_backup_restore import *  # noqa: F401 F403
 from materialize.checks.scenarios_upgrade import *  # noqa: F401 F403
 from materialize.checks.scenarios_zero_downtime import *  # noqa: F401 F403
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.debezium import Debezium
@@ -164,7 +168,7 @@ def setup(c: Composition) -> None:
         "mysql",
         "debezium",
         "ssh-bastion-host",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     c.enable_minio_versioning()

--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -15,7 +15,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -80,7 +84,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     for disruption in selected_by_name(args.disruptions, disruptions):
         c.down(destroy_volumes=True)
-        c.up("redpanda", "materialized", {"name": "testdrive", "persistent": True})
+        c.up("redpanda", "materialized", Service("testdrive", idle=True))
 
         toxiproxy_start(c)
 

--- a/test/race-condition/mzcompose.py
+++ b/test/race-condition/mzcompose.py
@@ -17,7 +17,11 @@ import time
 from textwrap import dedent
 from uuid import uuid4
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
@@ -613,7 +617,7 @@ class Concurrent(Scenario):
         for i in range(num_executions):
             # Clean up old state
             self.c.down(destroy_volumes=True)
-            self.c.up(*SERVICE_NAMES, {"name": "testdrive", "persistent": True})
+            self.c.up(*SERVICE_NAMES, Service("testdrive", idle=True))
 
             for obj in self.objs:
                 self.run_fragment(obj.prepare())
@@ -726,7 +730,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         datetime.datetime.now() + datetime.timedelta(seconds=args.runtime)
     ).timestamp()
 
-    c.up(*SERVICE_NAMES, {"name": "testdrive", "persistent": True})
+    c.up(*SERVICE_NAMES, Service("testdrive", idle=True))
 
     seed = args.seed
 

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -21,7 +21,11 @@ from typing import Any
 
 from psycopg import Cursor
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack
@@ -476,7 +480,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             "clusterd_1_2",
             "clusterd_2_1",
             "clusterd_2_2",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         c.sql(

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -24,7 +24,7 @@ from psycopg.errors import (
 )
 
 from materialize import buildkite
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
@@ -114,7 +114,7 @@ def workflow_github_2454(c: Composition) -> None:
 
 # Test that `mz_internal.mz_object_dependencies` re-populates.
 def workflow_github_5108(c: Composition) -> None:
-    c.up("materialized", {"name": "testdrive_no_reset", "persistent": True})
+    c.up("materialized", Service("testdrive_no_reset", idle=True))
 
     c.testdrive(
         service="testdrive_no_reset",
@@ -279,7 +279,7 @@ def workflow_storage_managed_collections(c: Composition) -> None:
 
 
 def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
-    c.up("materialized", {"name": "testdrive_no_reset", "persistent": True})
+    c.up("materialized", Service("testdrive_no_reset", idle=True))
 
     c.testdrive(
         service="testdrive_no_reset",
@@ -581,7 +581,7 @@ def workflow_bound_size_mz_status_history(c: Composition) -> None:
         "kafka",
         "schema-registry",
         "materialized",
-        {"name": "testdrive_no_reset", "persistent": True},
+        Service("testdrive_no_reset", idle=True),
     )
 
     c.testdrive(
@@ -667,7 +667,7 @@ def workflow_bound_size_mz_cluster_replica_metrics_history(c: Composition) -> No
     """
 
     c.down(destroy_volumes=True)
-    c.up("materialized", {"name": "testdrive_no_reset", "persistent": True})
+    c.up("materialized", Service("testdrive_no_reset", idle=True))
 
     # The replica metrics are updated once per minute and on envd startup. We
     # can thus restart envd to generate metrics rows without having to block
@@ -769,7 +769,7 @@ def workflow_index_compute_dependencies(c: Composition) -> None:
     This test should codify this assumption so we can get an early signal if
     this is broken for some reason in the future.
     """
-    c.up("materialized", {"name": "testdrive_no_reset", "persistent": True})
+    c.up("materialized", Service("testdrive_no_reset", idle=True))
 
     def depends_on(c: Composition, obj_name: str, dep_name: str, expected: bool):
         """Check whether `(obj_name, dep_name)` is a compute dependency or not."""

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.composition import Composition, Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -38,7 +38,7 @@ def workflow_default(c: Composition) -> None:
 
 
 def setup(c: Composition) -> None:
-    c.up("materialized", {"name": "testdrive", "persistent": True})
+    c.up("materialized", Service("testdrive", idle=True))
 
 
 # Test that the catalog is consistent for the three types of retain histories (disabled, default,

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -19,6 +19,7 @@ from enum import Enum
 
 from materialize.mzcompose.composition import (
     Composition,
+    MzComposeService,
     Service,
     WorkflowArgumentParser,
 )
@@ -222,7 +223,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    c.up({"name": "rqg", "persistent": True})
+    c.up(Service("rqg", idle=True))
 
     if args.workloads is not None and len(args.workloads) > 0:
         workloads_to_run = [w for w in WORKLOADS if w.name in args.workloads]
@@ -243,7 +244,7 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
         return f"materialize/materialized:{tag}" if tag else None
 
     # A list of psql-compatible services participating in the test
-    participants: list[Service] = [
+    participants: list[MzComposeService] = [
         Materialized(
             name="mz_this",
             ports=["16875:6875", "16876:6876", "16877:6877", "16878:6878"],

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -20,7 +20,11 @@ from typing import Protocol
 
 from materialize import buildkite
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
@@ -73,7 +77,7 @@ class KafkaTransactionLogGreaterThan1:
         print(f"+++ Running disruption scenario {self.name}")
         seed = random.randint(0, 256**4)
 
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         with c.override(
             Testdrive(
@@ -148,7 +152,7 @@ class KafkaDisruption:
             "redpanda",
             "materialized",
             "clusterd",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         with c.override(
@@ -263,7 +267,7 @@ class KafkaSinkDisruption:
             "redpanda",
             "materialized",
             "clusterd",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         with c.override(
@@ -372,7 +376,7 @@ class PgDisruption:
             "postgres",
             "materialized",
             "clusterd",
-            {"name": "testdrive", "persistent": True},
+            Service("testdrive", idle=True),
         )
 
         with c.override(

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -14,7 +14,11 @@ Test that setting feature flags works
 import argparse
 from textwrap import dedent, indent
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -230,7 +234,7 @@ class FeatureTestScenario:
 
 
 def run_test(c: Composition, args: argparse.Namespace) -> None:
-    c.up("redpanda", "materialized", {"name": "testdrive", "persistent": True})
+    c.up("redpanda", "materialized", Service("testdrive", idle=True))
 
     scenarios = (
         [globals()[args.scenario]]

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -17,7 +17,11 @@ import threading
 from textwrap import dedent
 
 from materialize import MZ_ROOT
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.sql_server import SqlServer
@@ -124,7 +128,7 @@ def workflow_snapshot_consistency(
 
     initial_rows = 100
     with c.override(SqlServer()):
-        c.up("materialized", "sql-server", {"name": "testdrive", "persistent": True})
+        c.up("materialized", "sql-server", Service("testdrive", idle=True))
 
         # Setup MS SQL server and materialize
         c.testdrive(

--- a/test/sqlancer/mzcompose.py
+++ b/test/sqlancer/mzcompose.py
@@ -19,9 +19,9 @@ from threading import Thread
 from materialize import spawn
 from materialize.mzcompose.composition import (
     Composition,
-    Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 
 SERVICES = [

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -24,7 +24,11 @@ from pathlib import Path
 from queue import Queue
 
 from materialize import buildkite, ci_util, file_util
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
 from materialize.mzcompose.services.sql_logic_test import SqlLogicTest
@@ -108,7 +112,7 @@ def run_sqllogictest(
             work_queue.put((step, file))
 
     # Hacky way to make sure we have downloaded the image
-    c.up({"name": "slt_1", "persistent": True})
+    c.up(Service("slt_1", idle=True))
 
     def worker(container_name: str):
         exception: Exception | None = None

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -22,9 +22,9 @@ from typing import Any
 
 from materialize.mzcompose.composition import (
     Composition,
-    Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.sqlsmith import known_errors
 

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -16,7 +16,11 @@ import time
 from dataclasses import dataclass
 from textwrap import dedent
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
@@ -231,7 +235,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "redpanda",
         "postgres",
         "materialized",
-        {"name": "testdrive", "persistent": True},
+        Service("testdrive", idle=True),
     )
 
     for database_object in database_objects:

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -28,6 +28,7 @@ import yaml
 from materialize import MZ_ROOT, ci_util, git, spawn
 from materialize.mzcompose.composition import (
     Composition,
+    Service,
     WorkflowArgumentParser,
 )
 from materialize.mzcompose.services.testdrive import Testdrive
@@ -526,7 +527,7 @@ class State:
 
         if run_testdrive_files:
             with c.override(testdrive(no_reset=False)):
-                c.up({"name": "testdrive", "persistent": True})
+                c.up(Service("testdrive", idle=True))
                 c.run_testdrive_files(*TD_CMD, *files)
 
     def connect(self, c: Composition) -> None:
@@ -598,7 +599,7 @@ class State:
                 cur.execute("ALTER SYSTEM SET enable_create_table_from_source = true")
 
         with c.override(testdrive(no_reset=False)):
-            c.up({"name": "testdrive", "persistent": True})
+            c.up(Service("testdrive", idle=True))
             c.testdrive(
                 dedent(
                     """
@@ -849,7 +850,7 @@ def workflow_aws_upgrade(c: Composition, parser: WorkflowArgumentParser) -> None
 
             if args.run_testdrive_files:
                 with c.override(testdrive(no_reset=False)):
-                    c.up({"name": "testdrive", "persistent": True})
+                    c.up(Service("testdrive", idle=True))
                     c.run_testdrive_files(*TD_CMD, *args.files)
     finally:
         aws.cleanup()

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -17,7 +17,11 @@ import glob
 import os
 
 from materialize import MZ_ROOT, buildkite, ci_util
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.fivetran_destination import FivetranDestination
 from materialize.mzcompose.services.kafka import Kafka
@@ -151,7 +155,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     with c.override(testdrive, materialized):
-        c.up(*dependencies, {"name": "testdrive", "persistent": True})
+        c.up(*dependencies, Service("testdrive", idle=True))
 
         c.sql(
             "ALTER SYSTEM SET max_clusters = 50;",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -18,7 +18,11 @@ import os
 from textwrap import dedent
 
 from materialize import ci_util
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
@@ -443,7 +447,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
             Testdrive(no_reset=True),
         ):
             c.rm("testdrive")
-            c.up({"name": "testdrive", "persistent": True})
+            c.up(Service("testdrive", idle=True))
             c.exec("testdrive", f"rocksdb-cleanup/{testdrive_file}")
 
             (_, kept_source_path) = rocksdb_path("kept_upsert_tbl")
@@ -512,7 +516,7 @@ def workflow_load_test(c: Composition, parser: WorkflowArgumentParser) -> None:
         ),
     ):
         c.rm("testdrive")
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
         c.exec("testdrive", "load-test/setup.td")
         c.testdrive(
             dedent(
@@ -651,7 +655,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
         Testdrive(no_reset=True, consistent_seed=True),
     ):
         c.rm("testdrive")
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         c.testdrive(
             dedent(

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -19,7 +19,11 @@ import time
 from datetime import timedelta
 from enum import Enum
 
-from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
 from materialize.mzcompose.services.azurite import Azurite
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.clusterd import Clusterd
@@ -261,7 +265,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.rm("materialized")
 
-        c.up({"name": "testdrive", "persistent": True})
+        c.up(Service("testdrive", idle=True))
 
         print("Generating test...")
         test = Test(


### PR DESCRIPTION
Hopefully more intuitive that it takes a list of services. Taking a list would increase the diff by a lot

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
