### PR TITLE
Fix parse order of WITH ORDINALITY and table alias

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -600,12 +600,12 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
                 with_ordinality,
             } => {
                 f.write_node(function);
+                if *with_ordinality {
+                    f.write_str(" WITH ORDINALITY");
+                }
                 if let Some(alias) = &alias {
                     f.write_str(" AS ");
                     f.write_node(alias);
-                }
-                if *with_ordinality {
-                    f.write_str(" WITH ORDINALITY");
                 }
             }
             TableFactor::RowsFrom {
@@ -616,12 +616,12 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
                 f.write_str("ROWS FROM (");
                 f.write_node(&display::comma_separated(functions));
                 f.write_str(")");
+                if *with_ordinality {
+                    f.write_str(" WITH ORDINALITY");
+                }
                 if let Some(alias) = alias {
                     f.write_str(" AS ");
                     f.write_node(alias);
-                }
-                if *with_ordinality {
-                    f.write_str(" WITH ORDINALITY");
                 }
             }
             TableFactor::Derived {

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1096,6 +1096,34 @@ SELECT foo FROM LATERAL bar
                            ^
 
 parse-statement
+SELECT foo FROM LATERAL bar(1) WITH ORDINALITY
+----
+SELECT foo FROM bar(1) WITH ORDINALITY
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT foo FROM LATERAL bar(1) AS alias
+----
+SELECT foo FROM bar(1) AS alias
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT foo FROM LATERAL bar(1) WITH ORDINALITY AS alias
+----
+SELECT foo FROM bar(1) WITH ORDINALITY AS alias
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT foo FROM LATERAL bar(1) AS alias WITH ORDINALITY
+----
+SELECT foo FROM bar(1) WITH ORDINALITY AS alias
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
 SELECT 'foo' OFFSET 0 ROWS
 ----
 SELECT 'foo' OFFSET 0
@@ -1290,6 +1318,34 @@ SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
+SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) WITH ORDINALITY ON true
+----
+SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) WITH ORDINALITY ON true
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: None, with_ordinality: true }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) AS alias ON true
+----
+SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) AS alias ON true
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) WITH ORDINALITY AS alias ON true
+----
+SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) WITH ORDINALITY AS alias ON true
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) AS alias WITH ORDINALITY ON true
+----
+SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) WITH ORDINALITY AS alias ON true
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
@@ -1302,6 +1358,20 @@ SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) A
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS alias
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS alias
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias WITH ORDINALITY
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS alias
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
@@ -1325,11 +1395,68 @@ SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDI
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) WITH ORDINALITY AS t (letter, position)
+----
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) WITH ORDINALITY AS t (letter, position)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("unnest")])), args: Args { args: [Array([Value(String("a")), Value(String("b")), Value(String("c"))])], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("t"), columns: [Ident("letter"), Ident("position")], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# Weird order; supported only for backcompat reasons
+parse-statement
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) AS t (letter, position) WITH ORDINALITY
+----
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) WITH ORDINALITY AS t (letter, position)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: Function { name: Name(UnresolvedItemName([Ident("unnest")])), args: Args { args: [Array([Value(String("a")), Value(String("b")), Value(String("c"))])], order_by: [] }, filter: None, over: None, distinct: false }, alias: Some(TableAlias { name: Ident("t"), columns: [Ident("letter"), Ident("position")], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) WITH ORDINALITY AS t (letter, position) WITH ORDINALITY
+----
+error: WITH ORDINALITY specified twice
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) WITH ORDINALITY AS t (letter, position) WITH ORDINALITY
+                                                                                        ^
+
+parse-statement
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) AS WITH ORDINALITY t (letter, position) WITH ORDINALITY
+----
+error: Expected end of statement, found ORDINALITY
+SELECT * FROM unnest(ARRAY['a', 'b', 'c']) AS WITH ORDINALITY t (letter, position) WITH ORDINALITY
+                                                   ^
+
+parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS t (a)
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS t (a)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("t"), columns: [Ident("a")], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b)
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("t"), columns: [Ident("a"), Ident("b")], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS t (a, b) WITH ORDINALITY
+----
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false }, Function { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] }, filter: None, over: None, distinct: false }], alias: Some(TableAlias { name: Ident("t"), columns: [Ident("a"), Ident("b")], strict: false }), with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Ensure parsing AS OF is case-insensitive
 parse-statement

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -56,6 +56,85 @@ generate_series ordinality
 3 2
 4 3
 
+query TI colnames,rowsort
+SELECT *
+FROM unnest(ARRAY['a','b','c']) WITH ORDINALITY AS t(letter, position);
+----
+letter position
+a  1
+b  2
+c  3
+
+# Weird order; supported only for backcompat reasons
+query TI colnames,rowsort
+SELECT *
+FROM unnest(ARRAY['a','b','c']) AS t(letter, position) WITH ORDINALITY;
+----
+letter position
+a  1
+b  2
+c  3
+
+query T colnames,rowsort
+SELECT *
+FROM unnest(ARRAY['a','b','c']) AS t(letter);
+----
+letter
+a
+b
+c
+
+query II colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
+----
+generate_series generate_series
+1  3
+2  4
+NULL  5
+
+query III colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
+----
+generate_series generate_series ordinality
+1  3  1
+2  4  2
+NULL  5  3
+
+query II colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS t (a)
+----
+a generate_series
+1  3
+2  4
+NULL  5
+
+query II colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS t (a, b)
+----
+a b
+1  3
+2  4
+NULL  5
+
+query III colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b)
+----
+a b ordinality
+1  3  1
+2  4  2
+NULL  5  3
+
+query III colnames,rowsort
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b, c)
+----
+a b c
+1  3  1
+2  4  2
+NULL  5  3
+
+query error db error: ERROR: t has 3 columns available but 4 columns specified
+SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY AS t (a, b, c, d)
+
 query I rowsort
 SELECT generate_series FROM generate_series(-2, 2)
 ----
@@ -186,6 +265,28 @@ SELECT x.a, generate_series FROM x, LATERAL (SELECT * FROM generate_series(1, x.
 3  1
 3  2
 3  3
+
+query III
+SELECT x.a, generate_series, ordinality
+FROM x, LATERAL (SELECT * FROM generate_series(1, x.a) WITH ORDINALITY)
+----
+1  1  1
+2  1  1
+2  2  2
+3  1  1
+3  2  2
+3  3  3
+
+query III
+SELECT x.a, g, o
+FROM x, LATERAL (SELECT * FROM generate_series(1, x.a) WITH ORDINALITY AS t(g, o))
+----
+1  1  1
+2  1  1
+2  2  2
+3  1  1
+3  2  2
+3  3  3
 
 # Regression test for database-issues#1700: crash when a filter references an output column of
 # a table function


### PR DESCRIPTION
Fix https://github.com/MaterializeInc/database-issues/issues/9551

(Nightly upgrade tests: https://buildkite.com/materialize/nightly/builds/12813 )

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
