### PR TITLE
0dt test: Adapt expected error messages

### DIFF
--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -754,6 +754,7 @@ def workflow_basic(c: Composition) -> None:
                     "server closed the connection unexpectedly" in str(e)
                     or "Can't create a connection to host" in str(e)
                     or "Connection refused" in str(e)
+                    or "the connection is closed" in str(e)
                 ), f"Unexpected error: {e}"
             except CommandFailureCausedUIError as e:
                 # service "mz_old" is not running
@@ -2218,6 +2219,7 @@ def workflow_ddl(c: Composition) -> None:
                     "server closed the connection unexpectedly" in str(e)
                     or "Can't create a connection to host" in str(e)
                     or "Connection refused" in str(e)
+                    or "the connection is closed" in str(e)
                 ), f"Unexpected error: {e}"
             except CommandFailureCausedUIError as e:
                 # service "mz_old" is not running


### PR DESCRIPTION
Seen in https://materializeinc.slack.com/archives/C01LKF361MZ/p1756316235068869

I'm not sure if something changed the error message recently.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
