### PR TITLE
sqllogictest: Run git pull automatically

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -72,12 +72,10 @@ def update_sqlite_repo() -> None:
             spawn.runv(["git", "-C", str(path), "pull"])
         else:
             spawn.runv(["git", "-C", str(path), "fetch"])
-            local = spawn.capture(["git", "rev-parse", "@"])
-            remote = spawn.capture(["git", "rev-parse", "@{upstream}"])
+            local = spawn.capture(["git", "-C", str(path), "rev-parse", "@"])
+            remote = spawn.capture(["git", "-C", str(path), "rev-parse", "@{upstream}"])
             if local != remote:
-                raise ValueError(
-                    f"The test/sqllogictest/sqlite repository should be on the latest state ({remote}), but is on {local}"
-                )
+                spawn.runv(["git", "-C", str(path), "pull"])
     else:
         path.mkdir(exist_ok=True)
         spawn.runv(


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
