### PR TITLE
apply the randomized defaults manually in the materialize crd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,6 +7024,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "urlencoding",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -128,7 +128,7 @@ pub mod v1alpha1 {
         //
         // Defaults to a random value in order to ensure that the first
         // generation rollout is automatically triggered.
-        #[serde(default = "Uuid::new_v4")]
+        #[serde(default)]
         pub request_rollout: Uuid,
         // If force_promote is set to the same value as request_rollout, the
         // current rollout will skip waiting for clusters in the new
@@ -166,11 +166,7 @@ pub mod v1alpha1 {
         // NOTE: This value MUST NOT be changed in an existing instance,
         // since it affects things like the way data is stored in the persist
         // backend.
-        // This is safe to be set via a default because the controller code
-        // runs an initial reconcile loop in order to set the finalizer on
-        // the resource before running any user code, and that initial loop
-        // will populate any defaults.
-        #[serde(default = "Uuid::new_v4")]
+        #[serde(default)]
         pub environment_id: Uuid,
 
         // The configuration for generating an x509 certificate using cert-manager for balancerd

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -44,6 +44,7 @@ tokio-postgres = "0.7.8"
 tower-http = "0.6.6"
 tracing = "0.1.37"
 urlencoding = "2.1.3"
+uuid = { version = "1.17", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [features]


### PR DESCRIPTION
### Motivation

it turns out that if you set a default in the crd, it is calculated once at crd generation time, and then that fixed default is used for every resource created from that crd, which is not at all what we want (my understanding of what was going on based on the comment i left on the crd struct field was actually incorrect).

### Tips for reviewer

this appears to work correctly now when i run it in kind

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
