### PR TITLE
Remove optional types from LIR

### DIFF
--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -985,23 +985,6 @@ impl AvailableCollections {
             arrangement.fmt_text(f, ctx)?;
             writeln!(f, "")?;
         }
-        // types field
-        if let Some(types) = self.types.as_ref() {
-            if types.len() > 0 {
-                write!(f, "{}types=[", ctx.indent)?;
-                write!(
-                    f,
-                    "{}",
-                    separated(
-                        ", ",
-                        types
-                            .iter()
-                            .map(|c| ctx.humanizer.humanize_column_type(c, false))
-                    )
-                )?;
-                writeln!(f, "]")?;
-            }
-        }
         Ok(())
     }
 }

--- a/src/compute-types/src/plan.proto
+++ b/src/compute-types/src/plan.proto
@@ -23,13 +23,8 @@ import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 
 message ProtoAvailableCollections {
-  message ProtoColumnTypes {
-    repeated mz_repr.relation_and_scalar.ProtoColumnType types = 1;
-  }
-
   bool raw = 1;
   repeated mz_compute_types.plan.threshold.ProtoArrangement arranged = 2;
-  optional ProtoColumnTypes types = 3;
 }
 
 message ProtoGetPlan {

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -25,7 +25,7 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::explain::text::text_string_at;
 use mz_repr::explain::{DummyHumanizer, ExplainConfig, ExprHumanizer, PlanRenderingContext};
 use mz_repr::optimize::OptimizerFeatures;
-use mz_repr::{ColumnType, Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row};
 use proptest::arbitrary::Arbitrary;
 use proptest::prelude::*;
 use proptest::strategy::Strategy;
@@ -34,7 +34,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::dataflows::DataflowDescription;
 use crate::plan::join::JoinPlan;
-use crate::plan::proto_available_collections::ProtoColumnTypes;
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
 use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
@@ -87,24 +86,11 @@ pub(crate) fn any_arranged_thin()
     )
 }
 
-impl RustType<ProtoColumnTypes> for Vec<ColumnType> {
-    fn into_proto(&self) -> ProtoColumnTypes {
-        ProtoColumnTypes {
-            types: self.into_proto(),
-        }
-    }
-
-    fn from_proto(proto: ProtoColumnTypes) -> Result<Self, TryFromProtoError> {
-        proto.types.into_rust()
-    }
-}
-
 impl RustType<ProtoAvailableCollections> for AvailableCollections {
     fn into_proto(&self) -> ProtoAvailableCollections {
         ProtoAvailableCollections {
             raw: self.raw,
             arranged: self.arranged.into_proto(),
-            types: None::<Vec<ColumnType>>.into_proto(),
         }
     }
 

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -74,10 +74,6 @@ pub struct AvailableCollections {
     /// The documentation for `KeyValRowMapping` explains these fields better.
     #[proptest(strategy = "prop::collection::vec(any_arranged_thin(), 0..3)")]
     pub arranged: Vec<(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>,
-    /// The types of the columns in the raw form of the collection, if known. We
-    /// only capture types when necessary to support arrangement specialization,
-    /// so this only done for specific LIR operators during lowering.
-    pub types: Option<Vec<ColumnType>>,
 }
 
 /// A strategy that produces arrangements that are thinner than the default. That is
@@ -108,7 +104,7 @@ impl RustType<ProtoAvailableCollections> for AvailableCollections {
         ProtoAvailableCollections {
             raw: self.raw,
             arranged: self.arranged.into_proto(),
-            types: self.types.into_proto(),
+            types: None::<Vec<ColumnType>>.into_proto(),
         }
     }
 
@@ -117,7 +113,6 @@ impl RustType<ProtoAvailableCollections> for AvailableCollections {
             Self {
                 raw: x.raw,
                 arranged: x.arranged.into_rust()?,
-                types: x.types.into_rust()?,
             }
         })
     }
@@ -129,17 +124,11 @@ impl AvailableCollections {
         Self {
             raw: true,
             arranged: Vec::new(),
-            types: None,
         }
     }
 
