### PR TITLE
benchmarks: Fix finding ancestor

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -75,7 +75,7 @@ def is_in_pull_request() -> bool:
     if git.is_on_release_version():
         return False
 
-    if git.contains_commit("HEAD", "main", fetch=True):
+    if git.contains_commit("HEAD", "main"):
         return False
 
     return True

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -345,12 +345,8 @@ def is_on_release_version() -> bool:
 def contains_commit(
     commit_sha: str,
     target: str = "HEAD",
-    fetch: bool = False,
     remote_url: str = MATERIALIZE_REMOTE_URL,
 ) -> bool:
-    if fetch:
-        remote = get_remote(remote_url)
-        target = f"{remote}/{target}"
     return is_ancestor(commit_sha, target)
 
 


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/C01LKF361MZ/p1754597953979529?thread_ts=1754595718.702039&cid=C01LKF361MZ

> fatal: couldn't find remote ref origin/main

Nightly run with benchmarks: https://buildkite.com/materialize/nightly/builds/12808

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
