### PR TITLE
Mention `RUST_MIN_STACK` in the developer docs

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -159,9 +159,11 @@ You can run a sqllogictest file like so:
 $ bin/sqllogictest [--release] -- test/sqllogictest/TESTFILE.slt
 ```
 
-For larger test files, it is imperative that you compile in release mode, i.e.,
-by passing the `--release` flag as above. The extra compile time will quickly be
-made up for by a much faster execution.
+When running many test files (or extremely large test files), it can be beneficial
+to compile in release mode, i.e., by passing the `--release` flag as above. The
+extra compile time will quickly be made up for by a much faster execution.
+
+Our debug builds use a lot more stack space than our release builds, so they often run into stack overflows. You can work around this by setting the `RUST_MIN_STACK` environment variable to a higher value when running `bin/sqllogictest`, e.g. 100000000.
 
 To add logging for tests, append `-vv`, e.g.:
 

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -378,6 +378,8 @@ psql -U mz_system -h localhost -p 6877 materialize
 
 In order to run Materialize with large clusters and more memory available, you have to set a license key. Set `export MZ_LICENSE_KEY=$HOME/license-key` and write the `materialize dev license key` from 1Password into that file. In order to have `mzcompose` based tests pick up the license key, set `export MZ_CI_LICENSE_KEY=$(cat $MZ_LICENSE_KEY)`.
 
+Our debug builds use a lot more stack space than our release builds, so they often run into stack overflows. You can work around this by setting the `RUST_MIN_STACK` environment variable to a higher value when running `bin/environmentd` (or `bin/sqllogictest`), e.g. 100000000.
+
 ## Console UI
 
 Console can point at your local environmentd. To use this feature, pass the


### PR DESCRIPTION
As it says on the tin. For example, currently, running any `FETCH` statement in debug mode runs into a stack overflow. Same for `transactions.slt`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
