### PR TITLE
docs: Shorter kubectl commands in upgrade steps

### DIFF
--- a/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-cloud.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-cloud.html
@@ -56,8 +56,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify the operator upgrade by checking its events:
 
    ```bash
-   MZ_OPERATOR=$(kubectl -n materialize get pods --no-headers | grep operator  | awk '{print $1}')
-   kubectl -n materialize describe pod/$MZ_OPERATOR
+   kubectl -n materialize describe pod -l app.kubernetes.io/name=materialize-operator
    ```
 
    - The **Containers** section should show the ``--helm-chart-version``
@@ -136,8 +135,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify upgrade by checking the `balancerd` events:
 
    ```bash
-   MZ_BALANCERD=$(kubectl -n materialize-environment get pods --no-headers | grep balancerd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_BALANCERD
+   kubectl -n materialize-environment describe pod -l app=balancerd
    ```
 
    The **Events** section should list that the new version of the `balancerd`
@@ -146,8 +144,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify the upgrade by checking the `environmentd` events:
 
    ```bash
-   MZ_ENVIRONMENTD=$(kubectl -n materialize-environment get pods --no-headers | grep environmentd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_ENVIRONMENTD
+   kubectl -n materialize-environment describe pod -l app=environmentd
    ```
 
    The **Events** section should list that the new version of the `environmentd`

--- a/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-local-kind.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-local-kind.html
@@ -49,8 +49,7 @@ site.Data.self_managed.latest_versions.environmentd_version }}
    Verify the operator upgrade by checking its events:
 
    ```bash
-   MZ_OPERATOR=$(kubectl -n materialize get pods --no-headers | grep operator  | awk '{print $1}')
-   kubectl -n materialize describe pod/$MZ_OPERATOR
+   kubectl -n materialize describe pod -l app.kubernetes.io/name=materialize-operator
    ```
 
 1. Create a new `upgrade-materialize.yaml` file with the following content:
@@ -90,8 +89,7 @@ site.Data.self_managed.latest_versions.environmentd_version }}
    Verify upgrade by checking the `balancerd` events:
 
    ```bash
-   MZ_BALANCERD=$(kubectl -n materialize-environment get pods --no-headers | grep balancerd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_BALANCERD
+   kubectl -n materialize-environment describe pod -l app=balancerd
    ```
 
    The **Events** section should list that the new version of the `balancerd`
@@ -100,8 +98,7 @@ site.Data.self_managed.latest_versions.environmentd_version }}
    Verify the upgrade by checking the `environmentd` events:
 
    ```bash
-   MZ_ENVIRONMENTD=$(kubectl -n materialize-environment get pods --no-headers | grep environmentd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_ENVIRONMENTD
+   kubectl -n materialize-environment describe pod -l app=environmentd
    ```
 
    The **Events** section should list that the new version of the `environmentd`

--- a/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-local-minikube.html
+++ b/doc/user/layouts/shortcodes/self-managed/versions/upgrade/upgrade-steps-local-minikube.html
@@ -51,8 +51,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify the operator upgrade by checking its events:
 
    ```bash
-   MZ_OPERATOR=$(kubectl -n materialize get pods --no-headers | grep operator  | awk '{print $1}')
-   kubectl -n materialize describe pod/$MZ_OPERATOR
+   kubectl -n materialize describe pod -l app.kubernetes.io/name=materialize-operator
    ```
 
 1. Create a new `upgrade-materialize.yaml` file with the following content:
@@ -92,8 +91,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify upgrade by checking the `balancerd` events:
 
    ```bash
-   MZ_BALANCERD=$(kubectl -n materialize-environment get pods --no-headers | grep balancerd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_BALANCERD
+   kubectl -n materialize-environment describe pod -l app=balancerd
    ```
 
    The **Events** section should list that the new version of the `balancerd`
@@ -102,8 +100,7 @@ site.Data.self_managed.latest_versions.operator_helm_chart_version }}
    Verify the upgrade by checking the `environmentd` events:
 
    ```bash
-   MZ_ENVIRONMENTD=$(kubectl -n materialize-environment get pods --no-headers | grep environmentd  | awk '{print $1}')
-   kubectl -n materialize-environment describe pod/$MZ_ENVIRONMENTD
+   kubectl -n materialize-environment describe pod -l app=environmentd
    ```
 
    The **Events** section should list that the new version of the `environmentd`


### PR DESCRIPTION
There is also `kubectl -n materialize-environment get pods -o name | grep balancerd` instead of `kubectl -n materialize-environment get pods --no-headers | grep balancerd  | awk '{print $1}'`
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
