### PR TITLE
adapter: add dyncfg to force swap for cc sizes

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -563,6 +563,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "storage_statistics_retention_duration",
     "enable_ctp_cluster_protocols",
     "enable_paused_cluster_readhold_downgrade",
+    "force_swap_for_cc_sizes",
 ]
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1304,6 +1304,7 @@ class FlipFlagsAction(Action):
             "enable_ctp_cluster_protocols",
             "enable_paused_cluster_readhold_downgrade",
             "enable_mz_join_core_v2",
+            "force_swap_for_cc_sizes",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -143,6 +143,15 @@ pub const PERSIST_FAST_PATH_ORDER: Config<bool> = Config::new(
     "If set, send queries with a compatible literal constraint or ordering clause down the Persist fast path.",
 );
 
+/// This flag exists solely to facilitate the slow rollout of swap for cc replica sizes. The plan
+/// is to remove it once the rollout is complete and the cc replica size definitions have been
+/// adjusted to enable swap directly.
+pub const FORCE_SWAP_FOR_CC_SIZES: Config<bool> = Config::new(
+    "force_swap_for_cc_sizes",
+    false,
+    "Whether to enable swap for all cc replica sizes.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -165,4 +174,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_PASSWORD_AUTH)
         .add(&CONSTRAINT_BASED_TIMESTAMP_SELECTION)
         .add(&PERSIST_FAST_PATH_ORDER)
+        .add(&FORCE_SWAP_FOR_CC_SIZES)
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, Instant};
 use futures::future::{BoxFuture, FutureExt};
 use itertools::{Either, Itertools};
 use mz_adapter_types::bootstrap_builtin_cluster_config::BootstrapBuiltinClusterConfig;
-use mz_adapter_types::dyncfgs::{ENABLE_CONTINUAL_TASK_BUILTINS, ENABLE_EXPRESSION_CACHE};
+use mz_adapter_types::dyncfgs::{
+    ENABLE_CONTINUAL_TASK_BUILTINS, ENABLE_EXPRESSION_CACHE, FORCE_SWAP_FOR_CC_SIZES,
+};
 use mz_auth::hash::scram256_hash;
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::{
@@ -37,7 +39,7 @@ use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     BootstrapStateUpdateKind, CommentsMap, DefaultPrivileges, RoleAuth, StateUpdate,
 };
-use mz_controller::clusters::ReplicaLogging;
+use mz_controller::clusters::{ReplicaLocation, ReplicaLogging};
 use mz_controller_types::ClusterId;
 use mz_ore::cast::usize_to_u64;
 use mz_ore::collections::HashSet;
@@ -484,6 +486,41 @@ impl Catalog {
         txn.commit(config.boot_ts).await?;
 
         cleanup_action.await;
+
+        // Force cc sizes to use swap, if requested.
+        if FORCE_SWAP_FOR_CC_SIZES.get(state.system_configuration.dyncfgs()) {
+            info!("force-enabling swap for cc replica sizes");
+
+            for size in state.cluster_replica_sizes.0.values_mut() {
+                if size.is_cc {
+                    size.swap_enabled = true;
+                    size.cpu_exclusive = false;
+                    size.selectors.remove("materialize.cloud/scratch-fs");
+                    size.selectors
+                        .insert("materialize.cloud/swap".into(), "true".into());
+                }
+            }
+
+            // The size definitions were copied into the in-memory replica configs during
+            // `CatalogState` initialization above. We can't move this code before that because we
+            // need to wait for the `system_configuration` to be fully initialized. Instead we also
+            // patch the replica configs here.
+            for cluster in state.clusters_by_id.values_mut() {
+                for replica in cluster.replicas_by_id_.values_mut() {
+                    if let ReplicaLocation::Managed(loc) = &mut replica.config.location {
+                        let alloc = &mut loc.allocation;
+                        if alloc.is_cc {
+                            alloc.swap_enabled = true;
+                            alloc.cpu_exclusive = false;
+                            alloc.selectors.remove("materialize.cloud/scratch-fs");
+                            alloc
+                                .selectors
+                                .insert("materialize.cloud/swap".into(), "true".into());
+                        }
+                    }
+                }
+            }
+        }
 
         Ok(InitializeStateResult {
             state,


### PR DESCRIPTION
To allow a slow rollout of swap for cc sizes via LD, this PR introduces a `force_swap_for_cc_sizes` dyncfg. If enabled, this config on envd startup patches the replica size definitions to ensure swap is always enabled for cc sizes.

Once the rollout is complete the plan is to change the externally provided cc size definitions to enable swap directly, and remove the dyncfg again.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/9416

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
