### PR TITLE
ci: Introduce CI_UNPARALLELIZE

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -200,6 +200,7 @@ so it is executed.""",
     permit_rerunning_successful_steps(pipeline)
     set_retry_on_agent_lost(pipeline)
     set_default_agents_queue(pipeline)
+    unparallelize(pipeline)
     set_parallelism_name(pipeline)
     check_depends_on(pipeline, args.pipeline)
     add_version_to_preflight_tests(pipeline)
@@ -1055,6 +1056,19 @@ def remove_mz_specific_keys(pipeline: Any) -> None:
             raise UIError(
                 f"Every step should have an explicit timeout_in_minutes value, missing in: {step}"
             )
+
+
+def unparallelize(pipeline: Any) -> None:
+    """Removes parallelism in the test, which will run longer, but exposes some interesting parallelism in some tests."""
+    if not ui.env_is_truthy("CI_UNPARALLELIZE"):
+        return
+
+    for step in steps(pipeline):
+        if "parallelism" not in step:
+            continue
+
+        step["timeout_in_minutes"] *= step["parallelism"]
+        del step["parallelism"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This helps with reproducing some bugs for example. In addition I sometimes like to run CI with very low priority and without parallelization on a PR when I'm just testing something unimportant and very slow, like a regular coverage or sanitizer run.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
