### PR TITLE
mysql: add support for integer enums

### DIFF
--- a/src/mysql-util/src/desc.rs
+++ b/src/mysql-util/src/desc.rs
@@ -228,7 +228,9 @@ impl MySqlColumnDesc {
                             .all(|(self_val, other_val)| self_val == other_val)
                 } else {
                     // For the `UInt16` enum representation we support addition of new enums but
-                    // no other changes.
+                    // no other changes. We therefore weaken the assertion to allow for more variants
+                    // in the other `MySqlColumnMeta` which represents a schema newer than the schema
+                    // we snapshotted at.
                     self_enum.values.len() <= other_enum.values.len()
                         && self_enum
                             .values

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -21,8 +21,8 @@ pub use tunnel::{
 
 mod desc;
 pub use desc::{
-    MySqlColumnDesc, MySqlKeyDesc, MySqlTableDesc, ProtoMySqlColumnDesc, ProtoMySqlKeyDesc,
-    ProtoMySqlTableDesc,
+    MySqlColumnDesc, MySqlColumnMeta, MySqlKeyDesc, MySqlTableDesc, ProtoMySqlColumnDesc,
+    ProtoMySqlKeyDesc, ProtoMySqlTableDesc,
 };
 
 mod replication;

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -458,9 +458,9 @@ fn parse_data_type(
         }
         "enum" => {
             // We must include the meta to ensure that we know during snapshot that
-            // the column must be cast to an integer. We will also continue to validate
-            // during replication and snapshot that the enums don't change outside
-            // of the addition of new variants not included in the list created here.
+            // the column must be cast to an integer. We will also include all known
+            // enum variants at this moment to ensure that we continue validate that
+            // replicated data still matches the snapshotted schema.
             let meta = MySqlColumnMeta::Enum(MySqlColumnMetaEnum {
                 values: enum_vals_from_column_type(info.column_type.as_str()).map_err(|_| {
                     UnsupportedDataType {

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -456,6 +456,10 @@ fn parse_data_type(
             };
             return Ok((ScalarType::UInt64, Some(MySqlColumnMeta::Bit(precision))));
         }
+        "enum" => {
+            let meta = MySqlColumnMeta::Enum(MySqlColumnMetaEnum { values: vec![] });
+            return Ok((ScalarType::UInt16, Some(meta)));
+        }
         typ => {
             tracing::warn!(?typ, "found unsupported data type");
             return Err(UnsupportedDataType {

--- a/test/mysql-cdc-old-syntax/mysql-cdc.td
+++ b/test/mysql-cdc-old-syntax/mysql-cdc.td
@@ -232,23 +232,6 @@ contains:Address resolved to a private IP
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false
 
-! CREATE SOURCE "mz_source"
-  IN CLUSTER cdc_cluster
-  FROM MYSQL CONNECTION mysql_conn
-  FOR TABLES (
-    public."enum_table"
-  );
-contains:referenced tables use unsupported types
-
-! CREATE SOURCE "mz_source"
-  IN CLUSTER cdc_cluster
-  FROM MYSQL CONNECTION mysql_conn
-  FOR TABLES (
-    public."enum_table",
-    public.another_enum_table
-  );
-contains:referenced tables use unsupported types
-
 ! CREATE SOURCE mz_source
   IN CLUSTER cdc_cluster
   FROM MYSQL CONNECTION mysql_conn (
@@ -678,6 +661,24 @@ DELETE FROM mixED_CAse;
 
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.
+
+> CREATE SOURCE "mz_source_both_enum"
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (
+    public."enum_table",
+    public.another_enum_table
+  );
+
+> SELECT * FROM enum_table;
+1
+2
+
+> SELECT * FROM another_enum_table;
+1
+2
+
+> DROP SOURCE mz_source_both_enum CASCADE;
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster

--- a/test/mysql-cdc-old-syntax/types-enum.td
+++ b/test/mysql-cdc-old-syntax/types-enum.td
@@ -31,17 +31,17 @@ USE public;
 CREATE TABLE enum_type (f1 ENUM ('val1', 'val2'), f2 TEXT);
 INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2');
 
-# TODO: database-issues#7719 (enum unsupported)
-! CREATE SOURCE mz_source
-  FROM MYSQL CONNECTION mysql_conn
-  FOR ALL TABLES;
-contains:referenced tables use unsupported types
-
 > CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn (
     TEXT COLUMNS (public.enum_type.f1)
   )
   FOR ALL TABLES;
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.enum_type AS enum_type_int;
+
+> SELECT * FROM enum_type_int;
+1 val1
+2 val2
 
 > SELECT * FROM enum_type;
 val1 val1
@@ -57,11 +57,22 @@ val1 val1
 val2 val2
 val1 val1
 
+> SELECT * FROM enum_type_int;
+1 val1
+2 val2
+1 val1
+
 $ mysql-execute name=mysql
 INSERT INTO enum_type VALUES ('val3', 'val3');
 
 ! SELECT * FROM enum_type;
 contains:received invalid enum value: 3 for column f1
+
+> SELECT * FROM enum_type_int;
+1 val1
+2 val2
+1 val1
+3 val3
 
 $ mysql-execute name=mysql
 DELETE FROM enum_type WHERE f1 = 'val3';
@@ -71,10 +82,18 @@ val1 val1
 val2 val2
 val1 val1
 
+> SELECT * FROM enum_type_int;
+1 val1
+2 val2
+1 val1
+
 # Add an additional enum value type and change the ordering
 $ mysql-execute name=mysql
 ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val2', 'val1', 'val3', 'val4');
 INSERT INTO enum_type VALUES ('val1', 'val1');
 
 ! SELECT * FROM enum_type;
+contains:incompatible schema change: column f1 in table enum_type has been altered
+
+! SELECT * FROM enum_type_int;
 contains:incompatible schema change: column f1 in table enum_type has been altered

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -240,12 +240,6 @@ ALTER SYSTEM SET storage_enforce_external_addresses = false
   IN CLUSTER cdc_cluster
   FROM MYSQL CONNECTION mysql_conn;
 
-! CREATE TABLE enum_table FROM SOURCE mz_source (REFERENCE public.enum_table);
-contains:referenced tables use unsupported types
-
-! CREATE TABLE another_enum_table FROM SOURCE mz_source (REFERENCE public.another_enum_table);
-contains:referenced tables use unsupported types
-
 ! CREATE SOURCE mz_source_2
   IN CLUSTER cdc_cluster
   FROM MYSQL CONNECTION mysql_conn (
@@ -668,6 +662,18 @@ DELETE FROM mixED_CAse;
   WITH (TEXT COLUMNS = ["колона", pk]);
 contains:TEXT COLUMNS refers to table not currently being added
 
+> CREATE TABLE enum_table_int FROM SOURCE enum_source (REFERENCE public.enum_table);
+
+> CREATE TABLE another_enum_table_int FROM SOURCE enum_source (REFERENCE public.another_enum_table);
+
+> SELECT * FROM enum_table_int
+1
+2
+
+> SELECT * FROM another_enum_table_int
+1
+2
+
 > CREATE TABLE enum_table
   FROM SOURCE enum_source
   (REFERENCE public."enum_table")
@@ -685,6 +691,8 @@ enum_source_progress    progress  <null>       ""
 > SELECT * FROM (SHOW TABLES) WHERE name LIKE '%enum%';
 another_enum_table      ""
 enum_table              ""
+another_enum_table_int  ""
+enum_table_int          ""
 
 > SELECT * FROM enum_table
 var0

--- a/test/mysql-cdc/table-in-mysql-schema.td
+++ b/test/mysql-cdc/table-in-mysql-schema.td
@@ -50,8 +50,7 @@ contains:reference to public.timezone not found in source
 
 > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
-! CREATE TABLE t_in_mysql FROM SOURCE mz_source (REFERENCE mysql.time_zone);
-contains:referenced tables use unsupported types
+> CREATE TABLE t_in_mysql_int_enum FROM SOURCE mz_source (REFERENCE mysql.time_zone);
 
 $ mysql-execute name=mysql
 USE mysql;

--- a/test/mysql-cdc/types-enum.td
+++ b/test/mysql-cdc/types-enum.td
@@ -9,9 +9,8 @@
 
 $ set-sql-timeout duration=1s
 
-
 #
-# ENUM supported only as TEXT
+# ENUM supported as TEXT or INT
 #
 
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
@@ -30,20 +29,36 @@ SET SESSION sql_mode='';
 USE public;
 
 CREATE TABLE enum_type (f1 ENUM ('val1', 'val2'), f2 TEXT);
-INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'val2');
+INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'not-present');
 
 > CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
 
-# TODO: database-issues#7719 (enum unsupported)
-! CREATE TABLE enum_type FROM SOURCE mz_source (REFERENCE public.enum_type);
-contains:referenced tables use unsupported types
+> CREATE TABLE enum_type FROM SOURCE mz_source (REFERENCE public.enum_type);
+
+$ mysql-execute name=mysql
+INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'not-present');
+
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+0 not-present
+1 val1
+2 val2
+0 not-present
+
+> DROP TABLE enum_type;
+
+$ mysql-execute name=mysql
+DROP TABLE enum_type;
+CREATE TABLE enum_type (f1 ENUM ('val1', 'val2'), f2 TEXT);
+INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'not-present');
 
 > CREATE TABLE enum_type FROM SOURCE mz_source (REFERENCE public.enum_type) WITH (TEXT COLUMNS (f1));
 
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
-"" val2
+"" not-present
 
 # Add an additional enum value type
 $ mysql-execute name=mysql
@@ -53,7 +68,7 @@ INSERT INTO enum_type VALUES ('val1', 'val1');
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
-"" val2
+"" not-present
 val1 val1
 
 $ mysql-execute name=mysql
@@ -68,7 +83,7 @@ DELETE FROM enum_type WHERE f1 = 'val3';
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
-"" val2
+"" not-present
 val1 val1
 
 $ mysql-execute name=mysql
@@ -80,7 +95,7 @@ COMMIT;
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
-"" val2
+"" not-present
 val1 val1
 <null> val1
 "" val1
@@ -93,7 +108,7 @@ COMMIT;
 > SELECT * FROM enum_type;
 val1 val1
 val2 val2
-val2 val2
+val2 not-present
 val1 val1
 val2 val1
 val2 val1

--- a/test/mysql-cdc/types-enum.td
+++ b/test/mysql-cdc/types-enum.td
@@ -46,16 +46,12 @@ INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present',
 2 val2
 0 not-present
 
-> DROP TABLE enum_type;
+> CREATE TABLE enum_type_string FROM SOURCE mz_source (REFERENCE public.enum_type) WITH (TEXT COLUMNS (f1));
 
-$ mysql-execute name=mysql
-DROP TABLE enum_type;
-CREATE TABLE enum_type (f1 ENUM ('val1', 'val2'), f2 TEXT);
-INSERT INTO enum_type VALUES ('val1', 'val1'), ('val2', 'val2'), ('not-present', 'not-present');
-
-> CREATE TABLE enum_type FROM SOURCE mz_source (REFERENCE public.enum_type) WITH (TEXT COLUMNS (f1));
-
-> SELECT * FROM enum_type;
+> SELECT * FROM enum_type_string;
+val1 val1
+val2 val2
+"" not-present
 val1 val1
 val2 val2
 "" not-present
@@ -65,58 +61,153 @@ $ mysql-execute name=mysql
 ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val1', 'val2', 'val3');
 INSERT INTO enum_type VALUES ('val1', 'val1');
 
-> SELECT * FROM enum_type;
+> SELECT * FROM enum_type_string;
 val1 val1
 val2 val2
 "" not-present
 val1 val1
+val2 val2
+"" not-present
+val1 val1
+
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+0 not-present
+1 val1
+2 val2
+0 not-present
+1 val1
 
 $ mysql-execute name=mysql
 INSERT INTO enum_type VALUES ('val3', 'val3');
 
-! SELECT * FROM enum_type;
+! SELECT * FROM enum_type_string;
 contains:received invalid enum value: 3 for column f1
+
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+0 not-present
+1 val1
+2 val2
+0 not-present
+1 val1
+3 val3
 
 $ mysql-execute name=mysql
 DELETE FROM enum_type WHERE f1 = 'val3';
 
-> SELECT * FROM enum_type;
+> SELECT * FROM enum_type_string;
+val1 val1
+val2 val2
+"" not-present
 val1 val1
 val2 val2
 "" not-present
 val1 val1
 
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+0 not-present
+1 val1
+2 val2
+0 not-present
+1 val1
+
 $ mysql-execute name=mysql
 USE public;
 INSERT INTO enum_type VALUES (NULL, 'val1');
-INSERT INTO enum_type VALUES ('not-present', 'val1');
+INSERT INTO enum_type VALUES ('not-present', 'not-present');
 COMMIT;
 
-> SELECT * FROM enum_type;
+> SELECT * FROM enum_type_string;
+val1 val1
+val2 val2
+"" not-present
 val1 val1
 val2 val2
 "" not-present
 val1 val1
 <null> val1
-"" val1
+"" not-present
+
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+0 not-present
+1 val1
+2 val2
+0 not-present
+1 val1
+<null> val1
+0 not-present
 
 $ mysql-execute name=mysql
 USE public;
 UPDATE enum_type SET f1 = 'val2' WHERE f1 IS NULL OR f1 = '';
 COMMIT;
 
-> SELECT * FROM enum_type;
+> SELECT * FROM enum_type_string;
+val1 val1
+val2 val2
+val2 not-present
 val1 val1
 val2 val2
 val2 not-present
 val1 val1
 val2 val1
-val2 val1
+val2 not-present
 
-# Add an additional enum value type and change the ordering
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+2 not-present
+1 val1
+2 val2
+2 not-present
+1 val1
+2 val1
+2 not-present
+
+# Change the ordering
 $ mysql-execute name=mysql
 ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val2', 'val1', 'val3', 'val4');
-INSERT INTO enum_type VALUES ('val1', 'val1');
+
+! SELECT * FROM enum_type_string;
+contains:incompatible schema change: column f1 in table enum_type has been altered
 
 ! SELECT * FROM enum_type;
 contains:incompatible schema change: column f1 in table enum_type has been altered
+
+> DROP SOURCE mz_source CASCADE;
+
+$ mysql-execute name=mysql
+ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val1', 'val2', 'val3');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn;
+
+> CREATE TABLE enum_type FROM SOURCE mz_source (REFERENCE public.enum_type);
+
+> CREATE TABLE enum_type_string FROM SOURCE mz_source (REFERENCE public.enum_type) WITH (TEXT COLUMNS (f1));
+
+# Add an additional enum value type
+$ mysql-execute name=mysql
+ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val1', 'val2', 'val3', 'val4');
+INSERT INTO enum_type VALUES ('val4', 'val4');
+
+! SELECT * FROM enum_type_string;
+contains:received invalid enum value: 4 for column f1
+
+> SELECT * FROM enum_type;
+1 val1
+2 val2
+2 not-present
+1 val1
+2 val2
+2 not-present
+1 val1
+2 val1
+2 not-present
+4 val4

--- a/test/testdrive/force-source-tables.td
+++ b/test/testdrive/force-source-tables.td
@@ -269,22 +269,32 @@ INSERT INTO mysql_table VALUES ('var1', 1234), ('var0', 0);
 > SHOW SUBSOURCES ON mysql_source
 mysql_source_progress progress
 
-! CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table");
-contains:referenced tables use unsupported types
-
-> CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table") WITH (TEXT COLUMNS = (a));
+> CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table");
 
 > SELECT * FROM mysql_table_1;
+1 0
+2 1234
+
+> CREATE TABLE mysql_table_1_string FROM SOURCE mysql_source (REFERENCE "public"."mysql_table") WITH (TEXT COLUMNS = (a));
+
+> SELECT * FROM mysql_table_1_string;
 var0 0
 var1 1234
 
-> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mysql_table_1';
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mysql_table_1' OR name = 'mysql_table_1_string';
+running
 running
 
 $ mysql-execute name=mysql
 INSERT INTO mysql_table VALUES ('var1', 5678), ('var0', 1);
 
 > SELECT * FROM mysql_table_1;
+1 0
+2 1234
+1 1
+2 5678
+
+> SELECT * FROM mysql_table_1_string;
 var0 0
 var1 1234
 var0 1
@@ -349,6 +359,7 @@ mysql_table public {a,b,c}
 mysql_table_new public {foo,bar}
 
 > SHOW TABLES ON mysql_source;
+mysql_table_1_string ""
 mysql_table_2 ""
 mysql_table_3 ""
 

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -266,26 +266,38 @@ INSERT INTO mysql_table VALUES ('var1', 1234), ('var0', 0);
 > SHOW SUBSOURCES ON mysql_source
 mysql_source_progress progress
 
-! CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table");
-contains:referenced tables use unsupported types
-
-> CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table") WITH (TEXT COLUMNS = (a));
+> CREATE TABLE mysql_table_1 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table");
 
 > SELECT * FROM mysql_table_1;
+1 0
+2 1234
+
+> CREATE TABLE mysql_table_1_string FROM SOURCE mysql_source (REFERENCE "public"."mysql_table") WITH (TEXT COLUMNS = (a));
+
+> SELECT * FROM mysql_table_1_string;
 var0 0
 var1 1234
 
-> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mysql_table_1';
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mysql_table_1' OR name = 'mysql_table_1_string';
+running
 running
 
 $ mysql-execute name=mysql
 INSERT INTO mysql_table VALUES ('var1', 5678), ('var0', 1);
 
 > SELECT * FROM mysql_table_1;
+1 0
+2 1234
+1 1
+2 5678
+
+> SELECT * FROM mysql_table_1_string;
 var0 0
 var1 1234
 var0 1
 var1 5678
+
+> DROP TABLE mysql_table_1_string;
 
 > CREATE TABLE mysql_table_2 FROM SOURCE mysql_source (REFERENCE "public"."mysql_table") WITH (TEXT COLUMNS = (a));
 


### PR DESCRIPTION
Note: snapshotting the table and replicating the table result in different formats. we snapshot as a string representation by `select c1 from t1` then see `c1` replicated in the binlog as an `int`. so we had to update the snapshotting logic to snapshot as an int. I looked at different ways to convert enum to int one way recommended online was to do `c1+0` but this resulted in a Double being outputted due to our usage of backticks when constructing the snapshot query, plus it's pretty gross. so we are using an explicit cast to unsigned int which appears to be okay.

~I will check this afternoon if we can explicitly cast to uint16 or what casting to a generic unsigned entails.~
checked: I don't see a way to go below a u64 in mysql when casting. as far as I can tell `unsigned integer` just goes to `unsigned bigint`.
see: http://dev.mysql.com/doc/refman/8.4/en/cast-functions.html

**Note (09/01/25):** I will squash all commits into one commit before merging to enable cherry picking into a patch release.

### Motivation

  * This PR fixes a recognized bug.

    https://github.com/MaterializeInc/database-issues/issues/9615

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
