### PR TITLE
SLT: Print instructions for how to rewrite results as well as the diff

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2080,7 +2080,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
           run: slow-tests
-          args: [--replicas=4]
+          args: [--replicas=4, --parallelism=8]
 
   - group: "Race Condition"
     key: race-condition

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -171,7 +171,7 @@ cleanup() {
   echo "Compressing parallel-workload-queries.log"
   bin/ci-builder run "$builder" zstd --rm parallel-workload-queries.log || true
 
-  mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml'; find mz_debug_* -name '*.log')
+  mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml' -printf '%P\n'; find . -maxdepth 1 -name 'mz_debug_*.log' -printf '%P\n'; find . -maxdepth 1 -name 'slt*.diff' -printf '%P\n')
   artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 
   echo "--- Running trufflehog to scan artifacts for secrets & uploading artifacts"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -299,6 +299,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
           run: fast-tests
+          args: [--parallelism=8]
     agents:
       queue: hetzner-aarch64-16cpu-32gb
 

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -104,6 +104,8 @@ ERROR_RE = re.compile(
     | worker_.*\ still\ running: [\s\S]* Threads\ have\ not\ stopped\ within\ 5\ minutes,\ exiting\ hard
     # source-table migration
     | source-table-migration\ issue
+    # sql logic tests
+    | Rewrite\ SLT\ files\ locally\ with:\ [\s\S]*? ^EOF$
     )
     .* $
     """,

--- a/src/sqllogictest/ci/Dockerfile
+++ b/src/sqllogictest/ci/Dockerfile
@@ -12,3 +12,5 @@ MZFROM prod-base
 COPY clusterd sqllogictest /usr/local/bin/
 
 WORKDIR /workdir
+
+USER materialize


### PR DESCRIPTION
Demo run, see annotation: https://buildkite.com/materialize/test/builds/107791 (I have fixed the text after that run to include `--rewrite-results`)
<img width="1103" height="754" alt="Screenshot 2025-08-13 at 18 41 20" src="https://github.com/user-attachments/assets/dab2f86b-d809-4a6c-b1bc-d4b86e127d86" />
Motivated by https://materializeinc.slack.com/archives/C01LKF361MZ/p1755031723538639
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
