### PR TITLE
cluster,orchestrator-k8s: report swap usage

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -8857,9 +8857,9 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION: LazyLock<BuiltinView> = LazyLock::new
 SELECT
     r.id AS replica_id,
     m.process_id,
-    m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
-    m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent,
-    m.disk_bytes::float8 / s.disk_bytes * 100 AS disk_percent
+    m.cpu_nano_cores::float8 / NULLIF(s.cpu_nano_cores, 0) * 100 AS cpu_percent,
+    m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
+    m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent
 FROM
     mz_catalog.mz_cluster_replicas AS r
         JOIN mz_catalog.mz_cluster_replica_sizes AS s ON r.size = s.size
@@ -8907,9 +8907,9 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
 SELECT
     r.id AS replica_id,
     m.process_id,
-    m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
-    m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent,
-    m.disk_bytes::float8 / s.disk_bytes * 100 AS disk_percent,
+    m.cpu_nano_cores::float8 / NULLIF(s.cpu_nano_cores, 0) * 100 AS cpu_percent,
+    m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
+    m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent,
     m.occurred_at
 FROM
     mz_catalog.mz_cluster_replicas AS r
@@ -12279,9 +12279,9 @@ replica_metrics_history AS (
     m.occurred_at,
     m.replica_id,
     r.size,
-    (SUM(m.cpu_nano_cores::float8) / s.cpu_nano_cores) / s.processes AS cpu_percent,
-    (SUM(m.memory_bytes::float8) / s.memory_bytes) / s.processes AS memory_percent,
-    (SUM(m.disk_bytes::float8) / s.disk_bytes) / s.processes AS disk_percent,
+    (SUM(m.cpu_nano_cores::float8) / NULLIF(s.cpu_nano_cores, 0)) / s.processes AS cpu_percent,
+    (SUM(m.memory_bytes::float8) / NULLIF(s.memory_bytes, 0)) / s.processes AS memory_percent,
+    (SUM(m.disk_bytes::float8) / NULLIF(s.disk_bytes, 0)) / s.processes AS disk_percent,
     SUM(m.disk_bytes::float8) AS disk_bytes,
     SUM(m.memory_bytes::float8) AS memory_bytes,
     s.disk_bytes::numeric * s.processes AS total_disk_bytes,

--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -296,15 +296,17 @@ impl LimiterMetrics {
     }
 }
 
-struct ProcStatus {
+/// Helper for reading and parsing `/proc/self/status` on Linux.
+pub struct ProcStatus {
     /// Resident Set Size (RSS) in bytes.
-    vm_rss: usize,
+    pub vm_rss: usize,
     /// Swap memory in bytes.
-    vm_swap: usize,
+    pub vm_swap: usize,
 }
 
 impl ProcStatus {
-    fn from_proc() -> anyhow::Result<Self> {
+    /// Populate a new `ProcStatus` with information in /proc/self/status.
+    pub fn from_proc() -> anyhow::Result<Self> {
         let contents = std::fs::read_to_string("/proc/self/status")?;
         let mut vm_rss = 0;
         let mut vm_swap = 0;

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -411,7 +411,7 @@ ORDER BY r.id;
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last] output=[#0..=#5]
     Project (#0{id}..=#3{size}, #5{name}, #29)
-      Map (((uint8_to_double(#27{memory_bytes}) / uint8_to_double(#21{memory_bytes})) * 100))
+      Map (((uint8_to_double(#27{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#21{memory_bytes})) then null else #21{memory_bytes} end)) * 100))
         Join on=(#0{id} = #15{id} = #24{replica_id} AND #2{cluster_id} = #4{id} AND #16{size} = #17{size}) type=delta
           ArrangeBy keys=[[#0{id}], [#2{cluster_id}]]
             Project (#0{id}..=#3{size})


### PR DESCRIPTION
This PR adds swap usage reporting to the cluster and kubernetes orchestrator, that works the same way as the existing disk usage reporting. In the orchestrator, both disk and swap usage are simply summed up. We expect replicas to either use an explicit disk or swap, so no information is lost this way.

As a result of this change, swap usage is now reported through `mz_cluster_replica_metrics`. Note that the swap limit is not yet written to `mz_cluster_replica_sizes`, so percentage based utilization is still broken for swap replicas.

Needs a change in the console to not break the UI in environments that run swap replicas: https://github.com/MaterializeInc/console/pull/3866

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/9366

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
