### PR TITLE
Fix cargo docs following new nightly version

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -162,7 +162,7 @@ cleanup() {
   mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\n"; find . -name 'junit_*.xml')
 
   {
-    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+    bin/ci-builder run stable trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio,uplead filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
   } &
   artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -176,7 +176,7 @@ cleanup() {
 
   echo "--- Running trufflehog to scan artifacts for secrets & uploading artifacts"
   {
-    bin/ci-builder run "$builder" trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+    bin/ci-builder run "$builder" trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio,uplead filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
   } &
 
   unset CI_EXTRA_ARGS # We don't want extra args for the annotation

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -89,7 +89,7 @@ where
     /// Invariant: role_metadata must be `Some` after the user has
     /// successfully connected to and authenticated with Materialize.
     ///
-    /// Prefer using this value over [`Self.user.name`].
+    /// Prefer using this value over [`SessionConfig::user`].
     //
     // It would be better for this not to be an Option, but the
     // `Session` is initialized before the user has connected to

--- a/src/build-tools/src/lib.rs
+++ b/src/build-tools/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! For example, many crates have a build script that depends on the Protobuf
 //! compiler, `protoc`. If we're building with Cargo we'll bootstrap `protoc`
-//! by compiling it with [`protobuf-src`], but if we're building with Bazel
+//! by compiling it with `protobuf-src`, but if we're building with Bazel
 //! then we'll use the version of `protoc` included in the runfiles.
 
 use cfg_if::cfg_if;

--- a/src/cloud-api/src/lib.rs
+++ b/src/cloud-api/src/lib.rs
@@ -50,7 +50,7 @@
 //!
 //! ## Note
 //!
-//! This crate is implemented following a similar pattern to [`mz-frontegg-client`], [rust-orb-billing] and [rust-frontegg].
+//! This crate is implemented following a similar pattern to `mz-frontegg-client`, [rust-orb-billing] and [rust-frontegg].
 //!
 //! [mz-frontegg-client]:
 //! [rust-orb-billing]: <https://github.com/MaterializeInc/rust-orb-billing>

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -183,7 +183,7 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
     /// A map associating a global ID to the set of all the unfulfilled watch
     /// set ids that include it.
     ///
-    /// See [`self.install_watch_set`] for a description of watch sets.
+    /// See [`Controller::install_compute_watch_set`]/[`Controller::install_storage_watch_set`] for a description of watch sets.
     // When a watch set is fulfilled for a given object (that is, when
     // the object's frontier advances to at least the watch set's
     // timestamp), the corresponding entry will be removed from the set.
@@ -195,9 +195,9 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
 
     /// A list of watch sets that were already fulfilled as soon as
     /// they were installed, and thus that must be returned to the
-    /// client on the next call to [`self.process`].
+    /// client on the next call to [`Controller::process_compute_response`]/[`Controller::process_storage_response`].
     ///
-    /// See [`self.install_watch_set`] for a description of watch sets.
+    /// See [`Controller::install_compute_watch_set`]/[`Controller::install_storage_watch_set`] for a description of watch sets.
     immediate_watch_sets: Vec<WatchSetId>,
 
     /// Dynamic system configuration.

--- a/src/fivetran-destination/src/lib.rs
+++ b/src/fivetran-destination/src/lib.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![allow(dead_code)]
-
 mod crypto;
 mod destination;
 mod error;

--- a/src/fivetran-destination/src/lib.rs
+++ b/src/fivetran-destination/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![allow(dead_code)]
+
 mod crypto;
 mod destination;
 mod error;

--- a/src/frontegg-client/src/error.rs
+++ b/src/frontegg-client/src/error.rs
@@ -18,7 +18,7 @@
 //!
 //! It contains three variants:
 //! * [`Error::Auth`]: represents an authentication error from the
-//!   [`mz-frontegg-auth`] crate.
+//!   `mz-frontegg-auth` crate.
 //! * [`Error::Transport`]: represents a transport error from the `reqwest`
 //!   crate during a network request.
 //! * [`Error::Api`]: represents an Frontegg API error from a request.

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -60,7 +60,7 @@ macro_rules! cast_from {
                 }
             }
 
-            /// Casts [`$from`] to [`$to`].
+            /// Casts `from` to `to`.
             ///
             /// This is equivalent to the [`crate::cast::CastFrom`] implementation but is
             /// available as a `const fn`.

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -275,7 +275,7 @@ impl Ident {
     }
 
     /// An identifier can be printed in bare mode if
-    ///  * it matches the regex [a-z_][a-z0-9_]* and
+    ///  * it matches the regex `[a-z_][a-z0-9_]*` and
     ///  * it is not a "reserved keyword."
     pub fn can_be_printed_bare(&self) -> bool {
         let mut chars = self.0.chars();

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -72,8 +72,7 @@ impl Generator for Auction {
         now: NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>)>
-    {
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>> {
         let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let organizations = COMPANIES.iter().enumerate().map(|(offset, name)| {

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -27,8 +27,7 @@ impl Generator for Counter {
         _now: NowFn,
         _seed: Option<u64>,
         resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>)>
-    {
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>> {
         let max_cardinality = self.max_cardinality;
 
         Box::new(

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -25,8 +25,7 @@ impl Generator for Datums {
         _: NowFn,
         _seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>)>
-    {
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>> {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -34,8 +34,7 @@ impl Generator for Marketing {
         now: mz_ore::now::NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>)>
-    {
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>> {
         let mut rng: SmallRng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let mut counter = 0;

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -43,8 +43,7 @@ impl Generator for Tpch {
         _: NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>)>
-    {
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, Diff)>)>> {
         let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
         let mut ctx = Context {
             tpch: self.clone(),


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/deploy/builds/19309#_

Follow-up to https://github.com/MaterializeInc/materialize/pull/33290

Reproducer: `rustup run nightly bin/doc --document-private-items`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
