### PR TITLE
Do `least_valid_read` on `ReadHolds` instead of `Catalog`

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -72,7 +72,7 @@ use crate::util::{ClientTransmitter, ResultExt};
 use crate::webhook::{
     AppendWebhookResponse, AppendWebhookValidator, WebhookAppender, WebhookAppenderInvalidator,
 };
-use crate::{AppendWebhookError, ExecuteContext, TimestampProvider, catalog, metrics};
+use crate::{AppendWebhookError, ExecuteContext, catalog, metrics};
 
 use super::ExecuteContextExtra;
 
@@ -1221,7 +1221,7 @@ impl Coordinator {
                 // after its creation might see input changes that happened after the CRATE MATERIALIZED
                 // VIEW statement returned.
                 let oracle_timestamp = timestamp;
-                let least_valid_read = self.least_valid_read(&read_holds);
+                let least_valid_read = read_holds.least_valid_read();
                 timestamp.advance_by(least_valid_read.borrow());
 
                 if oracle_timestamp != timestamp {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -64,7 +64,7 @@ use crate::session::{Session, Transaction, TransactionOps};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::telemetry::{EventDetails, SegmentClientExt};
 use crate::util::ResultExt;
-use crate::{AdapterError, ExecuteContext, TimestampProvider, catalog, flags};
+use crate::{AdapterError, ExecuteContext, catalog, flags};
 
 impl Coordinator {
     /// Same as [`Self::catalog_transact_conn`] but takes a [`Session`].
@@ -1280,7 +1280,7 @@ impl Coordinator {
         // TODO: Maybe in the future, pass those holds on to storage, to hold on
         // to them and downgrade when possible?
         let read_holds = self.acquire_read_holds(&id_bundle);
-        let as_of = self.least_valid_read(&read_holds);
+        let as_of = read_holds.least_valid_read();
 
         let storage_sink_from_entry = self.catalog().get_entry_by_global_id(&sink.from);
         let storage_sink_desc = mz_storage_types::sinks::StorageSinkDesc {

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -33,7 +33,7 @@ use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::optimize::dataflows::dataflow_import_id_bundle;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;
-use crate::{AdapterNotice, ExecuteContext, TimestampProvider, catalog};
+use crate::{AdapterNotice, ExecuteContext, catalog};
 
 impl Staged for CreateIndexStage {
     type Ctx = ExecuteContext;
@@ -484,7 +484,7 @@ impl Coordinator {
                     // TODO: Maybe in the future, pass those holds on to compute, to
                     // hold on to them and downgrade when possible?
                     let read_holds = coord.acquire_read_holds(&id_bundle);
-                    let since = coord.least_valid_read(&read_holds);
+                    let since = read_holds.least_valid_read();
                     df_desc.set_as_of(since);
 
                     coord

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -762,7 +762,7 @@ impl Coordinator {
 
         // For non-REFRESH MVs both the `dataflow_as_of` and the `storage_as_of` should be simply
         // `least_valid_read`.
-        let least_valid_read = self.least_valid_read(read_holds);
+        let least_valid_read = read_holds.least_valid_read();
         let mut dataflow_as_of = least_valid_read.clone();
         let mut storage_as_of = least_valid_read.clone();
 


### PR DESCRIPTION
`least_valid_read` doesn't need access to any `Catalog` state; it can be done simply on `ReadHolds`. This PR modifies all call sites of `Catalog::least_valid_read` to instead call `ReadHolds::least_valid_read` directly, and deletes `Catalog::least_valid_read`. This makes the code at these call sites easier to use from outside the Coordinator, and thus works towards the [Small Coordinator vision](https://github.com/aljoscha/materialize/blob/design-small-coordinator/doc/developer/design/20250717_a_small_coordinator_more_scalable_isolated_materialize.md#processing-selects), specifically https://github.com/MaterializeInc/database-issues/issues/9593.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
