### PR TITLE
materialized container: Time out when initializing fails

### DIFF
--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -22,7 +22,15 @@ RUN bash -c '\
   set -euo pipefail; \
   tini -- entrypoint.sh & \
   tini_pid=$!; \
-  until curl -sf localhost:6878/api/readyz; do sleep 0.1; done; \
+  start_time=$(date +%s); \
+  while ! curl -sf localhost:6878/api/readyz; do \
+    sleep 0.1; \
+    now=$(date +%s); \
+    if (( now - start_time > 30 )); then \
+      echo "Timed out, failing build"; \
+      exit 1; \
+    fi; \
+  done; \
   kill -TERM "$tini_pid"; \
   wait "$tini_pid" || true; \
   pg_ctlcluster 16 main stop --mode=fast --force'


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/107434#01988262-f51c-46c1-9683-5103676fb135

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
