### PR TITLE
[sql_server] remove enabling sql server in test as defaults to enabled

### DIFF
--- a/test/sql-server-cdc/10-sql-server-cdc.td
+++ b/test/sql-server-cdc/10-sql-server-cdc.td
@@ -30,9 +30,6 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't3_text', @
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE CONNECTION sql_server_test_connection TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,

--- a/test/sql-server-cdc/11-sql-server-cdc-ssl.td
+++ b/test/sql-server-cdc/11-sql-server-cdc-ssl.td
@@ -9,9 +9,6 @@
 
 # Setup SQL Server state.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE SECRET ssl_ca AS '${arg.ssl-ca}'
 > CREATE SECRET alt_ssl_ca AS '${arg.alt-ssl-ca}'
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'

--- a/test/sql-server-cdc/15-expose-progress.td
+++ b/test/sql-server-cdc/15-expose-progress.td
@@ -25,9 +25,6 @@ INSERT INTO t15_pk VALUES ('a', 'hello world'), ('b', 'foobar'), ('c', 'anotha o
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE CONNECTION sql_server_test_15_connection TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,

--- a/test/sql-server-cdc/20-column-options.td
+++ b/test/sql-server-cdc/20-column-options.td
@@ -11,9 +11,6 @@
 #
 # Create a table that has CDC enabled.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
 

--- a/test/sql-server-cdc/25-constraints.td
+++ b/test/sql-server-cdc/25-constraints.td
@@ -31,9 +31,6 @@ INSERT INTO t25_pk2 VALUES ('i am an ID', '1000', 'uhhmmmm');
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE CONNECTION sql_server_test_25_connection TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,

--- a/test/sql-server-cdc/30-add-subsource.td
+++ b/test/sql-server-cdc/30-add-subsource.td
@@ -33,9 +33,6 @@ INSERT INTO t2_add_subsource VALUES ('100'), ('200'), (NULL), ('300');
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET log_filter = 'mz_sql=debug,info';
 
 > CREATE CONNECTION IF NOT EXISTS sql_server_test_add_subsource_conn TO SQL SERVER (

--- a/test/sql-server-cdc/40-data-types.td
+++ b/test/sql-server-cdc/40-data-types.td
@@ -95,9 +95,6 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_nvarc
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET log_filter = 'mz_storage::source::sql_server=debug,mz_sql_server_util=debug,info';
 
 > CREATE CONNECTION sql_server_test_40_connection TO SQL SERVER (

--- a/test/sql-server-cdc/50-unsupported-types.td
+++ b/test/sql-server-cdc/50-unsupported-types.td
@@ -44,9 +44,6 @@ INSERT INTO table_varchar_max VALUES (42, NULL);
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE CONNECTION sql_server_test_50_connection TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,

--- a/test/sql-server-cdc/source-tables.td
+++ b/test/sql-server-cdc/source-tables.td
@@ -36,9 +36,6 @@ INSERT INTO text_cols VALUES (1.444889, '12:00:00', '$100.99', 0x1100AB);
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_sql_server_source = true;
-
 > CREATE CONNECTION ms_conn TO SQL SERVER (
     HOST 'sql-server',
     PORT 1433,


### PR DESCRIPTION
### Motivation
   * This PR refactors existing code.
      sql server is enabled by default

### Tips for reviewer

small set of refactors to the sql server cdc tests following updates in: https://github.com/MaterializeInc/materialize/pull/33265

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
