### PR TITLE
tests: Run more `git merge-base` with github api

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -1015,7 +1015,10 @@ def have_paths_changed(globs: Iterable[str]) -> bool:
         print(f"Failed to get changed files from Github, running locally: {e}")
 
         # Make sure we have an up to date view of main.
-        spawn.runv(["git", "fetch", "origin", "main"])
+        command = ["git", "fetch"]
+        if spawn.capture(["git rev-parse", "--is-shallow-repository"]) == "true":
+            command.append("--unshallow")
+        spawn.runv(command + ["origin", "main"])
 
         diff = subprocess.run(
             ["git", "diff", "--no-patch", "--quiet", "origin/main...", "--", *globs]

--- a/ci/test/check-merge-with-target.sh
+++ b/ci/test/check-merge-with-target.sh
@@ -17,6 +17,11 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 . misc/buildkite/git.bash
 
+if git rev-parse --is-shallow-repository | grep -q true; then
+  git fetch --unshallow origin "$BUILDKITE_PIPELINE_DEFAULT_BRANCH"
+else
+  git fetch origin "$BUILDKITE_PIPELINE_DEFAULT_BRANCH"
+fi
 fetch_pr_target_branch
 merge_pr_target_branch
 

--- a/misc/buildkite/git.bash
+++ b/misc/buildkite/git.bash
@@ -42,5 +42,11 @@ merge_pr_target_branch() {
 }
 
 get_common_ancestor_commit_of_pr_and_target() {
+  # Make sure we have an up to date view of main
+  if git rev-parse --is-shallow-repository | grep -q true; then
+    run git fetch --unshallow "$MZ_REPO_REF" "$MZ_REPO_PULL_REQUEST_BASE_BRANCH"
+  else
+    run git fetch "$MZ_REPO_REF" "$MZ_REPO_PULL_REQUEST_BASE_BRANCH"
+  fi
   run git merge-base HEAD "$MZ_REPO_REF"/"$MZ_REPO_PULL_REQUEST_BASE_BRANCH"
 }

--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -103,7 +103,7 @@ def get_pipeline_default_branch(fallback: str = "main"):
 def get_merge_base(url: str = "https://github.com/MaterializeInc/materialize") -> str:
     base_branch = get_pull_request_base_branch() or get_pipeline_default_branch()
     merge_base = git.get_common_ancestor_commit(
-        remote=git.get_remote(url), branch=base_branch, fetch_branch=True
+        remote=git.get_remote(url), branch=base_branch
     )
     return merge_base
 

--- a/misc/python/materialize/test_analytics/data/build/build_data_storage.py
+++ b/misc/python/materialize/test_analytics/data/build/build_data_storage.py
@@ -32,7 +32,7 @@ class BuildDataStorage(BaseDataStorage):
         branch = buildkite.get_var(BuildkiteEnvVar.BUILDKITE_BRANCH)
         commit_hash = buildkite.get_var(BuildkiteEnvVar.BUILDKITE_COMMIT)
         main_ancestor_commit_hash = git.get_common_ancestor_commit(
-            remote=git.get_remote(), branch="main", fetch_branch=True
+            remote=git.get_remote(), branch="main"
         )
         mz_version = MzVersion.parse_cargo()
 


### PR DESCRIPTION
So that we don't need to download full git history in CI (saves ~20 seconds per run)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
