### PR TITLE
docker buildx: Load into local docker by default

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -986,7 +986,7 @@ class ResolvedImage:
                 self.spec(),
                 f"--platform=linux/{self.image.rd.arch.go_str()}",
                 str(self.image.path),
-                *(("--push",) if push else ()),
+                *(["--push"] if push else ["--load"]),
             ]
         spawn.runv(cmd, stdin=f, stdout=sys.stderr.buffer)
 


### PR DESCRIPTION
Reported by Moritz in https://materializeinc.slack.com/archives/C01LKF361MZ/p1756384364415299

This seems correct to me, I couldn't figure out why it works for me locally and in CI without `--load`, maybe my Docker version uses Buildkit cache by default and @antiguru's doesn't.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
