### PR TITLE
ci: Use buildkite metadata to notify about build being done

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -311,14 +311,8 @@ def get_job_url_from_pipeline_and_build(
     return get_job_url_from_build_url(build_url, build_job_id)
 
 
-def is_build_failed(build: str) -> bool:
-    try:
-        return (
-            spawn.capture(
-                ["buildkite-agent", "meta-data", "get", build],
-                stderr=subprocess.DEVNULL,
-            )
-            == "failed"
-        )
-    except subprocess.CalledProcessError:
-        return False
+def get_build_status(build: str) -> str:
+    return spawn.capture(
+        ["buildkite-agent", "meta-data", "get", build],
+        stderr=subprocess.DEVNULL,
+    )


### PR DESCRIPTION
Repeatedly `docker pull`ing doesn't seem particularly reliable: https://buildkite.com/materialize/test/builds/107642#01989a35-3fa2-47cc-9b7f-353f66026edb

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
