### PR TITLE
[controller] Stream through retractions instead of snapshotting

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -80,6 +80,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::retry::Retry;
 use mz_ore::soft_panic_or_log;
 use mz_ore::task::AbortOnDropHandle;
+use mz_persist_client::batch::Added;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_types::Codec64;
@@ -1514,45 +1515,52 @@ where
     };
 
     let mut rows = storage_collections
-        .snapshot(id, as_of_ts)
+        .snapshot_cursor(id, as_of_ts)
         .await
         .map_err(|e| anyhow!("reading snapshot: {e:?}"))?;
 
     let now = mz_ore::now::to_datetime(now());
     let keep_since = now - keep_duration;
 
-    // Produce retractions by inverting diffs of rows we want to delete and setting the diffs
-    // of all other rows to 0.
-    for (row, diff) in &mut rows {
-        let datums = row.unpack();
-        let occurred_at = datums[occurred_at_col].unwrap_timestamptz();
-        *diff = if *occurred_at < keep_since { -*diff } else { 0 };
-    }
-
-    // Consolidate to avoid superfluous writes.
-    consolidation::consolidate(&mut rows);
-
-    if rows.is_empty() {
-        return Ok(());
-    }
-
     // It is very important that we append our retractions at the timestamp
     // right after the timestamp at which we got our snapshot. Otherwise,
     // it's possible for someone else to sneak in retractions or other
     // unexpected changes.
     let old_upper_ts = upper_ts.clone();
-    let write_ts = old_upper_ts.clone();
     let new_upper_ts = TimestampManipulation::step_forward(&old_upper_ts);
 
-    let updates = rows
-        .into_iter()
-        .map(|(row, diff)| ((SourceData(Ok(row)), ()), write_ts.clone(), diff));
+    // Produce retractions by inverting diffs of rows we want to delete.
+    let mut builder = write_handle.builder(Antichain::from_elem(old_upper_ts.clone()));
+    while let Some(chunk) = rows.next().await {
+        for ((key, _v), _t, diff) in chunk {
+            let data = key.map_err(|e| anyhow!("decoding error in metrics snapshot: {e}"))?;
+            let Ok(row) = &data.0 else { continue };
+            let datums = row.unpack();
+            let occurred_at = datums[occurred_at_col].unwrap_timestamptz();
+            if *occurred_at >= keep_since {
+                continue;
+            }
+            let diff = -diff;
+            match builder.add(&data, &(), &old_upper_ts, &diff).await? {
+                Added::Record => {}
+                Added::RecordAndParts => {
+                    debug!(?id, "added part to builder");
+                }
+            }
+        }
+    }
+
+    let mut updates = builder
+        .finish(Antichain::from_elem(new_upper_ts.clone()))
+        .await?;
+    let mut batches = vec![&mut updates];
 
     write_handle
-        .compare_and_append(
-            updates,
+        .compare_and_append_batch(
+            batches.as_mut_slice(),
             Antichain::from_elem(old_upper_ts),
             Antichain::from_elem(new_upper_ts),
+            true,
         )
         .await
         .expect("valid usage")


### PR DESCRIPTION
### Motivation

We've observed high memory use from the collection data that's temporarily fully snapshotted in memory, and there's no reason we can't just stream out an updated batch as we go.

Part of https://github.com/MaterializeInc/incidents-and-escalations/issues/286

### Tips for reviewer

My first version used the unconsolidated stream, but that could cause exponential growth in the data size in some bad cases - if we called this method frequently without having compaction run in the background. Using the consolidated snapshot should use no more memory than the current version, but typically less, and doesn't have the risk of exponential data growth.