### PR TITLE
ssh connection test: bump timeouts to 60s

### DIFF
--- a/test/ssh-connection/kafka-source-after-ssh-failure-restart-replica.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure-restart-replica.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # This test script runs after the SSH bastion host has been terminated.
+$ set-sql-timeout duration=60s
 
 > DROP CLUSTER REPLICA sc.r1
 > CREATE CLUSTER REPLICA sc.r1 SIZE 'scale=1,workers=32'

--- a/test/ssh-connection/kafka-source-after-ssh-restart.td
+++ b/test/ssh-connection/kafka-source-after-ssh-restart.td
@@ -11,6 +11,7 @@
 # We specifically make sure that new data written to the Kafka topic is visible
 # in the source, as that is the true measure of health, vs what is reported in
 # the mz_source_statuses relation.
+$ set-sql-timeout duration=60s
 
 $ kafka-ingest topic=thetopic format=bytes
 three


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/9533

As Marty noted in https://github.com/MaterializeInc/database-issues/issues/9533#issuecomment-3224982736

I thought 20 s would be plenty, but apparently not!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
