### PR TITLE
[EXPLAIN] Fix `mz_mappable_objects` to use correct global ids

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6129,9 +6129,9 @@ pub static MZ_MAPPABLE_OBJECTS: LazyLock<BuiltinView> = LazyLock::new(|| {
     sql: "
 SELECT SUBSTRING(name FROM 11) AS name, global_id
 FROM mz_introspection.mz_dataflows md JOIN mz_introspection.mz_dataflow_global_ids mdgi USING (id)
-WHERE name LIKE 'Dataflow: %' AND
-      (global_id IN (SELECT id FROM mz_catalog.mz_indexes UNION SELECT on_id FROM mz_catalog.mz_indexes)
-       OR EXISTS (SELECT 1 FROM mz_catalog.mz_materialized_views mmv WHERE POSITION(mmv.name IN name) <> 0))",
+WHERE md.name LIKE 'Dataflow: %' AND
+      (mdgi.global_id IN (SELECT id FROM mz_catalog.mz_indexes UNION SELECT on_id FROM mz_catalog.mz_indexes)
+       OR EXISTS (SELECT 1 FROM mz_catalog.mz_materialized_views mmv WHERE POSITION(mmv.id IN md.name) <> 0))",
     access: vec![PUBLIC_SELECT],
 }
 });

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -128,6 +128,7 @@ use mz_compute_types::plan::render_plan::{
     self, BindStage, LetBind, LetFreePlan, RecBind, RenderPlan,
 };
 use mz_expr::{EvalError, Id, LocalId};
+use mz_ore::str::separated;
 use mz_persist_client::operators::shard_source::{ErrorHandler, SnapshotMode};
 use mz_repr::explain::DummyHumanizer;
 use mz_repr::{Datum, Diff, GlobalId, Row, SharedRow};
@@ -214,7 +215,17 @@ pub fn build_compute_dataflow<A: Allocate>(
 
     // If you change the format here to something other than "Dataflow: {name}",
     // you should also update MZ_MAPPABLE_OBJECTS in `src/catalog/src/builtin.rs`
-    let name = format!("Dataflow: {}", &dataflow.debug_name);
+    let name = format!(
+        "Dataflow: {}",
+        separated(
+            ", ",
+            &dataflow
+                .objects_to_build
+                .iter()
+                .map(|o| o.id.to_string())
+                .collect::<Vec<_>>()
+        )
+    );
     let input_name = format!("InputRegion: {}", &dataflow.debug_name);
     let build_name = format!("BuildRegion: {}", &dataflow.debug_name);
 


### PR DESCRIPTION
Attempting @petrosagg's fix: store relevant `global_id`s in `mz_introspection.mz_dataflows`, rather than the `debug_name`.

### Motivation

  * This PR fixes a recognized bug.
     https://github.com/MaterializeInc/database-issues/issues/9596

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
