### PR TITLE
[doc] clarify that wallclock lag measures freshness

### DIFF
--- a/doc/user/content/concepts/reaction-time.md
+++ b/doc/user/content/concepts/reaction-time.md
@@ -28,6 +28,16 @@ Together, these concepts form the basis for understanding how Materialize enable
 | Data Warehouse | Poor (stale) | Freshness is often poor due to scheduled batch ingestion. Changes may take minutes to hours to propagate.                  |
 | Materialize    | Excellent    | Freshness is low, typically within milliseconds to a few seconds, due to continuous ingestion and incremental view maintenance.                  |
 
+### Monitoring Freshness
+
+You can monitor data freshness in Materialize by querying wallclock lag measurements from the [`mz_internal.mz_wallclock_global_lag`](/sql/system-catalog/mz_internal/#mz_wallclock_global_lag) system catalog view.
+Wallclock lag indicates how far behind real-world wall-clock time your data objects are, helping you understand freshness across your materialized views, indexes, and sources.
+
+```sql
+SELECT object_id, lag
+FROM mz_internal.mz_wallclock_global_lag;
+```
+
 ---
 
 ## Query Latency

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1254,8 +1254,9 @@ operations in the system.
 
 ## `mz_wallclock_global_lag`
 
-The `mz_wallclock_global_lag` view contains the most recently recorded wallclock lag
-for each table, source, index, materialized view, and sink in the system.
+The `mz_wallclock_global_lag` view contains the most recent wallclock lag for tables, sources, indexes, materialized views, and sinks.
+Wallclock lag measures how far behind real-world wall-clock time each
+  object's data is, indicating the [freshness](/concepts/reaction-time/#freshness) of results when querying that object.
 
 <!-- RELATION_SPEC mz_internal.mz_wallclock_global_lag -->
 | Field         | Type         | Meaning
@@ -1266,8 +1267,7 @@ for each table, source, index, materialized view, and sink in the system.
 ## `mz_wallclock_lag_history`
 
 The `mz_wallclock_lag_history` table records the historical wallclock lag,
-i.e., the difference between the write frontier and the current wallclock time,
-for each table, source, index, materialized view, and sink in the system.
+i.e., the [freshness](/concepts/reaction-time/#freshness), for each table, source, index, materialized view, and sink in the system.
 
 <!-- RELATION_SPEC mz_internal.mz_wallclock_lag_history -->
 | Field         | Type         | Meaning


### PR DESCRIPTION
### Motivation

In the docs we don't say anywhere that wallclock lag has anything to do with freshness. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
