### PR TITLE
ci: Introduce sbomgen step

### DIFF
--- a/bin/sbomgen
+++ b/bin/sbomgen
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# sbomgen - Generate software bill of materials (SBOM) and upload to AWS
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+. misc/shlib/shlib.bash
+
+find . -type f -name "Dockerfile" -exec sed -i 's/MZFROM/FROM/g' {} +
+inspector-sbomgen directory --path . --outfile sbom.json --disable-progress-bar || true
+inspector-sbomgen directory --path . --outfile inspector-results.json --disable-progress-bar --scan-sbom --scan-sbom-output-format cyclonedx --aws-region us-east-1 || true

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -345,6 +345,13 @@ RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linu
     && chmod +x yq \
     && mv yq /usr/local/bin
 
+RUN curl -fsSL https://amazon-inspector-sbomgen.s3.amazonaws.com/1.4.0/linux/$ARCH_GO/inspector-sbomgen.zip > inspector-sbomgen.zip \
+    && if [ $ARCH_GO = amd64 ]; then echo 'c8ca73761afd742e1deb98b04eb5714c9c2a574b652a763b18e23560e66aea24 inspector-sbomgen.zip' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo '188d9757782278653e65605aaf186feda104345ba2f9de438873e568f1ff6204 inspector-sbomgen.zip' | sha256sum --check; fi \
+    && unzip inspector-sbomgen.zip \
+    && mv inspector-sbomgen-1.4.0/linux/$ARCH_GO/inspector-sbomgen /usr/local/bin \
+    && chmod +x /usr/local/bin/inspector-sbomgen
+
 # Hardcode some known SSH hosts, or else SSH will ask whether the host is
 # trustworthy on the first connection.
 

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -122,6 +122,20 @@ steps:
         coverage: skip
         sanitizer: skip
 
+      - id: sbomgen
+        timeout_in_minutes: 30
+        label: Generate SBOM and upload to AWS
+        command: bin/ci-builder run stable bin/sbomgen
+        depends_on: []
+        agents:
+          # Because of scratch-aws-access
+          queue: linux-aarch64-small
+        branches: "main v*.*"
+        sanitizer: skip
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+        artifact_paths: [sbom.json, inspector-results.json]
+
   - id: miri-test
     label: ":rust: Miri test (full)"
     depends_on: []


### PR DESCRIPTION
Requested in https://materializeinc.slack.com/archives/CUCF68PEV/p1754539502682189
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
