### PR TITLE
storage: write down shard mappings on ALTER TABLE

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1512,6 +1512,8 @@ where
             .await
             .expect("table worker unexpectedly shut down");
 
+        self.append_shard_mappings([new_collection].into_iter(), Diff::ONE);
+
         Ok(())
     }
 


### PR DESCRIPTION
Before, we would brick builtin collections because we _do_ remove these shards mappings when dropping the table. But because we never added them in the first place there would now be negative multiplicities in there.

Before this change, the bad behaviour could be triggered with:

```
$ create table t (ciao int);
$ alter table t add column bar text;
$ drop table t;
```

We immediately notice because there's an index:

```
environmentd: 2025-08-20T13:39:00.168037Z  INFO coord::handle_message{kind="command-execute"}:handle_message:message_command:coord::handle_execute{session="0198c7b4-1c03-7b96-b434-50828b3354ba"}:coord::handle_execute_inner{stmt="DROP TABLE t"}:sequence_drop_objects:coord::catalog_transact:coord::catalog_transact_conn:coord::catalog_transact_inner:catalog::transact:catalog::transact_inner:transact_op: mz_adapter::catalog::transact: drop table materialize.public.t (u2)
environmentd: 2025-08-20T13:39:00.199236Z  INFO PersistTableWriteWorkerInner::send{otel.name="PersistTableWriteCmd::DropHandle"}: mz_storage_controller::persist_handles: drop tables ids=[User(2), User(3)]
environmentd: 2025-08-20T13:39:00.245857Z  INFO coord::handle_message{kind="controller_ready(storage)"}:handle_message: mz_storage_controller: dropping collection state id=u2
environmentd: 2025-08-20T13:39:00.245931Z  INFO coord::handle_message{kind="controller_ready(storage)"}:handle_message: mz_storage_controller: dropping collection state id=u3
environmentd: 2025-08-20T13:39:00.246006Z  INFO coord::handle_message{kind="controller_ready(storage)"}:handle_message: mz_storage_client::storage_collections: removing collection state because the since advanced to []! id=u2
environmentd: 2025-08-20T13:39:00.246028Z  INFO coord::handle_message{kind="controller_ready(storage)"}:handle_message: mz_storage_client::storage_collections: removing collection state because the since advanced to []! id=u3
environmentd: 2025-08-20T13:39:00.250482Z  INFO mz_storage_client::storage_collections: removing persist handles because the since advanced to []! id=u3
environmentd: 2025-08-20T13:39:00.250515Z  INFO mz_storage_client::storage_collections: enqueing shard finalization due to dropped collection and dropped persist handle id=u3 dropped_shard_id=s1a79f8d1-b0ad-4925-acd3-d42589fc1384
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:00.530825Z  WARN mz_compute::render::errors: [customer-data] Non-positive multiplicity in DistinctBy (row=DatumSeq { bytes: [19, 37, 115, 49, 97, 55, 57, 102, 56, 100, 49, 45, 98, 48, 97, 100, 45, 52, 57, 50, 53, 45, 97, 99, 100, 51, 45, 100, 52, 50, 53, 56, 57, 102, 99, 49, 51, 56, 52, 40, 128, 83, 69, 226, 62, 125, 93, 24] }, count=-1) dataflow="mz_catalog.mz_recent_storage_usage_ind"
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:00.530859Z ERROR mz_compute::render::errors: Non-positive multiplicity in DistinctBy
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:00.540256Z  WARN mz_compute::render::errors: [customer-data] Invalid negative unsigned aggregation in ReduceAccumulable (aggr=AggregateExpr { func: SumUInt64, expr: Column(1, "size_bytes"), distinct: false }, accum=Overflowing(-1)) dataflow="mz_catalog.mz_recent_storage_usage_ind"
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:00.540277Z ERROR mz_compute::render::errors: Invalid negative unsigned aggregation in ReduceAccumulable
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:01.274520Z  WARN mz_compute::render::errors: [customer-data] Non-positive multiplicity in DistinctBy (row=DatumSeq { bytes: [19, 37, 115, 49, 97, 55, 57, 102, 56, 100, 49, 45, 98, 48, 97, 100, 45, 52, 57, 50, 53, 45, 97, 99, 100, 51, 45, 100, 52, 50, 53, 56, 57, 102, 99, 49, 51, 56, 52, 40, 0, 135, 80, 90, 63, 125, 93, 24] }, count=-1) dataflow="mz_catalog.mz_recent_storage_usage_ind"
cluster-s2-replica-s2-gen-1: 2025-08-20T13:39:01.274546Z ERROR mz_compute::render::errors: Non-positive multiplicity in DistinctBy
```

But you can also see it by querying `mz_storage_shards`:

```
$ select * from mz_internal.mz_storage_shards where object_id like 'u%';
```