### PR TITLE
terraform tests: Default to enableLicenseKeyChecks: true

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1390,6 +1390,7 @@ steps:
             args: [--no-cleanup]
             ci-builder: stable
       branches: "main v*.* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      skip: "https://github.com/MaterializeInc/terraform-aws-materialize/issues/71"
 
     - id: terraform-aws-upgrade
       label: "Terraform + Helm Chart Upgrade on AWS"
@@ -1409,6 +1410,7 @@ steps:
             args: [--no-cleanup]
             ci-builder: stable
       branches: "main v*.* *aws* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      skip: "https://github.com/MaterializeInc/terraform-aws-materialize/issues/71"
 
     - id: terraform-gcp
       label: "Terraform + Helm Chart E2E on GCP"

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -238,13 +238,21 @@ cleanup() {
   fi
 
   if [ "$BUILDKITE_STEP_KEY" = "terraform-aws" ]; then
-    mzcompose run aws-temporary --no-setup --no-test --no-run-mz-debug || CI_ANNOTATE_ERRORS_RESULT=1
+      if ! mzcompose run aws-temporary --no-setup --no-test --no-run-mz-debug; then
+          CI_ANNOTATE_ERRORS_RESULT=1
+      fi
   elif [ "$BUILDKITE_STEP_KEY" = "terraform-aws-upgrade" ]; then
-    mzcompose run aws-upgrade --no-setup --no-test --no-run-mz-debug || CI_ANNOTATE_ERRORS_RESULT=1
+      if ! mzcompose run aws-upgrade --no-setup --no-test --no-run-mz-debug; then
+          CI_ANNOTATE_ERRORS_RESULT=1
+      fi
   elif [ "$BUILDKITE_STEP_KEY" = "terraform-gcp" ]; then
-    mzcompose run gcp-temporary --no-setup --no-test --no-run-mz-debug || CI_ANNOTATE_ERRORS_RESULT=1
+      if ! mzcompose run gcp-temporary --no-setup --no-test --no-run-mz-debug; then
+          CI_ANNOTATE_ERRORS_RESULT=1
+      fi
   elif [ "$BUILDKITE_STEP_KEY" = "terraform-azure" ]; then
-    mzcompose run azure-temporary --no-setup --no-test --no-run-mz-debug || CI_ANNOTATE_ERRORS_RESULT=1
+      if ! mzcompose run azure-temporary --no-setup --no-test --no-run-mz-debug; then
+          CI_ANNOTATE_ERRORS_RESULT=1
+      fi
   fi
   rm -rf ~/.kube # Remove potential state from E2E Terraform tests
 

--- a/test/terraform/aws-persistent/main.tf
+++ b/test/terraform/aws-persistent/main.tf
@@ -38,6 +38,23 @@ module "materialize_infrastructure" {
   operator_version = var.operator_version
   orchestratord_version = var.orchestratord_version
 
+  # TODO: This currently fails: https://github.com/MaterializeInc/terraform-aws-materialize/issues/71
+  helm_values = {
+      operator = {
+        args = {
+          enableLicenseKeyChecks = true
+        },
+      },
+      clusters = {
+        defaultReplicationFactor = {
+            system = 1
+            probe = 1
+            support = 1
+            analytics = 1
+        }
+      }
+  }
+
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"
   availability_zones   = ["us-east-1a", "us-east-1b"]

--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -74,19 +74,22 @@ module "materialize_infrastructure" {
   install_cert_manager = false
   use_self_signed_cluster_issuer = false
 
-  # TODO: Doesn't seem to work yet
-  # helm_values = {
-  #   operator = {
-  #     clusters = {
-  #       defaultReplicationFactor = {
-  #           system = 1
-  #           probe = 1
-  #           support = 1
-  #           analytics = 1
-  #       }
-  #     }
-  #   }
-  # }
+  # TODO: This currently fails: https://github.com/MaterializeInc/terraform-aws-materialize/issues/71
+  helm_values = {
+      operator = {
+        args = {
+          enableLicenseKeyChecks = true
+        }
+      },
+      clusters = {
+        defaultReplicationFactor = {
+            system = 1
+            probe = 1
+            support = 1
+            analytics = 1
+        }
+      }
+  }
 
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"

--- a/test/terraform/aws-upgrade/main.tf
+++ b/test/terraform/aws-upgrade/main.tf
@@ -74,19 +74,21 @@ module "materialize_infrastructure" {
   install_cert_manager = false
   use_self_signed_cluster_issuer = false
 
-  # TODO: Doesn't seem to work yet
-  # helm_values = {
-  #   operator = {
-  #     clusters = {
-  #       defaultReplicationFactor = {
-  #           system = 1
-  #           probe = 1
-  #           support = 1
-  #           analytics = 1
-  #       }
-  #     }
-  #   }
-  # }
+  helm_values = {
+      operator = {
+        args = {
+          enableLicenseKeyChecks = true
+        }
+      },
+      clusters = {
+        defaultReplicationFactor = {
+            system = 1
+            probe = 1
+            support = 1
+            analytics = 1
+        }
+      }
+  }
 
   # VPC Configuration
   vpc_cidr             = "10.0.0.0/16"

--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -74,6 +74,22 @@ module "materialize" {
   install_cert_manager = false
   use_self_signed_cluster_issuer = false
 
+  helm_values = {
+      operator = {
+        args = {
+          enableLicenseKeyChecks = true
+        }
+      },
+      clusters = {
+        defaultReplicationFactor = {
+            system = 1
+            probe = 1
+            support = 1
+            analytics = 1
+        }
+      }
+  }
+
   materialize_instances = var.materialize_instances
 
   database_config = {

--- a/test/terraform/gcp-temporary/main.tf
+++ b/test/terraform/gcp-temporary/main.tf
@@ -81,6 +81,11 @@ module "materialize" {
   use_self_signed_cluster_issuer = false
 
   helm_values = {
+      operator = {
+        args = {
+          enableLicenseKeyChecks = true
+        }
+      },
       clusters = {
         defaultReplicationFactor = {
             system = 1


### PR DESCRIPTION
Seen in https://materializeinc.slack.com/archives/C07PN7KSB0T/p1755682291053539

@doy-materialize Is it fine to change this globally? The terraform test just uses the default values.yaml without modifying it. If this is not fine, I'll have to pass it in specifically for the test.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
