### PR TITLE
restore the default of disabling license key checks for now

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- if .Values.operator.args.enableInternalStatementLogging }}
         - "--enable-internal-statement-logging"
         {{- end }}
+        {{- if not .Values.operator.args.enableLicenseKeyChecks }}
+        - "--disable-license-key-checks"
+        {{- end }}
 
         {{/* AWS Configuration */}}
         {{- if eq .Values.operator.cloudProvider.type "aws" }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[12]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[13]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[12]
+      path: spec.template.spec.containers[0].args[13]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[12]
+      path: spec.template.spec.containers[0].args[13]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[12]
+      path: spec.template.spec.containers[0].args[13]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly


### PR DESCRIPTION
### Motivation

we still want to keep license keys disabled for the next self-managed patch release of 2025.2, but this should allow customers to enable them if they would like. we'll remove this once we get ready to actually release 2025.3.

### Tips for reviewer

i'm leaving the configuration option undocumented for now because i don't think this is a thing we want to make broadly available yet (we can just tell customers what to do individually if it is required) - once we get to the next full release, license keys will be unconditionally enabled, and so it won't need an option regardless.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
