### PR TITLE
Remove test/sqllogictest/sqlite submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ flake.lock
 /src/testdrive/ci/protobuf-bin
 /src/testdrive/ci/protobuf-include
 /known-docker-images.txt
+/test/sqllogictest/sqlite

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "sqllogictest"]
-	path = test/sqllogictest/sqlite
-	url = https://github.com/MaterializeInc/sqllogictest.git
 [submodule "fivetran-sdk"]
 	path = misc/fivetran-sdk
 	url = https://github.com/fivetran/fivetran_sdk.git

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from queue import Queue
 
 from materialize import buildkite, ci_util, file_util
+from materialize.cli.run import update_sqlite_repo
 from materialize.mzcompose.composition import (
     Composition,
     Service,
@@ -57,11 +58,13 @@ def workflow_default(c: Composition) -> None:
 
 def workflow_fast_tests(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run fast SQL logic tests"""
+    update_sqlite_repo()
     run_sqllogictest(c, parser, compileFastSltConfig())
 
 
 def workflow_slow_tests(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run slow SQL logic tests"""
+    update_sqlite_repo()
     run_sqllogictest(
         c,
         parser,
@@ -71,6 +74,7 @@ def workflow_slow_tests(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_selection(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run specific SQL logic tests using pattern"""
+    update_sqlite_repo()
     parser.add_argument(
         "--pattern",
         type=str,


### PR DESCRIPTION
I bet most people never use it and it's pretty huge: 431 MiB locally vs 196 MiB for the Materialize repo. Opinions?
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
