### PR TITLE
coverage: More fixes

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -380,6 +380,9 @@ def increase_agents_timeouts(
                 step["name"] = "Build x86_64 with coverage"
             if step.get("id") == "build-aarch64":
                 step["name"] = "Build aarch64 with coverage"
+            if step.get("id") == "cargo-test":
+                step["agents"]["queue"] = "hetzner-x86-64-dedi-32cpu-128gb"
+                del step["parallelism"]
     else:
         for step in steps(pipeline):
             if step.get("coverage") == "only":

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -211,10 +211,10 @@ cleanup() {
           # shellcheck disable=SC2044
           for i in $(find . -name '*.profraw'); do
               echo "$i"
-              cp "$i" profraws/
+              cp "$i" profraws/ || true
               rm -f "$i" || true
               if ! bin/ci-builder run stable rust-profdata merge -o /dev/null "profraws/$(basename "$i")"; then
-                  rm -f "profraws/$(basename "$i")"
+                  rm -f "profraws/$(basename "$i")" || true
               fi
           done
           find profraws -name '*.profraw' -exec bin/ci-builder run stable rust-profdata merge -sparse -o coverage/"$BUILDKITE_JOB_ID".profdata {} +

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -29,7 +29,7 @@ bin/ci-annotate-errors junit_coverage*.xml
 ci_unimportant_heading "Create coverage report"
 REPORT=coverage_without_unittests_"$BUILDKITE_BUILD_ID"
 REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
-find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-[^/]*/materialize/.*/#SF:#" {} +
+find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-[^/]*/materialize/[^/]*/#SF:#" {} +
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
 find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +
 tar -I zstd -cf "$REPORT".tar.zst "$REPORT"


### PR DESCRIPTION
Green run with this state finally: https://buildkite.com/materialize/test/builds/107605#01989904-7ba9-4efc-ba84-8d2c5d0e556d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
