### PR TITLE
Persist: simplify the compaction chunking heuristic

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -667,10 +667,8 @@ where
             );
             let total_chunked_runs = chunked_runs.len();
 
-            let mut applied = 0;
-
-            for (runs, run_chunk_max_memory_usage) in
-                chunked_runs
+            for (applied, (runs, run_chunk_max_memory_usage)) in
+                chunked_runs.into_iter().enumerate()
             {
                 metrics.compaction.chunks_compacted.inc();
                 metrics
@@ -772,7 +770,6 @@ where
                 };
 
                 yield Ok(res);
-                applied += 1;
             }
         }
     }
@@ -804,9 +801,10 @@ where
         Self::compact_all(stream, req).await
     }
 
-    /// Sorts and groups all runs from the inputs into chunks, each of which has been determined
-    /// to consume no more than `run_reserved_memory_bytes` at a time, unless the input parts
-    /// were written with a different target size than this build.
+    /// Chunks runs with the following rules:
+    /// 1. Runs from multiple batches are allowed to be mixed as long as _every_ run in the
+    ///    from the batch is present in the chunk.
+    /// 2. Otherwise runs are split into chunks of runs from a single batch.
     fn chunk_runs<'a>(
         ordered_runs: &'a [(
             RunLocation,
@@ -835,97 +833,89 @@ where
                 acc
             });
 
-        let all_batches_have_one_run = grouped.values().all(|runs| runs.len() <= 1);
+        let mut grouped = grouped.into_iter().peekable();
 
-        let mut chunks = Vec::new();
+        let mut chunks = vec![];
+        let mut current_chunk = vec![];
+        let mut current_chunk_max_memory_usage = 0;
 
-        // There are two cases to consider here:
-        // 1. All input batches have ≤1 run each, in which case we can compact runs
-        //    from different batches together as memory allows.
-        // 2. Some input batches have >1 run, in which case we must compact runs only
-        //    within each individual batch to maintain batch boundaries.
-        // In both cases, we should compact runs in the order they were written.
-        // This is all to make it easy to apply the compaction result incrementally.
-        // By ensuring we never write out batches that contain runs from separate input batches
-        // (except for when each input batch has exactly one run), we can easily slot the
-        // results in to the existing batches. The special case of a single run per input batch
-        // means that each batch is, by itself, fully "compact", and the result of compaction
-        // will cleanly replace the input batches in a grouped manner.
+        fn max_part_bytes<T>(parts: &[RunPart<T>], cfg: &CompactConfig) -> usize {
+            parts
+                .iter()
+                .map(|p| p.max_part_bytes())
+                .max()
+                .unwrap_or(cfg.batch.blob_target_size)
+        }
 
