### PR TITLE
Rewrite `FlatMapElimination`

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3792,19 +3792,16 @@ pub enum TableFunc {
     WithOrdinality(WithOrdinality),
 }
 
-/// Private enum variant of `TableFunc`. Don't construct this directly, but use
-/// `TableFunc::with_ordinality` instead.
-///
 /// Evaluates the inner table function, expands its results into unary (repeating each row as
 /// many times as the diff indicates), and appends an integer corresponding to the ordinal
 /// position (starting from 1). For example, it numbers the elements of a list when calling
 /// `unnest_list`.
 ///
-/// TODO(ggevay): This struct (and its field) is pub only temporarily, until we make
-/// `FlatMapElimination` not dive into it.
+/// Private enum variant of `TableFunc`. Don't construct this directly, but use
+/// `TableFunc::with_ordinality` instead.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
-pub struct WithOrdinality {
-    pub inner: Box<TableFunc>,
+struct WithOrdinality {
+    inner: Box<TableFunc>,
 }
 
 impl TableFunc {

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -648,12 +648,20 @@ impl MirScalarExpr {
         mem::replace(self, MirScalarExpr::literal_null(ScalarType::String))
     }
 
+    /// If the expression is a literal, this returns the literal's Datum or the literal's EvalError.
+    /// Otherwise, it returns None.
     pub fn as_literal(&self) -> Option<Result<Datum<'_>, &EvalError>> {
         if let MirScalarExpr::Literal(lit, _column_type) = self {
             Some(lit.as_ref().map(|row| row.unpack_first()))
         } else {
             None
         }
+    }
+
+    /// Flattens the two failure modes of `as_literal` into one layer of Option: returns the
+    /// literal's Datum only if the expression is a literal, and it's not a literal error.
+    pub fn as_literal_non_error(&self) -> Option<Datum<'_>> {
+        self.as_literal().map(|eval_err| eval_err.ok()).flatten()
     }
 
     pub fn as_literal_owned(&self) -> Option<Result<Row, EvalError>> {

--- a/src/transform/src/canonicalization/flat_map_elimination.rs
+++ b/src/transform/src/canonicalization/flat_map_elimination.rs
@@ -7,16 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Turns `FlatMap` into `Map` if only one row is produced by flatmap.
-//!
+//! For a `FlatMap` whose args are all constants, turns it into `Map` if only 1 row is produced by
+//! the table function, or turns it into an empty constant if 0 rows are produced by the table
+//! function. Additionally, a `Wrap` whose width is larger than its number of arguments can be
+//! removed.
 
+use itertools::Itertools;
 use mz_expr::visit::Visit;
 use mz_expr::{MirRelationExpr, MirScalarExpr, TableFunc};
-use mz_repr::{Datum, Diff, ScalarType};
+use mz_repr::{Diff, Row, RowArena};
 
 use crate::TransformCtx;
 
-/// Turns `FlatMap` into `Map` if only one row is produced by flatmap.
+/// See comment at the top of the file.
 #[derive(Debug)]
 pub struct FlatMapElimination;
 
@@ -42,70 +45,49 @@ impl crate::Transform for FlatMapElimination {
 }
 
 impl FlatMapElimination {
-    /// Turns `FlatMap` into `Map` if only one row is produced by flatmap.
+    /// See comment at the top of the file.
     pub fn action(relation: &mut MirRelationExpr) {
         if let MirRelationExpr::FlatMap { func, exprs, input } = relation {
-            let (func, with_ordinality) = if let TableFunc::WithOrdinality(with_ordinality) = func {
-                // get to the actual function, but remember that we have a WITH ORDINALITY clause.
-                (&*with_ordinality.inner, true)
-            } else {
-                (&*func, false)
-            };
-
-            if let TableFunc::GuardSubquerySize { .. } = func {
-                // (`with_ordinality` doesn't matter because this function never emits rows)
-                if let Some(1) = exprs[0].as_literal_int64() {
-                    relation.take_safely(None);
-                }
-            } else if let TableFunc::Wrap { width, .. } = func {
+            // Treat Wrap specially.
+            if let TableFunc::Wrap { width, .. } = func {
                 if *width >= exprs.len() {
                     *relation = input.take_dangerous().map(std::mem::take(exprs));
-                    if with_ordinality {
-                        *relation = relation.take_dangerous().map_one(MirScalarExpr::literal(
-                            Ok(Datum::Int64(1)),
-                            ScalarType::Int64,
-                        ));
-                    }
+                    return;
                 }
-            } else if is_supported_unnest(func) {
-                let func = func.clone();
-                let exprs = exprs.clone();
-                use mz_expr::MirScalarExpr;
-                use mz_repr::RowArena;
-                if let MirScalarExpr::Literal(Ok(row), ..) = &exprs[0] {
-                    let temp_storage = RowArena::default();
-                    if let Ok(mut iter) = func.eval(&[row.iter().next().unwrap()], &temp_storage) {
-                        match (iter.next(), iter.next()) {
-                            (None, _) => {
-                                // If there are no elements in the literal argument, no output.
-                                relation.take_safely(None);
-                            }
-                            (Some((row, Diff::ONE)), None) => {
-                                assert_eq!(func.output_type().column_types.len(), 1);
-                                *relation =
-                                    input.take_dangerous().map(vec![MirScalarExpr::Literal(
-                                        Ok(row),
-                                        func.output_type().column_types[0].clone(),
-                                    )]);
-                                if with_ordinality {
-                                    *relation =
-                                        relation.take_dangerous().map_one(MirScalarExpr::literal(
-                                            Ok(Datum::Int64(1)),
-                                            ScalarType::Int64,
-                                        ));
-                                }
-                            }
-                            _ => {}
-                        }
-                    };
+            }
+            // For all other table functions, check for all arguments being literals.
+            let mut args = vec![];
+            for e in exprs {
+                match e.as_literal() {
+                    Some(Ok(datum)) => args.push(datum),
+                    // Give up if any arg is not a literal, or if it's a literal error.
+                    _ => return,
                 }
+            }
+            let temp_storage = RowArena::new();
+            let (first, second) = match func.eval(&args, &temp_storage) {
+                Ok(mut r) => (r.next(), r.next()),
+                // don't play with errors
+                Err(_) => return,
+            };
+            match (first, second) {
+                // The table function evaluated to an empty collection.
+                (None, None) => {
+                    relation.take_safely(None);
+                }
+                // The table function evaluated to a collection with exactly 1 row.
+                (Some((first_row, Diff::ONE)), None) => {
+                    let types = func.output_type().column_types;
+                    let map_exprs = first_row
+                        .into_iter()
+                        .zip_eq(types)
+                        .map(|(d, typ)| MirScalarExpr::Literal(Ok(Row::pack_slice(&[d])), typ))
+                        .collect();
+                    *relation = input.take_dangerous().map(map_exprs);
+                }
+                // The table function evaluated to a collection with more than 1 row; nothing to do.
+                _ => {}
             }
         }
     }
-}
-
-/// Returns `true` for `unnest_~` variants supported by [`FlatMapElimination`].
-fn is_supported_unnest(func: &TableFunc) -> bool {
-    use TableFunc::*;
-    matches!(func, UnnestArray { .. } | UnnestList { .. })
 }

--- a/src/transform/src/canonicalization/flat_map_elimination.rs
+++ b/src/transform/src/canonicalization/flat_map_elimination.rs
@@ -7,10 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! For a `FlatMap` whose args are all constants, turns it into `Map` if only 1 row is produced by
-//! the table function, or turns it into an empty constant if 0 rows are produced by the table
-//! function. Additionally, a `Wrap` whose width is larger than its number of arguments can be
-//! removed.
+//! For a `FlatMap` where the table function's arguments are all constants, turns it into `Map` if
+//! only 1 row is produced by the table function, or turns it into an empty constant collection if 0
+//! rows are produced by the table function.
+//!
+//! It does an additional optimization on the `Wrap` table function: when `Wrap`'s width is larger
+//! than its number of arguments, it removes the `FlatMap Wrap ...`, because such `Wrap`s would have
+//! no effect.
 
 use itertools::Itertools;
 use mz_expr::visit::Visit;
@@ -19,7 +22,7 @@ use mz_repr::{Diff, Row, RowArena};
 
 use crate::TransformCtx;
 
-/// See comment at the top of the file.
+/// Attempts to eliminate FlatMaps that are sure to have 0 or 1 results on each input row.
 #[derive(Debug)]
 pub struct FlatMapElimination;
 
@@ -45,48 +48,55 @@ impl crate::Transform for FlatMapElimination {
 }
 
 impl FlatMapElimination {
-    /// See comment at the top of the file.
+    /// Apply `FlatMapElimination` to the root of the given `MirRelationExpr`.
     pub fn action(relation: &mut MirRelationExpr) {
+        // Treat Wrap specially: we can sometimes optimize it out even when it has non-literal
+        // arguments.
+        //
+        // (No need to look for WithOrdinality here, as that never occurs with Wrap: users can't
+        // call Wrap directly; we only create calls to Wrap ourselves, and we don't use
+        // WithOrdinality on it.)
         if let MirRelationExpr::FlatMap { func, exprs, input } = relation {
-            // Treat Wrap specially.
             if let TableFunc::Wrap { width, .. } = func {
                 if *width >= exprs.len() {
                     *relation = input.take_dangerous().map(std::mem::take(exprs));
-                    return;
                 }
             }
-            // For all other table functions, check for all arguments being literals.
-            let mut args = vec![];
-            for e in exprs {
-                match e.as_literal() {
-                    Some(Ok(datum)) => args.push(datum),
-                    // Give up if any arg is not a literal, or if it's a literal error.
-                    _ => return,
+        }
+        // For all other table functions (and Wraps that are not covered by the above), check
+        // whether all arguments are literals (with no errors), in which case we'll evaluate the
+        // table function and check how many output rows it has, and maybe turn the FlatMap into
+        // something simpler.
+        if let MirRelationExpr::FlatMap { func, exprs, input } = relation {
+            if let Some(args) = exprs
+                .iter()
+                .map(|e| e.as_literal_non_error())
+                .collect::<Option<Vec<_>>>()
+            {
+                let temp_storage = RowArena::new();
+                let (first, second) = match func.eval(&args, &temp_storage) {
+                    Ok(mut r) => (r.next(), r.next()),
+                    // don't play with errors
+                    Err(_) => return,
+                };
+                match (first, second) {
+                    // The table function evaluated to an empty collection.
+                    (None, _) => {
+                        relation.take_safely(None);
+                    }
+                    // The table function evaluated to a collection with exactly 1 row.
+                    (Some((first_row, Diff::ONE)), None) => {
+                        let types = func.output_type().column_types;
+                        let map_exprs = first_row
+                            .into_iter()
+                            .zip_eq(types)
+                            .map(|(d, typ)| MirScalarExpr::Literal(Ok(Row::pack_slice(&[d])), typ))
+                            .collect();
+                        *relation = input.take_dangerous().map(map_exprs);
+                    }
+                    // The table function evaluated to a collection with more than 1 row; nothing to do.
+                    _ => {}
                 }
-            }
-            let temp_storage = RowArena::new();
-            let (first, second) = match func.eval(&args, &temp_storage) {
-                Ok(mut r) => (r.next(), r.next()),
-                // don't play with errors
-                Err(_) => return,
-            };
-            match (first, second) {
-                // The table function evaluated to an empty collection.
-                (None, None) => {
-                    relation.take_safely(None);
-                }
-                // The table function evaluated to a collection with exactly 1 row.
-                (Some((first_row, Diff::ONE)), None) => {
-                    let types = func.output_type().column_types;
-                    let map_exprs = first_row
-                        .into_iter()
-                        .zip_eq(types)
-                        .map(|(d, typ)| MirScalarExpr::Literal(Ok(Row::pack_slice(&[d])), typ))
-                        .collect();
-                    *relation = input.take_dangerous().map(map_exprs);
-                }
-                // The table function evaluated to a collection with more than 1 row; nothing to do.
-                _ => {}
             }
         }
     }

--- a/src/transform/tests/test_transforms/flat_map_elimination.spec
+++ b/src/transform/tests/test_transforms/flat_map_elimination.spec
@@ -83,7 +83,7 @@ FlatMap wrap3(0, 1, 2, 3)
 ## Support for unnest_~ calls
 ## --------------------------
 
-# Rewrite possible for `unnset_array`
+# Rewrite possible for `unnest_array`
 # Example SQL: select unnest(array[f1]) from t1 where f1 = 5;
 apply pipeline=flat_map_elimination
 FlatMap unnest_array({5})
@@ -101,7 +101,7 @@ FlatMap unnest_list([5])
 Map (5)
   Get t0
 
-# Rewrite not possible: unnest_array(-) argument is not resuced
+# Rewrite not possible: unnest_array(-) argument is not reduced to a literal
 apply pipeline=flat_map_elimination
 FlatMap unnest_array(array[5])
   Get t0
@@ -109,7 +109,7 @@ FlatMap unnest_array(array[5])
 FlatMap unnest_array(array[5])
   Get t0
 
-# Rewrite not possible: unnest_list(-) argument is not resuced
+# Rewrite not possible: unnest_list(-) argument is not reduced to a literal
 apply pipeline=flat_map_elimination
 FlatMap unnest_list(list[5])
   Get t0
@@ -119,16 +119,37 @@ FlatMap unnest_list(list[5])
 
 # Rewrite not possible: unnest_array(-) argument is not a singleton
 apply pipeline=flat_map_elimination
+FlatMap unnest_array({5, 6})
+  Get t0
+----
+FlatMap unnest_array({5, 6})
+  Get t0
+
+# Rewrite not possible: unnest_list(-) argument is not a singleton
+apply pipeline=flat_map_elimination
 FlatMap unnest_list([5, 6])
   Get t0
 ----
 FlatMap unnest_list([5, 6])
   Get t0
 
-# Rewrite not possible: unnest_list(-) argument is not a singleton
+# generate_series can produce 0, 1, or more rows, based on its arguments
 apply pipeline=flat_map_elimination
-FlatMap unnest_list(list[5])
+FlatMap generate_series(5, 2, 1)
   Get t0
 ----
-FlatMap unnest_list(list[5])
+Constant <empty>
+
+apply pipeline=flat_map_elimination
+FlatMap generate_series(5, 5, 1)
   Get t0
+----
+Map (5)
+  Get t0
+
+apply pipeline=flat_map_elimination
+FlatMap generate_series(5, 6, 1)
+  Get t0
+----
+FlatMap generate_series(5, 6, 1)
+  Get

--- a/src/transform/tests/test_transforms/flat_map_elimination.spec
+++ b/src/transform/tests/test_transforms/flat_map_elimination.spec
@@ -152,4 +152,4 @@ FlatMap generate_series(5, 6, 1)
   Get t0
 ----
 FlatMap generate_series(5, 6, 1)
-  Get
+  Get t0

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1710,3 +1710,33 @@ Source materialize.public.x
 Target cluster: quickstart
 
 EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (NO FAST PATH) FOR
+SELECT *
+FROM x, generate_series(1, x.a)
+WHERE x.a = 1
+----
+Explained Query:
+  Project (#0, #1, #0)
+    Filter (#0{a} = 1)
+      ReadStorage materialize.public.x
+
+Source materialize.public.x
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (NO FAST PATH) FOR
+SELECT *
+FROM x, generate_series(5, x.a)
+WHERE x.a = 1
+----
+Explained Query:
+  Constant <empty>
+
+Target cluster: quickstart
+
+EOF

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1715,7 +1715,7 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (NO FAST PATH) FOR
 SELECT *
 FROM x, generate_series(1, x.a)
-WHERE x.a = 1
+WHERE x.a = 1;
 ----
 Explained Query:
   Project (#0, #1, #0)
@@ -1732,10 +1732,27 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (NO FAST PATH) FOR
 SELECT *
 FROM x, generate_series(5, x.a)
-WHERE x.a = 1
+WHERE x.a = 1;
 ----
 Explained Query:
   Constant <empty>
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH (NO FAST PATH) FOR
+SELECT *
+FROM x, LATERAL (VALUES ((1), (x.a)))
+WHERE x.a = 1;
+----
+Explained Query:
+  Project (#0, #1, #0, #0)
+    Filter (#0{a} = 1)
+      ReadStorage materialize.public.x
+
+Source materialize.public.x
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -6874,7 +6874,8 @@ NULL  11  NULL  22  22  22  {22}
 # than one window function call in one test, because we currently forget the key information after a window function
 # call (even when `ReduceElision` simplifies the window function call).
 # TODO: Add an optimization that eliminates a Map-FlatMap pair where the Map is just creating a 1-element list on which
-# the FlatMap is immediately calling `unnest_list`.
+# the FlatMap is immediately calling `unnest_list`. We could use the `Equivalences` analysis for this, which would tell
+# us that the column reference in `unnest_list` is equal to a `list_create` with 1 argument.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(keys, humanized expressions) AS VERBOSE TEXT FOR
 SELECT


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/33291.

Rewrites `FlatMapElimination` to simplify and generalize it. It used to check for several specific table functions. @petrosagg noticed that it could instead just execute any table function whose arguments are all literals, and then check whether it has at most 1 rows, and if yes, then transform away the table function. The only table function where we still need a special check is `Wrap`: we can eliminate it in some cases even when not all arguments are literals. (I've removed the `WITH ORDINALITY` handling for `Wrap`, because these never actually appear together, because `Wrap` is a thing that users don't call, but we insert it ourselves.)

The new code is simpler, and also fires for more table functions, e.g., for appropriate `generate_series` calls.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