-    /// Represent a collection that is arranged in the
-    /// specified ways, with optionally given types describing
-    /// the rows that would be in the raw form of the collection.
-    pub fn new_arranged(
-        arranged: Vec<(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>,
-        types: Option<Vec<ColumnType>>,
-    ) -> Self {
+    /// Represent a collection that is arranged in the specified ways.
+    pub fn new_arranged(arranged: Vec<(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>) -> Self {
         assert!(
             !arranged.is_empty(),
             "Invariant violated: at least one collection must exist"
@@ -147,7 +136,6 @@ impl AvailableCollections {
         Self {
             raw: false,
             arranged,
-            types,
         }
     }
 

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -818,7 +818,7 @@ impl ReducePlan {
             .map(MirScalarExpr::column)
             .collect::<Vec<_>>();
         let (permutation, thinning) = permutation_for_arrangement(&key, arity);
-        AvailableCollections::new_arranged(vec![(key, permutation, thinning)], None)
+        AvailableCollections::new_arranged(vec![(key, permutation, thinning)])
     }
 
     /// Extracts a fusable MFP for the reduction from the given `mfp` along with a residual

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -25,7 +25,6 @@
 
 use mz_expr::{MirScalarExpr, permutation_for_arrangement};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
-use mz_repr::ColumnType;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -92,10 +91,10 @@ impl ThresholdPlan {
     /// This is likely either an empty vector, for no arrangement,
     /// or a singleton vector containing the list of expressions
     /// that key a single arrangement.
-    pub fn keys(&self, types: Option<Vec<ColumnType>>) -> AvailableCollections {
+    pub fn keys(&self) -> AvailableCollections {
         match self {
             ThresholdPlan::Basic(plan) => {
-                AvailableCollections::new_arranged(vec![plan.ensure_arrangement.clone()], types)
+                AvailableCollections::new_arranged(vec![plan.ensure_arrangement.clone()])
             }
         }
     }

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -393,7 +393,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Mfp
       project=(#2)

--- a/test/sqllogictest/explain/materialized_view.slt
+++ b/test/sqllogictest/explain/materialized_view.slt
@@ -103,11 +103,9 @@ materialize.public.mv:
     Get::PassArrangements materialize.public.accounts
       raw=false
       arrangements[0]={ key=[#1{balance}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      types=[integer]
       Constant
         - (100)
 
@@ -152,11 +150,9 @@ materialize.public.mv:
     Get::PassArrangements materialize.public.accounts
       raw=false
       arrangements[0]={ key=[#1{balance}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      types=[integer]
       Constant
         - (100)
 
@@ -202,11 +198,9 @@ materialize.public.mv:
     Get::PassArrangements materialize.public.accounts
       raw=false
       arrangements[0]={ key=[#1{balance}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      types=[integer]
       Constant
         - (100)
 

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -289,13 +289,11 @@ Explained Query:
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#1{c}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-            types=[integer, text]
             Get::PassArrangements l0
               raw=true
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0{c}], permutation=id, thinning=() }
-            types=[text]
             Get::Collection l0
               project=(#1)
               raw=true

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -215,16 +215,6 @@ SELECT * FROM t
                     1
                   ]
                 ]
-              ],
-              "types": [
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                },
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                }
               ]
             },
             "plan": "PassArrangements"
@@ -257,8 +247,7 @@ SELECT * FROM u
             },
             "keys": {
               "raw": true,
-              "arranged": [],
-              "types": null
+              "arranged": []
             },
             "plan": "PassArrangements"
           }
@@ -315,16 +304,6 @@ SELECT a + b, 1 FROM t
                     1
                   ]
                 ]
-              ],
-              "types": [
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                },
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                }
               ]
             },
             "plan": {
@@ -412,8 +391,7 @@ SELECT c + d, 1 FROM u
             },
             "keys": {
               "raw": true,
-              "arranged": [],
-              "types": null
+              "arranged": []
             },
             "plan": {
               "Collection": {
@@ -538,16 +516,6 @@ SELECT * FROM ov
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": "PassArrangements"
@@ -565,8 +533,7 @@ SELECT * FROM ov
                   },
                   "forms": {
                     "raw": true,
-                    "arranged": [],
-                    "types": null
+                    "arranged": []
                   }
                 }
               }
