### PR TITLE
Disable the legacy WITH ORDINALITY implementation fallback

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1672,7 +1672,9 @@ pub struct TableFuncPlan {
 ///    `sql_impl_table_func_inner`.
 ///
 /// TODO(ggevay, database-issues#9598): when a table function in 2. is used with WITH ORDINALITY or
-/// ROWS FROM, we fall back to the legacy WITH ORDINALITY implementation, which relies on the
+/// ROWS FROM, we can't use the new implementation of WITH ORDINALITY. Depending on
+/// `enable_with_ordinality_legacy_fallback`, we either fall back to the legacy implementation or
+/// error out the query planning. The legacy WITH ORDINALITY implementation relies on the
 /// row_number window function, and is mostly broken. It can give an incorrect ordering, and also
 /// has an extreme performance problem in some cases. Discussed in
 /// <https://github.com/MaterializeInc/database-issues/issues/4764#issuecomment-2854572614>

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2210,6 +2210,12 @@ feature_flags!(
         default: false,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_with_ordinality_legacy_fallback,
+        desc: "When the new WITH ORDINALITY implementation can't be used with a table func, whether to fall back to the legacy implementation or error out.",
+        default: false,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/sqllogictest/cockroach/rows_from.slt
+++ b/test/sqllogictest/cockroach/rows_from.slt
@@ -19,6 +19,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_with_ordinality_legacy_fallback = true
+----
+COMPLETE 0
+
 query II colnames
 SELECT * FROM ROWS FROM (generate_series(1,2), generate_series(4,8))
 ----

--- a/test/sqllogictest/github-2996.slt
+++ b/test/sqllogictest/github-2996.slt
@@ -11,6 +11,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_with_ordinality_legacy_fallback = true
+----
+COMPLETE 0
+
 query IIIT rowsort
 SELECT
     t.*, CASE WHEN x IS NULL THEN NULL ELSE t.* END

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -493,7 +493,7 @@ ORDER BY 1
 {hello,world}
 {hello,world}
 
-# TODO: Correct ordering when database-issues#9598 is fixed.
+# TODO: Add WITH ORDINALITY when database-issues#9598 is fixed.
 query T
 SELECT foo FROM regexp_split_to_table('the quick brown fox jumps over the lazy dog', '\s+') AS foo ORDER BY 1
 ----
@@ -507,7 +507,7 @@ quick
 the
 the
 
-# TODO: Correct ordering when database-issues#9598 is fixed.
+# TODO: Add WITH ORDINALITY when database-issues#9598 is fixed.
 query T
 SELECT foo FROM regexp_split_to_table('the quick brown fox', '\s*') AS foo ORDER BY 1
 ----

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1232,6 +1232,11 @@ NULL  NULL  NULL  12
 # about this. For further details, see comment in `plan_table_function_internal`.
 ########################################################################################################################
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_with_ordinality_legacy_fallback = true
+----
+COMPLETE 0
+
 query IIII colnames
 SELECT * FROM ROWS FROM (generate_series(1, 2), information_schema._pg_expandarray(array[9]), generate_series(3, 6)) ORDER BY 4;
 ----


### PR DESCRIPTION
WITH ORDINALITY was recently rewritten, but the new implementation can't be used for some table functions, see https://github.com/MaterializeInc/database-issues/issues/9598. These cases are probably rare, so this PR just disables WITH ORDINALITY for these cases for now. I've checked that no customer is using WITH ORDINALITY with these problematic window functions currently: In the release that was rolled out today to customers, there is a Sentry error that would show if anyone is using the problematic combination, and this Sentry error didn't happen.

(We can fix https://github.com/MaterializeInc/database-issues/issues/9598 later. It's not too hard to do, it's just not worth it for now, because it's probably a rare setup.)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
