### PR TITLE
ci: Switch to LTO on non-PR branches too

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -121,7 +121,7 @@ so it is executed.""",
         pipeline.get("env", {}).get("CI_BAZEL_LTO", 0) == 1
         or bool(os.environ["BUILDKITE_TAG"])
         or (
-            os.environ["BUILDKITE_BRANCH"] == "main"
+            not ui.env_is_truthy("BUILDKITE_PULL_REQUEST")
             and args.pipeline in ("nightly", "release-qualification")
         )
         or ui.env_is_truthy("CI_RELEASE_LTO_BUILD")


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/C01LKF361MZ/p1754921945758739

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
