### PR TITLE
sql server tests & testdrive: Improvements

### DIFF
--- a/misc/python/materialize/mzcompose/services/sql_server.py
+++ b/misc/python/materialize/mzcompose/services/sql_server.py
@@ -41,6 +41,11 @@ class SqlServer(Service):
                     f"SA_PASSWORD={sa_password}",
                     *environment_extra,
                 ],
+                "healthcheck": {
+                    "test": f"/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P '{sa_password}' -Q 'SELECT 1'",
+                    "interval": "1s",
+                    "start_period": "30s",
+                },
             },
         )
         self.sa_password = sa_password

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -192,7 +192,7 @@ async fn try_run_sql(
     .await;
 
     if query_with_timeout.is_err() {
-        bail!("query timed out")
+        bail!("query timed out\n")
     }
 
     let rows: Vec<_> = query_with_timeout
@@ -236,7 +236,7 @@ async fn try_run_sql(
                         return Ok(());
                     } else {
                         bail!(
-                            "column name mismatch\nexpected: {:?}\nactual:   {:?}",
+                            "column name mismatch\nexpected: {:?}\nactual:   {:?}\n",
                             column_names,
                             actual_columns
                         );


### PR DESCRIPTION
Noticed in https://github.com/MaterializeInc/materialize/pull/33250

Less controversial than the rest of that PR, so split them out

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
