### PR TITLE
DNM  describe_fetch seems incorrect. Let's see whether we are using it at all.

### DIFF
--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -211,6 +211,7 @@ pub fn describe_fetch(
     _: &StatementContext,
     _: FetchStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
+    panic!("ggggggggggggggggggggggggggggggggggggg");
     Ok(StatementDesc::new(None))
 }
 


### PR DESCRIPTION
Just running CI to see whether we are using `describe_fetch`.

https://buildkite.com/materialize/nightly/builds/13018

Edit: Well, we _are_ using it, but not testing it. :sweat_smile: