### PR TITLE
ci: Nightly fixes (2025-08-07 edition)

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -203,7 +203,7 @@ so it is executed.""",
     set_parallelism_name(pipeline)
     check_depends_on(pipeline, args.pipeline)
     add_version_to_preflight_tests(pipeline)
-    move_build_to_bazel_lto(pipeline, args.pipeline)
+    move_build_to_bazel_lto(pipeline, bazel_lto)
     trim_builds_prep_thread.join()
     trim_builds(pipeline, hash_check)
     add_cargo_test_dependency(
@@ -946,8 +946,8 @@ def remove_dependencies_on_prs(
             del step["depends_on"]
 
 
-def move_build_to_bazel_lto(pipeline: Any, pipeline_name: str) -> None:
-    if not os.environ["BUILDKITE_TAG"] and not ui.env_is_truthy("CI_RELEASE_LTO_BUILD"):
+def move_build_to_bazel_lto(pipeline: Any, bazel_lto: bool) -> None:
+    if not bazel_lto:
         return
     pipeline.setdefault("env", {})["CI_BAZEL_BUILD"] = 1
     pipeline["env"]["CI_BAZEL_LTO"] = 1

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1561,7 +1561,7 @@ steps:
         label: "RQG dbt3-joins workload"
         depends_on: build-aarch64
         # Some queries run very slow on Postgres, set a higher timeout to give them a chance to finish
-        timeout_in_minutes: 160
+        timeout_in_minutes: 120
         agents:
           # Runs into timeout/OoM on small agents
           queue: hetzner-aarch64-8cpu-16gb
@@ -1572,6 +1572,7 @@ steps:
               composition: rqg
               args: ["dbt3-joins", "--seed=$BUILDKITE_JOB_ID"]
               ci-builder: stable
+        skip: "still hangs, even after 2 hours to finish"
 
       - id: rqg-lateral-joins
         label: "RQG lateral-joins workload"


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/12793

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
