### PR TITLE
some more fixes for running environmentd via orchestratord

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -65,7 +65,7 @@ def main():
     )
     parser_environment.add_argument("--postgres-url", default=DEFAULT_POSTGRES)
     parser_environment.add_argument("--s3-bucket", default=DEFAULT_MINIO)
-    parser_environment.add_argument("--license-key-file", required=True)
+    parser_environment.add_argument("--license-key-file")
     parser_environment.add_argument(
         "--external-login-password-mz-system", required=False
     )
@@ -237,8 +237,12 @@ def environment(args: argparse.Namespace):
         )
     )
 
-    with open(args.license_key_file) as f:
-        license_key = f.read()
+    if args.license_key_file:
+        with open(args.license_key_file) as f:
+            license_key = f.read()
+            license_key_args = {"license_key": license_key}
+    else:
+        license_key_args = {}
 
     backend_secret_name = f"materialize-backend-{environment_id}"
 
@@ -252,7 +256,7 @@ def environment(args: argparse.Namespace):
             "stringData": {
                 "metadata_backend_url": metadata_backend_url,
                 "persist_backend_url": persist_backend_url,
-                "license_key": license_key,
+                **license_key_args,
             },
         },
         {

--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -57,6 +57,7 @@ def main():
     parser_reset.set_defaults(func=reset)
 
     parser_environment = subparsers.add_parser("environment")
+    parser_environment.add_argument("--environmentd-version")
     parser_environment.add_argument("--dev", action="store_true")
     parser_environment.add_argument("--namespace", default="materialize")
     parser_environment.add_argument(
@@ -169,13 +170,17 @@ def reset(args: argparse.Namespace):
 def environment(args: argparse.Namespace):
     env_kubectl = make_env_kubectl(args)
 
-    for image in ["environmentd", "clusterd", "balancerd"]:
-        acquire(
-            image,
-            dev=args.dev,
-            cluster=args.kind_cluster_name,
-        )
-    environmentd_image_ref = f"materialize/environmentd:{DEV_IMAGE_TAG}"
+    if args.environmentd_version:
+        image_tag = args.environmentd_version
+    else:
+        for image in ["environmentd", "clusterd", "balancerd"]:
+            acquire(
+                image,
+                dev=args.dev,
+                cluster=args.kind_cluster_name,
+            )
+        image_tag = DEV_IMAGE_TAG
+    environmentd_image_ref = f"materialize/environmentd:{image_tag}"
 
     try:
         kubectl(

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1264,11 +1264,10 @@ fn create_environmentd_statefulset_object(
         args.push("--orchestrator-kubernetes-enable-prometheus-scrape-annotations".into());
     }
 
-    if mz.meets_minimum_version(&V143)
-        && !mz.meets_minimum_version(&V153)
-        && config.disable_license_key_checks
-    {
-        args.push("--disable-license-key-checks".into());
+    if config.disable_license_key_checks {
+        if mz.meets_minimum_version(&V143) && !mz.meets_minimum_version(&V153) {
+            args.push("--disable-license-key-checks".into());
+        }
     } else if mz.meets_minimum_version(&V140_DEV0) {
         volume_mounts.push(VolumeMount {
             name: "license-key".to_string(),


### PR DESCRIPTION
### Motivation

the first commit is just a bug fix for how we determine whether license keys should be used, the others are improvements to bin/orchestratord to make it easier to run different versions

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
