### PR TITLE
tests: Speed up SQL Server tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -383,7 +383,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/sql-server-cdc]
-    parallelism: 2
+    parallelism: 3
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sql-server-cdc

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -98,7 +98,7 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # must start test-certs, otherwise the certificates needed by sql-server may not be avaiable
     # in the secrets volume when it starts up
-    c.up("materialized", "test-certs", "sql-server")
+    c.up("materialized", "test-certs", "sql-server", Service("testdrive", idle=True))
     seed = random.getrandbits(16)
 
     ssl_ca = c.exec(


### PR DESCRIPTION
It's currently the slowest test. I'm not sure if there is a better way to speed up SQL Server source.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
