### PR TITLE
tests: Fix up test/nightly/rq pipelines (2025-08-18)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -747,6 +747,21 @@ steps:
         agents:
           queue: hetzner-aarch64-16cpu-32gb
 
+      - id: sql-server-cdc-old-syntax
+        label: "SQL Server CDC old syntax tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 120
+        inputs: [test/sql-server-cdc-old-syntax]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sql-server-cdc-old-syntax
+        agents:
+          # The SQL Server Docker image isn't available on ARM.
+          #
+          # See: <https://github.com/microsoft/mssql-docker/issues/864>
+          queue: hetzner-x86-64-8cpu-16gb
+
+
   - group: AWS
     key: aws
     steps:
@@ -1486,7 +1501,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -1523,7 +1538,7 @@ steps:
         timeout_in_minutes: 40
         agents:
           # Ran out of memory retrieving query results.
-          queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -57,7 +57,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -70,7 +70,7 @@ steps:
       # 24h
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -82,7 +82,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -95,7 +95,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -106,7 +106,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -118,7 +118,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -129,7 +129,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -153,7 +153,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1440
       agents:
-        queue: hetzner-aarch64-8cpu-16gb
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -379,38 +379,20 @@ steps:
       # Too slow on aarch64
       queue: hetzner-x86-64-4cpu-8gb
 
-  - group: "SQL Server tests"
-    key: sql-server-tests
-    steps:
-      - id: sql-server-cdc
-        label: "SQL Server CDC tests"
-        depends_on: build-x86_64
-        timeout_in_minutes: 30
-        inputs: [test/sql-server-cdc]
-        parallelism: 3
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: sql-server-cdc
-        agents:
-          # The SQL Server Docker image isn't available on ARM.
-          #
-          # See: <https://github.com/microsoft/mssql-docker/issues/864>
-          queue: hetzner-x86-64-8cpu-16gb
-
-      - id: sql-server-cdc-old-syntax
-        label: "SQL Server CDC old syntax tests"
-        depends_on: build-x86_64
-        timeout_in_minutes: 30
-        inputs: [test/sql-server-cdc-old-syntax]
-        parallelism: 6
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: sql-server-cdc-old-syntax
-        agents:
-          # The SQL Server Docker image isn't available on ARM.
-          #
-          # See: <https://github.com/microsoft/mssql-docker/issues/864>
-          queue: hetzner-x86-64-8cpu-16gb
+  - id: sql-server-cdc
+    label: "SQL Server CDC tests"
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [test/sql-server-cdc]
+    parallelism: 3
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sql-server-cdc
+    agents:
+      # The SQL Server Docker image isn't available on ARM.
+      #
+      # See: <https://github.com/microsoft/mssql-docker/issues/864>
+      queue: hetzner-x86-64-8cpu-16gb
 
   - group: "Connection tests"
     key: connection-tests

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1851,7 +1851,7 @@ class KillAction(Action):
     ):
         super().__init__(rng, composition)
         self.system_param_fn = system_param_fn
-        self.system_parameters = {}
+        self.system_parameters = {"memory_limiter_interval": "0"}
         self.azurite = azurite
         self.sanity_restart = sanity_restart
 
@@ -1922,6 +1922,7 @@ class ZeroDowntimeDeployAction(Action):
                 healthcheck=LEADER_STATUS_HEALTHCHECK,
                 metadata_store="cockroach",
                 default_replication_factor=2,
+                additional_system_parameter_defaults={"memory_limiter_interval": "0"},
             ),
         ):
             self.composition.up(mz_service, detach=True)

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -382,7 +382,10 @@ class BackupAndRestoreLarge(Scenario):
             CreateViewParameterized(
                 max_views=5, expensive_aggregates=True, max_inputs=5
             ): 10,
-            CreateSinkParameterized(max_sinks=10): 10,
+            # Sinks don't make sense in this test since we don't record the
+            # state of a sink after a backup&restore cycle, see for example
+            # https://github.com/MaterializeInc/database-issues/issues/9589
+            # CreateSinkParameterized(max_sinks=10): 10,
             ValidateView: 10,
             DML: 50,
             BackupAndRestore: 0.1,

--- a/test/cloudtest/node_recovery/test_k8s_node_recovery.py
+++ b/test/cloudtest/node_recovery/test_k8s_node_recovery.py
@@ -140,7 +140,7 @@ def validate_state(
     comparison_operator = ">" if must_exceed_reached_index else ">="
     print(f"Expect '{expected_state}' within timeout of {timeout_in_sec}s")
 
-    testdrive_run_timeout_in_sec = 10
+    testdrive_run_timeout_in_sec = 20
 
     validation_succeeded = False
     last_error_message = None

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -98,6 +98,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             sanity_restart=sanity_restart,
             metadata_store="cockroach",
             default_replication_factor=2,
+            additional_system_parameter_defaults={"memory_limiter_interval": "0"},
         ),
         Toxiproxy(seed=random.randrange(2**63)),
     ):

--- a/test/testdrive/github-6335.td
+++ b/test/testdrive/github-6335.td
@@ -16,7 +16,7 @@
 # introspection sources that take a while to update.
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
-$ set-sql-timeout duration=240s
+$ set-sql-timeout duration=360s
 
 # This test uses introspection queries that need to be targeted to a replica
 > SET cluster_replica = r1


### PR DESCRIPTION
SQL Server CDC Old Syntax test was the slowest by far in Test pipeline, thus moving to Nightly.

Other changes based on weekend's Nightly and RQ failures
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
