### PR TITLE
update license key defaults

### DIFF
--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
         {{- if .Values.operator.args.enableInternalStatementLogging }}
         - "--enable-internal-statement-logging"
         {{- end }}
-        {{- if not .Values.operator.args.enableLicenseKeyChecks }}
-        - "--disable-license-key-checks"
+        {{- if .Values.operator.args.enableLicenseKeyChecks }}
+        - "--enable-license-key-checks"
         {{- end }}
 
         {{/* AWS Configuration */}}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[12]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured
@@ -75,10 +75,10 @@ tests:
     storage.storageClass.name: "my-storage-class"
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: is_cc":true
 
 - it: should configure for AWS provider correctly

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -169,7 +169,7 @@ pub struct MaterializeControllerArgs {
     default_certificate_specs: DefaultCertificateSpecs,
 
     #[clap(long, hide = true)]
-    disable_license_key_checks: bool,
+    enable_license_key_checks: bool,
 }
 
 fn parse_affinity(s: &str) -> anyhow::Result<Affinity> {

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1264,7 +1264,7 @@ fn create_environmentd_statefulset_object(
         args.push("--orchestrator-kubernetes-enable-prometheus-scrape-annotations".into());
     }
 
-    if config.disable_license_key_checks {
+    if !config.enable_license_key_checks {
         if mz.meets_minimum_version(&V143) && !mz.meets_minimum_version(&V153) {
             args.push("--disable-license-key-checks".into());
         }


### PR DESCRIPTION
* renames flag to enable-license-key-checks
* sets defaults to not enabled

This should make it a bit more straight-forward and safer to preserves the default that license key checks should be disabled
