### PR TITLE
Columnar data in persist source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,9 +2018,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "columnar"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0342a00e5e34da4ef8c48b7ef9cc6fbe16ac2967456382738e21fe662ece796"
+checksum = "03315bde8779a20f3dd80d2ef267e22c4be4bd869846ec00b2dd75d0c7c67c4c"
 dependencies = [
  "bytemuck",
  "columnar_derive",
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "columnar_derive"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1852d06353d9f8d6032581b3e61169d54c98204f9fb681ddcfb3c974f447255"
+checksum = "b2f0cf8b4fdf0324ae0cdce3f4c3dea78c53f4a54a2d81603ce7107e19288da7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6403,6 +6403,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "chrono-tz",
+ "columnar",
  "crc32fast",
  "criterion",
  "csv",
@@ -8010,6 +8011,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "columnar",
  "columnation",
  "crossbeam-channel",
  "csv-core",
@@ -8167,6 +8169,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytesize",
+ "columnar",
  "csv-async",
  "derivative",
  "differential-dataflow",
@@ -8220,6 +8223,7 @@ dependencies = [
  "aws-types",
  "base64 0.22.1",
  "bytes",
+ "columnar",
  "columnation",
  "criterion",
  "dec",
@@ -9872,7 +9876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -9892,7 +9896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![recursion_limit = "256"]
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::LazyLock;

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-columnar = "0.10.1"
+columnar = "0.10.2"
 columnation = "0.1.0"
 differential-dataflow = "0.17.0"
 itertools = "0.14.0"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.98"
 async-stream = "0.3.6"
 bytesize = "1.3.0"
-columnar = "0.10.1"
+columnar = "0.10.2"
 crossbeam-channel = "0.5.15"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = "0.17.0"

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -240,7 +240,7 @@ Error "division by zero"
 # constant_err
 build
 (constant_err
-  (invalid_layer 10 100)
+  (invalid_layer (10 100))
   [int64 int32 int64])
 ----
 ----

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.10.1"
 bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+columnar = "0.10.2"
 crc32fast = "1.4.2"
 csv = "1.3.1"
 differential-dataflow = "0.17.0"

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -10,6 +10,7 @@
 //! Core expression language.
 
 #![warn(missing_debug_implementations)]
+#![recursion_limit = "256"]
 
 use std::collections::BTreeSet;
 use std::ops::Deref;
@@ -51,8 +52,10 @@ pub use relation::{
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{
-    EvalError, FilterCharacteristics, MirScalarExpr, ProtoDomainLimit, ProtoEvalError,
-    ProtoMirScalarExpr, like_pattern,
+    DateDiffOverflow, EvalError, FilterCharacteristics, IncompatibleArrayDimensions,
+    IndexOutOfRange, InvalidByteSequence, InvalidIdentifier, InvalidJsonbCast, InvalidLayer,
+    MirScalarExpr, ProtoDomainLimit, ProtoEvalError, ProtoMirScalarExpr, StringValueTooLong,
+    Unsupported, like_pattern,
 };
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -12,6 +12,7 @@ use std::ops::BitOrAssign;
 use std::sync::Arc;
 use std::{fmt, mem};
 
+use columnar::Columnar;
 use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
@@ -2625,6 +2626,7 @@ impl FilterCharacteristics {
     Deserialize,
     Hash,
     MzReflect,
+    Columnar,
 )]
 pub enum DomainLimit {
     None,
@@ -2658,17 +2660,197 @@ impl RustType<ProtoDomainLimit> for DomainLimit {
 }
 
 #[derive(
-    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct Unsupported {
+    pub feature: Box<str>,
+    pub discussion_no: Option<usize>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct IndexOutOfRange {
+    pub provided: i32,
+    // The last valid index position, i.e. `v.len() - 1`
+    pub valid_end: i32,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct InvalidLayer {
+    pub max_layer: usize,
+    pub val: i64,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct InvalidByteSequence {
+    pub byte_sequence: Box<str>,
+    pub encoding_name: Box<str>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct InvalidJsonbCast {
+    pub from: Box<str>,
+    pub to: Box<str>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct StringValueTooLong {
+    pub target_type: Box<str>,
+    pub length: usize,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct IncompatibleArrayDimensions {
+    pub dims: Option<(usize, usize)>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct InvalidIdentifier {
+    pub ident: Box<str>,
+    pub detail: Option<Box<str>>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
+)]
+pub struct DateDiffOverflow {
+    pub unit: Box<str>,
+    pub a: Box<str>,
+    pub b: Box<str>,
+}
+
+#[derive(
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
 )]
 pub enum EvalError {
     CharacterNotValidForEncoding(i32),
     CharacterTooLargeForEncoding(i32),
     DateBinOutOfRange(Box<str>),
     DivisionByZero,
-    Unsupported {
-        feature: Box<str>,
-        discussion_no: Option<usize>,
-    },
+    Unsupported(Unsupported),
     FloatOverflow,
     FloatUnderflow,
     NumericFieldOverflow,
@@ -2688,11 +2870,7 @@ pub enum EvalError {
     TimestampOutOfRange,
     DateOutOfRange,
     CharOutOfRange,
-    IndexOutOfRange {
-        provided: i32,
-        // The last valid index position, i.e. `v.len() - 1`
-        valid_end: i32,
-    },
+    IndexOutOfRange(IndexOutOfRange),
     InvalidBase64Equals,
     InvalidBase64Symbol(char),
     InvalidBase64EndSequence,
@@ -2700,21 +2878,12 @@ pub enum EvalError {
     InvalidTimezoneInterval,
     InvalidTimezoneConversion,
     InvalidIanaTimezoneId(Box<str>),
-    InvalidLayer {
-        max_layer: usize,
-        val: i64,
-    },
+    InvalidLayer(InvalidLayer),
     InvalidArray(InvalidArrayError),
     InvalidEncodingName(Box<str>),
     InvalidHashAlgorithm(Box<str>),
-    InvalidByteSequence {
-        byte_sequence: Box<str>,
-        encoding_name: Box<str>,
-    },
-    InvalidJsonbCast {
-        from: Box<str>,
-        to: Box<str>,
-    },
+    InvalidByteSequence(InvalidByteSequence),
+    InvalidJsonbCast(InvalidJsonbCast),
     InvalidRegex(Box<str>),
     InvalidRegexFlag(char),
     InvalidParameterValue(Box<str>),
@@ -2738,14 +2907,9 @@ pub enum EvalError {
     Undefined(Box<str>),
     LikePatternTooLong,
     LikeEscapeTooLong,
-    StringValueTooLong {
-        target_type: Box<str>,
-        length: usize,
-    },
+    StringValueTooLong(StringValueTooLong),
     MultidimensionalArrayRemovalNotSupported,
-    IncompatibleArrayDimensions {
-        dims: Option<(usize, usize)>,
-    },
+    IncompatibleArrayDimensions(IncompatibleArrayDimensions),
     TypeFromOid(Box<str>),
     InvalidRange(InvalidRangeError),
     InvalidRoleId(Box<str>),
@@ -2753,18 +2917,11 @@ pub enum EvalError {
     LetRecLimitExceeded(Box<str>),
     MultiDimensionalArraySearch,
     MustNotBeNull(Box<str>),
-    InvalidIdentifier {
-        ident: Box<str>,
-        detail: Option<Box<str>>,
-    },
+    InvalidIdentifier(InvalidIdentifier),
     ArrayFillWrongArraySubscripts,
     // TODO: propagate this check more widely throughout the expr crate
     MaxArraySizeExceeded(usize),
-    DateDiffOverflow {
-        unit: Box<str>,
-        a: Box<str>,
-        b: Box<str>,
-    },
+    DateDiffOverflow(DateDiffOverflow),
     // The error for ErrorIfNull; this should not be used in other contexts as a generic error
     // printer.
     IfNullError(Box<str>),
@@ -2785,10 +2942,10 @@ impl fmt::Display for EvalError {
             }
             EvalError::DateBinOutOfRange(message) => f.write_str(message),
             EvalError::DivisionByZero => f.write_str("division by zero"),
-            EvalError::Unsupported {
+            EvalError::Unsupported(Unsupported {
                 feature,
                 discussion_no,
-            } => {
+            }) => {
                 write!(f, "{} not yet supported", feature)?;
                 if let Some(discussion_no) = discussion_no {
                     write!(
@@ -2824,10 +2981,10 @@ impl fmt::Display for EvalError {
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),
             EvalError::DateOutOfRange => f.write_str("date out of range"),
             EvalError::CharOutOfRange => f.write_str("\"char\" out of range"),
-            EvalError::IndexOutOfRange {
+            EvalError::IndexOutOfRange(IndexOutOfRange {
                 provided,
                 valid_end,
-            } => write!(f, "index {provided} out of valid range, 0..{valid_end}",),
+            }) => write!(f, "index {provided} out of valid range, 0..{valid_end}",),
             EvalError::InvalidBase64Equals => {
                 f.write_str("unexpected \"=\" while decoding base64 sequence")
             }
@@ -2837,7 +2994,7 @@ impl fmt::Display for EvalError {
                 c.escape_default()
             ),
             EvalError::InvalidBase64EndSequence => f.write_str("invalid base64 end sequence"),
-            EvalError::InvalidJsonbCast { from, to } => {
+            EvalError::InvalidJsonbCast(InvalidJsonbCast { from, to }) => {
                 write!(f, "cannot cast jsonb {} to type {}", from, to)
             }
             EvalError::InvalidTimezone(tz) => write!(f, "invalid time zone '{}'", tz),
@@ -2848,7 +3005,7 @@ impl fmt::Display for EvalError {
             EvalError::InvalidIanaTimezoneId(tz) => {
                 write!(f, "invalid IANA Time Zone Database identifier: '{}'", tz)
             }
-            EvalError::InvalidLayer { max_layer, val } => write!(
+            EvalError::InvalidLayer(InvalidLayer { max_layer, val }) => write!(
                 f,
                 "invalid layer: {}; must use value within [1, {}]",
                 val, max_layer
@@ -2856,10 +3013,10 @@ impl fmt::Display for EvalError {
             EvalError::InvalidArray(e) => e.fmt(f),
             EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
             EvalError::InvalidHashAlgorithm(alg) => write!(f, "invalid hash algorithm '{}'", alg),
-            EvalError::InvalidByteSequence {
+            EvalError::InvalidByteSequence(InvalidByteSequence {
                 byte_sequence,
                 encoding_name,
-            } => write!(
+            }) => write!(
                 f,
                 "invalid byte sequence '{}' for encoding '{}'",
                 byte_sequence, encoding_name
@@ -2926,10 +3083,10 @@ impl fmt::Display for EvalError {
             EvalError::LikeEscapeTooLong => {
                 write!(f, "invalid escape string")
             }
-            EvalError::StringValueTooLong {
+            EvalError::StringValueTooLong(StringValueTooLong {
                 target_type,
                 length,
-            } => {
+            }) => {
                 write!(f, "value too long for type {}({})", target_type, length)
             }
             EvalError::MultidimensionalArrayRemovalNotSupported => {
@@ -2938,7 +3095,7 @@ impl fmt::Display for EvalError {
                     "removing elements from multidimensional arrays is not supported"
                 )
             }
-            EvalError::IncompatibleArrayDimensions { dims: _ } => {
+            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions { dims: _ }) => {
                 write!(f, "cannot concatenate incompatible arrays")
             }
             EvalError::TypeFromOid(msg) => write!(f, "{msg}"),
@@ -2959,7 +3116,7 @@ impl fmt::Display for EvalError {
                 "searching for elements in multidimensional arrays is not supported"
             ),
             EvalError::MustNotBeNull(v) => write!(f, "{v} must not be null"),
-            EvalError::InvalidIdentifier { ident, .. } => {
+            EvalError::InvalidIdentifier(InvalidIdentifier { ident, .. }) => {
                 write!(f, "string is not a valid identifier: {}", ident.quoted())
             }
             EvalError::ArrayFillWrongArraySubscripts => {
@@ -2971,7 +3128,7 @@ impl fmt::Display for EvalError {
                     "array size exceeds the maximum allowed ({max_size} bytes)"
                 )
             }
-            EvalError::DateDiffOverflow { unit, a, b } => {
+            EvalError::DateDiffOverflow(DateDiffOverflow { unit, a, b }) => {
                 write!(f, "datediff overflow, {unit} of {a}, {b}")
             }
             EvalError::IfNullError(s) => f.write_str(s),
@@ -2987,16 +3144,20 @@ impl fmt::Display for EvalError {
 impl EvalError {
     pub fn detail(&self) -> Option<String> {
         match self {
-            EvalError::IncompatibleArrayDimensions { dims: None } => Some(
-                "Arrays with differing dimensions are not compatible for concatenation.".into(),
-            ),
-            EvalError::IncompatibleArrayDimensions {
+            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions { dims: None }) => {
+                Some(
+                    "Arrays with differing dimensions are not compatible for concatenation.".into(),
+                )
+            }
+            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {
                 dims: Some((a_dims, b_dims)),
-            } => Some(format!(
+            }) => Some(format!(
                 "Arrays of {} and {} dimensions are not compatible for concatenation.",
                 a_dims, b_dims
             )),
-            EvalError::InvalidIdentifier { detail, .. } => detail.as_deref().map(Into::into),
+            EvalError::InvalidIdentifier(InvalidIdentifier { detail, .. }) => {
+                detail.as_deref().map(Into::into)
+            }
             EvalError::ArrayFillWrongArraySubscripts => {
                 Some("Low bound array has different size than dimensions array.".into())
             }
@@ -3079,292 +3240,320 @@ impl From<InvalidRangeError> for EvalError {
 
 impl RustType<ProtoEvalError> for EvalError {
     fn into_proto(&self) -> ProtoEvalError {
-        use proto_eval_error::Kind::*;
+        use proto_eval_error::Kind;
         use proto_eval_error::*;
         let kind = match self {
-            EvalError::CharacterNotValidForEncoding(v) => CharacterNotValidForEncoding(*v),
-            EvalError::CharacterTooLargeForEncoding(v) => CharacterTooLargeForEncoding(*v),
-            EvalError::DateBinOutOfRange(v) => DateBinOutOfRange(v.into_proto()),
-            EvalError::DivisionByZero => DivisionByZero(()),
-            EvalError::Unsupported {
+            EvalError::CharacterNotValidForEncoding(v) => Kind::CharacterNotValidForEncoding(*v),
+            EvalError::CharacterTooLargeForEncoding(v) => Kind::CharacterTooLargeForEncoding(*v),
+            EvalError::DateBinOutOfRange(v) => Kind::DateBinOutOfRange(v.into_proto()),
+            EvalError::DivisionByZero => Kind::DivisionByZero(()),
+            EvalError::Unsupported(Unsupported {
                 feature,
                 discussion_no,
-            } => Unsupported(ProtoUnsupported {
+            }) => Kind::Unsupported(ProtoUnsupported {
                 feature: feature.into_proto(),
                 discussion_no: discussion_no.into_proto(),
             }),
-            EvalError::FloatOverflow => FloatOverflow(()),
-            EvalError::FloatUnderflow => FloatUnderflow(()),
-            EvalError::NumericFieldOverflow => NumericFieldOverflow(()),
-            EvalError::Float32OutOfRange(val) => Float32OutOfRange(ProtoValueOutOfRange {
+            EvalError::FloatOverflow => Kind::FloatOverflow(()),
+            EvalError::FloatUnderflow => Kind::FloatUnderflow(()),
+            EvalError::NumericFieldOverflow => Kind::NumericFieldOverflow(()),
+            EvalError::Float32OutOfRange(val) => Kind::Float32OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::Float64OutOfRange(val) => Float64OutOfRange(ProtoValueOutOfRange {
+            EvalError::Float64OutOfRange(val) => Kind::Float64OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::Int16OutOfRange(val) => Int16OutOfRange(ProtoValueOutOfRange {
+            EvalError::Int16OutOfRange(val) => Kind::Int16OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::Int32OutOfRange(val) => Int32OutOfRange(ProtoValueOutOfRange {
+            EvalError::Int32OutOfRange(val) => Kind::Int32OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::Int64OutOfRange(val) => Int64OutOfRange(ProtoValueOutOfRange {
+            EvalError::Int64OutOfRange(val) => Kind::Int64OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::UInt16OutOfRange(val) => Uint16OutOfRange(ProtoValueOutOfRange {
+            EvalError::UInt16OutOfRange(val) => Kind::Uint16OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::UInt32OutOfRange(val) => Uint32OutOfRange(ProtoValueOutOfRange {
+            EvalError::UInt32OutOfRange(val) => Kind::Uint32OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::UInt64OutOfRange(val) => Uint64OutOfRange(ProtoValueOutOfRange {
+            EvalError::UInt64OutOfRange(val) => Kind::Uint64OutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::MzTimestampOutOfRange(val) => MzTimestampOutOfRange(ProtoValueOutOfRange {
+            EvalError::MzTimestampOutOfRange(val) => {
+                Kind::MzTimestampOutOfRange(ProtoValueOutOfRange {
+                    value: val.to_string(),
+                })
+            }
+            EvalError::MzTimestampStepOverflow => Kind::MzTimestampStepOverflow(()),
+            EvalError::OidOutOfRange(val) => Kind::OidOutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::MzTimestampStepOverflow => MzTimestampStepOverflow(()),
-            EvalError::OidOutOfRange(val) => OidOutOfRange(ProtoValueOutOfRange {
+            EvalError::IntervalOutOfRange(val) => Kind::IntervalOutOfRange(ProtoValueOutOfRange {
                 value: val.to_string(),
             }),
-            EvalError::IntervalOutOfRange(val) => IntervalOutOfRange(ProtoValueOutOfRange {
-                value: val.to_string(),
-            }),
-            EvalError::TimestampCannotBeNan => TimestampCannotBeNan(()),
-            EvalError::TimestampOutOfRange => TimestampOutOfRange(()),
-            EvalError::DateOutOfRange => DateOutOfRange(()),
-            EvalError::CharOutOfRange => CharOutOfRange(()),
-            EvalError::IndexOutOfRange {
+            EvalError::TimestampCannotBeNan => Kind::TimestampCannotBeNan(()),
+            EvalError::TimestampOutOfRange => Kind::TimestampOutOfRange(()),
+            EvalError::DateOutOfRange => Kind::DateOutOfRange(()),
+            EvalError::CharOutOfRange => Kind::CharOutOfRange(()),
+            EvalError::IndexOutOfRange(IndexOutOfRange {
                 provided,
                 valid_end,
-            } => IndexOutOfRange(ProtoIndexOutOfRange {
+            }) => Kind::IndexOutOfRange(ProtoIndexOutOfRange {
                 provided: *provided,
                 valid_end: *valid_end,
             }),
-            EvalError::InvalidBase64Equals => InvalidBase64Equals(()),
-            EvalError::InvalidBase64Symbol(sym) => InvalidBase64Symbol(sym.into_proto()),
-            EvalError::InvalidBase64EndSequence => InvalidBase64EndSequence(()),
-            EvalError::InvalidTimezone(tz) => InvalidTimezone(tz.into_proto()),
-            EvalError::InvalidTimezoneInterval => InvalidTimezoneInterval(()),
-            EvalError::InvalidTimezoneConversion => InvalidTimezoneConversion(()),
-            EvalError::InvalidLayer { max_layer, val } => InvalidLayer(ProtoInvalidLayer {
-                max_layer: max_layer.into_proto(),
-                val: *val,
-            }),
-            EvalError::InvalidArray(error) => InvalidArray(error.into_proto()),
-            EvalError::InvalidEncodingName(v) => InvalidEncodingName(v.into_proto()),
-            EvalError::InvalidHashAlgorithm(v) => InvalidHashAlgorithm(v.into_proto()),
-            EvalError::InvalidByteSequence {
+            EvalError::InvalidBase64Equals => Kind::InvalidBase64Equals(()),
+            EvalError::InvalidBase64Symbol(sym) => Kind::InvalidBase64Symbol(sym.into_proto()),
+            EvalError::InvalidBase64EndSequence => Kind::InvalidBase64EndSequence(()),
+            EvalError::InvalidTimezone(tz) => Kind::InvalidTimezone(tz.into_proto()),
+            EvalError::InvalidTimezoneInterval => Kind::InvalidTimezoneInterval(()),
+            EvalError::InvalidTimezoneConversion => Kind::InvalidTimezoneConversion(()),
+            EvalError::InvalidLayer(InvalidLayer { max_layer, val }) => {
+                Kind::InvalidLayer(ProtoInvalidLayer {
+                    max_layer: max_layer.into_proto(),
+                    val: *val,
+                })
+            }
+            EvalError::InvalidArray(error) => Kind::InvalidArray(error.into_proto()),
+            EvalError::InvalidEncodingName(v) => Kind::InvalidEncodingName(v.into_proto()),
+            EvalError::InvalidHashAlgorithm(v) => Kind::InvalidHashAlgorithm(v.into_proto()),
+            EvalError::InvalidByteSequence(InvalidByteSequence {
                 byte_sequence,
                 encoding_name,
-            } => InvalidByteSequence(ProtoInvalidByteSequence {
+            }) => Kind::InvalidByteSequence(ProtoInvalidByteSequence {
                 byte_sequence: byte_sequence.into_proto(),
                 encoding_name: encoding_name.into_proto(),
             }),
-            EvalError::InvalidJsonbCast { from, to } => InvalidJsonbCast(ProtoInvalidJsonbCast {
-                from: from.into_proto(),
-                to: to.into_proto(),
-            }),
-            EvalError::InvalidRegex(v) => InvalidRegex(v.into_proto()),
-            EvalError::InvalidRegexFlag(v) => InvalidRegexFlag(v.into_proto()),
-            EvalError::InvalidParameterValue(v) => InvalidParameterValue(v.into_proto()),
-            EvalError::InvalidDatePart(part) => InvalidDatePart(part.into_proto()),
-            EvalError::KeyCannotBeNull => KeyCannotBeNull(()),
-            EvalError::NegSqrt => NegSqrt(()),
-            EvalError::NegLimit => NegLimit(()),
-            EvalError::NullCharacterNotPermitted => NullCharacterNotPermitted(()),
-            EvalError::UnknownUnits(v) => UnknownUnits(v.into_proto()),
-            EvalError::UnsupportedUnits(units, typ) => UnsupportedUnits(ProtoUnsupportedUnits {
-                units: units.into_proto(),
-                typ: typ.into_proto(),
-            }),
-            EvalError::UnterminatedLikeEscapeSequence => UnterminatedLikeEscapeSequence(()),
-            EvalError::Parse(error) => Parse(error.into_proto()),
-            EvalError::PrettyError(error) => PrettyError(error.into_proto()),
-            EvalError::ParseHex(error) => ParseHex(error.into_proto()),
-            EvalError::Internal(v) => Internal(v.into_proto()),
-            EvalError::InfinityOutOfDomain(v) => InfinityOutOfDomain(v.into_proto()),
-            EvalError::NegativeOutOfDomain(v) => NegativeOutOfDomain(v.into_proto()),
-            EvalError::ZeroOutOfDomain(v) => ZeroOutOfDomain(v.into_proto()),
-            EvalError::OutOfDomain(lower, upper, id) => OutOfDomain(ProtoOutOfDomain {
+            EvalError::InvalidJsonbCast(InvalidJsonbCast { from, to }) => {
+                Kind::InvalidJsonbCast(ProtoInvalidJsonbCast {
+                    from: from.into_proto(),
+                    to: to.into_proto(),
+                })
+            }
+            EvalError::InvalidRegex(v) => Kind::InvalidRegex(v.into_proto()),
+            EvalError::InvalidRegexFlag(v) => Kind::InvalidRegexFlag(v.into_proto()),
+            EvalError::InvalidParameterValue(v) => Kind::InvalidParameterValue(v.into_proto()),
+            EvalError::InvalidDatePart(part) => Kind::InvalidDatePart(part.into_proto()),
+            EvalError::KeyCannotBeNull => Kind::KeyCannotBeNull(()),
+            EvalError::NegSqrt => Kind::NegSqrt(()),
+            EvalError::NegLimit => Kind::NegLimit(()),
+            EvalError::NullCharacterNotPermitted => Kind::NullCharacterNotPermitted(()),
+            EvalError::UnknownUnits(v) => Kind::UnknownUnits(v.into_proto()),
+            EvalError::UnsupportedUnits(units, typ) => {
+                Kind::UnsupportedUnits(ProtoUnsupportedUnits {
+                    units: units.into_proto(),
+                    typ: typ.into_proto(),
+                })
+            }
+            EvalError::UnterminatedLikeEscapeSequence => Kind::UnterminatedLikeEscapeSequence(()),
+            EvalError::Parse(error) => Kind::Parse(error.into_proto()),
+            EvalError::PrettyError(error) => Kind::PrettyError(error.into_proto()),
+            EvalError::ParseHex(error) => Kind::ParseHex(error.into_proto()),
+            EvalError::Internal(v) => Kind::Internal(v.into_proto()),
+            EvalError::InfinityOutOfDomain(v) => Kind::InfinityOutOfDomain(v.into_proto()),
+            EvalError::NegativeOutOfDomain(v) => Kind::NegativeOutOfDomain(v.into_proto()),
+            EvalError::ZeroOutOfDomain(v) => Kind::ZeroOutOfDomain(v.into_proto()),
+            EvalError::OutOfDomain(lower, upper, id) => Kind::OutOfDomain(ProtoOutOfDomain {
                 lower: Some(lower.into_proto()),
                 upper: Some(upper.into_proto()),
                 id: id.into_proto(),
             }),
-            EvalError::ComplexOutOfRange(v) => ComplexOutOfRange(v.into_proto()),
-            EvalError::MultipleRowsFromSubquery => MultipleRowsFromSubquery(()),
-            EvalError::Undefined(v) => Undefined(v.into_proto()),
-            EvalError::LikePatternTooLong => LikePatternTooLong(()),
-            EvalError::LikeEscapeTooLong => LikeEscapeTooLong(()),
-            EvalError::StringValueTooLong {
+            EvalError::ComplexOutOfRange(v) => Kind::ComplexOutOfRange(v.into_proto()),
+            EvalError::MultipleRowsFromSubquery => Kind::MultipleRowsFromSubquery(()),
+            EvalError::Undefined(v) => Kind::Undefined(v.into_proto()),
+            EvalError::LikePatternTooLong => Kind::LikePatternTooLong(()),
+            EvalError::LikeEscapeTooLong => Kind::LikeEscapeTooLong(()),
+            EvalError::StringValueTooLong(StringValueTooLong {
                 target_type,
                 length,
-            } => StringValueTooLong(ProtoStringValueTooLong {
+            }) => Kind::StringValueTooLong(ProtoStringValueTooLong {
                 target_type: target_type.into_proto(),
                 length: length.into_proto(),
             }),
             EvalError::MultidimensionalArrayRemovalNotSupported => {
-                MultidimensionalArrayRemovalNotSupported(())
+                Kind::MultidimensionalArrayRemovalNotSupported(())
             }
-            EvalError::IncompatibleArrayDimensions { dims } => {
-                IncompatibleArrayDimensions(ProtoIncompatibleArrayDimensions {
+            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions { dims }) => {
+                Kind::IncompatibleArrayDimensions(ProtoIncompatibleArrayDimensions {
                     dims: dims.into_proto(),
                 })
             }
-            EvalError::TypeFromOid(v) => TypeFromOid(v.into_proto()),
-            EvalError::InvalidRange(error) => InvalidRange(error.into_proto()),
-            EvalError::InvalidRoleId(v) => InvalidRoleId(v.into_proto()),
-            EvalError::InvalidPrivileges(v) => InvalidPrivileges(v.into_proto()),
-            EvalError::LetRecLimitExceeded(v) => WmrRecursionLimitExceeded(v.into_proto()),
-            EvalError::MultiDimensionalArraySearch => MultiDimensionalArraySearch(()),
-            EvalError::MustNotBeNull(v) => MustNotBeNull(v.into_proto()),
-            EvalError::InvalidIdentifier { ident, detail } => {
-                InvalidIdentifier(ProtoInvalidIdentifier {
+            EvalError::TypeFromOid(v) => Kind::TypeFromOid(v.into_proto()),
+            EvalError::InvalidRange(error) => Kind::InvalidRange(error.into_proto()),
+            EvalError::InvalidRoleId(v) => Kind::InvalidRoleId(v.into_proto()),
+            EvalError::InvalidPrivileges(v) => Kind::InvalidPrivileges(v.into_proto()),
+            EvalError::LetRecLimitExceeded(v) => Kind::WmrRecursionLimitExceeded(v.into_proto()),
+            EvalError::MultiDimensionalArraySearch => Kind::MultiDimensionalArraySearch(()),
+            EvalError::MustNotBeNull(v) => Kind::MustNotBeNull(v.into_proto()),
+            EvalError::InvalidIdentifier(InvalidIdentifier { ident, detail }) => {
+                Kind::InvalidIdentifier(ProtoInvalidIdentifier {
                     ident: ident.into_proto(),
                     detail: detail.into_proto(),
                 })
             }
-            EvalError::ArrayFillWrongArraySubscripts => ArrayFillWrongArraySubscripts(()),
+            EvalError::ArrayFillWrongArraySubscripts => Kind::ArrayFillWrongArraySubscripts(()),
             EvalError::MaxArraySizeExceeded(max_size) => {
-                MaxArraySizeExceeded(u64::cast_from(*max_size))
+                Kind::MaxArraySizeExceeded(u64::cast_from(*max_size))
             }
-            EvalError::DateDiffOverflow { unit, a, b } => DateDiffOverflow(ProtoDateDiffOverflow {
-                unit: unit.into_proto(),
-                a: a.into_proto(),
-                b: b.into_proto(),
-            }),
-            EvalError::IfNullError(s) => IfNullError(s.into_proto()),
-            EvalError::LengthTooLarge => LengthTooLarge(()),
-            EvalError::AclArrayNullElement => AclArrayNullElement(()),
-            EvalError::MzAclArrayNullElement => MzAclArrayNullElement(()),
-            EvalError::InvalidIanaTimezoneId(s) => InvalidIanaTimezoneId(s.into_proto()),
+            EvalError::DateDiffOverflow(DateDiffOverflow { unit, a, b }) => {
+                Kind::DateDiffOverflow(ProtoDateDiffOverflow {
+                    unit: unit.into_proto(),
+                    a: a.into_proto(),
+                    b: b.into_proto(),
+                })
+            }
+            EvalError::IfNullError(s) => Kind::IfNullError(s.into_proto()),
+            EvalError::LengthTooLarge => Kind::LengthTooLarge(()),
+            EvalError::AclArrayNullElement => Kind::AclArrayNullElement(()),
+            EvalError::MzAclArrayNullElement => Kind::MzAclArrayNullElement(()),
+            EvalError::InvalidIanaTimezoneId(s) => Kind::InvalidIanaTimezoneId(s.into_proto()),
         };
         ProtoEvalError { kind: Some(kind) }
     }
 
     fn from_proto(proto: ProtoEvalError) -> Result<Self, TryFromProtoError> {
-        use proto_eval_error::Kind::*;
+        use proto_eval_error::Kind;
         match proto.kind {
             Some(kind) => match kind {
-                CharacterNotValidForEncoding(v) => Ok(EvalError::CharacterNotValidForEncoding(v)),
-                CharacterTooLargeForEncoding(v) => Ok(EvalError::CharacterTooLargeForEncoding(v)),
-                DateBinOutOfRange(v) => Ok(EvalError::DateBinOutOfRange(v.into())),
-                DivisionByZero(()) => Ok(EvalError::DivisionByZero),
-                Unsupported(v) => Ok(EvalError::Unsupported {
+                Kind::CharacterNotValidForEncoding(v) => {
+                    Ok(EvalError::CharacterNotValidForEncoding(v))
+                }
+                Kind::CharacterTooLargeForEncoding(v) => {
+                    Ok(EvalError::CharacterTooLargeForEncoding(v))
+                }
+                Kind::DateBinOutOfRange(v) => Ok(EvalError::DateBinOutOfRange(v.into())),
+                Kind::DivisionByZero(()) => Ok(EvalError::DivisionByZero),
+                Kind::Unsupported(v) => Ok(EvalError::Unsupported(Unsupported {
                     feature: v.feature.into(),
                     discussion_no: v.discussion_no.into_rust()?,
-                }),
-                FloatOverflow(()) => Ok(EvalError::FloatOverflow),
-                FloatUnderflow(()) => Ok(EvalError::FloatUnderflow),
-                NumericFieldOverflow(()) => Ok(EvalError::NumericFieldOverflow),
-                Float32OutOfRange(val) => Ok(EvalError::Float32OutOfRange(val.value.into())),
-                Float64OutOfRange(val) => Ok(EvalError::Float64OutOfRange(val.value.into())),
-                Int16OutOfRange(val) => Ok(EvalError::Int16OutOfRange(val.value.into())),
-                Int32OutOfRange(val) => Ok(EvalError::Int32OutOfRange(val.value.into())),
-                Int64OutOfRange(val) => Ok(EvalError::Int64OutOfRange(val.value.into())),
-                Uint16OutOfRange(val) => Ok(EvalError::UInt16OutOfRange(val.value.into())),
-                Uint32OutOfRange(val) => Ok(EvalError::UInt32OutOfRange(val.value.into())),
-                Uint64OutOfRange(val) => Ok(EvalError::UInt64OutOfRange(val.value.into())),
-                MzTimestampOutOfRange(val) => {
+                })),
+                Kind::FloatOverflow(()) => Ok(EvalError::FloatOverflow),
+                Kind::FloatUnderflow(()) => Ok(EvalError::FloatUnderflow),
+                Kind::NumericFieldOverflow(()) => Ok(EvalError::NumericFieldOverflow),
+                Kind::Float32OutOfRange(val) => Ok(EvalError::Float32OutOfRange(val.value.into())),
+                Kind::Float64OutOfRange(val) => Ok(EvalError::Float64OutOfRange(val.value.into())),
+                Kind::Int16OutOfRange(val) => Ok(EvalError::Int16OutOfRange(val.value.into())),
+                Kind::Int32OutOfRange(val) => Ok(EvalError::Int32OutOfRange(val.value.into())),
+                Kind::Int64OutOfRange(val) => Ok(EvalError::Int64OutOfRange(val.value.into())),
+                Kind::Uint16OutOfRange(val) => Ok(EvalError::UInt16OutOfRange(val.value.into())),
+                Kind::Uint32OutOfRange(val) => Ok(EvalError::UInt32OutOfRange(val.value.into())),
+                Kind::Uint64OutOfRange(val) => Ok(EvalError::UInt64OutOfRange(val.value.into())),
+                Kind::MzTimestampOutOfRange(val) => {
                     Ok(EvalError::MzTimestampOutOfRange(val.value.into()))
                 }
-                MzTimestampStepOverflow(()) => Ok(EvalError::MzTimestampStepOverflow),
-                OidOutOfRange(val) => Ok(EvalError::OidOutOfRange(val.value.into())),
-                IntervalOutOfRange(val) => Ok(EvalError::IntervalOutOfRange(val.value.into())),
-                TimestampCannotBeNan(()) => Ok(EvalError::TimestampCannotBeNan),
-                TimestampOutOfRange(()) => Ok(EvalError::TimestampOutOfRange),
-                DateOutOfRange(()) => Ok(EvalError::DateOutOfRange),
-                CharOutOfRange(()) => Ok(EvalError::CharOutOfRange),
-                IndexOutOfRange(v) => Ok(EvalError::IndexOutOfRange {
+                Kind::MzTimestampStepOverflow(()) => Ok(EvalError::MzTimestampStepOverflow),
+                Kind::OidOutOfRange(val) => Ok(EvalError::OidOutOfRange(val.value.into())),
+                Kind::IntervalOutOfRange(val) => {
+                    Ok(EvalError::IntervalOutOfRange(val.value.into()))
+                }
+                Kind::TimestampCannotBeNan(()) => Ok(EvalError::TimestampCannotBeNan),
+                Kind::TimestampOutOfRange(()) => Ok(EvalError::TimestampOutOfRange),
+                Kind::DateOutOfRange(()) => Ok(EvalError::DateOutOfRange),
+                Kind::CharOutOfRange(()) => Ok(EvalError::CharOutOfRange),
+                Kind::IndexOutOfRange(v) => Ok(EvalError::IndexOutOfRange(IndexOutOfRange {
                     provided: v.provided,
                     valid_end: v.valid_end,
-                }),
-                InvalidBase64Equals(()) => Ok(EvalError::InvalidBase64Equals),
-                InvalidBase64Symbol(v) => char::from_proto(v).map(EvalError::InvalidBase64Symbol),
-                InvalidBase64EndSequence(()) => Ok(EvalError::InvalidBase64EndSequence),
-                InvalidTimezone(v) => Ok(EvalError::InvalidTimezone(v.into())),
-                InvalidTimezoneInterval(()) => Ok(EvalError::InvalidTimezoneInterval),
-                InvalidTimezoneConversion(()) => Ok(EvalError::InvalidTimezoneConversion),
-                InvalidLayer(v) => Ok(EvalError::InvalidLayer {
+                })),
+                Kind::InvalidBase64Equals(()) => Ok(EvalError::InvalidBase64Equals),
+                Kind::InvalidBase64Symbol(v) => {
+                    char::from_proto(v).map(EvalError::InvalidBase64Symbol)
+                }
+                Kind::InvalidBase64EndSequence(()) => Ok(EvalError::InvalidBase64EndSequence),
+                Kind::InvalidTimezone(v) => Ok(EvalError::InvalidTimezone(v.into())),
+                Kind::InvalidTimezoneInterval(()) => Ok(EvalError::InvalidTimezoneInterval),
+                Kind::InvalidTimezoneConversion(()) => Ok(EvalError::InvalidTimezoneConversion),
+                Kind::InvalidLayer(v) => Ok(EvalError::InvalidLayer(InvalidLayer {
                     max_layer: usize::from_proto(v.max_layer)?,
                     val: v.val,
-                }),
-                InvalidArray(error) => Ok(EvalError::InvalidArray(error.into_rust()?)),
-                InvalidEncodingName(v) => Ok(EvalError::InvalidEncodingName(v.into())),
-                InvalidHashAlgorithm(v) => Ok(EvalError::InvalidHashAlgorithm(v.into())),
-                InvalidByteSequence(v) => Ok(EvalError::InvalidByteSequence {
-                    byte_sequence: v.byte_sequence.into(),
-                    encoding_name: v.encoding_name.into(),
-                }),
-                InvalidJsonbCast(v) => Ok(EvalError::InvalidJsonbCast {
+                })),
+                Kind::InvalidArray(error) => Ok(EvalError::InvalidArray(error.into_rust()?)),
+                Kind::InvalidEncodingName(v) => Ok(EvalError::InvalidEncodingName(v.into())),
+                Kind::InvalidHashAlgorithm(v) => Ok(EvalError::InvalidHashAlgorithm(v.into())),
+                Kind::InvalidByteSequence(v) => {
+                    Ok(EvalError::InvalidByteSequence(InvalidByteSequence {
+                        byte_sequence: v.byte_sequence.into(),
+                        encoding_name: v.encoding_name.into(),
+                    }))
+                }
+                Kind::InvalidJsonbCast(v) => Ok(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                     from: v.from.into(),
                     to: v.to.into(),
-                }),
-                InvalidRegex(v) => Ok(EvalError::InvalidRegex(v.into())),
-                InvalidRegexFlag(v) => Ok(EvalError::InvalidRegexFlag(char::from_proto(v)?)),
-                InvalidParameterValue(v) => Ok(EvalError::InvalidParameterValue(v.into())),
-                InvalidDatePart(part) => Ok(EvalError::InvalidDatePart(part.into())),
-                KeyCannotBeNull(()) => Ok(EvalError::KeyCannotBeNull),
-                NegSqrt(()) => Ok(EvalError::NegSqrt),
-                NegLimit(()) => Ok(EvalError::NegLimit),
-                NullCharacterNotPermitted(()) => Ok(EvalError::NullCharacterNotPermitted),
-                UnknownUnits(v) => Ok(EvalError::UnknownUnits(v.into())),
-                UnsupportedUnits(v) => {
+                })),
+                Kind::InvalidRegex(v) => Ok(EvalError::InvalidRegex(v.into())),
+                Kind::InvalidRegexFlag(v) => Ok(EvalError::InvalidRegexFlag(char::from_proto(v)?)),
+                Kind::InvalidParameterValue(v) => Ok(EvalError::InvalidParameterValue(v.into())),
+                Kind::InvalidDatePart(part) => Ok(EvalError::InvalidDatePart(part.into())),
+                Kind::KeyCannotBeNull(()) => Ok(EvalError::KeyCannotBeNull),
+                Kind::NegSqrt(()) => Ok(EvalError::NegSqrt),
+                Kind::NegLimit(()) => Ok(EvalError::NegLimit),
+                Kind::NullCharacterNotPermitted(()) => Ok(EvalError::NullCharacterNotPermitted),
+                Kind::UnknownUnits(v) => Ok(EvalError::UnknownUnits(v.into())),
+                Kind::UnsupportedUnits(v) => {
                     Ok(EvalError::UnsupportedUnits(v.units.into(), v.typ.into()))
                 }
-                UnterminatedLikeEscapeSequence(()) => Ok(EvalError::UnterminatedLikeEscapeSequence),
-                Parse(error) => Ok(EvalError::Parse(error.into_rust()?)),
-                ParseHex(error) => Ok(EvalError::ParseHex(error.into_rust()?)),
-                Internal(v) => Ok(EvalError::Internal(v.into())),
-                InfinityOutOfDomain(v) => Ok(EvalError::InfinityOutOfDomain(v.into())),
-                NegativeOutOfDomain(v) => Ok(EvalError::NegativeOutOfDomain(v.into())),
-                ZeroOutOfDomain(v) => Ok(EvalError::ZeroOutOfDomain(v.into())),
-                OutOfDomain(v) => Ok(EvalError::OutOfDomain(
+                Kind::UnterminatedLikeEscapeSequence(()) => {
+                    Ok(EvalError::UnterminatedLikeEscapeSequence)
+                }
+                Kind::Parse(error) => Ok(EvalError::Parse(error.into_rust()?)),
+                Kind::ParseHex(error) => Ok(EvalError::ParseHex(error.into_rust()?)),
+                Kind::Internal(v) => Ok(EvalError::Internal(v.into())),
+                Kind::InfinityOutOfDomain(v) => Ok(EvalError::InfinityOutOfDomain(v.into())),
+                Kind::NegativeOutOfDomain(v) => Ok(EvalError::NegativeOutOfDomain(v.into())),
+                Kind::ZeroOutOfDomain(v) => Ok(EvalError::ZeroOutOfDomain(v.into())),
+                Kind::OutOfDomain(v) => Ok(EvalError::OutOfDomain(
                     v.lower.into_rust_if_some("ProtoDomainLimit::lower")?,
                     v.upper.into_rust_if_some("ProtoDomainLimit::upper")?,
                     v.id.into(),
                 )),
-                ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v.into())),
-                MultipleRowsFromSubquery(()) => Ok(EvalError::MultipleRowsFromSubquery),
-                Undefined(v) => Ok(EvalError::Undefined(v.into())),
-                LikePatternTooLong(()) => Ok(EvalError::LikePatternTooLong),
-                LikeEscapeTooLong(()) => Ok(EvalError::LikeEscapeTooLong),
-                StringValueTooLong(v) => Ok(EvalError::StringValueTooLong {
-                    target_type: v.target_type.into(),
-                    length: usize::from_proto(v.length)?,
-                }),
-                MultidimensionalArrayRemovalNotSupported(()) => {
+                Kind::ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v.into())),
+                Kind::MultipleRowsFromSubquery(()) => Ok(EvalError::MultipleRowsFromSubquery),
+                Kind::Undefined(v) => Ok(EvalError::Undefined(v.into())),
+                Kind::LikePatternTooLong(()) => Ok(EvalError::LikePatternTooLong),
+                Kind::LikeEscapeTooLong(()) => Ok(EvalError::LikeEscapeTooLong),
+                Kind::StringValueTooLong(v) => {
+                    Ok(EvalError::StringValueTooLong(StringValueTooLong {
+                        target_type: v.target_type.into(),
+                        length: usize::from_proto(v.length)?,
+                    }))
+                }
+                Kind::MultidimensionalArrayRemovalNotSupported(()) => {
                     Ok(EvalError::MultidimensionalArrayRemovalNotSupported)
                 }
-                IncompatibleArrayDimensions(v) => Ok(EvalError::IncompatibleArrayDimensions {
-                    dims: v.dims.into_rust()?,
-                }),
-                TypeFromOid(v) => Ok(EvalError::TypeFromOid(v.into())),
-                InvalidRange(e) => Ok(EvalError::InvalidRange(e.into_rust()?)),
-                InvalidRoleId(v) => Ok(EvalError::InvalidRoleId(v.into())),
-                InvalidPrivileges(v) => Ok(EvalError::InvalidPrivileges(v.into())),
-                WmrRecursionLimitExceeded(v) => Ok(EvalError::LetRecLimitExceeded(v.into())),
-                MultiDimensionalArraySearch(()) => Ok(EvalError::MultiDimensionalArraySearch),
-                MustNotBeNull(v) => Ok(EvalError::MustNotBeNull(v.into())),
-                InvalidIdentifier(v) => Ok(EvalError::InvalidIdentifier {
+                Kind::IncompatibleArrayDimensions(v) => Ok(EvalError::IncompatibleArrayDimensions(
+                    IncompatibleArrayDimensions {
+                        dims: v.dims.into_rust()?,
+                    },
+                )),
+                Kind::TypeFromOid(v) => Ok(EvalError::TypeFromOid(v.into())),
+                Kind::InvalidRange(e) => Ok(EvalError::InvalidRange(e.into_rust()?)),
+                Kind::InvalidRoleId(v) => Ok(EvalError::InvalidRoleId(v.into())),
+                Kind::InvalidPrivileges(v) => Ok(EvalError::InvalidPrivileges(v.into())),
+                Kind::WmrRecursionLimitExceeded(v) => Ok(EvalError::LetRecLimitExceeded(v.into())),
+                Kind::MultiDimensionalArraySearch(()) => Ok(EvalError::MultiDimensionalArraySearch),
+                Kind::MustNotBeNull(v) => Ok(EvalError::MustNotBeNull(v.into())),
+                Kind::InvalidIdentifier(v) => Ok(EvalError::InvalidIdentifier(InvalidIdentifier {
                     ident: v.ident.into(),
                     detail: v.detail.into_rust()?,
-                }),
-                ArrayFillWrongArraySubscripts(()) => Ok(EvalError::ArrayFillWrongArraySubscripts),
-                MaxArraySizeExceeded(max_size) => {
+                })),
+                Kind::ArrayFillWrongArraySubscripts(()) => {
+                    Ok(EvalError::ArrayFillWrongArraySubscripts)
+                }
+                Kind::MaxArraySizeExceeded(max_size) => {
                     Ok(EvalError::MaxArraySizeExceeded(usize::cast_from(max_size)))
                 }
-                DateDiffOverflow(v) => Ok(EvalError::DateDiffOverflow {
+                Kind::DateDiffOverflow(v) => Ok(EvalError::DateDiffOverflow(DateDiffOverflow {
                     unit: v.unit.into(),
                     a: v.a.into(),
                     b: v.b.into(),
-                }),
-                IfNullError(v) => Ok(EvalError::IfNullError(v.into())),
-                LengthTooLarge(()) => Ok(EvalError::LengthTooLarge),
-                AclArrayNullElement(()) => Ok(EvalError::AclArrayNullElement),
-                MzAclArrayNullElement(()) => Ok(EvalError::MzAclArrayNullElement),
-                InvalidIanaTimezoneId(s) => Ok(EvalError::InvalidIanaTimezoneId(s.into())),
-                PrettyError(s) => Ok(EvalError::PrettyError(s.into())),
+                })),
+                Kind::IfNullError(v) => Ok(EvalError::IfNullError(v.into())),
+                Kind::LengthTooLarge(()) => Ok(EvalError::LengthTooLarge),
+                Kind::AclArrayNullElement(()) => Ok(EvalError::AclArrayNullElement),
+                Kind::MzAclArrayNullElement(()) => Ok(EvalError::MzAclArrayNullElement),
+                Kind::InvalidIanaTimezoneId(s) => Ok(EvalError::InvalidIanaTimezoneId(s.into())),
+                Kind::PrettyError(s) => Ok(EvalError::PrettyError(s.into())),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
         }

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -15,6 +15,7 @@ use mz_repr::{ColumnType, Datum, Row, RowArena, RowPacker, ScalarType};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use crate::scalar::Unsupported;
 use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
 use crate::{EvalError, MirScalarExpr};
 
@@ -38,14 +39,14 @@ impl LazyUnaryFunc for CastArrayToListOneDim {
         let arr = a.unwrap_array();
         let ndims = arr.dims().ndims();
         if ndims > 1 {
-            return Err(EvalError::Unsupported {
+            return Err(EvalError::Unsupported(Unsupported {
                 feature: format!(
                     "casting multi-dimensional array to list; got array with {} dimensions",
                     ndims
                 )
                 .into(),
                 discussion_no: None,
-            });
+            }));
         }
 
         Ok(Datum::List(arr.elements()))

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::EvalError;
 use crate::func::most_significant_unit;
+use crate::scalar::Unsupported;
 use crate::scalar::func::EagerUnaryFunc;
 
 sqlfunc!(
@@ -140,10 +141,10 @@ pub fn extract_date_inner(units: DateTimeUnits, date: NaiveDate) -> Result<Numer
         DateTimeUnits::Timezone
         | DateTimeUnits::TimezoneHour
         | DateTimeUnits::TimezoneMinute
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported(Unsupported {
             feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
-        }),
+        })),
     }
 }
 

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -17,6 +17,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::EvalError;
+use crate::scalar::InvalidJsonbCast;
 use crate::scalar::func::EagerUnaryFunc;
 use crate::scalar::func::impls::numeric::*;
 
@@ -37,10 +38,10 @@ sqlfunc!(
     fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "smallint".into(),
-            }),
+            })),
         }
     }
 );
@@ -51,10 +52,10 @@ sqlfunc!(
     fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "integer".into(),
-            }),
+            })),
         }
     }
 );
@@ -65,10 +66,10 @@ sqlfunc!(
     fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "bigint".into(),
-            }),
+            })),
         }
     }
 );
@@ -79,10 +80,10 @@ sqlfunc!(
     fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "real".into(),
-            }),
+            })),
         }
     }
 );
@@ -93,10 +94,10 @@ sqlfunc!(
     fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "double precision".into(),
-            }),
+            })),
         }
     }
 );
@@ -121,10 +122,10 @@ impl<'a> EagerUnaryFunc<'a> for CastJsonbToNumeric {
                     Ok(num.into_inner())
                 }
             },
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "numeric".into(),
-            }),
+            })),
         }
     }
 
@@ -150,10 +151,10 @@ sqlfunc!(
         match a.into_datum() {
             Datum::True => Ok(true),
             Datum::False => Ok(false),
-            datum => Err(EvalError::InvalidJsonbCast {
+            datum => Err(EvalError::InvalidJsonbCast(InvalidJsonbCast {
                 from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
                 to: "boolean".into(),
-            }),
+            })),
         }
     }
 );

--- a/src/expr/src/scalar/func/impls/pg_legacy_char.rs
+++ b/src/expr/src/scalar/func/impls/pg_legacy_char.rs
@@ -15,6 +15,7 @@ use mz_repr::adt::system::PgLegacyChar;
 use mz_repr::adt::varchar::{VarChar, VarCharMaxLength};
 
 use crate::EvalError;
+use crate::scalar::InvalidByteSequence;
 
 pub fn format_pg_legacy_char<B>(buf: &mut B, c: u8) -> Result<(), EvalError>
 where
@@ -27,10 +28,10 @@ where
             buf.write_str(s);
             Ok(())
         }
-        Err(_) => Err(EvalError::InvalidByteSequence {
+        Err(_) => Err(EvalError::InvalidByteSequence(InvalidByteSequence {
             byte_sequence: format!("{:#02x}", c).into(),
             encoding_name: "UTF8".into(),
-        }),
+        })),
     }
 }
 

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_bool.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::True => Ok(true),\n            Datum::False => Ok(false),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"boolean\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_boolean\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::True => Ok(true),\n            Datum::False => Ok(false),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"boolean\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,10 +51,12 @@ pub fn cast_jsonb_to_bool<'a>(a: JsonbRef<'a>) -> Result<bool, EvalError> {
             Datum::True => Ok(true),
             Datum::False => Ok(false),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "boolean".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "boolean".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_real\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"real\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_real\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"real\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -50,10 +50,12 @@ pub fn cast_jsonb_to_float32<'a>(a: JsonbRef<'a>) -> Result<f32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float32(a.into_inner()),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "real".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "real".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_float64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_double\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"double precision\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_double\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"double precision\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -50,10 +50,12 @@ pub fn cast_jsonb_to_float64<'a>(a: JsonbRef<'a>) -> Result<f64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_float64(a.into_inner()),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "double precision".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "double precision".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"smallint\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_smallint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"smallint\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -50,10 +50,12 @@ pub fn cast_jsonb_to_int16<'a>(a: JsonbRef<'a>) -> Result<i16, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int16(a.into_inner()),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "smallint".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "smallint".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_integer\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"integer\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_integer\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"integer\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -50,10 +50,12 @@ pub fn cast_jsonb_to_int32<'a>(a: JsonbRef<'a>) -> Result<i32, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int32(a.into_inner()),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "integer".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "integer".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64.snap
+++ b/src/expr/src/scalar/func/impls/snapshots/mz_expr__scalar__func__impls__jsonb__cast_jsonb_to_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func/impls/jsonb.rs
-expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),\n            datum => {\n                Err(EvalError::InvalidJsonbCast {\n                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                    to: \"bigint\".into(),\n                })\n            }\n        }\n    }\n}\n"
+expression: "#[sqlfunc(\n    sqlname = \"jsonb_to_bigint\",\n    preserves_uniqueness = false,\n    inverse = None,\n    is_monotone = true,\n)]\n#[allow(clippy::extra_unused_lifetimes)]\npub fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {\n    {\n        match a.into_datum() {\n            Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),\n            datum => {\n                Err(\n                    EvalError::InvalidJsonbCast(InvalidJsonbCast {\n                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),\n                        to: \"bigint\".into(),\n                    }),\n                )\n            }\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -50,10 +50,12 @@ pub fn cast_jsonb_to_int64<'a>(a: JsonbRef<'a>) -> Result<i64, EvalError> {
         match a.into_datum() {
             Datum::Numeric(a) => cast_numeric_to_int64(a.into_inner()),
             datum => {
-                Err(EvalError::InvalidJsonbCast {
-                    from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
-                    to: "bigint".into(),
-                })
+                Err(
+                    EvalError::InvalidJsonbCast(InvalidJsonbCast {
+                        from: jsonb_typeof(JsonbRef::from_datum(datum)).into(),
+                        to: "bigint".into(),
+                    }),
+                )
             }
         }
     }

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -21,6 +21,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::EvalError;
+use crate::scalar::Unsupported;
 use crate::scalar::func::EagerUnaryFunc;
 
 sqlfunc!(
@@ -79,10 +80,10 @@ where
             "time".into(),
         )),
         DateTimeUnits::Timezone | DateTimeUnits::TimezoneHour | DateTimeUnits::TimezoneMinute => {
-            Err(EvalError::Unsupported {
+            Err(EvalError::Unsupported(Unsupported {
                 feature: format!("'{}' timestamp units", units).into(),
                 discussion_no: None,
-            })
+            }))
         }
     }
 }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -25,6 +25,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::EvalError;
+use crate::scalar::Unsupported;
 use crate::scalar::func::format::DateTimeFormat;
 use crate::scalar::func::{EagerUnaryFunc, TimestampLike};
 
@@ -312,10 +313,10 @@ where
         | DateTimeUnits::DayOfWeek
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported(Unsupported {
             feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
-        }),
+        })),
     }
 }
 
@@ -393,10 +394,10 @@ where
         DateTimeUnits::Timezone
         | DateTimeUnits::TimezoneHour
         | DateTimeUnits::TimezoneMinute
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported(Unsupported {
             feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
-        }),
+        })),
     }
 }
 
@@ -542,10 +543,10 @@ pub fn date_trunc_inner<T: TimestampLike>(units: DateTimeUnits, ts: &T) -> Resul
         | DateTimeUnits::DayOfWeek
         | DateTimeUnits::DayOfYear
         | DateTimeUnits::IsoDayOfWeek
-        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported {
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::Unsupported(Unsupported {
             feature: format!("'{}' timestamp units", units).into(),
             discussion_no: None,
-        }),
+        })),
     }
 }
 

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -43,7 +43,7 @@ use crate::func::{
     regexp_split_to_array_re, stringify_datum, timezone_time,
 };
 use crate::scalar::ProtoVariadicFunc;