@@ -667,16 +634,6 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                         1
                                       ]
                                     ]
-                                  ],
-                                  "types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
                                   ]
                                 },
                                 "plan": {
@@ -718,8 +675,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                       },
                                       "keys": {
                                         "raw": true,
-                                        "arranged": [],
-                                        "types": null
+                                        "arranged": []
                                       },
                                       "plan": {
                                         "Collection": {
@@ -767,12 +723,6 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                         ],
                         []
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   }
                 }
@@ -872,16 +822,6 @@ SELECT * FROM ov
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": "PassArrangements"
@@ -899,8 +839,7 @@ SELECT * FROM ov
                   },
                   "forms": {
                     "raw": true,
-                    "arranged": [],
-                    "types": null
+                    "arranged": []
                   }
                 }
               }
@@ -1007,16 +946,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                               1
                                             ]
                                           ]
-                                        ],
-                                        "types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
                                         ]
                                       },
                                       "plan": {
@@ -1058,8 +987,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                             },
                                             "keys": {
                                               "raw": true,
-                                              "arranged": [],
-                                              "types": null
+                                              "arranged": []
                                             },
                                             "plan": {
                                               "Collection": {
@@ -1107,12 +1035,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                               ],
                               []
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         }
                       }
@@ -1168,12 +1090,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                 ],
                                 []
                               ]
-                            ],
-                            "types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
                             ]
                           },
                           "plan": {
@@ -1252,12 +1168,6 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                 ],
                                 []
                               ]
-                            ],
-                            "types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
                             ]
                           },
                           "plan": {
@@ -1402,16 +1312,6 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                       1
                                                     ]
                                                   ]
-                                                ],
-                                                "types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
                                                 ]
                                               },
                                               "plan": "PassArrangements"
@@ -1469,12 +1369,6 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                     ],
                                                     []
                                                   ]
-                                                ],
-                                                "types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  }
                                                 ]
                                               }
                                             }
@@ -1549,8 +1443,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                             },
                                             "keys": {
                                               "raw": true,
-                                              "arranged": [],
-                                              "types": null
+                                              "arranged": []
                                             },
                                             "plan": {
                                               "Collection": {
@@ -1598,12 +1491,6 @@ SELECT x * 5 FROM cte WHERE x = 5
                               ],
                               []
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
                           ]
                         }
                       }
@@ -1770,16 +1657,6 @@ SELECT generate_series(a, b) from t
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -1884,16 +1761,6 @@ SELECT DISTINCT a, b FROM t
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -1995,16 +1862,6 @@ GROUP BY a
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -2162,16 +2019,6 @@ FROM t
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -2320,8 +2167,7 @@ FROM t
                                         1
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -2338,8 +2184,7 @@ FROM t
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -2378,8 +2223,7 @@ FROM t
                                                       1
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -2530,16 +2374,6 @@ SELECT * FROM hierarchical_group_by
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -2651,16 +2485,6 @@ MATERIALIZED VIEW hierarchical_global_mv
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -2774,8 +2598,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                                         1
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -2792,8 +2615,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -2832,8 +2654,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                                                       1
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -2982,16 +2803,6 @@ SELECT * FROM hierarchical_global
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -3097,8 +2908,7 @@ SELECT * FROM hierarchical_global
                                         1
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -3115,8 +2925,7 @@ SELECT * FROM hierarchical_global
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -3155,8 +2964,7 @@ SELECT * FROM hierarchical_global
                                                       1
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -3312,16 +3120,6 @@ GROUP BY a
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -3765,16 +3563,6 @@ FROM t
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -4209,8 +3997,7 @@ FROM t
                                         1
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -4227,8 +4014,7 @@ FROM t
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -4267,8 +4053,7 @@ FROM t
                                                       1
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -4419,16 +4204,6 @@ MATERIALIZED VIEW collated_group_by_mv
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -4966,16 +4741,6 @@ SELECT * FROM collated_group_by
                           1
                         ]
                       ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
                     ]
                   },
                   "plan": "PassArrangements"
