### PR TITLE
mzcompose: Don't wait on user input for docker pull & mirror mssql-server

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -241,6 +241,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                                 ["docker", "pull", clusterd["image"]],
                                 check=True,
                                 capture_output=True,
+                                stdin=subprocess.DEVNULL,
                             )
                             container_id = subprocess.check_output(
                                 ["docker", "create", clusterd["image"]], text=True

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -1003,6 +1003,7 @@ class ResolvedImage:
                 try:
                     spawn.runv(
                         command,
+                        stdin=subprocess.DEVNULL,
                         stdout=sys.stderr.buffer,
                     )
                     self.acquired = True

--- a/misc/python/materialize/mzcompose/services/sql_server.py
+++ b/misc/python/materialize/mzcompose/services/sql_server.py
@@ -23,15 +23,13 @@ class SqlServer(Service):
         # lowercase letters, base-10 digits and/or non-alphanumeric symbols.
         sa_password: str = DEFAULT_SA_PASSWORD,
         name: str = "sql-server",
-        # 2017 mssql images core on OSx, 2019 is the earliest that has passed
-        image: str = "mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04",
         environment_extra: list[str] = [],
         volumes_extra: list[str] = [],
     ) -> None:
         super().__init__(
             name=name,
             config={
-                "image": image,
+                "mzbuild": "mssql-server",
                 "ports": [1433],
                 "volumes": volumes_extra,
                 "environment": [

--- a/test/mssql-server/Dockerfile
+++ b/test/mssql-server/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Mirrored to DockerHub
+
+# 2017 mssql images core on OSx, 2019 is the earliest that has passed
+FROM mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04

--- a/test/mssql-server/mzbuild.yml
+++ b/test/mssql-server/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: mssql-server

--- a/test/mz-debug/mzcompose.py
+++ b/test/mz-debug/mzcompose.py
@@ -55,6 +55,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ["docker", "pull", mz_debug["image"]],
         check=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
     )
     container_id = subprocess.check_output(
         ["docker", "create", mz_debug["image"]], text=True


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/107511#0198895a-e09b-44ab-84f8-5fda1c12fe38
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
