### PR TITLE
ci: Fixes for nightly (2025-08-22)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -263,6 +263,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-matrix
+        skip: "https://github.com/MaterializeInc/database-issues/issues/9510"
 
       - id: kafka-multi-broker
         label: Kafka multi-broker test

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -28,6 +28,7 @@ ISSUE_RE = re.compile(
     | ( cloud\# | cloud/issues/ ) (?P<cloud>[0-9]+)
     | ( incidents-and-escalations\# | incidents-and-escalations/issues/ ) (?P<incidentsandescalations>[0-9]+)
     | ( database-issues\# | database-issues/issues/ ) (?P<databaseissues>[0-9]+)
+    | ( terraform-aws-materialize\# | terraform-aws-materialize/issues/ ) (?P<terraformawsmaterialize>[0-9]+)
     # only match from the beginning of the line or after a space character to avoid matching Buildkite URLs
     | (^|\s) \# (?P<ambiguous>[0-9]+)
     )
@@ -41,6 +42,7 @@ GROUP_REPO = {
     "cloud": "MaterializeInc/cloud",
     "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
     "databaseissues": "MaterializeInc/database-issues",
+    "terraformawsmaterialize": "MaterializeInc/terraform-aws-materialize",
     "ambiguous": None,
 }
 


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/12938
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
