### PR TITLE
ci: Disable Terraform GCP test for now (too flaky), bump MySQL start_period

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1430,6 +1430,7 @@ steps:
             args: [--no-cleanup]
             ci-builder: stable
       branches: "main v*.* *gcp* *tf* *terraform* *helm* *self-managed* *orchestratord*"
+      skip: "https://github.com/MaterializeInc/terraform-google-materialize/issues/11"
 
     - id: terraform-azure
       label: "Terraform + Helm Chart E2E on Azure"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -342,6 +342,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=BackupAndRestoreBeforeManipulate, "--seed=$BUILDKITE_JOB_ID"]
+        skip: "Too flaky"
 
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
@@ -354,6 +355,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=BackupAndRestoreAfterManipulate, "--seed=$BUILDKITE_JOB_ID"]
+        skip: "Too flaky"
 
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
@@ -366,6 +368,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=BackupAndRestoreMulti, "--seed=$BUILDKITE_JOB_ID"]
+        skip: "Too flaky"
 
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -29,6 +29,7 @@ ISSUE_RE = re.compile(
     | ( incidents-and-escalations\# | incidents-and-escalations/issues/ ) (?P<incidentsandescalations>[0-9]+)
     | ( database-issues\# | database-issues/issues/ ) (?P<databaseissues>[0-9]+)
     | ( terraform-aws-materialize\# | terraform-aws-materialize/issues/ ) (?P<terraformawsmaterialize>[0-9]+)
+    | ( terraform-google-materialize\# | terraform-google-materialize/issues/ ) (?P<terraformgooglematerialize>[0-9]+)
     # only match from the beginning of the line or after a space character to avoid matching Buildkite URLs
     | (^|\s) \# (?P<ambiguous>[0-9]+)
     )
@@ -43,6 +44,7 @@ GROUP_REPO = {
     "incidentsandescalations": "MaterializeInc/incidents-and-escalations",
     "databaseissues": "MaterializeInc/database-issues",
     "terraformawsmaterialize": "MaterializeInc/terraform-aws-materialize",
+    "terraformgooglematerialize": "MaterializeInc/terraform-google-materialize",
     "ambiguous": None,
 }
 

--- a/misc/python/materialize/mzcompose/services/mysql.py
+++ b/misc/python/materialize/mzcompose/services/mysql.py
@@ -69,7 +69,8 @@ class MySql(Service):
                         "--protocol=TCP",
                     ],
                     "interval": "1s",
-                    "start_period": "60s",
+                    # MySQL can be slow to start up
+                    "start_period": "180s",
                 },
                 "volumes": volumes,
             },


### PR DESCRIPTION
https://buildkite.com/materialize/nightly/builds/12975#0198eb6e-e98e-4d8d-ab1f-a5afecbd0199

https://materializeinc.slack.com/archives/C01LKF361MZ/p1756303657970459
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