@@ -5503,16 +5268,6 @@ MATERIALIZED VIEW collated_global_mv
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -6050,8 +5805,7 @@ MATERIALIZED VIEW collated_global_mv
                                         5
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -6072,8 +5826,7 @@ MATERIALIZED VIEW collated_global_mv
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -6120,8 +5873,7 @@ MATERIALIZED VIEW collated_global_mv
                                                       5
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -6334,16 +6086,6 @@ SELECT * FROM collated_global
                                 1
                               ]
                             ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
                           ]
                         },
                         "plan": {
@@ -6873,8 +6615,7 @@ SELECT * FROM collated_global
                                         5
                                       ]
                                     ]
-                                  ],
-                                  "types": null
+                                  ]
                                 },
                                 "plan": "PassArrangements"
                               }
@@ -6895,8 +6636,7 @@ SELECT * FROM collated_global
                           },
                           "forms": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           }
                         }
                       }
@@ -6943,8 +6683,7 @@ SELECT * FROM collated_global
                                                       5
                                                     ]
                                                   ]
-                                                ],
-                                                "types": null
+                                                ]
                                               },
                                               "plan": {
                                                 "Arrangement": [
@@ -7154,16 +6893,6 @@ WHERE a = c AND d = e AND b + d > 42
                             1
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
                       ]
                     },
                     "plan": "PassArrangements"
@@ -7186,8 +6915,7 @@ WHERE a = c AND d = e AND b + d > 42
                           },
                           "keys": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           },
                           "plan": {
                             "Collection": {
@@ -7249,16 +6977,6 @@ WHERE a = c AND d = e AND b + d > 42
                             0
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        }
                       ]
                     }
                   }
@@ -7280,8 +6998,7 @@ WHERE a = c AND d = e AND b + d > 42
                           },
                           "keys": {
                             "raw": true,
-                            "arranged": [],
-                            "types": null
+                            "arranged": []
                           },
                           "plan": {
                             "Collection": {
@@ -7321,12 +7038,6 @@ WHERE a = c AND d = e AND b + d > 42
                           ],
                           []
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        }
                       ]
                     }
                   }
@@ -8044,16 +7755,6 @@ WHERE a = c AND d = e AND f = a
                             1
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
                       ]
                     },
                     "plan": "PassArrangements"
@@ -8094,16 +7795,6 @@ WHERE a = c AND d = e AND f = a
                                   1
                                 ]
                               ]
-                            ],
-                            "types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
                             ]
                           },
                           "plan": {
@@ -8228,16 +7919,6 @@ WHERE a = c AND d = e AND f = a
                           ],
                           []
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        }
                       ]
                     }
                   }
@@ -8277,16 +7958,6 @@ WHERE a = c AND d = e AND f = a
                                   1
                                 ]
                               ]
-                            ],
-                            "types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
                             ]
                           },
                           "plan": {
@@ -8394,16 +8065,6 @@ WHERE a = c AND d = e AND f = a
                           ],
                           []
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": false
-                        }
                       ]
                     }
                   }
@@ -8863,16 +8524,6 @@ WHERE a = c and a = e
                             1
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
                       ]
                     },
                     "plan": "PassArrangements"
@@ -8908,16 +8559,6 @@ WHERE a = c and a = e
                             1
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
                       ]
                     },
                     "plan": "PassArrangements"
@@ -8953,16 +8594,6 @@ WHERE a = c and a = e
                             1
                           ]
                         ]
-                      ],
-                      "types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
                       ]
                     },
                     "plan": "PassArrangements"

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -155,7 +155,6 @@ Explained Query:
   Get::PassArrangements materialize.public.t
     raw=false
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -191,7 +190,6 @@ Explained Query:
     key=#0{a}
     raw=false
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -226,7 +224,6 @@ materialize.public.ov_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=true
 
