### PR TITLE
cloudtest: Update error message for privatelink connections

### DIFF
--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -216,7 +216,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
         )
     with pytest.raises(
         ProgrammingError,
-        match="invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka",
+        match="invalid CONNECTION: POSTGRES does not support PORT for AWS PRIVATELINK",
     ):
         mz.environmentd.sql(
             dedent(


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/33113

Failed in https://buildkite.com/materialize/nightly/builds/12753#019860f6-2585-4c08-b149-1372ff06c9e8
```
AssertionError: Regex pattern did not match.
 Regex: 'invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka'
 Input: "{'S': 'ERROR', 'C': 'XX000', 'M': 'invalid CONNECTION: POSTGRES does not support PORT for AWS PRIVATELINK'}"
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
