### PR TITLE
benchmarks: Assert that build profile is consistent

### DIFF
--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -16,6 +16,9 @@ ENV RUST_BACKTRACE=1
 # (database-issues#9159).
 ENV RUST_LIB_BACKTRACE=0
 
+ARG BUILD_PROFILE=optimize
+LABEL build.profile=$BUILD_PROFILE
+
 RUN sed -i -e 's#http://archive\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \
            -e 's#http://security\.ubuntu\.com#http://us-east-1.ec2.archive.ubuntu.com#' \
            -e 's#http://ports\.ubuntu\.com#http://us-east-1.ec2.ports.ubuntu.com#' /etc/apt/sources.list.d/ubuntu.sources

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -943,6 +943,7 @@ class ResolvedImage:
             pre_image.run(prep[type(pre_image)])
         build_args = {
             **self.image.build_args,
+            "BUILD_PROFILE": self.image.rd.profile.name,
             "ARCH_GCC": str(self.image.rd.arch),
             "ARCH_GO": self.image.rd.arch.go_str(),
             "CI_SANITIZER": str(self.image.rd.sanitizer),

--- a/misc/python/materialize/scalability/endpoint/endpoints.py
+++ b/misc/python/materialize/scalability/endpoint/endpoints.py
@@ -185,6 +185,7 @@ class MaterializeContainer(MaterializeNonRemote):
             )
         ):
             self.composition.up("materialized")
+            self.composition.verify_build_profile()
 
             if self.use_balancerd:
                 self.composition.up("balancerd")

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -483,6 +483,7 @@ def run_once(
             else:
                 print("~~~ Starting up services")
                 c.up(*service_names, Service("testdrive", idle=True))
+                c.verify_build_profile()
 
                 mz_version = c.query_mz_version()
                 mz_string = f"{mz_version} (docker)"


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/C01LKF361MZ/p1754937684311829?thread_ts=1754921945.758739&cid=C01LKF361MZ
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
