### PR TITLE
metrics: bump bucket size for peek time histograms

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -119,7 +119,7 @@ impl Metrics {
                 name: "mz_time_to_first_row_seconds",
                 help: "Latency of an execute for a successful query from pgwire's perspective",
                 var_labels: ["instance_id", "isolation_level", "strategy"],
-                buckets: histogram_seconds_buckets(0.000_128, 32.0)
+                buckets: histogram_seconds_buckets(0.000_128, 8192.0)
             }),
             statement_logging_records: registry.register(metric! {
                 name: "mz_statement_logging_record_count",

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -167,7 +167,7 @@ impl ComputeControllerMetrics {
                 name: "mz_compute_peek_duration_seconds",
                 help: "A histogram of peek durations since restart.",
                 var_labels: ["instance_id", "result"],
-                buckets: histogram_seconds_buckets(0.000_500, 32.),
+                buckets: histogram_seconds_buckets(0.000_500, 8192.),
             )),
             connected_replica_count: metrics_registry.register(metric!(
                 name: "mz_compute_controller_connected_replica_count",

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -135,7 +135,7 @@ impl ComputeMetrics {
                 help: "The time spent in each compute step_or_park call",
                 const_labels: {"cluster" => "compute"},
                 var_labels: ["worker_id"],
-                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 32.0),
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 1024.0),
             )),
             shared_row_heap_capacity_bytes: registry.register(metric!(
                 name: "mz_dataflow_shared_row_heap_capacity_bytes",
@@ -144,15 +144,15 @@ impl ComputeMetrics {
             )),
             persist_peek_seconds: registry.register(metric!(
                 name: "mz_persist_peek_seconds",
-                help: "Time spent in (experimental) Persist fast-path peeks.",
+                help: "Time spent in Persist fast-path peeks.",
                 var_labels: ["worker_id"],
-                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8192.0),
             )),
             stashed_peek_seconds: registry.register(metric!(
                 name: "mz_stashed_peek_seconds",
                 help: "Time spent reading a peek result and stashing it in the peek result stash (aka. persist blob).",
                 var_labels: ["worker_id"],
-                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8192.0),
             )),
             handle_command_duration_seconds: registry.register(metric!(
                 name: "mz_cluster_handle_command_duration_seconds",


### PR DESCRIPTION
Most of the histograms recording peek/SELECT time metrics have only have buckets up to 32s. Peek durations routinely go above that and it's annoying to not know how high they actually are. Fix this by making peek histograms go to 8192s instead.

### Motivation

  * This PR improves metrics.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