-        if all_batches_have_one_run {
-            // All batches have ≤1 run — compact across batches
-            let mut current_chunk = Vec::new();
-            let mut current_memory = 0;
+        while let Some((_spine_id, runs)) = grouped.next() {
+            let batch_size = runs
+                .iter()
+                .map(|(_, _, _, parts)| max_part_bytes(parts, cfg))
+                .sum::<usize>();
 
-            for (_spine_id, mut runs) in grouped.into_iter() {
-                let (run_id, desc, meta, parts) = runs.pop().unwrap();
+            // If the whole batch fits into the current mixed-batch chunk, add it and consider continuing to mix
+            if current_chunk_max_memory_usage + batch_size <= run_reserved_memory_bytes {
+                current_chunk.extend(runs);
+                current_chunk_max_memory_usage += batch_size;
 
-                let run_size = parts
-                    .iter()
-                    .map(|p| p.max_part_bytes())
-                    .max()
-                    .unwrap_or(cfg.batch.blob_target_size);
-
-                if !current_chunk.is_empty()
-                    && current_memory + run_size > run_reserved_memory_bytes
-                {
-                    if current_chunk.len() == 1 {
-                        metrics.compaction.memory_violations.inc();
-                        current_chunk.push((run_id, desc, meta, &*parts));
-                        current_memory += run_size;
-                        chunks.push((std::mem::take(&mut current_chunk), current_memory));
-                        current_memory = 0;
+                // If the next batch also fits, keep mixing; otherwise flush now
+                if let Some((_, next_runs)) = grouped.peek() {
+                    let next_batch_size = next_runs
+                        .iter()
+                        .map(|(_, _, _, parts)| max_part_bytes(parts, cfg))
+                        .sum::<usize>();
+                    if current_chunk_max_memory_usage + next_batch_size <= run_reserved_memory_bytes
+                    {
                         continue;
                     }
-
-                    chunks.push((std::mem::take(&mut current_chunk), current_memory));
-                    current_memory = 0;
                 }
+                continue; // important: do not re-process these runs per-run; we've already added them
+            }
 
-                current_chunk.push((run_id, desc, meta, &*parts));
-                current_memory += run_size;
+            // Otherwise, we cannot mix this batch partially. Flush any existing mixed chunk first.
+            if !current_chunk.is_empty() {
+                chunks.push((
+                    std::mem::take(&mut current_chunk),
+                    current_chunk_max_memory_usage,
+                ));
+                current_chunk_max_memory_usage = 0;
+            }
+
+            // Now process this batch alone, splitting into single-batch chunks as needed.
+            let mut run_iter = runs.into_iter().peekable();
+            // Reuse the mixed-chunk buffers for single-batch splitting; we've just flushed them above.
+            debug_assert!(current_chunk.is_empty());
+            debug_assert_eq!(current_chunk_max_memory_usage, 0);
+
+            while let Some((run_id, desc, meta, parts)) = run_iter.next() {
+                let run_size = max_part_bytes(parts, cfg);
+                current_chunk.push((run_id, desc, meta, parts));
+                current_chunk_max_memory_usage += run_size;
+
+                if let Some((_, _, _, next_parts)) = run_iter.peek() {
+                    let next_size = max_part_bytes(next_parts, cfg);
+                    if current_chunk_max_memory_usage + next_size <= run_reserved_memory_bytes {
+                        continue;
+                    }
+                    if current_chunk.len() == 1 {
+                        metrics.compaction.memory_violations.inc();
+                        continue;
+                    }
+                }
             }
 
             if !current_chunk.is_empty() {
-                chunks.push((current_chunk, current_memory));
+                chunks.push((
+                    std::mem::take(&mut current_chunk),
+                    current_chunk_max_memory_usage,
+                ));
+                current_chunk_max_memory_usage = 0;
             }
-        } else {
-            // Some batches have >1 run — compact only within each batch
-            for (_spine_id, runs) in grouped.into_iter() {
-                let mut current_chunk = Vec::new();
-                let mut current_memory = 0;
+        }
 
-                for (run_id, desc, meta, parts) in runs {
-                    let run_size = parts
-                        .iter()
-                        .map(|p| p.max_part_bytes())
-                        .max()
-                        .unwrap_or(cfg.batch.blob_target_size);
-
-                    if !current_chunk.is_empty()
-                        && current_memory + run_size > run_reserved_memory_bytes
-                    {
-                        if current_chunk.len() == 1 {
-                            metrics.compaction.memory_violations.inc();
-                            current_chunk.push((run_id, desc, meta, &*parts));
-                            current_memory += run_size;
-                            chunks.push((std::mem::take(&mut current_chunk), current_memory));
-                            current_memory = 0;
-                            continue;
-                        }
-
-                        chunks.push((std::mem::take(&mut current_chunk), current_memory));
-                        current_memory = 0;
-                    }
-
-                    current_chunk.push((run_id, desc, meta, &*parts));
-                    current_memory += run_size;
-                }
-
-                if !current_chunk.is_empty() {
-                    chunks.push((current_chunk, current_memory));
-                }
-            }
+        // If we ended with a mixed-batch chunk in progress, flush it.
+        if !current_chunk.is_empty() {
+            chunks.push((current_chunk, current_chunk_max_memory_usage));
         }
 
         chunks


### PR DESCRIPTION
Eagerly attempt to stuff batches into chunks as space allows, falling back to chunking withing a given batch.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
