### PR TITLE
Revert "Drop postgresql connection with Client (#33322)"

### DIFF
--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -15,13 +15,14 @@ use std::time::Duration;
 use mz_ore::future::{InTask, OreFutureExt};
 use mz_ore::netio::DUMMY_DNS_PORT;
 use mz_ore::option::OptionExt;
-use mz_ore::task::{self, AbortOnDropHandle};
+use mz_ore::task;
 use mz_proto::{RustType, TryFromProtoError};
 use mz_repr::CatalogItemId;
 use mz_ssh_util::tunnel::{SshTimeoutConfig, SshTunnelConfig};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio_postgres::config::{Host, ReplicationMode};
 use tokio_postgres::tls::MakeTlsConnect;
@@ -70,13 +71,26 @@ pub const DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT: Duration = Duration::ZERO;
 pub struct Client {
     inner: tokio_postgres::Client,
     server_version: Option<String>,
-    // Holds a handle to the task with the connection to ensure that when
-    // the client is dropped, the task can be aborted to close the connection.
-    // This is also useful for maintaining the lifetimes of dependent object (e.g. ssh tunnel).
-    _connection_handle: AbortOnDropHandle<()>,
 }
 
 impl Client {
+    fn new<S, T>(
+        client: tokio_postgres::Client,
+        connection: &tokio_postgres::Connection<S, T>,
+    ) -> Client
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+        T: AsyncRead + AsyncWrite + Unpin,
+    {
+        let server_version = connection
+            .parameter("server_version")
+            .map(|v| v.to_string());
+        Client {
+            inner: client,
+            server_version,
+        }
+    }
+
     /// Reports the value of the `server_version` parameter reported by the
     /// server.
     pub fn server_version(&self) -> Option<&str> {
@@ -274,19 +288,8 @@ impl Config {
                 let (client, connection) = async move { postgres_config.connect(tls).await }
                     .run_in_task_if(self.in_task, || "pg_connect".to_string())
                     .await?;
-
-                let client = Client {
-                    inner: client,
-                    server_version: connection
-                        .parameter("server_version")
-                        .map(|v| v.to_string()),
-                    _connection_handle: task::spawn(|| task_name, async {
-                        if let Err(e) = connection.await {
-                            warn!("postgres direct connection failed: {e}");
-                        }
-                    })
-                    .abort_on_drop(),
-                };
+                let client = Client::new(client, &connection);
+                task::spawn(|| task_name, connection);
                 Ok(client)
             }
             TunnelConfig::Ssh { config } => {
@@ -317,20 +320,14 @@ impl Config {
                     async move { postgres_config.connect_raw(tcp_stream, tls).await }
                         .run_in_task_if(self.in_task, || "pg_connect".to_string())
                         .await?;
+                let client = Client::new(client, &connection);
+                task::spawn(|| task_name, async {
+                    let _tunnel = tunnel; // Keep SSH tunnel alive for duration of connection.
 
-                let client = Client {
-                    inner: client,
-                    server_version: connection
-                        .parameter("server_version")
-                        .map(|v| v.to_string()),
-                    _connection_handle: task::spawn(|| task_name, async {
-                        let _tunnel = tunnel; // Keep SSH tunnel alive for duration of connection.
-                        if let Err(e) = connection.await {
-                            warn!("postgres via SSH tunnel connection failed: {e}");
-                        }
-                    })
-                    .abort_on_drop(),
-                };
+                    if let Err(e) = connection.await {
+                        warn!("postgres connection failed: {e}");
+                    }
+                });
                 Ok(client)
             }
             TunnelConfig::AwsPrivatelink { connection_id } => {
@@ -366,19 +363,8 @@ impl Config {
                 let (client, connection) = async move { postgres_config.connect(tls).await }
                     .run_in_task_if(self.in_task, || "pg_connect".to_string())
                     .await?;
-
-                let client = Client {
-                    inner: client,
-                    server_version: connection
-                        .parameter("server_version")
-                        .map(|v| v.to_string()),
-                    _connection_handle: task::spawn(|| task_name, async {
-                        if let Err(e) = connection.await {
-                            warn!("postgres AWS link connection failed: {e}");
-                        }
-                    })
-                    .abort_on_drop(),
-                };
+                let client = Client::new(client, &connection);
+                task::spawn(|| task_name, connection);
                 Ok(client)
             }
         }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -784,9 +784,6 @@ async fn raw_stream<'a>(
         // Ensure we don't pre-drop the task
         let _max_lsn_task_handle = max_lsn_task_handle;
 
-        // ensure we don't drop the replication client!
-        let _replication_client = replication_client;
-
         let mut uppers = pin!(uppers);
         let mut last_committed_upper = resume_lsn;
 


### PR DESCRIPTION
This reverts commit 70e90bbe71354461de70f46d25dd4bc839d7a106.


### Motivation

addresses https://github.com/MaterializeInc/database-issues/issues/7288 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
