### PR TITLE
sql_server: add deterministic capture instance selection

### DIFF
--- a/src/sql-server-util/src/desc.rs
+++ b/src/sql-server-util/src/desc.rs
@@ -38,6 +38,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+use crate::cdc::Lsn;
 use crate::{SqlServerDecodeError, SqlServerError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_sql_server_util.rs"));
@@ -159,6 +160,8 @@ pub struct SqlServerTableRaw {
     pub name: Arc<str>,
     /// The capture instance replicating changes.
     pub capture_instance: Arc<str>,
+    /// The start lsn of the capture instance was created replicating changes.
+    pub capture_instance_start_lsn: Lsn,
     /// Columns for the table.
     pub columns: Arc<[SqlServerColumnRaw]>,
 }
@@ -985,6 +988,7 @@ impl SqlServerRowDecoder {
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::cdc::Lsn;
     use crate::desc::{
         SqlServerColumnDecodeType, SqlServerColumnDesc, SqlServerTableDesc, SqlServerTableRaw,
         tiberius_numeric_to_mz_numeric,
@@ -1090,6 +1094,7 @@ mod tests {
             schema_name: "my_schema".into(),
             name: "my_table".into(),
             capture_instance: "my_table_CT".into(),
+            capture_instance_start_lsn: Lsn::default(),
             columns: sql_server_columns.into(),
         };
         let sql_server_desc = SqlServerTableDesc::new(sql_server_desc);
@@ -1162,6 +1167,7 @@ mod tests {
                 schema_name: "my_schema".into(),
                 name: "my_table".into(),
                 capture_instance: "my_table_CT".into(),
+                capture_instance_start_lsn: Lsn::default(),
                 columns: columns.into(),
             };
             let mut sql_server_desc = SqlServerTableDesc::new(sql_server_desc);

--- a/test/sql-server-cdc/80-deterministic-capture-instance-selection.td
+++ b/test/sql-server-cdc/80-deterministic-capture-instance-selection.td
@@ -1,0 +1,75 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Validate that when multiple capture instances exist for a table,
+# we select the one with the highest LSN (most recent CDC tracking).
+#
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+USE test;
+CREATE TABLE t1 (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+
+INSERT INTO t1 VALUES ('a', 'hello world'), ('b', 'foobar'), ('c', 'anotha one');
+
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1', @role_name = 'SA', @supports_net_changes = 0, @capture_instance = 'first';
+
+# Increase start_lsn for next capture instance.
+INSERT INTO t1 VALUES ('d', 'after cdc'), ('e', 'also after'), ('f', 'one more');
+
+# Drop column before creating second capture instance to test that we pick the
+# capture instance with the higher LSN (second) which has the updated schema.
+ALTER TABLE t1 DROP COLUMN val_col;
+
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1', @role_name = 'SA', @supports_net_changes = 0, @capture_instance = 'second';
+
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+> CREATE CONNECTION sql_server_test_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass
+  );
+
+> VALIDATE CONNECTION sql_server_test_connection;
+
+> CREATE SOURCE t1_pk_sql_server
+  FROM SQL SERVER CONNECTION sql_server_test_connection
+  FOR TABLES(t1);
+
+> SELECT * FROM t1;
+a
+b
+c
+d
+e
+f
+
+$ sql-server-execute name=sql-server
+USE test;
+EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 't1', @capture_instance = 'first';
+
+INSERT INTO t1 VALUES ('g'), ('h'), ('i');
+
+> SELECT * FROM t1;
+a
+b
+c
+d
+e
+f
+g
+h
+i


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

    https://github.com/MaterializeInc/database-issues/issues/9607

### Tips for Reviewer
There are a variety of fields on `cdc.change_tables`. we want to pick one that is strictly increasing so that we can pick the newest change table/capture instance. we want to pick the newest change table when a source is created to make sure we are getting the latest schema changes. change tables in SQL server reflect the schema of the source table when the change table was created. notably though change tables do not afaict have any of the constraints of source tables.

fields:
- object_id - the id of the change table is not guaranteed to be strictly increasing.
- create_date - should be, assuming monotonic clock, strictly increasing. but if clock skews then we no longer have a strictly increasing sequence.
- start_lsn - appears to be strictly increasing when subjected to enabling CDC in parallel for multiple tables.

went with start_lsn as it appears to be the safest option. or at least I haven't made it break yet. I did look at using a combo of start_lsn and create_date but in the end it didn't seem worth the added complexity.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
