### PR TITLE
[optimizer] Remove default `nullable` value

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -46,18 +46,7 @@ pub struct ColumnType {
     /// The underlying scalar type (e.g., Int32 or String) of this column.
     pub scalar_type: ScalarType,
     /// Whether this datum can be null.
-    #[serde(default = "return_true")]
     pub nullable: bool,
-}
-
-/// This method exists solely for the purpose of making ColumnType nullable by
-/// default in unit tests. The default value of a bool is false, and the only
-/// way to make an object take on any other value by default is to pass it a
-/// function that returns the desired default value. See
-/// <https://github.com/serde-rs/serde/issues/1030>
-#[inline(always)]
-fn return_true() -> bool {
-    true
 }
 
 impl ColumnType {


### PR DESCRIPTION
CI run to see if this breaks MzReflect. (Spoiler: it does.)

### Motivation

https://github.com/MaterializeInc/materialize/pull/33321#discussion_r2288833457

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
