### PR TITLE
compute: remove unneeded dyncfgs

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -408,7 +408,6 @@ def get_default_system_parameters(
 # apply.
 UNINTERESTING_SYSTEM_PARAMETERS = [
     "enable_mz_join_core",
-    "enable_compute_mv_append_smearing",
     "linear_join_yielding",
     "enable_lgalloc_eager_reclamation",
     "lgalloc_background_interval",
@@ -502,7 +501,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "persist_enable_arrow_lgalloc_cc_sizes",
     "controller_past_generation_replica_cleanup_retry_interval",
     "wallclock_lag_recording_interval",
-    "enable_wallclock_lag_histogram_collection",
     "wallclock_lag_histogram_period_interval",
     "enable_timely_zero_copy",
     "enable_timely_zero_copy_lgalloc",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1108,7 +1108,6 @@ class FlipFlagsAction(Action):
         self.uninteresting_flags: list[str] = [
             "enable_mz_join_core",
             "enable_compute_correction_v2",
-            "enable_compute_mv_append_smearing",
             "linear_join_yielding",
             "enable_lgalloc",
             "enable_lgalloc_eager_reclamation",
@@ -1228,7 +1227,6 @@ class FlipFlagsAction(Action):
             "enable_0dt_deployment_sources",
             "enable_0dt_caught_up_replica_status_check",
             "wallclock_lag_recording_interval",
-            "enable_wallclock_lag_histogram_collection",
             "wallclock_lag_histogram_period_interval",
             "enable_timely_zero_copy",
             "enable_timely_zero_copy_lgalloc",

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -26,8 +26,7 @@ use mz_compute_types::sinks::{
 };
 use mz_compute_types::sources::SourceInstanceDesc;
 use mz_controller_types::dyncfgs::{
-    ENABLE_PAUSED_CLUSTER_READHOLD_DOWNGRADE, ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION,
-    WALLCLOCK_LAG_RECORDING_INTERVAL,
+    ENABLE_PAUSED_CLUSTER_READHOLD_DOWNGRADE, WALLCLOCK_LAG_RECORDING_INTERVAL,
 };
 use mz_dyncfg::ConfigSet;
 use mz_expr::RowSetFinishing;
@@ -607,10 +606,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             let collection_unreadable = PartialOrder::less_equal(&write_frontier, &read_frontier);
             if collection_unreadable {
                 unreadable_collections.insert(id);
-            }
-
-            if !ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION.get(&self.dyncfg) {
-                continue;
             }
 
             if let Some(stash) = &mut collection.wallclock_lag_histogram_stash {

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -36,13 +36,6 @@ pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "Whether compute should use the new MV sink correction buffer implementation.",
 );
 
-/// Whether the MV sink should distribute appends among workers.
-pub const ENABLE_MV_APPEND_SMEARING: Config<bool> = Config::new(
-    "enable_compute_mv_append_smearing",
-    true,
-    "Whether the MV sink should distribute appends among workers.",
-);
-
 /// Whether to enable temporal bucketing in compute.
 pub const ENABLE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
     "enable_compute_temporal_bucketing",
@@ -390,7 +383,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_MZ_JOIN_CORE)
         .add(&ENABLE_MZ_JOIN_CORE_V2)
         .add(&ENABLE_CORRECTION_V2)
-        .add(&ENABLE_MV_APPEND_SMEARING)
         .add(&ENABLE_TEMPORAL_BUCKETING)
         .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -122,7 +122,6 @@ use std::sync::Arc;
 
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::StreamExt;
-use mz_compute_types::dyncfgs::ENABLE_MV_APPEND_SMEARING;
 use mz_compute_types::sinks::{ComputeSinkDesc, MaterializedViewSinkConnection};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
@@ -265,7 +264,6 @@ where
         as_of.clone(),
         compute_state.read_only_rx.clone(),
         &desired,
-        Rc::clone(&compute_state.worker_config),
     );
 
     let (batches, write_token) = write::render(
@@ -476,7 +474,6 @@ mod mint {
         as_of: Antichain<Timestamp>,
         mut read_only_rx: watch::Receiver<bool>,
         desired: &DesiredStreams<S>,
-        worker_config: Rc<ConfigSet>,
     ) -> (
         DesiredStreams<S>,
         DescsStream<S>,
@@ -543,7 +540,7 @@ mod mint {
             let mut cap_set = CapabilitySet::from_elem(desc_cap);
 
             let read_only = *read_only_rx.borrow_and_update();
-            let mut state = State::new(sink_id, worker_count, as_of, read_only, worker_config);
+            let mut state = State::new(sink_id, worker_count, as_of, read_only);
 
             // Create a stream that reports advancements of the target shard's frontier and updates
             // the shared sink frontier.
@@ -646,8 +643,6 @@ mod mint {
         ///
         /// In read-only mode, minting of batch descriptions is disabled.
         read_only: bool,
-        /// Dynamic configuration.
-        worker_config: Rc<ConfigSet>,
     }
 
     impl State {
@@ -656,7 +651,6 @@ mod mint {
             worker_count: usize,
             as_of: Antichain<Timestamp>,
             read_only: bool,
-            worker_config: Rc<ConfigSet>,
         ) -> Self {
             // Initializing `persist_frontier` to the `as_of` ensures that the first minted batch
             // description will have a `lower` of `as_of` or beyond, and thus that we don't spend
@@ -671,7 +665,6 @@ mod mint {
                 next_append_worker: 0,
                 last_lower: None,
                 read_only,
-                worker_config,
             }
         }
 
@@ -733,10 +726,7 @@ mod mint {
             let append_worker = self.next_append_worker;
             let desc = BatchDescription::new(lower, upper, append_worker);
 
-            if ENABLE_MV_APPEND_SMEARING.get(&self.worker_config) {
-                self.next_append_worker = (self.next_append_worker + 1) % self.worker_count;
-            }
-
+            self.next_append_worker = (append_worker + 1) % self.worker_count;
             self.last_lower = Some(desc.lower.clone());
 
             self.trace(format!("minted batch description: {desc:?}"));

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -32,12 +32,6 @@ pub const WALLCLOCK_LAG_RECORDING_INTERVAL: Config<Duration> = Config::new(
     "The interval at which to record `WallclockLagHistory` introspection.",
 );
 
-pub const ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION: Config<bool> = Config::new(
-    "enable_wallclock_lag_histogram_collection",
-    true,
-    "Whether to record `WallclockLagHistogram` introspection.",
-);
-
 pub const WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL: Config<Duration> = Config::new(
     "wallclock_lag_histogram_period_interval",
     Duration::from_secs(24 * 60 * 60),
@@ -86,7 +80,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL)
         .add(&ENABLE_0DT_DEPLOYMENT_SOURCES)
         .add(&WALLCLOCK_LAG_RECORDING_INTERVAL)
-        .add(&ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION)
         .add(&WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL)
         .add(&ENABLE_TIMELY_ZERO_COPY)
         .add(&ENABLE_TIMELY_ZERO_COPY_LGALLOC)

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -29,8 +29,7 @@ use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::metrics::{ControllerMetrics, WallclockLagMetrics};
 use mz_cluster_client::{ReplicaId, WallclockLagFn};
 use mz_controller_types::dyncfgs::{
-    ENABLE_0DT_DEPLOYMENT_SOURCES, ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION,
-    WALLCLOCK_LAG_RECORDING_INTERVAL,
+    ENABLE_0DT_DEPLOYMENT_SOURCES, WALLCLOCK_LAG_RECORDING_INTERVAL,
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
@@ -3635,10 +3634,6 @@ where
             // maximum value instead.
             let secs = lag.unwrap_seconds_or(u64::MAX);
             collection.wallclock_lag_metrics.observe(secs);
-
-            if !ENABLE_WALLCLOCK_LAG_HISTOGRAM_COLLECTION.get(self.config.config_set()) {
-                continue;
-            }
 
             if let Some(stash) = &mut collection.wallclock_lag_histogram_stash {
                 let bucket = lag.map_seconds(|secs| secs.next_power_of_two());


### PR DESCRIPTION
This PR removes two dyncfgs that were added to de-risk feature rollout and are not needed anymore now:

 * enable_compute_mv_append_smearing
 * enable_wallclock_lag_histogram_collection

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
