### PR TITLE
ci: Nightly fixes (2025-08-28)

### DIFF
--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -664,14 +664,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # and kafka implementations, if --extended is passed
     workflows = [
         # These tests core functionality related to kafka with ssh and error reporting.
-        # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9533 is fixed
-        # (workflow_kafka, (False,), True),
+        (workflow_kafka, (False,), True),
         (workflow_hidden_hosts, (False,), True),
         # These tests core functionality related to pg with ssh and error reporting.
         (workflow_basic_ssh_features, (), False),
         (workflow_pg, (), True),
-        # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9533 is fixed
-        # (workflow_kafka_restart_replica, (), True),
+        (workflow_kafka_restart_replica, (), True),
         (workflow_kafka_sink, (), True),
     ]
     if args.extended:

--- a/test/testdrive-old-kafka-src-syntax/snapshot-source-statistics.td
+++ b/test/testdrive-old-kafka-src-syntax/snapshot-source-statistics.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=120s
 $ set-arg-default default-replica-size=scale=1,workers=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/test/testdrive/snapshot-source-statistics.td
+++ b/test/testdrive/snapshot-source-statistics.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=120s
 $ set-arg-default default-replica-size=scale=1,workers=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/13006

@martykulma We should have gone with your PR, you thought about reenabling these!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
