### PR TITLE
bin/environmentd: Fix the replica sizes

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -486,42 +486,42 @@ pub struct Args {
     #[clap(
         long,
         env = "BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_default_cluster_replica_size: String,
     /// The size of the builtin system cluster replicas if bootstrapping.
     #[clap(
         long,
         env = "BOOTSTRAP_BUILTIN_SYSTEM_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_builtin_system_cluster_replica_size: String,
     /// The size of the builtin catalog server cluster replicas if bootstrapping.
     #[clap(
         long,
         env = "BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_builtin_catalog_server_cluster_replica_size: String,
     /// The size of the builtin probe cluster replicas if bootstrapping.
     #[clap(
         long,
         env = "BOOTSTRAP_BUILTIN_PROBE_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_builtin_probe_cluster_replica_size: String,
     /// The size of the builtin support cluster replicas if bootstrapping.
     #[clap(
         long,
         env = "BOOTSTRAP_BUILTIN_SUPPORT_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_builtin_support_cluster_replica_size: String,
     /// The size of the builtin analytics cluster replicas if bootstrapping.
     #[clap(
         long,
         env = "BOOTSTRAP_BUILTIN_ANALYTICS_CLUSTER_REPLICA_SIZE",
-        default_value = "1"
+        default_value = "scale=1,workers=1"
     )]
     bootstrap_builtin_analytics_cluster_replica_size: String,
     #[clap(


### PR DESCRIPTION
Reported by Marty (who also found the fix)

Broken in https://github.com/MaterializeInc/materialize/pull/33273

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
