### PR TITLE
bin/{sqllogictest,environmentd}: Bump RUST_MIN_STACK in Debug mode

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -156,17 +156,18 @@ data.
 You can run a sqllogictest file like so:
 
 ```shell
-$ bin/sqllogictest [--release] -- test/sqllogictest/TESTFILE.slt
+$ bin/sqllogictest [--release] [--optimized] -- test/sqllogictest/TESTFILE.slt
 ```
 
-For larger test files, it is imperative that you compile in release mode, i.e.,
-by passing the `--release` flag as above. The extra compile time will quickly be
-made up for by a much faster execution.
+For larger test files, it is imperative that you compile in optimized mode, i.e.,
+by passing the `--optimized` flag as above. The extra compile time will quickly be
+made up for by a much faster execution. Release mode is usually not worth the
+extra compile time locally.
 
 To add logging for tests, append `-vv`, e.g.:
 
 ```shell
-$ bin/sqllogictest [--release] -- test/sqllogictest/TESTFILE.slt -vv
+$ bin/sqllogictest [--release] [--optimized] -- test/sqllogictest/TESTFILE.slt -vv
 ```
 
 There are currently three classes of sqllogictest files:

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -294,7 +294,7 @@ drive the process:
 
 ```shell
 cd materialize
-bin/environmentd [--release] [<environmentd arg>...]
+bin/environmentd [--release] [--optimized] [<environmentd arg>...]
 ```
 
 ### WebAssembly / WASM


### PR DESCRIPTION
Alternative to https://github.com/MaterializeInc/materialize/pull/33470
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