-use crate::{EvalError, MirScalarExpr};
+use crate::{EvalError, MirScalarExpr, Unsupported};
 
 pub fn and<'a>(
     datums: &[Datum<'a>],
@@ -121,10 +121,10 @@ fn array_fill<'a>(
 
     let fill = datums[0];
     if matches!(fill, Datum::Array(_)) {
-        return Err(EvalError::Unsupported {
+        return Err(EvalError::Unsupported(Unsupported {
             feature: "array_fill with arrays".into(),
             discussion_no: None,
-        });
+        }));
     }
 
     let arr = match datums[1] {
@@ -592,10 +592,10 @@ fn make_acl_item<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
         .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string().into()))?;
     let is_grantable = datums[3].unwrap_bool();
     if is_grantable {
-        return Err(EvalError::Unsupported {
+        return Err(EvalError::Unsupported(Unsupported {
             feature: "GRANT OPTION".into(),
             discussion_no: None,
-        });
+        }));
     }
 
     Ok(Datum::AclItem(AclItem {

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_array_concat.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__array_array_concat.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn array_array_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    if a.is_null() {\n        return Ok(b);\n    } else if b.is_null() {\n        return Ok(a);\n    }\n    let a_array = a.unwrap_array();\n    let b_array = b.unwrap_array();\n    let a_dims: Vec<ArrayDimension> = a_array.dims().into_iter().collect();\n    let b_dims: Vec<ArrayDimension> = b_array.dims().into_iter().collect();\n    let a_ndims = a_dims.len();\n    let b_ndims = b_dims.len();\n    if a_ndims == 0 {\n        return Ok(b);\n    } else if b_ndims == 0 {\n        return Ok(a);\n    }\n    #[allow(clippy::as_conversions)]\n    if (a_ndims as isize - b_ndims as isize).abs() > 1 {\n        return Err(EvalError::IncompatibleArrayDimensions {\n            dims: Some((a_ndims, b_ndims)),\n        });\n    }\n    let mut dims;\n    match a_ndims.cmp(&b_ndims) {\n        Ordering::Equal => {\n            if &a_dims[1..] != &b_dims[1..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + b_dims[0].length, }\n            ];\n            dims.extend(&a_dims[1..]);\n        }\n        Ordering::Less => {\n            if &a_dims[..] != &b_dims[1..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : b_dims[0].lower_bound, length : b_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(a_dims);\n        }\n        Ordering::Greater => {\n            if &a_dims[1..] != &b_dims[..] {\n                return Err(EvalError::IncompatibleArrayDimensions {\n                    dims: None,\n                });\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(b_dims);\n        }\n    }\n    let elems = a_array.elements().iter().chain(b_array.elements().iter());\n    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)\n}\n"
+expression: "#[sqlfunc(\n    output_type_expr = \"input_type_a.scalar_type.without_modifiers().nullable(true)\",\n    is_infix_op = true,\n    sqlname = \"||\",\n    propagates_nulls = false,\n    introduces_nulls = false\n)]\nfn array_array_concat<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    if a.is_null() {\n        return Ok(b);\n    } else if b.is_null() {\n        return Ok(a);\n    }\n    let a_array = a.unwrap_array();\n    let b_array = b.unwrap_array();\n    let a_dims: Vec<ArrayDimension> = a_array.dims().into_iter().collect();\n    let b_dims: Vec<ArrayDimension> = b_array.dims().into_iter().collect();\n    let a_ndims = a_dims.len();\n    let b_ndims = b_dims.len();\n    if a_ndims == 0 {\n        return Ok(b);\n    } else if b_ndims == 0 {\n        return Ok(a);\n    }\n    #[allow(clippy::as_conversions)]\n    if (a_ndims as isize - b_ndims as isize).abs() > 1 {\n        return Err(\n            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {\n                dims: Some((a_ndims, b_ndims)),\n            }),\n        );\n    }\n    let mut dims;\n    match a_ndims.cmp(&b_ndims) {\n        Ordering::Equal => {\n            if &a_dims[1..] != &b_dims[1..] {\n                return Err(\n                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {\n                        dims: None,\n                    }),\n                );\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + b_dims[0].length, }\n            ];\n            dims.extend(&a_dims[1..]);\n        }\n        Ordering::Less => {\n            if &a_dims[..] != &b_dims[1..] {\n                return Err(\n                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {\n                        dims: None,\n                    }),\n                );\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : b_dims[0].lower_bound, length : b_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(a_dims);\n        }\n        Ordering::Greater => {\n            if &a_dims[1..] != &b_dims[..] {\n                return Err(\n                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {\n                        dims: None,\n                    }),\n                );\n            }\n            dims = vec![\n                ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]\n                .length + 1, }\n            ];\n            dims.extend(b_dims);\n        }\n    }\n    let elems = a_array.elements().iter().chain(b_array.elements().iter());\n    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, elems))?)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -84,17 +84,21 @@ fn array_array_concat<'a>(
     }
     #[allow(clippy::as_conversions)]
     if (a_ndims as isize - b_ndims as isize).abs() > 1 {
-        return Err(EvalError::IncompatibleArrayDimensions {
-            dims: Some((a_ndims, b_ndims)),
-        });
+        return Err(
+            EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {
+                dims: Some((a_ndims, b_ndims)),
+            }),
+        );
     }
     let mut dims;
     match a_ndims.cmp(&b_ndims) {
         Ordering::Equal => {
             if &a_dims[1..] != &b_dims[1..] {
-                return Err(EvalError::IncompatibleArrayDimensions {
-                    dims: None,
-                });
+                return Err(
+                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {
+                        dims: None,
+                    }),
+                );
             }
             dims = vec![
                 ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]
@@ -104,9 +108,11 @@ fn array_array_concat<'a>(
         }
         Ordering::Less => {
             if &a_dims[..] != &b_dims[1..] {
-                return Err(EvalError::IncompatibleArrayDimensions {
-                    dims: None,
-                });
+                return Err(
+                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {
+                        dims: None,
+                    }),
+                );
             }
             dims = vec![
                 ArrayDimension { lower_bound : b_dims[0].lower_bound, length : b_dims[0]
@@ -116,9 +122,11 @@ fn array_array_concat<'a>(
         }
         Ordering::Greater => {
             if &a_dims[1..] != &b_dims[..] {
-                return Err(EvalError::IncompatibleArrayDimensions {
-                    dims: None,
-                });
+                return Err(
+                    EvalError::IncompatibleArrayDimensions(IncompatibleArrayDimensions {
+                        dims: None,
+                    }),
+                );
             }
             dims = vec![
                 ArrayDimension { lower_bound : a_dims[0].lower_bound, length : a_dims[0]

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__convert_from.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"String\", sqlname = \"convert_from\", propagates_nulls = true)]\nfn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some(\"utf-8\") {\n        return Err(EvalError::InvalidEncodingName(encoding_name));\n    }\n    match str::from_utf8(a.unwrap_bytes()) {\n        Ok(from) => Ok(Datum::String(from)),\n        Err(e) => {\n            Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.to_string().into(),\n                encoding_name,\n            })\n        }\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"String\", sqlname = \"convert_from\", propagates_nulls = true)]\nfn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    if encoding_from_whatwg_label(&encoding_name).map(|e| e.name()) != Some(\"utf-8\") {\n        return Err(EvalError::InvalidEncodingName(encoding_name));\n    }\n    match str::from_utf8(a.unwrap_bytes()) {\n        Ok(from) => Ok(Datum::String(from)),\n        Err(e) => {\n            Err(\n                EvalError::InvalidByteSequence(InvalidByteSequence {\n                    byte_sequence: e.to_string().into(),\n                    encoding_name,\n                }),\n            )\n        }\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -66,10 +66,12 @@ fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> 
     match str::from_utf8(a.unwrap_bytes()) {
         Ok(from) => Ok(Datum::String(from)),
         Err(e) => {
-            Err(EvalError::InvalidByteSequence {
-                byte_sequence: e.to_string().into(),
-                encoding_name,
-            })
+            Err(
+                EvalError::InvalidByteSequence(InvalidByteSequence {
+                    byte_sequence: e.to_string().into(),
+                    encoding_name,
+                }),
+            )
         }
     }
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__encoded_bytes_char_length.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"i32\", sqlname = \"length\", propagates_nulls = true)]\nfn encoded_bytes_char_length<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    let enc = match encoding_from_whatwg_label(&encoding_name) {\n        Some(enc) => enc,\n        None => return Err(EvalError::InvalidEncodingName(encoding_name)),\n    };\n    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {\n        Ok(s) => s,\n        Err(e) => {\n            return Err(EvalError::InvalidByteSequence {\n                byte_sequence: e.into(),\n                encoding_name,\n            });\n        }\n    };\n    let count = decoded_string.chars().count();\n    match i32::try_from(count) {\n        Ok(l) => Ok(Datum::from(l)),\n        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n    }\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", sqlname = \"length\", propagates_nulls = true)]\nfn encoded_bytes_char_length<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n) -> Result<Datum<'a>, EvalError> {\n    let encoding_name = b.unwrap_str().to_lowercase().replace('_', \"-\").into_boxed_str();\n    let enc = match encoding_from_whatwg_label(&encoding_name) {\n        Some(enc) => enc,\n        None => return Err(EvalError::InvalidEncodingName(encoding_name)),\n    };\n    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {\n        Ok(s) => s,\n        Err(e) => {\n            return Err(\n                EvalError::InvalidByteSequence(InvalidByteSequence {\n                    byte_sequence: e.into(),\n                    encoding_name,\n                }),\n            );\n        }\n    };\n    let count = decoded_string.chars().count();\n    match i32::try_from(count) {\n        Ok(l) => Ok(Datum::from(l)),\n        Err(_) => Err(EvalError::Int32OutOfRange(count.to_string().into())),\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -70,10 +70,12 @@ fn encoded_bytes_char_length<'a>(
     let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {
         Ok(s) => s,
         Err(e) => {
-            return Err(EvalError::InvalidByteSequence {
-                byte_sequence: e.into(),
-                encoding_name,
-            });
+            return Err(
+                EvalError::InvalidByteSequence(InvalidByteSequence {
+                    byte_sequence: e.into(),
+                    encoding_name,
+                }),
+            );
         }
     };
     let count = decoded_string.chars().count();

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_bit.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,\n    };\n    let index = usize::try_from(index).map_err(|_| err.clone())?;\n    let byte_index = index / 8;\n    let bit_index = index % 8;\n    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;\n    assert!(i == 0 || i == 1);\n    Ok(Datum::from(i32::from(i)))\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange(IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,\n    });\n    let index = usize::try_from(index).map_err(|_| err.clone())?;\n    let byte_index = index / 8;\n    let bit_index = index % 8;\n    let i = bytes.get(byte_index).map(|b| (*b >> bit_index) & 1).ok_or(err)?;\n    assert!(i == 0 || i == 1);\n    Ok(Datum::from(i32::from(i)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -61,10 +61,10 @@ impl std::fmt::Display for GetBit {
 fn get_bit<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let bytes = a.unwrap_bytes();
     let index = b.unwrap_int32();
-    let err = EvalError::IndexOutOfRange {
+    let err = EvalError::IndexOutOfRange(IndexOutOfRange {
         provided: index,
         valid_end: i32::try_from(bytes.len().saturating_mul(8)).unwrap() - 1,
-    };
+    });
     let index = usize::try_from(index).map_err(|_| err.clone())?;
     let byte_index = index / 8;
     let bit_index = index % 8;

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__get_byte.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len()).unwrap() - 1,\n    };\n    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;\n    Ok(Datum::from(i32::from(*i)))\n}\n"
+expression: "#[sqlfunc(output_type = \"i32\", propagates_nulls = true)]\nfn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let bytes = a.unwrap_bytes();\n    let index = b.unwrap_int32();\n    let err = EvalError::IndexOutOfRange(IndexOutOfRange {\n        provided: index,\n        valid_end: i32::try_from(bytes.len()).unwrap() - 1,\n    });\n    let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;\n    Ok(Datum::from(i32::from(*i)))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -61,10 +61,10 @@ impl std::fmt::Display for GetByte {
 fn get_byte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let bytes = a.unwrap_bytes();
     let index = b.unwrap_int32();
-    let err = EvalError::IndexOutOfRange {
+    let err = EvalError::IndexOutOfRange(IndexOutOfRange {
         provided: index,
         valid_end: i32::try_from(bytes.len()).unwrap() - 1,
-    };
+    });
     let i: &u8 = bytes.get(usize::try_from(index).map_err(|_| err.clone())?).ok_or(err)?;
     Ok(Datum::from(i32::from(*i)))
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__parse_ident.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__parse_ident.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(output_type = \"mz_repr::ArrayRustType<String>\", propagates_nulls = true)]\nfn parse_ident<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    fn is_ident_start(c: char) -> bool {\n        matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '\\u{80}'..= char::MAX)\n    }\n    fn is_ident_cont(c: char) -> bool {\n        matches!(c, '0'..='9' | '$') || is_ident_start(c)\n    }\n    let ident = a.unwrap_str();\n    let strict = b.unwrap_bool();\n    let mut elems = vec![];\n    let buf = &mut LexBuf::new(ident);\n    let mut after_dot = false;\n    buf.take_while(|ch| ch.is_ascii_whitespace());\n    loop {\n        let mut missing_ident = true;\n        let c = buf.next();\n        if c == Some('\"') {\n            let s = buf.take_while(|ch| !matches!(ch, '\"'));\n            if buf.next() != Some('\"') {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"String has unclosed double quotes.\".into()),\n                });\n            }\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        } else if c.map(is_ident_start).unwrap_or(false) {\n            buf.prev();\n            let s = buf.take_while(is_ident_cont);\n            let s = temp_storage.push_string(s.to_ascii_lowercase());\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        }\n        if missing_ident {\n            if c == Some('.') {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"No valid identifier before \\\".\\\".\".into()),\n                });\n            } else if after_dot {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: Some(\"No valid identifier after \\\".\\\".\".into()),\n                });\n            } else {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: None,\n                });\n            }\n        }\n        buf.take_while(|ch| ch.is_ascii_whitespace());\n        match buf.next() {\n            Some('.') => {\n                after_dot = true;\n                buf.take_while(|ch| ch.is_ascii_whitespace());\n            }\n            Some(_) if strict => {\n                return Err(EvalError::InvalidIdentifier {\n                    ident: ident.into(),\n                    detail: None,\n                });\n            }\n            _ => break,\n        }\n    }\n    Ok(\n        temp_storage\n            .try_make_datum(|packer| {\n                packer\n                    .try_push_array(\n                        &[\n                            ArrayDimension {\n                                lower_bound: 1,\n                                length: elems.len(),\n                            },\n                        ],\n                        elems,\n                    )\n            })?,\n    )\n}\n"
+expression: "#[sqlfunc(output_type = \"mz_repr::ArrayRustType<String>\", propagates_nulls = true)]\nfn parse_ident<'a>(\n    a: Datum<'a>,\n    b: Datum<'a>,\n    temp_storage: &'a RowArena,\n) -> Result<Datum<'a>, EvalError> {\n    fn is_ident_start(c: char) -> bool {\n        matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '\\u{80}'..= char::MAX)\n    }\n    fn is_ident_cont(c: char) -> bool {\n        matches!(c, '0'..='9' | '$') || is_ident_start(c)\n    }\n    let ident = a.unwrap_str();\n    let strict = b.unwrap_bool();\n    let mut elems = vec![];\n    let buf = &mut LexBuf::new(ident);\n    let mut after_dot = false;\n    buf.take_while(|ch| ch.is_ascii_whitespace());\n    loop {\n        let mut missing_ident = true;\n        let c = buf.next();\n        if c == Some('\"') {\n            let s = buf.take_while(|ch| !matches!(ch, '\"'));\n            if buf.next() != Some('\"') {\n                return Err(\n                    EvalError::InvalidIdentifier(InvalidIdentifier {\n                        ident: ident.into(),\n                        detail: Some(\"String has unclosed double quotes.\".into()),\n                    }),\n                );\n            }\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        } else if c.map(is_ident_start).unwrap_or(false) {\n            buf.prev();\n            let s = buf.take_while(is_ident_cont);\n            let s = temp_storage.push_string(s.to_ascii_lowercase());\n            elems.push(Datum::String(s));\n            missing_ident = false;\n        }\n        if missing_ident {\n            if c == Some('.') {\n                return Err(\n                    EvalError::InvalidIdentifier(InvalidIdentifier {\n                        ident: ident.into(),\n                        detail: Some(\"No valid identifier before \\\".\\\".\".into()),\n                    }),\n                );\n            } else if after_dot {\n                return Err(\n                    EvalError::InvalidIdentifier(InvalidIdentifier {\n                        ident: ident.into(),\n                        detail: Some(\"No valid identifier after \\\".\\\".\".into()),\n                    }),\n                );\n            } else {\n                return Err(\n                    EvalError::InvalidIdentifier(InvalidIdentifier {\n                        ident: ident.into(),\n                        detail: None,\n                    }),\n                );\n            }\n        }\n        buf.take_while(|ch| ch.is_ascii_whitespace());\n        match buf.next() {\n            Some('.') => {\n                after_dot = true;\n                buf.take_while(|ch| ch.is_ascii_whitespace());\n            }\n            Some(_) if strict => {\n                return Err(\n                    EvalError::InvalidIdentifier(InvalidIdentifier {\n                        ident: ident.into(),\n                        detail: None,\n                    }),\n                );\n            }\n            _ => break,\n        }\n    }\n    Ok(\n        temp_storage\n            .try_make_datum(|packer| {\n                packer\n                    .try_push_array(\n                        &[\n                            ArrayDimension {\n                                lower_bound: 1,\n                                length: elems.len(),\n                            },\n                        ],\n                        elems,\n                    )\n            })?,\n    )\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -81,10 +81,12 @@ fn parse_ident<'a>(
         if c == Some('"') {
             let s = buf.take_while(|ch| !matches!(ch, '"'));
             if buf.next() != Some('"') {
-                return Err(EvalError::InvalidIdentifier {
-                    ident: ident.into(),
-                    detail: Some("String has unclosed double quotes.".into()),
-                });
+                return Err(
+                    EvalError::InvalidIdentifier(InvalidIdentifier {
+                        ident: ident.into(),
+                        detail: Some("String has unclosed double quotes.".into()),
+                    }),
+                );
             }
             elems.push(Datum::String(s));
             missing_ident = false;
@@ -97,20 +99,26 @@ fn parse_ident<'a>(
         }
         if missing_ident {
             if c == Some('.') {
-                return Err(EvalError::InvalidIdentifier {
-                    ident: ident.into(),
-                    detail: Some("No valid identifier before \".\".".into()),
-                });
+                return Err(
+                    EvalError::InvalidIdentifier(InvalidIdentifier {
+                        ident: ident.into(),
+                        detail: Some("No valid identifier before \".\".".into()),
+                    }),
+                );
             } else if after_dot {
-                return Err(EvalError::InvalidIdentifier {
-                    ident: ident.into(),
-                    detail: Some("No valid identifier after \".\".".into()),
-                });
+                return Err(
+                    EvalError::InvalidIdentifier(InvalidIdentifier {
+                        ident: ident.into(),
+                        detail: Some("No valid identifier after \".\".".into()),
+                    }),
+                );
             } else {
-                return Err(EvalError::InvalidIdentifier {
-                    ident: ident.into(),
-                    detail: None,
-                });
+                return Err(
+                    EvalError::InvalidIdentifier(InvalidIdentifier {
+                        ident: ident.into(),
+                        detail: None,
+                    }),
+                );
             }
         }
         buf.take_while(|ch| ch.is_ascii_whitespace());
@@ -120,10 +128,12 @@ fn parse_ident<'a>(
                 buf.take_while(|ch| ch.is_ascii_whitespace());
             }
             Some(_) if strict => {
-                return Err(EvalError::InvalidIdentifier {
-                    ident: ident.into(),
-                    detail: None,
-                });
+                return Err(
+                    EvalError::InvalidIdentifier(InvalidIdentifier {
+                        ident: ident.into(),
+                        detail: None,
+                    }),
+                );
             }
             _ => break,
         }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -24,7 +24,7 @@ bytes = { version = "1.10.1", optional = true }
 chrono = { version = "0.4.39", default-features = false, features = ["std"], optional = true }
 clap = { version = "4.5.23", features = ["env", "string"], optional = true }
 columnation = { version = "0.1.0", optional = true }
-columnar = { version = "0.10.1", optional = true }
+columnar = { version = "0.10.2", optional = true }
 compact_bytes = { version = "0.2.1", optional = true }
 ctor = { version = "0.4.2", optional = true }
 differential-dataflow = { version = "0.17.0", optional = true }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = "1.3.2"
 bytemuck = { version = "1.23.1", features = ["latest_stable_rust"] }
 bytes = "1.10.1"
 cfg-if = "1.0.1"
-columnar = "0.10.1"
+columnar = "0.10.2"
 columnation = "0.1.0"
 chrono = { version = "0.4.39", default-features = false, features = ["serde", "std"] }
 compact_bytes = "0.2.1"

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -15,6 +15,7 @@ use std::hash::{Hash, Hasher};
 
 use bitflags::bitflags;
 use chrono::{DateTime, NaiveDateTime, Utc};
+use columnar::Columnar;
 use dec::OrderedDecimal;
 use mz_lowertest::MzReflect;
 use mz_proto::{RustType, TryFromProtoError};
@@ -739,7 +740,18 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
 }
 
 #[derive(
-    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
 )]
 pub enum InvalidRangeError {
     MisorderedRangeBounds,

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 
 use crate::adt::array::{
     Array, ArrayDimension, ArrayDimensions, InvalidArrayError, MAX_ARRAY_DIMENSIONS,
+    WrongCardinality,
 };
 use crate::adt::date::Date;
 use crate::adt::interval::Interval;
@@ -2267,10 +2268,10 @@ impl RowPacker<'_> {
         };
         if nelements != cardinality {
             self.row.data.truncate(start);
-            return Err(InvalidArrayError::WrongCardinality {
+            return Err(InvalidArrayError::WrongCardinality(WrongCardinality {
                 actual: nelements,
                 expected: cardinality,
-            }
+            })
             .into());
         }
 
@@ -2342,10 +2343,10 @@ impl RowPacker<'_> {
         };
         if nelements != cardinality {
             self.row.data.truncate(start);
-            return Err(InvalidArrayError::WrongCardinality {
+            return Err(InvalidArrayError::WrongCardinality(WrongCardinality {
                 actual: nelements,
                 expected: cardinality,
-            });
+            }));
         }
 
         Ok(())
