### PR TITLE
adapter: exclude crash-looping clusters from 0dt caught up checks

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -550,6 +550,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "enable_0dt_caught_up_check",
     "with_0dt_caught_up_check_allowed_lag",
     "with_0dt_caught_up_check_cutoff",
+    "enable_0dt_caught_up_replica_status_check",
     "plan_insights_notice_fast_path_clusters_optimize_duration",
     "enable_continual_task_builtins",
     "enable_expression_cache",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1226,6 +1226,7 @@ class FlipFlagsAction(Action):
             "persist_enable_arrow_lgalloc_noncc_sizes",
             "controller_past_generation_replica_cleanup_retry_interval",
             "enable_0dt_deployment_sources",
+            "enable_0dt_caught_up_replica_status_check",
             "wallclock_lag_recording_interval",
             "enable_wallclock_lag_histogram_collection",
             "wallclock_lag_histogram_period_interval",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -67,8 +67,8 @@ pub const WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG: Config<Duration> = Config::new(
 
 pub const WITH_0DT_CAUGHT_UP_CHECK_CUTOFF: Config<Duration> = Config::new(
     "with_0dt_caught_up_check_cutoff",
-    Duration::from_secs(2 * 60 * 60), // 2 hours
-    "Collections whose write frontier is behind 'now' by more than the cutoff are ignored when doing caught-up checks for 0dt deployments.",
+    Duration::from_secs(10 * 60), // 10 minutes
+    "During a 0dt deployment, if a cluster has only 'problematic' (crash-looping) replicas _and_ any collection that is behind by more than this cutoff, the cluster will be ignored in caught-up checks.",
 );
 
 pub const ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK: Config<bool> = Config::new(

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -71,6 +71,12 @@ pub const WITH_0DT_CAUGHT_UP_CHECK_CUTOFF: Config<Duration> = Config::new(
     "Collections whose write frontier is behind 'now' by more than the cutoff are ignored when doing caught-up checks for 0dt deployments.",
 );
 
+pub const ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK: Config<bool> = Config::new(
+    "enable_0dt_caught_up_replica_status_check",
+    true,
+    "Enable checking for crash/OOM-looping replicas during 0dt caught-up checks. Emergency break-glass flag to disable this feature if needed.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -149,6 +155,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_0DT_CAUGHT_UP_CHECK)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_CUTOFF)
+        .add(&ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)


### PR DESCRIPTION
We already have logic in the caught-up check that tries to exclude collections whose frontier is too far behind current wall-clock time, but that doesn't catch cases where a replica is "limping" along and sometimes makes process. This has made the release tedious at times, where we had to wait a long time for cutting over.

This is a more explicit approach where we straightaway ignore clusters that only have crash-looping replicas. We don't consider and wait for them before cutting over in a 0dt deployment.

@ggevay and @teskje , you might be interested to review, I think you have most acutely felt the pain of this recently. 🕊️ 