### PR TITLE
Allow setting annotations/labels on environmentd/clusterd/serviceaccount

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -82,8 +82,11 @@ pub mod v1alpha1 {
         pub environmentd_extra_args: Option<Vec<String>>,
         // Extra environment variables to pass to the environmentd binary
         pub environmentd_extra_env: Option<Vec<EnvVar>>,
+        // DEPRECATED
         // If running in AWS, override the IAM role to use to give
-        // environmentd access to the persist S3 bucket
+        // environmentd access to the persist S3 bucket.
+        // DEPRECATED
+        // Use `service_account_annotations` to set "eks.amazonaws.com/role-arn" instead.
         pub environmentd_iam_role_arn: Option<String>,
         // If running in AWS, override the IAM role to use to support
         // the CREATE CONNECTION feature
@@ -100,6 +103,19 @@ pub mod v1alpha1 {
         // Name of the kubernetes service account to use.
         // If not set, we will create one with the same name as this Materialize object.
         pub service_account_name: Option<String>,
+        // Annotations to apply to the service account
+        //
+        // Annotations on service accounts are commonly used by cloud providers for IAM.
+        // AWS uses "eks.amazonaws.com/role-arn".
+        // Azure uses "azure.workload.identity/client-id", but
+        // additionally requires "azure.workload.identity/use": "true" on the pods.
+        pub service_account_annotations: Option<BTreeMap<String, String>>,
+        // Labels to apply to the service account
+        pub service_account_labels: Option<BTreeMap<String, String>>,
+        // Annotations to apply to the pods
+        pub pod_annotations: Option<BTreeMap<String, String>>,
+        // Labels to apply to the pods
+        pub pod_labels: Option<BTreeMap<String, String>>,
 
         // When changes are made to the environmentd resources (either via
         // modifying fields in the spec here or by deploying a new

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -182,6 +182,10 @@ pub struct Args {
     /// Name of a non-default Kubernetes scheduler, if any.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SCHEDULER_NAME")]
     orchestrator_kubernetes_scheduler_name: Option<String>,
+    /// Annotations to apply to all services created by the Kubernetes orchestrator
+    /// in the form `KEY=VALUE`.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_ANNOTATION")]
+    orchestrator_kubernetes_service_annotation: Vec<KeyValueArg<String, String>>,
     /// Labels to apply to all services created by the Kubernetes orchestrator
     /// in the form `KEY=VALUE`.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_LABEL")]
@@ -801,6 +805,11 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     .block_on(KubernetesOrchestrator::new(KubernetesOrchestratorConfig {
                         context: args.orchestrator_kubernetes_context.clone(),
                         scheduler_name: args.orchestrator_kubernetes_scheduler_name,
+                        service_annotations: args
+                            .orchestrator_kubernetes_service_annotation
+                            .into_iter()
+                            .map(|l| (l.key, l.value))
+                            .collect(),
                         service_labels: args
                             .orchestrator_kubernetes_service_label
                             .into_iter()

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -73,6 +73,8 @@ pub struct KubernetesOrchestratorConfig {
     pub context: String,
     /// The name of a non-default Kubernetes scheduler to use, if any.
     pub scheduler_name: Option<String>,
+    /// Annotations to install on every service created by the orchestrator.
+    pub service_annotations: BTreeMap<String, String>,
     /// Labels to install on every service created by the orchestrator.
     pub service_labels: BTreeMap<String, String>,
     /// Node selector to install on every service created by the orchestrator.
@@ -844,6 +846,9 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 pod_annotations.insert("prometheus.io/path".to_owned(), "/metrics".to_string());
                 pod_annotations.insert("prometheus.io/scheme".to_owned(), "http".to_string());
             }
+        }
+        for (key, value) in &self.config.service_annotations {
+            pod_annotations.insert(key.clone(), value.clone());
         }
 
         let default_node_selector = if disk {

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -44,7 +44,7 @@ use reqwest::StatusCode;
 use semver::{BuildMetadata, Prerelease, Version};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tracing::trace;
+use tracing::{trace, warn};
 
 use super::matching_image_from_environmentd_image_ref;
 use crate::controller::materialize::tls::{create_certificate, issuer_ref_defined};
@@ -72,6 +72,13 @@ static V147_DEV0: LazyLock<Version> = LazyLock::new(|| Version {
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
 });
 const V153: Version = Version::new(0, 153, 0);
+static V154_DEV0: LazyLock<Version> = LazyLock::new(|| Version {
+    major: 0,
+    minor: 154,
+    patch: 0,
+    pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+    build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+});
 
 /// Describes the status of a deployment.
 ///
@@ -646,21 +653,34 @@ fn create_service_account_object(
     mz: &Materialize,
 ) -> Option<ServiceAccount> {
     if mz.create_service_account() {
-        let annotations = match (
+        let mut annotations: BTreeMap<String, String> = mz
+            .spec
+            .service_account_annotations
+            .clone()
+            .unwrap_or_default();
+        if let (CloudProvider::Aws, Some(role_arn)) = (
             config.cloud_provider,
             mz.spec
                 .environmentd_iam_role_arn
                 .as_deref()
                 .or(config.aws_info.environmentd_iam_role_arn.as_deref()),
         ) {
-            (CloudProvider::Aws, Some(role_arn)) => Some(btreemap! {
-                "eks.amazonaws.com/role-arn".to_string() => role_arn.to_string()
-            }),
-            _ => None,
+            warn!(
+                "Use of Materialize.spec.environmentd_iam_role_arn is deprecated. Please set \"eks.amazonaws.com/role-arn\" in Materialize.spec.service_account_annotations instead."
+            );
+            annotations.insert(
+                "eks.amazonaws.com/role-arn".to_string(),
+                role_arn.to_string(),
+            );
         };
+
+        let mut labels = mz.default_labels();
+        labels.extend(mz.spec.service_account_labels.clone().unwrap_or_default());
+
         Some(ServiceAccount {
             metadata: ObjectMeta {
-                annotations,
+                annotations: Some(annotations),
+                labels: Some(labels),
                 ..mz.managed_resource_meta(mz.service_account_name())
             },
             ..Default::default()
@@ -1115,11 +1135,30 @@ fn create_environmentd_statefulset_object(
             scheduler_name
         ));
     }
-    for (key, val) in mz.default_labels() {
-        args.push(format!(
-            "--orchestrator-kubernetes-service-label={key}={val}"
-        ));
+    if mz.meets_minimum_version(&V154_DEV0) {
+        args.extend(
+            mz.spec
+                .pod_annotations
+                .as_ref()
+                .map(|annotations| annotations.iter())
+                .unwrap_or_default()
+                .map(|(key, val)| {
+                    format!("--orchestrator-kubernetes-service-annotation={key}={val}")
+                }),
+        );
     }
+    args.extend(
+        mz.default_labels()
+            .iter()
+            .chain(
+                mz.spec
+                    .pod_labels
+                    .as_ref()
+                    .map(|labels| labels.iter())
+                    .unwrap_or_default(),
+            )
+            .map(|(key, val)| format!("--orchestrator-kubernetes-service-label={key}={val}")),
+    );
     if let Some(status) = &mz.status {
         args.push(format!(
             "--orchestrator-kubernetes-name-prefix=mz{}-",
@@ -1402,6 +1441,14 @@ fn create_environmentd_statefulset_object(
         mz.environmentd_app_name(),
     );
     pod_template_labels.insert("app".to_owned(), "environmentd".to_string());
+    pod_template_labels.extend(
+        mz.spec
+            .pod_labels
+            .as_ref()
+            .map(|labels| labels.iter())
+            .unwrap_or_default()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
 
     let mut pod_template_annotations = btreemap! {
         // We can re-enable eviction once we have HA
@@ -1437,6 +1484,14 @@ fn create_environmentd_statefulset_object(
             "/metrics/mz_storage".to_string(),
         );
     }
+    pod_template_annotations.extend(
+        mz.spec
+            .pod_annotations
+            .as_ref()
+            .map(|annotations| annotations.iter())
+            .unwrap_or_default()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
 
     let mut tolerations = vec![
         // When the node becomes `NotReady` it indicates there is a problem with the node,


### PR DESCRIPTION
Allow setting user-defined annotations and labels on environmentd pods, clusterd pods, and the service account.

### Motivation

On the path toward cloud-agnosticism and deprecating the `environmentd_iam_role_arn` field, we need a cloud-agnostic way of handling IAM. AWS and Azure both map roles to service accounts using annotations on the service account. Azure also needs labels on the pods.

For consistency, allow setting both annotations and labels on all these objects.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
