### PR TITLE
tests: Nightly/RQ fixes (2025-08-13 edition)

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -264,6 +264,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
               args: [ "--mysql-version=8.0.40" ]
+        skip: "Doesn't support new RESET BINARY LOGS AND GTIDS syntax"
 
   - group: "Postgres: other versions"
     key: postgres-versions
@@ -333,7 +334,7 @@ steps:
       - id: checks-backup-restore-before-manipulate
         label: "Checks backup + restore between the two manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 30
         parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
@@ -345,7 +346,7 @@ steps:
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 30
         parallelism: 3
         agents:
           queue: hetzner-aarch64-16cpu-32gb
@@ -357,7 +358,7 @@ steps:
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 30
         parallelism: 4
         agents:
           queue: hetzner-aarch64-16cpu-32gb

--- a/misc/python/materialize/source_table_migration.py
+++ b/misc/python/materialize/source_table_migration.py
@@ -8,9 +8,7 @@
 # by the Apache License, Version 2.0.
 
 """Utilities for testing the source table migration"""
-from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
-from materialize.version_list import get_published_minor_mz_versions
 
 
 def verify_sources_after_source_table_migration(
@@ -54,25 +52,3 @@ def _verify_source(
 
         if fail:
             raise e
-
-
-_last_version: MzVersion | None = None
-
-
-def get_old_image_for_source_table_migration_test() -> str:
-    global _last_version
-    if _last_version is None:
-        current_version = MzVersion.parse_cargo()
-        minor_versions = [
-            v
-            for v in get_published_minor_mz_versions(
-                limit=4, exclude_current_minor_version=True
-            )
-            if v < current_version
-        ]
-        _last_version = minor_versions[0]
-    return f"materialize/materialized:{_last_version}"
-
-
-def get_new_image_for_source_table_migration_test() -> str | None:
-    return None

--- a/test/mysql-cdc-old-syntax/mzcompose.py
+++ b/test/mysql-cdc-old-syntax/mzcompose.py
@@ -36,8 +36,6 @@ from materialize.mzcompose.services.postgres import (
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.source_table_migration import (
-    get_new_image_for_source_table_migration_test,
-    get_old_image_for_source_table_migration_test,
     verify_sources_after_source_table_migration,
 )
 
@@ -325,7 +323,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         mz_old = Materialized(
             name="materialized",
-            image=get_old_image_for_source_table_migration_test(),
             external_metadata_store=True,
             external_blob_store=True,
             additional_system_parameter_defaults={
@@ -336,7 +333,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         mz_new = Materialized(
             name="materialized",
-            image=get_new_image_for_source_table_migration_test(),
             external_metadata_store=True,
             external_blob_store=True,
             additional_system_parameter_defaults={

--- a/test/pg-cdc-old-syntax/mzcompose.py
+++ b/test/pg-cdc-old-syntax/mzcompose.py
@@ -37,8 +37,6 @@ from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.source_table_migration import (
-    get_new_image_for_source_table_migration_test,
-    get_old_image_for_source_table_migration_test,
     verify_sources_after_source_table_migration,
 )
 
@@ -418,7 +416,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
     for file in sharded_files:
         mz_old = Materialized(
             name="materialized",
-            image=get_old_image_for_source_table_migration_test(),
             volumes_extra=["secrets:/share/secrets"],
             external_metadata_store=True,
             external_blob_store=True,
@@ -430,7 +427,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         mz_new = Materialized(
             name="materialized",
-            image=get_new_image_for_source_table_migration_test(),
             volumes_extra=["secrets:/share/secrets"],
             external_metadata_store=True,
             external_blob_store=True,

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -65,8 +65,14 @@ CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 ALTER TABLE table_a REPLICA IDENTITY FULL;
 INSERT INTO table_a VALUES (9, 'nine');
 
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9571 is fixed
+$ skip-if
+SELECT true
+
 ! SELECT * FROM table_a;
 regex:(table was dropped|incompatible schema change)
+
+$ skip-end
 
 # We are not aware that the new table_a is different
 ! CREATE TABLE table_a FROM SOURCE mz_source (REFERENCE table_a);

--- a/test/testdrive-old-kafka-src-syntax/mzcompose.py
+++ b/test/testdrive-old-kafka-src-syntax/mzcompose.py
@@ -34,8 +34,6 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.source_table_migration import (
-    get_new_image_for_source_table_migration_test,
-    get_old_image_for_source_table_migration_test,
     verify_sources_after_source_table_migration,
 )
 
@@ -340,7 +338,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     mz_old = Materialized(
         default_size=Materialized.Size.DEFAULT_SIZE,
-        image=get_old_image_for_source_table_migration_test(),
         external_blob_store=True,
         blob_store_is_azure=args.azurite,
         additional_system_parameter_defaults=dict(additional_system_parameter_defaults),
@@ -366,7 +363,6 @@ def workflow_migration(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     mz_new = Materialized(
         default_size=Materialized.Size.DEFAULT_SIZE,
-        image=get_new_image_for_source_table_migration_test(),
         external_blob_store=True,
         blob_store_is_azure=args.azurite,
         additional_system_parameter_defaults=additional_system_parameter_defaults,

--- a/test/testdrive/unified-compute-introspection.td
+++ b/test/testdrive/unified-compute-introspection.td
@@ -13,6 +13,7 @@
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
 
+$ set-sql-timeout duration=60s
 $ set-arg-default default-replica-size=scale=1,workers=1
 
 # Test dataflow error introspection.

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -680,7 +680,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
             )
 
         num_rows = 100_000  # out of disk with 200_000 rows
-        batch_size = 10_000
+        batch_size = 1_000
         for i in range(0, num_rows, batch_size):
             batch_num = min(batch_size, num_rows - i)
             make_inserts(c, i, batch_num)


### PR DESCRIPTION
Based on failures in https://buildkite.com/materialize/release-qualification/builds/908 and https://buildkite.com/materialize/nightly/builds/12844
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
