### PR TITLE
sql_server: add failing the source for incompatible schema changes

### DIFF
--- a/test/sql-server-resumption-old-syntax/populate-tables.td
+++ b/test/sql-server-resumption-old-syntax/populate-tables.td
@@ -34,7 +34,8 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't2', @role_
 INSERT INTO t2 SELECT a1.f1 + a6.f1 , N'abc\nxyz' FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
 DROP TABLE IF EXISTS alter_fail_drop_col;
-CREATE TABLE alter_fail_drop_col (f1 INTEGER, f2 INTEGER);
+# SQL Server CDC will continue to replicate a dropped NULL column as NULL so dropped column must be NOT NULL.
+CREATE TABLE alter_fail_drop_col (f1 INTEGER NOT NULL, f2 INTEGER NOT NULL);
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'alter_fail_drop_col ', @role_name = 'SA', @supports_net_changes = 0;
 
 INSERT INTO alter_fail_drop_col VALUES (1, 1);

--- a/test/sql-server-resumption-old-syntax/verify-data.td
+++ b/test/sql-server-resumption-old-syntax/verify-data.td
@@ -19,8 +19,11 @@
 ! SELECT * FROM alter_fail_drop_constraint;
 contains:Decode error
 
-# ! SELECT * FROM alter_fail_drop_col;
-# contains:has been altered
+# We can see either of InvalidData or InvalidColumn.
+# We see InvalidData if there was no data present.
+# We see InvalidColumn if there was a null present.
+! SELECT * FROM alter_fail_drop_col;
+contains:column 'f2'
 
 # Ensure non-definite errors are cleared.
 > SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%Connection refused%';


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

    https://github.com/MaterializeInc/database-issues/issues/9573

### Tips for reviewer

we differ from pg and mysql in that we just handle row decoding failures instead of actively monitoring for schema changes in the upstream tables using something like:
https://learn.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-ddl-history-transact-sql?view=sql-server-ver17

I wrote a different version of this that refactored to use an error message that matched the other sources but by updating the error message it would force all existing SQL Server sources to need to be dropped and recreated.

we can still make that change pre GA but it seems unnecessary

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
