### PR TITLE
Upgrade columnar, timely, differential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,9 +1864,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "columnar"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d21bd4fd3428271da95e0c5b727cfed00f2a4f3d3e1d84ba34b6d0d2e594c97"
+checksum = "f0342a00e5e34da4ef8c48b7ef9cc6fbe16ac2967456382738e21fe662ece796"
 dependencies = [
  "bytemuck",
  "columnar_derive",
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794e7026545b8909ce19c43e59fe7dac843d5e8ebf5cd78960801993578fa0a3"
+checksum = "8f7c7c4b47f54e4ad98b5d1c1208b58d9ea9d71ba922521790504815291b50ce"
 dependencies = [
  "columnar",
  "columnation",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dogs3"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bd942238bbf6ebea62a634602f85dab7bef7b0b651638daf8ff4e8e0755ac"
+checksum = "2e0609a56bc2da573c7b9396c49ba75ae314092d8ead94df4d7e61c6fcd3a8a4"
 dependencies = [
  "differential-dataflow",
  "serde",
@@ -11246,9 +11246,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24044953f29fb1b228ef6ced8abb41c5403c3c5661ca91d5286858dc1ceeaa39"
+checksum = "8142b20a15e44fabfd929d0784e2ee12842a4444f6d8d67087861e1722f81746"
 dependencies = [
  "bincode",
  "byteorder",
@@ -11265,15 +11265,15 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ce5527acdb648d10f460f160245555c9d5d3977cb63d4aea2f676e432e188"
+checksum = "df0788dcca0c3aac97a1ef21fb3cb31a3a465a44ff250c9ef68d37b8bf4984e6"
 
 [[package]]
 name = "timely_communication"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ab22daa4ee1c67304dad45a184100207c70f18441db8e1b59b337718744952"
+checksum = "4481a2173a615306ba2d15ec8780f4f87c2cccee2709398c4eb61a021204bb2e"
 dependencies = [
  "byteorder",
  "columnar",
@@ -11286,15 +11286,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63e60598564980ed3252d80bd0e16c7e6868d788124dacb7ce57662734e6a86"
+checksum = "30372c40c76a4125d4bc7c510a2b0562e16a235eb248f723e84411105a2f617d"
 
 [[package]]
 name = "timely_logging"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270d7819fa599702b8273292d88e058cec611091c9c75eb3b86a64914861b3ea"
+checksum = "23e4189dacdf0c6bc60e0eafefb877ee8cb0de8c4d28ccaed65f966ed406f709"
 dependencies = [
  "timely_container",
 ]

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.219"
-timely = "0.21.5"
+timely = "0.22.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 tracing = "0.1.37"
 

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,7 +19,7 @@ bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.31"
@@ -84,7 +84,7 @@ serde_plain = "1.0.2"
 sha2 = "0.10.9"
 smallvec = { version = "1.15.1", features = ["union"] }
 static_assertions = "1.1"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.17"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,7 +18,7 @@ bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 ipnet = "2.11.0"
 itertools = "0.14.0"
@@ -62,7 +62,7 @@ serde_plain = "1.0.2"
 static_assertions = "1.1"
 sha2 = "0.10.9"
 thiserror = "2.0.12"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1" }
 tracing = "0.1.37"
 uuid = "1.17.0"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.98"
 async-trait = "0.1.88"
 crossbeam-channel = "0.5.15"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 lgalloc = "0.6.0"
 mz-cluster-client = { path = "../cluster-client" }
@@ -21,7 +21,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing"] }
 mz-service = { path = "../service" }
 rand = "0.8.5"
 regex = "1.11.1"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = "1.17.0"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.15"
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 http = "1.2.0"
 mz-build-info = { path = "../build-info" }
@@ -44,7 +44,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "2.0.12"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 workspace = true
 
 [dependencies]
-columnar = "0.10.0"
+columnar = "0.10.1"
 columnation = "0.1.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 itertools = "0.14.0"
 mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
@@ -24,7 +24,7 @@ proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -13,11 +13,11 @@ workspace = true
 anyhow = "1.0.98"
 async-stream = "0.3.6"
 bytesize = "1.3.0"
-columnar = "0.10.0"
+columnar = "0.10.1"
 crossbeam-channel = "0.5.15"
 dec = { version = "0.4.8", features = ["serde"] }
-differential-dataflow = "0.16.0"
-differential-dogs3 = "0.16.0"
+differential-dataflow = "0.16.1"
+differential-dogs3 = "0.16.1"
 futures = "0.3.31"
 itertools = "0.14.0"
 lgalloc = "0.6"
@@ -41,7 +41,7 @@ prometheus = { version = "0.13.4", default-features = false }
 scopeguard = "1.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -34,7 +34,7 @@ mz-txn-wal = { path = "../txn-wal" }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = "1.44.1"
 tracing = "0.1.37"
 uuid = { version = "1.17.0" }

--- a/src/durable-cache/Cargo.toml
+++ b/src/durable-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.88"
 bytes = { version = "1.10.1" }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 itertools = { version = "0.14.0" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -159,7 +159,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.127"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.7"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
 [build-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 crc32fast = "1.4.2"
 csv = "1.3.1"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 dec = "0.4.8"
 derivative = "2.2.0"
 encoding = "0.2.0"
@@ -61,7 +61,7 @@ serde_json = "1.0.127"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 subtle = "2.6.1"
-timely = "0.21.5"
+timely = "0.22.0"
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.17.0", features = ["v5"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.4.3"
 bytes = "1.10.1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 itertools = "0.14.0"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -33,7 +33,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 prost-reflect = "0.15.3"
 seahash = "4"
 serde_json = "1.0.140"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde"] }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -24,10 +24,10 @@ bytes = { version = "1.10.1", optional = true }
 chrono = { version = "0.4.39", default-features = false, features = ["std"], optional = true }
 clap = { version = "4.5.23", features = ["env", "string"], optional = true }
 columnation = { version = "0.1.0", optional = true }
-columnar = { version = "0.10.0", optional = true }
+columnar = { version = "0.10.1", optional = true }
 compact_bytes = { version = "0.2.1", optional = true }
 ctor = { version = "0.4.2", optional = true }
-differential-dataflow = { version = "0.16.0", optional = true }
+differential-dataflow = { version = "0.16.1", optional = true }
 derivative = { version = "2.2.0" }
 either = "1.15.0"
 futures = { version = "0.3.31", optional = true }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.88"
 axum = "0.7.5"
 bytes = { version = "1.10.1", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 humantime = "2.2.0"
 mz-dyncfg = { path = "../dyncfg" }
@@ -41,7 +41,7 @@ num_enum = "0.7.4"
 prometheus = { version = "0.13.4", default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.88"
 bytes = { version = "1.10.1", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive"] }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 futures-util = "0.3"
 h2 = "0.4.11"
@@ -59,7 +59,7 @@ sentry-tracing = "0.38.1"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-timely = "0.21.5"
+timely = "0.22.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.4.2"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-timely = "0.21.5"
+timely = "0.22.0"
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -37,7 +37,7 @@ azure_core = "0.21.0"
 base64 = "0.22.1"
 bytes = "1.10.1"
 deadpool-postgres = "0.10.3"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.31"
 itertools = "0.14.0"
@@ -60,7 +60,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 reqwest = { version = "0.12", features = ["blocking", "json", "default-tls", "charset", "http2"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -32,12 +32,12 @@ bitflags = "1.3.2"
 bytemuck = { version = "1.23.1", features = ["latest_stable_rust"] }
 bytes = "1.10.1"
 cfg-if = "1.0.1"
-columnar = "0.10.0"
+columnar = "0.10.1"
 columnation = "0.1.0"
 chrono = { version = "0.4.39", default-features = false, features = ["serde", "std"] }
 compact_bytes = "0.2.1"
 dec = "0.4.8"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 enum-kinds = "0.5.1"
 hex = "0.4.3"
 itertools = "0.14.0"
@@ -68,7 +68,7 @@ serde_json = { version = "1.0.127", features = ["arbitrary_precision", "preserve
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.11.1"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.34"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -37,7 +37,7 @@ prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.29.11"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = "1.44.1"
 tokio-stream = "0.1.17"
 tonic = "0.12.1"

--- a/src/sql-server-util/Cargo.toml
+++ b/src/sql-server-util/Cargo.toml
@@ -37,7 +37,7 @@ smallvec = { version = "1.15.1", features = ["union"] }
 static_assertions = "1.1"
 thiserror = "2.0.11"
 tiberius = { version = "0.12", features = ["chrono", "sql-browser-tokio", "tds73", "native-tls"], default-features = false }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["net"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.15", features = ["compat"] }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.98"
 async-trait = "0.1.88"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 http = "1.2.0"
 itertools = { version = "0.14.0" }
@@ -48,7 +48,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127" }
 smallvec = { version = "1.15.1", features = ["serde", "union"] }
 static_assertions = "1.1"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = [
     "fs",
     "rt",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.88"
 bytes = "1.10.1"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 itertools = { version = "0.14.0" }
 mz-build-info = { path = "../build-info" }
@@ -38,7 +38,7 @@ proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.10.1"
 bytesize = "1.3.0"
 csv-async = { version = "1.3.1", features = ["tokio"] }
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 glob = "0.3.2"
 http = "1.2.0"
@@ -48,7 +48,7 @@ reqwest = { version = "0.11.13", features = ["stream"] }
 sentry = { version = "0.38.1", default-features = false, features = [] }
 serde = { version = "1.0.219", features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["union"] }
-timely = "0.21.5"
+timely = "0.22.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-stream = "0.1.17"

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.10.1"
 columnation = "0.1.0"
 dec = "0.4.8"
 derivative = "2.2.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 hex = "0.4.3"
 http = "1.2.0"
 itertools = { version = "0.14.0" }
@@ -67,7 +67,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127", features = ["preserve_order"] }
 thiserror = "2.0.12"
 tiberius = { version = "0.12", features = ["sql-browser-tokio", "tds73", "native-tls"], default-features = false }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -26,7 +26,7 @@ columnation = "0.1.0"
 crossbeam-channel = "0.5.15"
 csv-core = { version = "0.1.12" }
 dec = "0.4.8"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.31"
 indexmap = { version = "2.10.0", default-features = false, features = ["std"] }
@@ -78,7 +78,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.127" }
 serde_bytes = { version = "0.11.17" }
 sha2 = "0.10.9"
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.17"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 ahash = { version = "0.8.12", default-features = false }
 bincode = "1.3.3"
 bytemuck = "1.23.1"
-columnar = "0.10.0"
+columnar = "0.10.1"
 columnation = "0.1.0"
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 either = "1"
 futures-util = "0.3.31"
 lgalloc = "0.6"
@@ -23,7 +23,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["async", "proc
 num-traits = "0.2"
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.219", features = ["derive"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 enum-kinds = "0.5.1"
 itertools = "0.14.0"
 mz-compute-types = { path = "../compute-types" }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.88"
 bytes = { version = "1.10.1" }
-differential-dataflow = "0.16.0"
+differential-dataflow = "0.16.1"
 futures = "0.3.31"
 itertools = { version = "0.14.0" }
 mz-ore = { path = "../ore", features = ["process"] }
@@ -23,7 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.4", default-features = false }
 prost = { version = "0.13.5", features = ["no-recursion-limit"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-timely = "0.21.5"
+timely = "0.22.0"
 tokio = { version = "1.44.1", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -133,7 +133,7 @@ subtle = { version = "2.6.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.104", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.37", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
-timely = { version = "0.21.5" }
+timely = { version = "0.22.0" }
 tokio = { version = "1.44.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }
@@ -277,7 +277,7 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.104", features = ["extra-traits", "full", "visit", "visit-mut"] }
 time = { version = "0.3.37", features = ["local-offset", "macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.19", default-features = false, features = ["formatting", "parsing", "serde"] }
-timely = { version = "0.21.5" }
+timely = { version = "0.22.0" }
 tokio = { version = "1.44.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }


### PR DESCRIPTION
Bump the version of the columnar, timely, and differential dependencies.  No changes on the Materialize side required. The changes include some optimizations to creating Timely sessions, a better partition operator, and some housekeeping.
