### PR TITLE
mzbuild: Fix tools on macOS & ci: Fix terraform cleanup

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -226,11 +226,6 @@ cleanup() {
       fi
   fi
 
-  ci_unimportant_heading ":docker: Cleaning up after mzcompose"
-  # docker-compose kill may fail attempting to kill containers
-  # that have just exited on their own because of the
-  # "shared-fate" mechanism employed by Mz clusters
-  (sudo systemctl restart docker; docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes) &
   killall -9 clusterd || true # There might be remaining processes from a cargo-test run
 
   if [ "$BUILDKITE_STEP_KEY" = "terraform-aws" ]; then

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import multiprocessing
 import os
+import platform
 import re
 import shutil
 import stat
@@ -147,6 +148,15 @@ class RepositoryDetails:
         if self.bazel:
             return ["bazel", "run", f"@//misc/bazel/tools:{name}", "--"]
         else:
+            if platform.system() != "Linux":
+                # We can't use the local tools from macOS to build a Linux executable
+                return ["bin/ci-builder", "run", "stable", name]
+            # If we're on Linux, trust that the tools are installed instead of
+            # loading the slow ci-builder. If you don't have compilation tools
+            # installed you can still run `bin/ci-builder run stable
+            # bin/mzcompose ...`, and most likely the Cargo build will already
+            # fail earlier if you don't have compilation tools installed and
+            # run without the ci-builder.
             return [name]
 
     def cargo_target_dir(self) -> Path:


### PR DESCRIPTION
Thanks to @SangJunBak for reporting: https://materializeinc.slack.com/archives/C0246GEHL8N/p1754001167046539

Broken in https://github.com/MaterializeInc/materialize/pull/33118
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
