### PR TITLE
Support configuring swap in helm values.

### DIFF
--- a/misc/helm-charts/operator/templates/_helpers.tpl
+++ b/misc/helm-charts/operator/templates/_helpers.tpl
@@ -105,14 +105,33 @@ postgresql://{{ .Values.metadatadb.username }}:{{ .Values.metadatadb.password }}
 Helper template to process cluster sizes based on storage class configuration
 */}}
 {{- define "materialize.processClusterSizes" -}}
-{{- $result := dict }}
-{{- range $size, $config := .Values.operator.clusters.sizes }}
-{{- $newConfig := deepCopy $config }}
-{{- if not $.Values.storage.storageClass.name }}
-{{- $_ := set $newConfig "disk_limit" "0" }}
-{{- end }}
-{{- $_ := set $newConfig "is_cc" true }}
-{{- $_ := set $result $size $newConfig }}
-{{- end }}
-{{- $result | toYaml }}
+    {{- $result := dict }}
+
+    {{- range $size, $config := .Values.operator.clusters.sizes }}
+        {{- $newConfig := deepCopy $config }}
+
+        {{- if or (not $.Values.storage.storageClass.name) $.Values.operator.clusters.enable_swap }}
+            {{- $_ := set $newConfig "disk_limit" "0" }}
+        {{- end }}
+
+        {{- if and ($.Values.operator.clusters.enable_swap) (not (index $newConfig "memory_request")) }}
+            {{- $memory_limit_MiB_int := 0 }}
+
+            {{- if regexMatch "^[0-9]+MiB" $newConfig.memory_limit }}
+                {{- $memory_limit_MiB_int = ($newConfig.memory_limit | replace "MiB" "" | int)}}
+            {{- else if regexMatch "^[0-9]+GiB" $newConfig.memory_limit }}
+                {{- $memory_limit_MiB_int = ($newConfig.memory_limit | replace "GiB" "" | int | mul 1024)}}
+            {{- else }}
+                {{- fail "Cluster size memory_limit must be defined in either MiB or GiB"}}
+            {{- end }}
+
+            {{- $memory_request_MiB_int := sub $memory_limit_MiB_int 1 }}
+            {{- $_ := set $newConfig "memory_request" (print $memory_request_MiB_int "MiB") }}
+        {{- end }}
+
+        {{- $_ := set $newConfig "is_cc" true }}
+        {{- $_ := set $result $size $newConfig }}
+    {{- end }}
+
+    {{- $result | toYaml }}
 {{- end }}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -60,6 +60,11 @@ operator:
         # TODO: Add any other additions for GCP-specific configurations
 
   clusters:
+    # Configure sizes such that the pod QoS class is not Guaranteed,
+    # as is required for swap to be enabled.
+    # Disk doesn't make much sense with swap, as swap performs better than
+    # lgalloc, so it also gets disabled.
+    enable_swap: true
     # @ignored
     sizes:
       mz_probe:


### PR DESCRIPTION
Support configuring swap in helm values.

### Motivation

  * This PR adds a known-desirable feature.
Part of https://github.com/MaterializeInc/cloud/issues/11341

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
  This will need terraform changes to consume it, but they aren't blockers.
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
