### PR TITLE
terraform tests: No authenticatorKind for v25.1.*

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -26,6 +26,7 @@ import psycopg
 import yaml
 
 from materialize import MZ_ROOT, ci_util, git, spawn
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import (
     Composition,
     Service,
@@ -348,9 +349,14 @@ class State:
                     "requests": {"cpu": "100m", "memory": "256Mi"},
                 },
                 "backendSecretName": "materialize-backend",
-                "authenticatorKind": "None",
             },
         }
+
+        # Only supported since self-managed v25.2
+        if not tag.startswith("v") or MzVersion.parse_mz(tag) >= MzVersion.parse_mz(
+            "v0.147.0"
+        ):
+            self.materialize_environment["spec"]["authenticatorKind"] = "None"
 
         spawn.runv(
             ["kubectl", "apply", "-f", "-"],
@@ -698,9 +704,13 @@ class AWS(State):
                     "requests": {"cpu": "100m", "memory": "256Mi"},
                 },
                 "backendSecretName": "materialize-backend",
-                "authenticatorKind": "None",
             },
         }
+        # Only supported since self-managed v25.2
+        if not tag.startswith("v") or MzVersion.parse_mz(tag) >= MzVersion.parse_mz(
+            "v0.147.0"
+        ):
+            self.materialize_environment["spec"]["authenticatorKind"] = "None"
 
         self.version += 1
         spawn.runv(


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/publish-helm-charts/builds/53#019885cd-bbef-4363-951e-08446dfd5c80
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
