### PR TITLE
sasl/scram

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,6 +5378,7 @@ dependencies = [
  "arrow",
  "async-stream",
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "bytesize",
  "chrono",
@@ -5536,6 +5537,7 @@ name = "mz-auth"
 version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
+ "itertools 0.14.0",
  "mz-ore",
  "openssl",
  "proptest",
@@ -5743,6 +5745,7 @@ dependencies = [
  "mz-storage-client",
  "mz-storage-types",
  "mz-transform",
+ "openssl",
  "paste",
  "prometheus",
  "proptest",
@@ -7293,6 +7296,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "bytesize",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.98"
 arrow = { version = "55.2.0", default-features = false }
 async-stream = "0.3.6"
 async-trait = "0.1.88"
+base64 = "0.22.1"
 bytes = "1.10.1"
 bytesize = "1.3.0"
 chrono = { version = "0.4.39", default-features = false, features = ["std"] }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -151,6 +151,7 @@ impl Catalog {
             source_references: BTreeMap::new(),
             storage_metadata: Default::default(),
             temporary_schemas: BTreeMap::new(),
+            mock_authentication_nonce: Default::default(),
             config: mz_sql::catalog::CatalogConfig {
                 start_time: to_datetime((config.now)()),
                 start_instant: Instant::now(),
@@ -400,6 +401,13 @@ impl Catalog {
             .get_catalog_content_version()
             .unwrap_or("new")
             .to_string();
+
+        let mz_authentication_mock_nonce =
+            txn.get_authentication_mock_nonce().ok_or_else(|| {
+                Error::new(ErrorKind::SettingError("authentication nonce".to_string()))
+            })?;
+
+        state.mock_authentication_nonce = Some(mz_authentication_mock_nonce);
 
         // Migrate item ASTs.
         let builtin_table_update = if !config.skip_migrations {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -142,6 +142,7 @@ pub struct CatalogState {
     #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     pub(super) source_references: BTreeMap<CatalogItemId, SourceReferences>,
     pub(super) storage_metadata: StorageMetadata,
+    pub(super) mock_authentication_nonce: Option<String>,
 
     // Mutable state not derived from the durable catalog.
     #[serde(skip)]
@@ -316,6 +317,7 @@ impl CatalogState {
             source_references: Default::default(),
             storage_metadata: Default::default(),
             license_key: ValidatedLicenseKey::for_tests(),
+            mock_authentication_nonce: Default::default(),
         }
     }
 
@@ -2634,6 +2636,10 @@ impl CatalogState {
             }
             CommentObjectId::NetworkPolicy(id) => self.get_network_policy(&id).name.clone(),
         }
+    }
+
+    pub fn mock_authentication_nonce(&self) -> String {
+        self.mock_authentication_nonce.clone().unwrap_or_default()
     }
 }
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -73,6 +73,20 @@ pub enum Command {
         password: Option<Password>,
     },
 
+    AuthenticateGetSASLChallenge {
+        tx: oneshot::Sender<Result<SASLChallengeResponse, AdapterError>>,
+        role_name: String,
+        nonce: String,
+    },
+
+    AuthenticateVerifySASLProof {
+        tx: oneshot::Sender<Result<SASLVerifyProofResponse, AdapterError>>,
+        role_name: String,
+        proof: String,
+        auth_message: String,
+        mock_hash: String,
+    },
+
     Execute {
         portal_name: String,
         session: Session,
@@ -148,6 +162,8 @@ impl Command {
             Command::CancelRequest { .. }
             | Command::Startup { .. }
             | Command::AuthenticatePassword { .. }
+            | Command::AuthenticateGetSASLChallenge { .. }
+            | Command::AuthenticateVerifySASLProof { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
             | Command::GetWebhook { .. }
@@ -166,6 +182,8 @@ impl Command {
             Command::CancelRequest { .. }
             | Command::Startup { .. }
             | Command::AuthenticatePassword { .. }
+            | Command::AuthenticateGetSASLChallenge { .. }
+            | Command::AuthenticateVerifySASLProof { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
             | Command::GetWebhook { .. }
@@ -208,6 +226,22 @@ pub struct AuthResponse {
     pub role_id: RoleId,
     /// If the user is a superuser.
     pub superuser: bool,
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct SASLChallengeResponse {
+    pub iteration_count: usize,
+    /// Base64-encoded salt for the SASL challenge.
+    pub salt: String,
+    pub nonce: String,
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct SASLVerifyProofResponse {
+    pub verifier: String,
+    pub auth_resp: AuthResponse,
 }
 
 // Facile implementation for `StartupResponse`, which does not use the `allowed`

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -356,6 +356,8 @@ impl Message {
                 Command::CheckConsistency { .. } => "command-check_consistency",
                 Command::Dump { .. } => "command-dump",
                 Command::AuthenticatePassword { .. } => "command-auth_check",
+                Command::AuthenticateGetSASLChallenge { .. } => "command-auth_get_sasl_challenge",
+                Command::AuthenticateVerifySASLProof { .. } => "command-auth_verify_sasl_proof",
             },
             Message::ControllerReady {
                 controller: ControllerReadiness::Compute,

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -18,6 +18,7 @@ proptest-derive = "0.5.1"
 proptest = "1.7.0"
 static_assertions = "1.1"
 openssl = { version = "0.10.73", features = ["vendored"] }
+itertools = "0.14.0"
 
 [features]
 default = ["workspace-hack"]

--- a/src/authenticator/src/lib.rs
+++ b/src/authenticator/src/lib.rs
@@ -14,5 +14,6 @@ use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 pub enum Authenticator {
     Frontegg(FronteggAuthenticator),
     Password(AdapterClient),
+    Sasl(AdapterClient),
     None,
 }

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.88"
+base64 = "0.22.1"
 bincode = { version = "1.3.3" }
 bytes = { version = "1.10.1", features = ["serde"] }
 bytesize = "1.3.0"
@@ -49,6 +50,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-transform = { path = "../transform" }
+openssl = { version = "0.10.73", features = ["vendored"] }
 paste = "1.0.11"
 prometheus = { version = "0.13.4", default-features = false }
 proptest = { version = "1.7.0", default-features = false, features = ["std"] }

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -72,6 +72,7 @@ pub const OID_ALLOC_KEY: &str = "oid";
 pub(crate) const CATALOG_CONTENT_VERSION_KEY: &str = "catalog_content_version";
 pub const BUILTIN_MIGRATION_SHARD_KEY: &str = "builtin_migration_shard";
 pub const EXPRESSION_CACHE_SHARD_KEY: &str = "expression_cache_shard";
+pub const MOCK_AUTHENTICATION_NONCE_KEY: &str = "mock_authentication_nonce";
 
 #[derive(Clone, Debug)]
 pub struct BootstrapArgs {

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -62,10 +62,11 @@ use crate::durable::objects::{
 use crate::durable::{
     AUDIT_LOG_ID_ALLOC_KEY, BUILTIN_MIGRATION_SHARD_KEY, CATALOG_CONTENT_VERSION_KEY, CatalogError,
     DATABASE_ID_ALLOC_KEY, DefaultPrivilege, DurableCatalogError, DurableCatalogState,
-    EXPRESSION_CACHE_SHARD_KEY, NetworkPolicy, OID_ALLOC_KEY, SCHEMA_ID_ALLOC_KEY,
-    STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_ITEM_ALLOC_KEY,
-    SYSTEM_REPLICA_ID_ALLOC_KEY, Snapshot, SystemConfiguration, USER_ITEM_ALLOC_KEY,
-    USER_NETWORK_POLICY_ID_ALLOC_KEY, USER_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
+    EXPRESSION_CACHE_SHARD_KEY, MOCK_AUTHENTICATION_NONCE_KEY, NetworkPolicy, OID_ALLOC_KEY,
+    SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY,
+    SYSTEM_ITEM_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, Snapshot, SystemConfiguration,
+    USER_ITEM_ALLOC_KEY, USER_NETWORK_POLICY_ID_ALLOC_KEY, USER_REPLICA_ID_ALLOC_KEY,
+    USER_ROLE_ID_ALLOC_KEY,
 };
 use crate::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
 
@@ -1920,7 +1921,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Get the value of a persisted setting.
-    fn get_setting(&self, name: String) -> Option<&str> {
+    pub fn get_setting(&self, name: String) -> Option<&str> {
         self.settings
             .get(&SettingKey { name })
             .map(|entry| &*entry.value)
@@ -2194,6 +2195,14 @@ impl<'a> Transaction<'a> {
                 name: CATALOG_CONTENT_VERSION_KEY.to_string(),
             })
             .map(|value| &*value.value)
+    }
+
+    pub fn get_authentication_mock_nonce(&self) -> Option<String> {
+        self.settings
+            .get(&SettingKey {
+                name: MOCK_AUTHENTICATION_NONCE_KEY.to_string(),
+            })
+            .map(|value| value.value.clone())
     }
 
     /// Commit the current operation within the transaction. This does not cause anything to be

--- a/src/catalog/src/memory/error.rs
+++ b/src/catalog/src/memory/error.rs
@@ -102,6 +102,8 @@ pub enum ErrorKind {
     VarError(#[from] VarError),
     #[error("unknown cluster replica size {size}")]
     InvalidClusterReplicaSize { size: String, expected: Vec<String> },
+    #[error("failed to get catalog setting: {0}")]
+    SettingError(String),
     #[error("internal error: {0}")]
     Internal(String),
 }

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -16,8 +16,8 @@ use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::objects::{DurableType, Snapshot};
 use mz_catalog::durable::{
     BUILTIN_MIGRATION_SHARD_KEY, CATALOG_VERSION, CatalogError, Database, DurableCatalogError,
-    DurableCatalogState, EXPRESSION_CACHE_SHARD_KEY, Epoch, FenceError, Schema,
-    TestCatalogStateBuilder, test_bootstrap_args,
+    DurableCatalogState, EXPRESSION_CACHE_SHARD_KEY, Epoch, FenceError,
+    MOCK_AUTHENTICATION_NONCE_KEY, Schema, TestCatalogStateBuilder, test_bootstrap_args,
 };
 use mz_ore::cast::usize_to_u64;
 use mz_ore::collections::HashSet;
@@ -65,6 +65,12 @@ impl StableSnapshot<'_> {
             name: EXPRESSION_CACHE_SHARD_KEY.to_string(),
         }
     }
+
+    fn mock_authentication_nonce_key() -> proto::SettingKey {
+        proto::SettingKey {
+            name: MOCK_AUTHENTICATION_NONCE_KEY.to_string(),
+        }
+    }
 }
 
 impl Debug for StableSnapshot<'_> {
@@ -97,6 +103,7 @@ impl Debug for StableSnapshot<'_> {
         let mut settings: BTreeMap<proto::SettingKey, proto::SettingValue> = settings.clone();
         settings.remove(&Self::builtin_migration_shard_key());
         settings.remove(&Self::expression_cache_shard_key());
+        settings.remove(&Self::mock_authentication_nonce_key());
         f.debug_struct("Snapshot")
             .field("databases", databases)
             .field("schemas", schemas)

--- a/src/catalog/tests/snapshots/debug__opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__opened_trace.snap
@@ -1,6 +1,5 @@
 ---
 source: src/catalog/tests/debug.rs
-assertion_line: 226
 expression: test_trace
 ---
 Trace {

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -766,6 +766,18 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         serde_json::from_reader(f)?
     };
 
+    for (_, listener) in &listeners_config.sql {
+        listener
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid SQL listener: {}", e))?;
+    }
+
+    for (_, listener) in &listeners_config.http {
+        listener
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid HTTP listener: {}", e))?;
+    }
+
     // Configure CORS.
     let allowed_origins = if !args.cors_allowed_origin.is_empty() {
         args.cors_allowed_origin

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -1002,6 +1002,14 @@ async fn auth(
                 });
             }
         },
+        Authenticator::Sasl(_) => {
+            // We shouldn't ever end up here as the configuration is validated at startup.
+            // If we do, it's a server misconfiguration.
+            // Just in case, we return a 401 rather than panic.
+            return Err(AuthError::MissingHttpAuthentication {
+                include_www_authenticate_header,
+            });
+        }
         Authenticator::None => {
             // If no authentication, use whatever is in the HTTP auth
             // header (without checking the password), or fall back to the

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -276,6 +276,7 @@ impl Listener<SqlListenerConfig> {
                 frontegg.expect("Frontegg args are required with AuthenticatorKind::Frontegg"),
             ),
             AuthenticatorKind::Password => Authenticator::Password(adapter_client.clone()),
+            AuthenticatorKind::Sasl => Authenticator::Sasl(adapter_client.clone()),
             AuthenticatorKind::None => Authenticator::None,
         };
 
@@ -401,6 +402,7 @@ impl Listeners {
             let authenticator_rx = match authenticator_kind {
                 AuthenticatorKind::Frontegg => authenticator_frontegg_rx.clone(),
                 AuthenticatorKind::Password => authenticator_password_rx.clone(),
+                AuthenticatorKind::Sasl => authenticator_password_rx.clone(),
                 AuthenticatorKind::None => authenticator_none_rx.clone(),
             };
             let source: &'static str = Box::leak(name.clone().into_boxed_str());

--- a/src/materialized/ci/listener_configs/password.json
+++ b/src/materialized/ci/listener_configs/password.json
@@ -5,6 +5,12 @@
       "authenticator_kind": "Password",
       "allowed_roles": "NormalAndInternal",
       "enable_tls": false
+    },
+    "externalsasl": {
+      "addr": "0.0.0.0:6877",
+      "authenticator_kind": "Sasl",
+      "allowed_roles": "NormalAndInternal",
+      "enable_tls": false
     }
   },
   "http": {

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -28,7 +28,8 @@ pub use conn::{
 };
 pub use format::Format;
 pub use message::{
-    ErrorResponse, FrontendMessage, FrontendStartupMessage, VERSION_3, VERSION_CANCEL,
-    VERSION_GSSENC, VERSION_SSL, VERSIONS,
+    ChannelBinding, ErrorResponse, FrontendMessage, FrontendStartupMessage, GS2Header,
+    SASLClientFinalResponse, SASLInitialResponse, VERSION_3, VERSION_CANCEL, VERSION_GSSENC,
+    VERSION_SSL, VERSIONS,
 };
 pub use severity::Severity;

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.88"
+base64 = "0.22.1"
 byteorder = "1.4.3"
 bytes = "1.10.1"
 bytesize = "1.3.0"


### PR DESCRIPTION
This implements the SASL/SCRAM [protocol](https://datatracker.ietf.org/doc/html/rfc5802) as implemented by postgres. The goal is to be compatible with postgres clients that support/expect SASL/SCRAM. 
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
