### PR TITLE
Use `MRE::pretty()` in error messages

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -805,8 +805,8 @@ impl Coordinator {
                 Self::send_diffs(session, diffs_plan)
             }
             None => panic!(
-                "tried using sequence_insert_constant on non-constant MirRelationExpr {:?}",
-                constants
+                "tried using sequence_insert_constant on non-constant MirRelationExpr\n{}",
+                constants.pretty(),
             ),
         }
     }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -239,8 +239,8 @@ impl HirRelationExpr {
             if let MirRelationExpr::Get { .. } = &get_outer {
             } else {
                 panic!(
-                    "get_outer: expected a MirRelationExpr::Get, found {:?}",
-                    get_outer
+                    "get_outer: expected a MirRelationExpr::Get, found\n{}",
+                    get_outer.pretty(),
                 );
             }
             assert_eq!(col_map.len(), get_outer.arity());
@@ -333,8 +333,8 @@ impl HirRelationExpr {
                             (id, typ)
                         } else {
                             panic!(
-                                "get_value: expected a MirRelationExpr::Get with local Id, found {:?}",
-                                get_value
+                                "get_value: expected a MirRelationExpr::Get with local Id, found\n{}",
+                                get_value.pretty(),
                             );
                         };
                         // Add the information about the CTE to the map and remove it when


### PR DESCRIPTION
This changes a few panic messages to use `MirRelationExpr::pretty` rather than `{:?}`. This is better both for readability and because `pretty` auto-redacts in prod.

Note that for redaction, a much more comprehensive approach is @bkirwi's https://github.com/MaterializeInc/materialize/pull/33460, which makes sure that we are redacting Datums everywhere, e.g., also in MirScalarExpr, HirScalarExpr, etc.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