@@ -238,7 +235,6 @@ materialize.public.ov:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -260,7 +256,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -279,14 +274,12 @@ Explained Query:
     ArrangeBy
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      types=[integer?]
       Union consolidate_output=true
         Get::Arrangement materialize.public.t
           project=(#0)
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
         Negate
           Get::Collection materialize.public.mv
             raw=true
@@ -314,14 +307,12 @@ Explained Query:
         ArrangeBy
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=() }
-          types=[integer?]
           Union consolidate_output=true
             Get::Arrangement materialize.public.t
               project=(#0)
               key=#0{a}
               raw=false
               arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-              types=[integer?, integer?]
             Negate
               Get::Collection materialize.public.mv
                 raw=true
@@ -333,14 +324,12 @@ Explained Query:
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
       Get::Arrangement l0
         project=(#1)
         map=((#0{x} - 1))
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
 
 Source materialize.public.mv
   project=(#1)
@@ -367,7 +356,6 @@ Explained Query:
       ArrangeBy
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer]
         Union consolidate_output=true
           Join::Linear
             linear_stage[0]
@@ -379,11 +367,9 @@ Explained Query:
             Get::PassArrangements materialize.public.t
               raw=false
               arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-              types=[integer?, integer?]
             ArrangeBy
               raw=true
               arrangements[0]={ key=[#0], permutation=id, thinning=() }
-              types=[integer]
               Constant
                 - (5)
           Negate
@@ -414,7 +400,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -437,7 +422,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -468,7 +452,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -500,7 +483,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -547,7 +529,6 @@ materialize.public.hierarchical_group_by_mv:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -575,7 +556,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -605,7 +585,6 @@ materialize.public.hierarchical_global_mv:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -656,7 +635,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -708,7 +686,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -741,7 +718,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -797,7 +773,6 @@ materialize.public.collated_group_by_mv:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -834,7 +809,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -873,7 +847,6 @@ materialize.public.collated_global_mv:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -933,7 +906,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -973,7 +945,6 @@ materialize.public.t_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.t
       raw=true
 
@@ -992,7 +963,6 @@ materialize.public.ov_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=true
 
@@ -1004,7 +974,6 @@ materialize.public.ov:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1023,11 +992,9 @@ materialize.public.ov_b_idx:
     input_key=[#0{a}]
     raw=false
     arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.ov_a_idx (*** full scan ***, index export)
@@ -1097,18 +1064,15 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
       arrangements[1]={ key=[#1{d}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[integer, integer]
       Get::Collection materialize.public.u
         raw=true
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{e}], permutation=id, thinning=() }
-      types=[integer]
       Get::Collection materialize.public.v
         raw=true
 
@@ -1188,28 +1152,23 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
       arrangements[1]={ key=[#0{c}, #1{d}], permutation=id, thinning=() }
-      types=[integer, integer]
       Get::Arrangement materialize.public.u
         filter=((#0{c}) IS NOT NULL AND (#1{d}) IS NOT NULL)
         key=#0{c}
         raw=false
         arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{e}, #1{f}], permutation=id, thinning=() }
-      types=[integer, integer]
       Get::Arrangement materialize.public.v
         filter=((#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL)
         key=#0{e}
         raw=false
         arrangements[0]={ key=[#0{e}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (delta join 1st input (full scan))
@@ -1274,15 +1233,12 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     Get::PassArrangements materialize.public.u
       raw=false
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     Get::PassArrangements materialize.public.v
       raw=false
       arrangements[0]={ key=[#0{e}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (delta join 1st input (full scan))
@@ -1378,7 +1334,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1408,7 +1363,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1432,7 +1386,6 @@ Explained Query:
       ArrangeBy // { node_id: LirId(8) }
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer]
         Union consolidate_output=true // { node_id: LirId(7) }
           Join::Linear // { node_id: LirId(4) }
             linear_stage[0]
@@ -1444,11 +1397,9 @@ Explained Query:
             Get::PassArrangements materialize.public.t // { node_id: LirId(1) }
               raw=false
               arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-              types=[integer?, integer?]
             ArrangeBy // { node_id: LirId(3) }
               raw=true
               arrangements[0]={ key=[#0], permutation=id, thinning=() }
-              types=[integer]
               Constant // { node_id: LirId(2) }
                 - (5)
           Negate // { node_id: LirId(6) }
@@ -1495,7 +1446,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -140,7 +140,6 @@ Explained Query:
   Get::PassArrangements materialize.public.t
     raw=false
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -176,7 +175,6 @@ Explained Query:
     key=#0{a}
     raw=false
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -211,7 +209,6 @@ materialize.public.ov_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=true
 
@@ -223,7 +220,6 @@ materialize.public.ov:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -245,7 +241,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -264,14 +259,12 @@ Explained Query:
     ArrangeBy
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      types=[integer?]
       Union consolidate_output=true
         Get::Arrangement materialize.public.t
           project=(#0)
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
         Negate
           Get::Collection materialize.public.mv
             raw=true
@@ -299,14 +292,12 @@ Explained Query:
         ArrangeBy
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=() }
-          types=[integer?]
           Union consolidate_output=true
             Get::Arrangement materialize.public.t
               project=(#0)
               key=#0{a}
               raw=false
               arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-              types=[integer?, integer?]
             Negate
               Get::Collection materialize.public.mv
                 raw=true
@@ -318,14 +309,12 @@ Explained Query:
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
       Get::Arrangement l0
         project=(#1)
         map=((#0{x} - █))
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer?]
 
 Source materialize.public.mv
   project=(#1)
@@ -352,7 +341,6 @@ Explained Query:
       ArrangeBy
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer]
         Union consolidate_output=true
           Join::Linear
             linear_stage[0]
@@ -364,11 +352,9 @@ Explained Query:
             Get::PassArrangements materialize.public.t
               raw=false
               arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-              types=[integer?, integer?]
             ArrangeBy
               raw=true
               arrangements[0]={ key=[#0], permutation=id, thinning=() }
-              types=[integer]
               Constant
                 - (█)
           Negate
@@ -399,7 +385,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -422,7 +407,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -453,7 +437,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -485,7 +468,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -532,7 +514,6 @@ materialize.public.hierarchical_group_by_mv:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -560,7 +541,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -590,7 +570,6 @@ materialize.public.hierarchical_global_mv:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -641,7 +620,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -693,7 +671,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -726,7 +703,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -782,7 +758,6 @@ materialize.public.collated_group_by_mv:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -819,7 +794,6 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -858,7 +832,6 @@ materialize.public.collated_global_mv:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -918,7 +891,6 @@ Explained Query:
           key=#0{a}
           raw=false
           arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
   Return
     Union
       ArrangeBy
@@ -958,7 +930,6 @@ materialize.public.t_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.t
       raw=true
 
@@ -977,7 +948,6 @@ materialize.public.ov_a_idx:
   ArrangeBy
     raw=true
     arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=true
 
@@ -989,7 +959,6 @@ materialize.public.ov:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1008,11 +977,9 @@ materialize.public.ov_b_idx:
     input_key=[#0{a}]
     raw=false
     arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-    types=[integer?, integer?]
     Get::PassArrangements materialize.public.ov
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.ov_a_idx (*** full scan ***, index export)
@@ -1082,18 +1049,15 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
       arrangements[1]={ key=[#1{d}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[integer, integer]
       Get::Collection materialize.public.u
         raw=true
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{e}], permutation=id, thinning=() }
-      types=[integer]
       Get::Collection materialize.public.v
         raw=true
 
@@ -1173,28 +1137,23 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
       arrangements[1]={ key=[#0{c}, #1{d}], permutation=id, thinning=() }
-      types=[integer, integer]
       Get::Arrangement materialize.public.u
         filter=((#0{c}) IS NOT NULL AND (#1{d}) IS NOT NULL)
         key=#0{c}
         raw=false
         arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0{e}, #1{f}], permutation=id, thinning=() }
-      types=[integer, integer]
       Get::Arrangement materialize.public.v
         filter=((#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL)
         key=#0{e}
         raw=false
         arrangements[0]={ key=[#0{e}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (delta join 1st input (full scan))
@@ -1259,15 +1218,12 @@ Explained Query:
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     Get::PassArrangements materialize.public.u
       raw=false
       arrangements[0]={ key=[#0{c}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     Get::PassArrangements materialize.public.v
       raw=false
       arrangements[0]={ key=[#0{e}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (delta join 1st input (full scan))
@@ -1363,7 +1319,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1393,7 +1348,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -82,22 +82,18 @@ Explained Query:
       raw=true
       arrangements[0]={ key=[#1{k1}], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
       arrangements[1]={ key=[#2{k2}], permutation={#0: #1, #1: #2, #2: #0}, thinning=(#0, #1) }
-      types=[text?, integer, integer]
       Get::Arrangement materialize.public.t1
         project=(#1, #0, #2)
         filter=((#0{k1}) IS NOT NULL AND (#2{k2}) IS NOT NULL)
         key=#1{k1}
         raw=false
         arrangements[0]={ key=[#1{k1}], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
-        types=[text?, integer?, integer?]
     Get::PassArrangements materialize.public.t2
       raw=false
       arrangements[0]={ key=[#1{k1}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[text?, integer?]
     Get::PassArrangements materialize.public.t3
       raw=false
       arrangements[0]={ key=[#1{k2}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      types=[text?, integer?]
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***)

--- a/test/sqllogictest/github-2746.slt
+++ b/test/sqllogictest/github-2746.slt
@@ -70,7 +70,6 @@ Explained Query:
         ArrangeBy
           raw=true
           arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-          types=[integer]
           Get::Collection materialize.public.lineitem
             project=(#0)
             raw=true
@@ -94,7 +93,6 @@ Explained Query:
       ArrangeBy
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        types=[integer]
         Get::PassArrangements l0
           raw=true
       Reduce::Distinct
@@ -138,7 +136,6 @@ Explained Query:
           ArrangeBy
             raw=true
             arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-            types=[date, date]
             Get::Collection materialize.public.lineitem
               project=(#1, #2)
               raw=true
@@ -146,7 +143,6 @@ Explained Query:
             input_key=[#0]
             raw=false
             arrangements[0]={ key=[], permutation=id, thinning=(#0) }
-            types=[integer]
             Reduce::Distinct
               key_plan=id
               val_plan
@@ -156,7 +152,6 @@ Explained Query:
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-            types=[integer, date]
             Get::Collection materialize.public.orders
               filter=((#0) IS NOT NULL)
               raw=true

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -175,13 +175,11 @@ Explained Query:
       ArrangeBy
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
         Get::PassArrangements materialize.public.left
           raw=true
       ArrangeBy
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1, #2) }
-        types=[integer?, integer?, boolean?]
         Union
           Get::Collection l0
             project=(#0..=#2)
@@ -195,7 +193,6 @@ Explained Query:
               ArrangeBy
                 raw=false
                 arrangements[0]={ key=[#0], permutation=id, thinning=() }
-                types=[integer?]
                 Union consolidate_output=true
                   Negate
                     Get::Collection l0
@@ -210,7 +207,6 @@ Explained Query:
       ArrangeBy
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1, #2) }
-        types=[integer?, integer?, boolean?]
         Union
           Get::Collection materialize.public.right2
             project=(#0..=#2)
@@ -224,7 +220,6 @@ Explained Query:
               ArrangeBy
                 raw=false
                 arrangements[0]={ key=[#0], permutation=id, thinning=() }
-                types=[integer?]
                 Union consolidate_output=true
                   Negate
                     Get::Collection materialize.public.right2

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -177,11 +177,9 @@ Explained Query:
           Get::PassArrangements materialize.public.t1
             raw=false
             arrangements[0]={ key=[#0{a}, #1{b}], permutation=id, thinning=() }
-            types=[integer?, text?]
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
-            types=[integer, text]
             Constant
               - (2, "l2")
               - (3, "l3")

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -579,7 +579,6 @@ Explained Query:
       Get::PassArrangements materialize.public.potato
         raw=false
         arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-        types=[text?, text?]
   Return
     With Mutually Recursive
       cte l1 =
@@ -599,11 +598,9 @@ Explained Query:
                 Get::PassArrangements l0
                   raw=false
                   arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-                  types=[text?, text?]
                 ArrangeBy
                   raw=true
                   arrangements[0]={ key=[#0], permutation=id, thinning=() }
-                  types=[text]
                   Constant
                     - ("russet")
               Join::Linear
@@ -614,11 +611,9 @@ Explained Query:
                 Get::PassArrangements l0
                   raw=false
                   arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
-                  types=[text?, text?]
                 ArrangeBy
                   raw=true
                   arrangements[0]={ key=[#0{b}], permutation=id, thinning=() }
-                  types=[text]
                   Get::Collection l1
                     project=(#1)
                     filter=((#1{b}) IS NOT NULL)

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -373,11 +373,9 @@ Explained Query:
     Get::PassArrangements materialize.public.t1
       raw=false
       arrangements[0]={ key=[#0{f1}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
     Get::PassArrangements materialize.public.t2
       raw=false
       arrangements[0]={ key=[#0{f1}], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t1_f1_ind (differential join)

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -330,7 +330,6 @@ Explained Query:
           ArrangeBy
             raw=false
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
-            types=[integer, integer?]
             Union consolidate_output=true
               Get::Collection materialize.public.t
                 project=(#0, #1)
@@ -414,7 +413,6 @@ Explained Query:
       Get::PassArrangements materialize.public.t
         raw=false
         arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-        types=[integer?, integer?]
     cte l1 =
       Reduce::Hierarchical
         aggr_funcs=[max]
@@ -435,11 +433,9 @@ Explained Query:
           Get::PassArrangements l0
             raw=false
             arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-            types=[integer?, integer?]
           Get::PassArrangements l0
             raw=false
             arrangements[0]={ key=[#1{b}], permutation={#0: #1, #1: #0}, thinning=(#0) }
-            types=[integer?, integer?]
   Return
     Union
       Get::Arrangement l1
@@ -532,7 +528,6 @@ Explained Query:
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0{b}], permutation=id, thinning=() }
-            types=[integer]
             Get::Collection materialize.public.t
               project=(#1)
               filter=((1 = (#0{a} % 2)))
@@ -540,7 +535,6 @@ Explained Query:
           ArrangeBy
             raw=true
             arrangements[0]={ key=[#0{b}], permutation=id, thinning=() }
-            types=[integer]
             Get::Collection materialize.public.t
               project=(#1)
               raw=true

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -90,7 +90,6 @@ Explained Query:
       Get::PassArrangements materialize.public.i1
         raw=false
         arrangements[0]={ key=[#0{b}], permutation=id, thinning=() }
-        types=[bigint]
 
 Used Indexes:
   - materialize.public.i1_primary_idx (*** full scan ***)
@@ -137,7 +136,6 @@ Explained Query:
       Get::PassArrangements materialize.public.i4
         raw=false
         arrangements[0]={ key=[#0{c}], permutation=id, thinning=() }
-        types=[bigint]
 
 Used Indexes:
   - materialize.public.i4_primary_idx (*** full scan ***)
@@ -160,7 +158,6 @@ Explained Query:
       Get::PassArrangements materialize.public.i6
         raw=false
         arrangements[0]={ key=[#0{c}], permutation=id, thinning=() }
-        types=[bigint]
 
 Used Indexes:
   - materialize.public.i6_primary_idx (*** full scan ***)
@@ -186,7 +183,6 @@ Explained Query:
       Get::PassArrangements materialize.public.i9
         raw=false
         arrangements[0]={ key=[#0{b}], permutation=id, thinning=() }
-        types=[bigint]
 
 Used Indexes:
   - materialize.public.i9_primary_idx (*** full scan ***)


### PR DESCRIPTION
Our LIR types had space for optional types that were meant to inform specialization. There is no specialization and no concrete plans to implement such from type information. In particular, the type system itself may evolve, and until it stabilizes it makes some sense to extract these and re-introduce them once we have a clearer sense of what they would be for (vs maintaining them).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