@@ -3164,10 +3165,10 @@ mod tests {
         );
         assert_eq!(
             res,
-            Err(InvalidArrayError::WrongCardinality {
+            Err(InvalidArrayError::WrongCardinality(WrongCardinality {
                 actual: 2,
                 expected: 6,
-            })
+            }))
         );
         assert!(row.data.is_empty());
     }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -33,6 +33,7 @@ use std::sync::LazyLock;
 
 use chrono::offset::{Offset, TimeZone};
 use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+use columnar::Columnar;
 use dec::OrderedDecimal;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::ReinterpretCast;
@@ -1929,7 +1930,18 @@ where
 
 /// An error while parsing an input as a type.
 #[derive(
-    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
+    Columnar,
 )]
 pub struct ParseError {
     pub kind: ParseErrorKind,
@@ -1951,6 +1963,7 @@ pub struct ParseError {
     Deserialize,
     Hash,
     MzReflect,
+    Columnar,
 )]
 pub enum ParseErrorKind {
     OutOfRange,
@@ -2072,6 +2085,7 @@ impl RustType<ProtoParseError> for ParseError {
     Deserialize,
     Hash,
     MzReflect,
+    Columnar,
 )]
 pub enum ParseHexError {
     InvalidHexDigit(char),

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -19,6 +19,7 @@ aws-smithy-types = "1.1.8"
 aws-sdk-s3 = { version = "1.48.0", default-features = false }
 bytes = "1.10.1"
 bytesize = "1.3.0"
+columnar = "0.10.2"
 csv-async = { version = "1.3.1", features = ["tokio"] }
 derivative = "2.2.0"
 differential-dataflow = "0.17.0"

--- a/src/storage-operators/src/lib.rs
+++ b/src/storage-operators/src/lib.rs
@@ -9,6 +9,8 @@
 
 //! Shared Storage dataflow operators
 
+#![recursion_limit = "256"]
+
 pub mod metrics;
 pub mod oneshot_source;
 pub mod persist_source;

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -22,6 +22,7 @@ aws-credential-types = { version = "1.2.4", features = ["hardcoded-credentials"]
 aws-sdk-sts = { version = "1.41.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.3.7"
 bytes = "1.10.1"
+columnar = "0.10.2"
 columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -22,6 +22,7 @@ bytesize = "1.3.0"
 bincode = "1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
+columnar = "0.10.2"
 columnation = "0.1.0"
 crossbeam-channel = "0.5.15"
 csv-core = { version = "0.1.12" }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -10,6 +10,7 @@
 //! Materialize's storage layer.
 
 #![warn(missing_docs)]
+#![recursion_limit = "256"]
 
 pub mod decode;
 pub mod internal_control;

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -313,12 +313,7 @@ where
                             async {},
                             error_handler,
                         );
-                        (
-                            stream.as_collection(),
-                            Some(tok),
-                            feedback_handle,
-                            backpressure_metrics,
-                        )
+                        (stream, Some(tok), feedback_handle, backpressure_metrics)
                     };
 
                     let export_statistics = storage_state

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 ahash = { version = "0.8.12", default-features = false }
 bincode = "1.3.3"
 bytemuck = "1.23.1"
-columnar = "0.10.1"
+columnar = "0.10.2"
 columnation = "0.1.0"
 differential-dataflow = "0.17.0"
 either = "1"

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -73,13 +73,13 @@ decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallib
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_storage_types::errors::DataflowError,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 granular_backpressure(u1)  shard_source_descs_return(u1)  alloc::vec::Vec<core::convert::Infallible>
-granular_backpressure(u1)  txns_progress_frontiers(u1)  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
-persist_source::decode_and_mfp(u1)  InspectBatch  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+granular_backpressure(u1)  txns_progress_frontiers(u1)  mz_timely_util::columnar::Column<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+persist_source::decode_and_mfp(u1)  InspectBatch  mz_timely_util::columnar::Column<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
 persist_source_backpressure(backpressure(u1))  shard_source_fetch(u1)  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 shard_source_descs(u1)  granular_backpressure(u1)  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 shard_source_fetch(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 shard_source_fetch(u1)  persist_source::decode_and_mfp(u1)  alloc::vec::Vec<mz_persist_client::fetch::FetchedBlob<mz_storage_types::sources::SourceData,␠(),␠mz_repr::timestamp::Timestamp,␠i64>>
-txns_progress_frontiers(u1)  OkErr  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+txns_progress_frontiers(u1)  OkErr  mz_timely_util::columnar::Column<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
 txns_progress_source(u1)  FlatMap  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 
 query IT rowsort
@@ -98,7 +98,7 @@ GROUP BY type;
 2  alloc::vec::Vec<(u64,␠mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
-4  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+4  mz_timely_util::columnar::Column<(core::result::Result<mz_repr::row::Row,␠mz_storage_types::errors::DataflowError>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
 5  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_storage_types::errors::DataflowError,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 5  alloc::vec::Vec<core::convert::Infallible>
 6  alloc::vec::Vec<(mz_storage_types::errors::DataflowError,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>


### PR DESCRIPTION
Support columnar data in the persist source.

This PR adds support for encoding data in the persist source as columnar. To get there, we need to derive Columnar for DataflowError and all types it depends on, which also requires some changes to columnar itself.

See https://github.com/frankmcsherry/columnar/pull/64 for the columnar changes.
