### PR TITLE
misc: don't specify a memory limit for replicas by default

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -676,7 +676,7 @@ def cluster_replica_size_map() -> dict[str, dict[str, Any]]:
             "disabled": disabled,
             "disk_limit": None,
             "is_cc": is_cc,
-            "memory_limit": memory_limit or "4Gi",
+            "memory_limit": memory_limit,
             "scale": scale,
             "workers": workers,
             # "selectors": {},


### PR DESCRIPTION
We are specifying a default memory limit of 4GiB for all replicas created in mzcompose tests, even for replica sizes that don't explicitly mention a limit (like '1'). This turns out to be a bit of a footgun as tests might not expect the limit and become unreliable and/or slow by getting their replicas intermittently killed.

The default memory limit was introduced to ensure that `bin/environmentd` can be run without an unlimited license key. We can also achieve that by specifically adjusting the replica sizes passed under that command to have a default memory limit, while leaving the sizes used by mzcompose unlimited.

### Motivation

  * This PR fixes a previously unreported bug.

Some CI workloads are unreliable because they don't expect the default memory limit placed on replica sizes.
See [Slack thread](https://materializeinc.slack.com/archives/C01LKF361MZ/p1753964208658369).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
