### PR TITLE
ci+tests: Fixes for coverage

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -362,7 +362,6 @@ def increase_agents_timeouts(
                     visit(inner_step)
 
     if coverage:
-        pipeline["env"]["CI_BUILDER_SCCACHE"] = 1
         pipeline["env"]["CI_COVERAGE_ENABLED"] = 1
 
         for step in steps(pipeline):
@@ -374,7 +373,7 @@ def increase_agents_timeouts(
                 step["skip"] = True
             if step.get("id") == "build-x86_64":
                 step["name"] = "Build x86_64 with coverage"
-            if step.get("id") == "build-aarch":
+            if step.get("id") == "build-aarch64":
                 step["name"] = "Build aarch64 with coverage"
     else:
         for step in steps(pipeline):

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -88,8 +88,8 @@ cleanup() {
       ci_uncollapsed_heading "cloudtest: Fetching binaries for coverage"
       mkdir -p coverage/
       chmod 777 coverage/
-      kubectl cp environmentd-0:/usr/local/bin/environmentd coverage/environmentd
-      kubectl cp environmentd-0:/coverage coverage/
+      kubectl cp environmentd-0:/usr/local/bin/environmentd coverage/environmentd || true
+      kubectl cp environmentd-0:/coverage coverage/ || true
       for pod in $(kubectl get pods -o name | grep -E 'cluster-'); do
         kubectl cp "$pod":/coverage coverage/ || true # Could get deleted
         kubectl cp "$pod":/usr/local/bin/clusterd coverage/clusterd || true

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -59,17 +59,8 @@ if ! mzcompose --mz-quiet list-workflows | grep "$service" > /dev/null; then
 fi
 
 if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
-    ci_uncollapsed_heading ":docker: Fetching binaries for coverage"
-    mzcompose create
     mkdir -p coverage/
     chmod 777 coverage/
-    # Not all tests contain all of these containers:
-    mzcompose --mz-quiet cp sqllogictest:/usr/local/bin/sqllogictest coverage/ || true
-    mzcompose --mz-quiet cp sqllogictest:/usr/local/bin/clusterd coverage/ || true
-    mzcompose --mz-quiet cp materialized:/usr/local/bin/environmentd coverage/ || true
-    mzcompose --mz-quiet cp materialized:/usr/local/bin/clusterd coverage/ || true
-    mzcompose --mz-quiet cp testdrive:/usr/local/bin/testdrive coverage/ || true
-    mzcompose --mz-quiet cp balancerd:/usr/local/bin/balancerd coverage/ || true
 fi
 
 if is_truthy "${CI_HEAP_PROFILES:-}"; then
@@ -148,8 +139,24 @@ cleanup() {
       mzcompose cp testdrive:/usr/local/bin/testdrive cores/ || true
   fi
 
+  if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
+      ci_uncollapsed_heading ":docker: Fetching binaries for coverage"
+      # Not all tests contain all of these containers:
+      mzcompose --mz-quiet cp sqllogictest:/usr/local/bin/sqllogictest coverage/ || true
+      mzcompose --mz-quiet cp sqllogictest:/usr/local/bin/clusterd coverage/ || true
+      mzcompose --mz-quiet cp materialized:/usr/local/bin/materialized coverage/ || true
+      mzcompose --mz-quiet cp mz_1:/usr/local/bin/materialized coverage/ || true
+      mzcompose --mz-quiet cp mz_this:/usr/local/bin/materialized coverage/ || true
+      mzcompose --mz-quiet cp testdrive:/usr/local/bin/testdrive coverage/ || true
+      mzcompose --mz-quiet cp balancerd:/usr/local/bin/balancerd coverage/ || true
+  fi
+
   echo "Downing docker containers"
-  mzcompose down --timeout=0 --volumes || true  # Ignore failures, we still want the rest of the cleanup
+  if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
+    mzcompose down --volumes || true
+  else
+    mzcompose down --timeout=0 --volumes || true  # Ignore failures, we still want the rest of the cleanup
+  fi
 
   echo "Finding core files"
   find cores -name 'core.*' | while read -r core; do
@@ -201,16 +208,20 @@ cleanup() {
           # Workaround for "invalid instrumentation profile data (file header is corrupt)"
           rm -rf profraws
           mkdir profraws
-          find . -name '*.profraw' | while read -r i; do
-              cp "$i" profraws
-              rm "$i"
-              bin/ci-builder run stable rust-profdata show profraws/"$(basename "$i")" > /dev/null || rm profraws/"$(basename "$i")"
+          # shellcheck disable=SC2044
+          for i in $(find . -name '*.profraw'); do
+              echo "$i"
+              cp "$i" profraws/
+              rm -f "$i" || true
+              if ! bin/ci-builder run stable rust-profdata merge -o /dev/null "profraws/$(basename "$i")"; then
+                  rm -f "profraws/$(basename "$i")"
+              fi
           done
           find profraws -name '*.profraw' -exec bin/ci-builder run stable rust-profdata merge -sparse -o coverage/"$BUILDKITE_JOB_ID".profdata {} +
           find . -name '*.profraw' -delete
 
           ARGS=()
-          for program in clusterd environmentd balancerd sqllogictest testdrive; do
+          for program in materialized balancerd sqllogictest testdrive; do
               if [ -f coverage/"$program" ]; then
                   export_cov coverage/"$program"
                   ARGS+=("-a" coverage/"$BUILDKITE_JOB_ID"-"$program".lcov)

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -29,7 +29,7 @@ bin/ci-annotate-errors junit_coverage*.xml
 ci_unimportant_heading "Create coverage report"
 REPORT=coverage_without_unittests_"$BUILDKITE_BUILD_ID"
 REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
-find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/#SF:#" {} +
+find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-[^/]*/materialize/.*/#SF:#" {} +
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
 find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +
 tar -I zstd -cf "$REPORT".tar.zst "$REPORT"

--- a/misc/images/mz/Dockerfile
+++ b/misc/images/mz/Dockerfile
@@ -7,11 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
+MZFROM prod-base
 
 RUN apt-get update \
     && apt-get -qy install ca-certificates postgresql-client tini
 
 COPY mz /usr/local/bin/
+
+USER materialize
 
 ENTRYPOINT ["tini", "--", "mz"]

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -29,6 +29,8 @@ SOURCE_RE = re.compile(
     ( src/(.*$)"
     | bazel-out/.*/bin/(.*$)
     | external/(.*$)
+    | /usr/local/lib/rustlib/(.*$)
+    | /var/lib/buildkite-agent/builds/buildkite-.*/materialize/[^/]*/src/(.*$)
     )""",
     re.VERBOSE,
 )
@@ -101,7 +103,7 @@ def mark_covered_lines(
                 file = content
             else:
                 result = SOURCE_RE.search(content)
-                assert result, f"Unexpected file {content}"
+                assert result, f"not found: {content}"
                 file = result.group(1)
         # DA:111,15524
         # DA:112,0

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -575,7 +575,11 @@ class DockerComposeCommand(Command):
             return
 
         composition = load_composition(args)
-        if not ui.env_is_truthy("CI") or ui.env_is_truthy("CI_ALLOW_LOCAL_BUILD"):
+        if (
+            args.coverage
+            or not ui.env_is_truthy("CI")
+            or ui.env_is_truthy("CI_ALLOW_LOCAL_BUILD")
+        ):
             ui.section("Collecting mzbuild images")
             for d in composition.dependencies:
                 ui.say(d.spec())

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -176,7 +176,7 @@ def main() -> int:
     parser.add_argument(
         "--coverage",
         help="Build with coverage",
-        default=False,
+        default=ui.env_is_truthy("CI_COVERAGE_ENABLED"),
         action="store_true",
     )
     parser.add_argument(

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -182,11 +182,12 @@ def is_ancestor(earlier: str, later: str) -> bool:
             command.append("--unshallow")
         spawn.runv(command + [get_remote(), earlier, later])
 
-        try:
-            spawn.capture(["git", "merge-base", "--is-ancestor", earlier, later])
-        except subprocess.CalledProcessError:
-            return False
-        return True
+        return (
+            spawn.run_and_get_return_code(
+                ["git", "merge-base", "--is-ancestor", earlier, later]
+            )
+            == 0
+        )
 
 
 def is_dirty() -> bool:
@@ -333,7 +334,7 @@ def get_common_ancestor_commit(remote: str, branch: str) -> str:
         spawn.runv(command + [remote, branch])
 
         return spawn.capture(
-            ["git", "merge-base", "--is-ancestor", "HEAD", f"{remote}/{branch}"]
+            ["git", "merge-base", "HEAD", f"{remote}/{branch}"]
         ).strip()
 
 

--- a/misc/python/materialize/mzcompose/services/mz.py
+++ b/misc/python/materialize/mzcompose/services/mz.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import hashlib
+import os
 
 import toml
 
@@ -57,10 +58,13 @@ class Mz(Service):
 
         with open(config_name, "w") as f:
             f.write(config_str)
+        os.chmod(config_name, 0o777)
         super().__init__(
             name=name,
             config={
                 "mzbuild": "mz",
-                "volumes": [f"{config_name}:/root/.config/materialize/mz.toml"],
+                "volumes": [
+                    f"{config_name}:/home/materialize/.config/materialize/mz.toml"
+                ],
             },
         )

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -11,7 +11,7 @@ import json
 import random
 from typing import Any
 
-from materialize import buildkite
+from materialize import buildkite, ui
 from materialize.mzcompose import DEFAULT_MZ_VOLUMES, cluster_replica_size_map
 from materialize.mzcompose.service import (
     Service,
@@ -136,7 +136,9 @@ class Testdrive(Service):
             entrypoint.append(f"--materialize-param={k}={v}")
 
         if default_timeout is None:
-            default_timeout = "20s"
+            default_timeout = (
+                "120s" if ui.env_is_truthy("CI_COVERAGE_ENABLED") else "20s"
+            )
         entrypoint.append(f"--default-timeout={default_timeout}")
 
         if kafka_default_partitions:

--- a/src/persist-cli/ci-base/Dockerfile
+++ b/src/persist-cli/ci-base/Dockerfile
@@ -11,7 +11,7 @@
 # re-install the apt things or maelstrom every time we get a CI builder with a
 # cold cache.
 
-MZFROM ubuntu-base
+MZFROM prod-base
 
 RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     bzip2 \

--- a/src/persist-cli/ci/Dockerfile
+++ b/src/persist-cli/ci/Dockerfile
@@ -11,4 +11,6 @@ MZFROM maelstrom-persist-base
 
 COPY persistcli /usr/local/bin/persistcli
 
+USER ubuntu
+
 ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "/usr/local/share/java/maelstrom.jar", "test", "-w", "txn-list-append", "--bin=/usr/local/bin/persistcli"]

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -62,6 +62,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
+    (c.path / "maelstrom").mkdir(mode=0o777, exist_ok=True)
+
     if args.consensus == "mem":
         consensus_uri = "mem://consensus"
     elif args.consensus == "cockroach":


### PR DESCRIPTION
All noticed while trying to run https://github.com/MaterializeInc/materialize/pull/33245

Green nightly with the relevant tests: https://buildkite.com/materialize/nightly/builds/12796
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
