### PR TITLE
tests: Reenable 2 disabled tests since 7611 is fixed

### DIFF
--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -352,10 +352,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         if name in ("default", "migration"):
             return
 
-        # TODO: Flaky, reenable when database-issues#7611 is fixed
-        if name == "statuses":
-            return
-
         # TODO: Flaky, reenable when database-issues#8447 is fixed
         if name == "silent-connection-drop":
             return

--- a/test/pg-cdc-old-syntax/status/04-drop-publication.td
+++ b/test/pg-cdc-old-syntax/status/04-drop-publication.td
@@ -23,8 +23,8 @@ true
 > SELECT error ILIKE '%publication "mz_source" does not exist' FROM mz_internal.mz_source_statuses WHERE name = 't';
 true
 
-# TODO: This should be made reliable without sleeping, database-issues#7611
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+# TODO: This should be made reliable without sleeping
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=5s
 
 ! SELECT * FROM t;
 contains:publication "mz_source" does not exist

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -418,10 +418,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         if name in ("default", "large-scale"):
             return
 
-        # TODO: Flaky, reenable when database-issues#7611 is fixed
-        if name == "statuses":
-            return
-
         # TODO: Flaky, reenable when database-issues#8447 is fixed
         if name == "silent-connection-drop":
             return

--- a/test/pg-cdc/status/04-drop-publication.td
+++ b/test/pg-cdc/status/04-drop-publication.td
@@ -23,8 +23,8 @@ true
 > SELECT error ILIKE '%publication "mz_source" does not exist' FROM mz_internal.mz_source_statuses WHERE name = 't';
 true
 
-# TODO: This should be made reliable without sleeping, database-issues#7611
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+# TODO: This should be made reliable without sleeping
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=5s
 
 ! SELECT * FROM t;
 contains:publication "mz_source" does not exist


### PR DESCRIPTION
See https://github.com/MaterializeInc/database-issues/issues/7611

Follow-up to https://github.com/MaterializeInc/materialize/pull/33277

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
