### PR TITLE
zippy: Support system params via CI_MZ_SYSTEM_PARAMETER_DEFAULT

### DIFF
--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+import os
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import (
     LEADER_STATUS_HEALTHCHECK,
@@ -70,7 +72,21 @@ class MzStart(Action):
         capabilities: Capabilities,
         additional_system_parameter_defaults: dict[str, str] = {},
     ) -> None:
-        self.additional_system_parameter_defaults = additional_system_parameter_defaults
+        if additional_system_parameter_defaults:
+            self.additional_system_parameter_defaults = (
+                additional_system_parameter_defaults
+            )
+        else:
+            self.additional_system_parameter_defaults = {}
+            system_parameter_default = os.getenv("CI_MZ_SYSTEM_PARAMETER_DEFAULT", "")
+            if system_parameter_default:
+                for val in system_parameter_default.split(";"):
+                    x = val.split("=", maxsplit=1)
+                    assert (
+                        len(x) == 2
+                    ), f"CI_MZ_SYSTEM_PARAMETER_DEFAULT '{val}' should be the format <key>=<val>"
+                    self.additional_system_parameter_defaults[x[0]] = x[1]
+
         super().__init__(capabilities)
 
     def run(self, c: Composition, state: State) -> None:


### PR DESCRIPTION
The old approach doesn't work, see https://materializeinc.slack.com/archives/C01LKF361MZ/p1756218890810319

Currently testing with: `bin/mzcompose --find zippy down && CI_MZ_SYSTEM_PARAMETER_DEFAULT="enable_rbac_checks=false;enable_statement_lifecycle_logging=false" bin/mzcompose --find zippy run default --scenario=KafkaSources`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
