### PR TITLE
MSSQL: don't panic on empty resume upper

### DIFF
--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -171,8 +171,8 @@ pub(crate) fn render<G: Scope<Timestamp = Lsn>>(
                     Some(committed_upper) = committed_uppers.next() => {
                         let Some(committed_upper) = committed_upper.as_option() else {
                             // It's possible that the source has been dropped, in which case this can
-                            // observe an empty upper. There's no action to take in that case as
-                            // this dataflow will be dropped.
+                            // observe an empty upper. This operator should continue to loop until
+                            // the drop dataflow propagates.
                             continue;
                         };
 


### PR DESCRIPTION
Don't panic when encountering an empty resume_upper. The change will ignore an empty upper observed via the `committed_uppers` futures::Stream, and continue in the loop.

MySQL and PG sources also handle this as a non-error condition. Based on testing, this looks like a possible interleaving of creating a source and then dropping it shortly after.


### Motivation

fix https://github.com/MaterializeInc/database-issues/issues/9619

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
