### PR TITLE
Allow setting service account name in Materialize CR

### DIFF
--- a/src/cloud-provider/src/lib.rs
+++ b/src/cloud-provider/src/lib.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Identifies a supported cloud provider.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CloudProvider {
     /// A pseudo-provider value used by local development environments.
     Local,

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -97,6 +97,10 @@ pub mod v1alpha1 {
         // Resource requirements for the console pod
         pub console_resource_requirements: Option<ResourceRequirements>,
 
+        // Name of the kubernetes service account to use.
+        // If not set, we will create one with the same name as this Materialize object.
+        pub service_account_name: Option<String>,
+
         // When changes are made to the environmentd resources (either via
         // modifying fields in the spec here or by deploying a new
         // orchestratord version which changes how resources are generated),
@@ -177,8 +181,15 @@ pub mod v1alpha1 {
             self.meta().namespace.clone().unwrap()
         }
 
+        pub fn create_service_account(&self) -> bool {
+            self.spec.service_account_name.is_none()
+        }
+
         pub fn service_account_name(&self) -> String {
-            self.name_unchecked()
+            self.spec
+                .service_account_name
+                .clone()
+                .unwrap_or_else(|| self.name_unchecked())
         }
 
         pub fn role_name(&self) -> String {

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -263,10 +263,6 @@ impl Context {
                 config.aws_info.aws_account_id.is_some(),
                 "--aws-account-id is required when using --cloud-provider=aws"
             );
-            assert!(
-                config.aws_info.environmentd_iam_role_arn.is_some(),
-                "--environmentd-iam-role-arn is required when using --cloud-provider=aws"
-            );
         }
 
         Self {

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -108,7 +108,7 @@ pub struct ConnectionInfo {
 pub struct Resources {
     pub generation: u64,
     pub environmentd_network_policies: Vec<NetworkPolicy>,
-    pub service_account: Box<ServiceAccount>,
+    pub service_account: Box<Option<ServiceAccount>>,
     pub role: Box<Role>,
     pub role_binding: Box<RoleBinding>,
     pub public_service: Box<Service>,
@@ -183,8 +183,10 @@ impl Resources {
             apply_resource(&environmentd_network_policy_api, policy).await?;
         }
 
-        trace!("applying environmentd service account");
-        apply_resource(&service_account_api, &*self.service_account).await?;
+        if let Some(service_account) = &*self.service_account {
+            trace!("applying environmentd service account");
+            apply_resource(&service_account_api, service_account).await?;
+        }
 
         trace!("applying environmentd role");
         apply_resource(&role_api, &*self.role).await?;
@@ -642,27 +644,31 @@ fn create_environmentd_network_policies(
 fn create_service_account_object(
     config: &super::MaterializeControllerArgs,
     mz: &Materialize,
-) -> ServiceAccount {
-    let annotations = if config.cloud_provider == CloudProvider::Aws {
-        let role_arn = mz
-            .spec
-            .environmentd_iam_role_arn
-            .as_deref()
-            .or(config.aws_info.environmentd_iam_role_arn.as_deref())
-            .unwrap()
-            .to_string();
-        Some(btreemap! {
-            "eks.amazonaws.com/role-arn".to_string() => role_arn
+) -> Option<ServiceAccount> {
+    if mz.create_service_account() {
+        let annotations = if config.cloud_provider == CloudProvider::Aws {
+            let role_arn = mz
+                .spec
+                .environmentd_iam_role_arn
+                .as_deref()
+                .or(config.aws_info.environmentd_iam_role_arn.as_deref())
+                .unwrap()
+                .to_string();
+            Some(btreemap! {
+                "eks.amazonaws.com/role-arn".to_string() => role_arn
+            })
+        } else {
+            None
+        };
+        Some(ServiceAccount {
+            metadata: ObjectMeta {
+                annotations,
+                ..mz.managed_resource_meta(mz.service_account_name())
+            },
+            ..Default::default()
         })
     } else {
         None
-    };
-    ServiceAccount {
-        metadata: ObjectMeta {
-            annotations,
-            ..mz.managed_resource_meta(mz.service_account_name())
-        },
-        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Allow setting service account name in Materialize CR.
Also makes the `environmentd_iam_role_arn` optional in AWS.

### Motivation

  * This PR adds a feature that has not yet been specified.
Allow setting service account name in Materialize CR.
Requested in https://materializeinc.slack.com/archives/C07PN7KSB0T/p1754915398825409

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
