### PR TITLE
test: Turn on enable_with_ordinality_legacy_fallback for SQLsmith, and don't vary it in ParallelWorkload

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1305,6 +1305,7 @@ class FlipFlagsAction(Action):
             "enable_paused_cluster_readhold_downgrade",
             "enable_mz_join_core_v2",
             "force_swap_for_cc_sizes",
+            "enable_with_ordinality_legacy_fallback",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -42,6 +42,9 @@ SERVICES = [
         memory=f"{TOTAL_MEMORY / len(MZ_SERVERS)}GB",
         use_default_volumes=False,
         default_replication_factor=2,
+        additional_system_parameter_defaults={
+            "enable_with_ordinality_legacy_fallback": "true"
+        },
     )
     for mz_server in MZ_SERVERS
 ] + [


### PR DESCRIPTION
Turns out SQLsmith uses some of those exotic table functions that are currently [not supported](https://github.com/MaterializeInc/materialize/pull/33389) with `WITH ORDINALITY` with our the default feature flag settings. This PR makes SQLsmith turn on the flag that enables support.

Also, I made ParallelWorkload not touch this flag.

Discussion:
https://materializeinc.slack.com/archives/C01LKF361MZ/p1756314671979439?thread_ts=1756313678.082689&cid=C01LKF361MZ

Nightly: https://buildkite.com/materialize/nightly/builds/12993

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
