### PR TITLE
Use a unique path for rocksdb even if using mem env

### DIFF
--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -254,11 +254,10 @@ where
 
     let tuning = dataflow_paramters.upsert_rocksdb_tuning_config.clone();
 
-    // When running RocksDB in memory, the file system is emulated, so the path doesn't
-    // matter. However, we still need to pick one that exists on the host because of
-    // https://github.com/rust-rocksdb/rust-rocksdb/issues/1015.  RocksDB will still
-    // create a lock file at this path, so we need to ensure that whatever path is used
-    // will be unique per worker.
+    // When running RocksDB in memory, the file system is emulated. However, we still need to
+    // pick a path that exists because RocksDB will attempt to create the working directory
+    // (see https://github.com/rust-rocksdb/rust-rocksdb/issues/1015) and write a lock file,
+    // so we need to ensure the directory is unique per worker.
     let rocksdb_dir = instance_context
         .scratch_directory
         .clone()


### PR DESCRIPTION
When using `mem_env`, RocksDB still attempts to create a lock file, which can cause issues with multiple workers.

```
materialized2-1  | 2025-08-07T15:37:16.862948167Z cluster-u2-replica-u3-gen-3: 2025-08-07T15:37:16.862935Z ERROR mz_rocksdb: failed to create rocksdb at /tmp: IO error: /tmp/LOCK: lock is already held.
```

### Motivation

I just felt like it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
