### PR TITLE
fix `explain-analyze.td` for multi-replica testdrive

### DIFF
--- a/test/testdrive/explain-analyze.td
+++ b/test/testdrive/explain-analyze.td
@@ -9,6 +9,9 @@
 
 $ set-regex match=((\d+)\sbytes|u(\d+)) replacement=<XXX>
 
+# In case the environment has other replicas
+> SET cluster_replica = r1
+
 > CREATE SCHEMA blue;
 > CREATE SCHEMA green;
 


### PR DESCRIPTION
I'm not sure how/why I missed this on previous nightly runs, but `explain-analyze.td` needs to set a replica in case there are multiple replicas.

### Motivation

  * This PR fixes a previously unreported bug.
https://buildkite.com/organizations/materialize/pipelines/nightly/builds/12990/jobs/0198ec3f-5a11-4581-a21f-3fb3253d3993/log#5310

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
