### PR TITLE
Check session state in `verify_statement_revision`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7286,6 +7286,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dec",
+ "itertools 0.14.0",
  "mz-ore",
  "mz-pgrepr-consts",
  "mz-pgwire-common",

--- a/doc/user/content/sql/prepare.md
+++ b/doc/user/content/sql/prepare.md
@@ -15,7 +15,7 @@ menu:
 Field | Use
 ------|-----
 name | A name for this particular prepared statement that you can later use to execute or deallocate a statement. The name must be unique within a session.
-statement  |  Any `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement.
+statement  |  Any `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `FETCH` statement.
 
 ## Details
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -97,7 +97,7 @@ pub use crate::catalog::transact::{
 };
 use crate::command::CatalogDump;
 use crate::coord::TargetCluster;
-use crate::session::{PreparedStatement, Session};
+use crate::session::{Portal, PreparedStatement, Session};
 use crate::util::ResultExt;
 use crate::{AdapterError, AdapterNotice, ExecuteResponse};
 
@@ -429,6 +429,7 @@ pub struct ConnCatalog<'a> {
     search_path: Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
     role_id: RoleId,
     prepared_statements: Option<&'a BTreeMap<String, PreparedStatement>>,
+    portals: Option<&'a BTreeMap<String, Portal>>,
     notices_tx: UnboundedSender<AdapterNotice>,
 }
 
@@ -1794,6 +1795,11 @@ impl SessionCatalog for ConnCatalog<'_> {
             .as_ref()
             .map(|ps| ps.get(name).map(|ps| ps.desc()))
             .flatten()
+    }
+
+    fn get_portal_desc_unverified(&self, portal_name: &str) -> Option<&StatementDesc> {
+        self.portals
+            .and_then(|portals| portals.get(portal_name).map(|portal| &portal.desc))
     }
 
     fn active_database(&self) -> Option<&DatabaseId> {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -338,6 +338,7 @@ impl CatalogState {
             search_path,
             role_id: session.current_role_id().clone(),
             prepared_statements: Some(session.prepared_statements()),
+            portals: Some(session.portals()),
             notices_tx: session.retain_notice_transmitter(),
         }
     }
@@ -360,6 +361,7 @@ impl CatalogState {
             search_path: Vec::new(),
             role_id,
             prepared_statements: None,
+            portals: None,
             notices_tx,
         }
     }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -584,12 +584,14 @@ impl SessionClient {
 
         let desc = Coordinator::describe(&catalog, self.session(), stmt.clone(), param_types)?;
         let now = self.now();
+        let state_revision = self.session().state_revision();
         self.session().set_prepared_statement(
             name,
             stmt,
             sql,
             desc,
             catalog.transient_revision(),
+            state_revision,
             now,
         );
         Ok(())
@@ -611,6 +613,7 @@ impl SessionClient {
         let result_formats = vec![mz_pgwire_common::Format::Text; desc.arity()];
         let now = self.now();
         let logging = self.session().mint_logging(sql, Some(&stmt), now);
+        let session_state_revision = self.session().state_revision();
         self.session().set_portal(
             name,
             desc,
@@ -619,6 +622,7 @@ impl SessionClient {
             params,
             result_formats,
             catalog.transient_revision(),
+            session_state_revision,
         )?;
         Ok(())
     }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -45,7 +45,9 @@ use crate::coord::{
 };
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
-use crate::session::{EndTransactionAction, Session, TransactionOps, TransactionStatus, WriteOp};
+use crate::session::{
+    EndTransactionAction, Session, StateRevision, TransactionOps, TransactionStatus, WriteOp,
+};
 use crate::util::ClientTransmitter;
 
 // DO NOT make this visible in any way, i.e. do not add any version of
@@ -563,14 +565,16 @@ impl Coordinator {
                     {
                         ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
                     } else {
-                        let session_state_revision = ctx.session().state_revision();
+                        let state_revision = StateRevision {
+                            catalog_revision: self.catalog().transient_revision(),
+                            session_state_revision: ctx.session().state_revision(),
+                        };
                         ctx.session_mut().set_prepared_statement(
                             plan.name,
                             Some(plan.stmt),
                             plan.sql,
                             plan.desc,
-                            self.catalog().transient_revision(),
-                            session_state_revision,
+                            state_revision,
                             self.now(),
                         );
                         ctx.retire(Ok(ExecuteResponse::Prepare));

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -563,12 +563,14 @@ impl Coordinator {
                     {
                         ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
                     } else {
+                        let session_state_revision = ctx.session().state_revision();
                         ctx.session_mut().set_prepared_statement(
                             plan.name,
                             Some(plan.stmt),
                             plan.sql,
                             plan.desc,
                             self.catalog().transient_revision(),
+                            session_state_revision,
                             self.now(),
                         );
                         ctx.retire(Ok(ExecuteResponse::Prepare));

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4639,7 +4639,7 @@ impl Coordinator {
         let stmt = ps.stmt().cloned();
         let desc = ps.desc().clone();
         let catalog_revision = ps.catalog_revision;
-        let session_state_revision = session.state_revision();
+        let session_state_revision = ps.session_state_revision;
         let logging = Arc::clone(ps.logging());
         session.create_new_portal(
             stmt,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4638,9 +4638,18 @@ impl Coordinator {
             .expect("known to exist");
         let stmt = ps.stmt().cloned();
         let desc = ps.desc().clone();
-        let revision = ps.catalog_revision;
+        let catalog_revision = ps.catalog_revision;
+        let session_state_revision = session.state_revision();
         let logging = Arc::clone(ps.logging());
-        session.create_new_portal(stmt, logging, desc, plan.params, Vec::new(), revision)
+        session.create_new_portal(
+            stmt,
+            logging,
+            desc,
+            plan.params,
+            Vec::new(),
+            catalog_revision,
+            session_state_revision,
+        )
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4638,18 +4638,9 @@ impl Coordinator {
             .expect("known to exist");
         let stmt = ps.stmt().cloned();
         let desc = ps.desc().clone();
-        let catalog_revision = ps.catalog_revision;
-        let session_state_revision = ps.session_state_revision;
+        let state_revision = ps.state_revision;
         let logging = Arc::clone(ps.logging());
-        session.create_new_portal(
-            stmt,
-            logging,
-            desc,
-            plan.params,
-            Vec::new(),
-            catalog_revision,
-            session_state_revision,
-        )
+        session.create_new_portal(stmt, logging, desc, plan.params, Vec::new(), state_revision)
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -158,7 +158,7 @@ impl Coordinator {
             let portal = session
                 .get_portal_unverified_mut(name)
                 .expect("known to exist");
-            portal.state_revision = new_revision;
+            *portal.state_revision = new_revision;
         }
         Ok(())
     }

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -80,6 +80,7 @@ impl Coordinator {
             .collect();
         let result_formats = vec![mz_pgwire_common::Format::Text; desc.arity()];
         let logging = session.mint_logging(sql, Some(&stmt), now);
+        let session_state_revision = session.state_revision();
         session.set_portal(
             name,
             desc,
@@ -88,6 +89,7 @@ impl Coordinator {
             params,
             result_formats,
             catalog.transient_revision(),
+            session_state_revision,
         )?;
         Ok(())
     }
@@ -118,17 +120,18 @@ impl Coordinator {
             Some(ps) => ps,
             None => return Err(AdapterError::UnknownPreparedStatement(name.to_string())),
         };
-        if let Some(revision) = Self::verify_statement_revision(
+        if let Some(new_revision) = Self::verify_statement_revision(
             catalog,
             session,
             ps.stmt(),
             ps.desc(),
             ps.catalog_revision,
+            ps.session_state_revision,
         )? {
             let ps = session
                 .get_prepared_statement_mut_unverified(name)
                 .expect("known to exist");
-            ps.catalog_revision = revision;
+            (ps.catalog_revision, ps.session_state_revision) = new_revision;
         }
 
         Ok(())
@@ -150,28 +153,33 @@ impl Coordinator {
             portal.stmt.as_deref(),
             &portal.desc,
             portal.catalog_revision,
+            portal.session_state_revision,
         )? {
             let portal = session
                 .get_portal_unverified_mut(name)
                 .expect("known to exist");
-            portal.catalog_revision = revision;
+            portal.catalog_revision = revision.0;
         }
         Ok(())
     }
 
-    /// If the catalog and portal revisions don't match, re-describe the statement
-    /// and ensure its result type has not changed. Return `Some(x)` with the new
-    /// (valid) revision if its plan has changed. Return `None` if the revisions
-    /// match. Return an error if the plan has changed.
+    /// If the current catalog/session revisions don't match the given revisions, re-describe the
+    /// statement and ensure its result type has not changed. Return `Some((c, s))` with the new
+    /// (valid) catalog and session state revisions if its plan has changed. Return `None` if the
+    /// revisions match. Return an error if the plan has changed.
     fn verify_statement_revision(
         catalog: &Catalog,
         session: &Session,
         stmt: Option<&Statement<Raw>>,
         desc: &StatementDesc,
-        catalog_revision: u64,
-    ) -> Result<Option<u64>, AdapterError> {
-        let current_revision = catalog.transient_revision();
-        if catalog_revision != current_revision {
+        old_catalog_revision: u64,
+        old_session_state_revision: u64,
+    ) -> Result<Option<(u64, u64)>, AdapterError> {
+        let current_catalog_revision = catalog.transient_revision();
+        let current_session_state_revision = session.state_revision();
+        if old_catalog_revision != current_catalog_revision
+            || old_session_state_revision != current_session_state_revision
+        {
             let current_desc = Self::describe(
                 catalog,
                 session,
@@ -183,7 +191,10 @@ impl Coordinator {
                     "cached plan must not change result type".to_string(),
                 ))
             } else {
-                Ok(Some(current_revision))
+                Ok(Some((
+                    current_catalog_revision,
+                    current_session_state_revision,
+                )))
             }
         } else {
             Ok(None)

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -890,7 +890,10 @@ impl From<mz_sql::catalog::CatalogError> for AdapterError {
 
 impl From<PlanError> for AdapterError {
     fn from(e: PlanError) -> AdapterError {
-        AdapterError::PlanError(e)
+        match e {
+            PlanError::UnknownCursor(name) => AdapterError::UnknownCursor(name),
+            _ => AdapterError::PlanError(e),
+        }
     }
 }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -688,6 +688,11 @@ impl<T: TimestampManipulation> Session<T> {
         &self.prepared_statements
     }
 
+    /// Returns the portals for the session.
+    pub fn portals(&self) -> &BTreeMap<String, Portal> {
+        &self.portals
+    }
+
     /// Binds the specified portal to the specified prepared statement.
     ///
     /// If the prepared statement contains parameters, the values and types of

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1417,18 +1417,16 @@ async fn execute_stmt<S: ResultSender>(
 
     let desc = prep_stmt.desc().clone();
     let logging = Arc::clone(prep_stmt.logging());
-    let catalog_revision = prep_stmt.catalog_revision;
-    let session_state_revision = prep_stmt.session_state_revision;
-    let stmt = prep_stmt.stmt().cloned();
+    let stmt_ast = prep_stmt.stmt().cloned();
+    let state_revision = prep_stmt.state_revision;
     if let Err(err) = client.session().set_portal(
         EMPTY_PORTAL.into(),
         desc,
-        stmt,
+        stmt_ast,
         logging,
         params,
         result_formats,
-        catalog_revision,
-        session_state_revision,
+        state_revision,
     ) {
         return Ok(SqlResult::err(client, err).into());
     }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1416,9 +1416,10 @@ async fn execute_stmt<S: ResultSender>(
     ];
 
     let desc = prep_stmt.desc().clone();
-    let revision = prep_stmt.catalog_revision;
-    let stmt = prep_stmt.stmt().cloned();
     let logging = Arc::clone(prep_stmt.logging());
+    let catalog_revision = prep_stmt.catalog_revision;
+    let stmt = prep_stmt.stmt().cloned();
+    let session_state_revision = client.session().state_revision();
     if let Err(err) = client.session().set_portal(
         EMPTY_PORTAL.into(),
         desc,
@@ -1426,7 +1427,8 @@ async fn execute_stmt<S: ResultSender>(
         logging,
         params,
         result_formats,
-        revision,
+        catalog_revision,
+        session_state_revision,
     ) {
         return Ok(SqlResult::err(client, err).into());
     }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1418,8 +1418,8 @@ async fn execute_stmt<S: ResultSender>(
     let desc = prep_stmt.desc().clone();
     let logging = Arc::clone(prep_stmt.logging());
     let catalog_revision = prep_stmt.catalog_revision;
+    let session_state_revision = prep_stmt.session_state_revision;
     let stmt = prep_stmt.stmt().cloned();
-    let session_state_revision = client.session().state_revision();
     if let Err(err) = client.session().set_portal(
         EMPTY_PORTAL.into(),
         desc,

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -23,6 +23,7 @@ postgres-types = { version = "0.2.5", features = [
     "with-uuid-1",
 ] }
 uuid = "1.17.0"
+itertools = "0.14.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -13,6 +13,7 @@ use std::{io, str};
 
 use bytes::{BufMut, BytesMut};
 use chrono::{DateTime, NaiveDateTime, NaiveTime, Utc};
+use itertools::Itertools;
 use mz_ore::cast::ReinterpretCast;
 use mz_pgwire_common::Format;
 use mz_repr::adt::array::ArrayDimension;
@@ -892,7 +893,7 @@ fn pg_len(what: &str, len: usize) -> Result<i32, io::Error> {
 /// every datum in `row`.
 pub fn values_from_row(row: &RowRef, typ: &RelationType) -> Vec<Option<Value>> {
     row.iter()
-        .zip(typ.column_types.iter())
+        .zip_eq(typ.column_types.iter())
         .map(|(col, typ)| Value::from_datum(col, &typ.scalar_type))
         .collect()
 }

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use bytes::{Buf, BufMut, BytesMut};
 use bytesize::ByteSize;
 use futures::{SinkExt, TryStreamExt, sink};
+use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
 use mz_ore::cast::CastFrom;
 use mz_ore::future::OreSinkExt;
@@ -304,7 +305,7 @@ impl Encoder<BackendMessage> for Codec {
             }
             BackendMessage::DataRow(fields) => {
                 dst.put_length_i16(fields.len())?;
-                for (f, (ty, format)) in fields.iter().zip(&self.encode_state) {
+                for (f, (ty, format)) in fields.iter().zip_eq(&self.encode_state) {
                     if let Some(f) = f {
                         let base = dst.len();
                         dst.put_u32(0);

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1102,18 +1102,16 @@ where
 
         let desc = stmt.desc().clone();
         let logging = Arc::clone(stmt.logging());
-        let catalog_revision = stmt.catalog_revision;
-        let session_state_revision = stmt.session_state_revision;
-        let stmt = stmt.stmt().cloned();
+        let stmt_ast = stmt.stmt().cloned();
+        let state_revision = stmt.state_revision;
         if let Err(err) = self.adapter_client.session().set_portal(
             portal_name,
             desc,
-            stmt,
+            stmt_ast,
             logging,
             params,
             result_formats,
-            catalog_revision,
-            session_state_revision,
+            state_revision,
         ) {
             return self.error(err.into_response(Severity::Error)).await;
         }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1103,8 +1103,8 @@ where
         let desc = stmt.desc().clone();
         let logging = Arc::clone(stmt.logging());
         let catalog_revision = stmt.catalog_revision;
+        let session_state_revision = stmt.session_state_revision;
         let stmt = stmt.stmt().cloned();
-        let session_state_revision = self.adapter_client.session().state_revision();
         if let Err(err) = self.adapter_client.session().set_portal(
             portal_name,
             desc,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1101,9 +1101,10 @@ where
         }
 
         let desc = stmt.desc().clone();
-        let revision = stmt.catalog_revision;
         let logging = Arc::clone(stmt.logging());
+        let catalog_revision = stmt.catalog_revision;
         let stmt = stmt.stmt().cloned();
+        let session_state_revision = self.adapter_client.session().state_revision();
         if let Err(err) = self.adapter_client.session().set_portal(
             portal_name,
             desc,
@@ -1111,7 +1112,8 @@ where
             logging,
             params,
             result_formats,
-            revision,
+            catalog_revision,
+            session_state_revision,
         ) {
             return self.error(err.into_response(Severity::Error)).await;
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9083,7 +9083,8 @@ impl<'a> Parser<'a> {
             Statement::Select(_)
                 | Statement::Insert(_)
                 | Statement::Delete(_)
-                | Statement::Update(_),
+                | Statement::Update(_)
+                | Statement::Fetch(_),
         ) {
             return parser_err!(self, pos, "unpreparable statement").map_no_statement_parser_err();
         }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -107,6 +107,11 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionR
     /// None if the prepared statement does not exist.
     fn get_prepared_statement_desc(&self, name: &str) -> Option<&StatementDesc>;
 
+    /// Retrieves a reference to the specified portal's descriptor.
+    ///
+    /// If there is no such portal, returns `None`.
+    fn get_portal_desc_unverified(&self, portal_name: &str) -> Option<&StatementDesc>;
+
     /// Resolves the named database.
     ///
     /// If `database_name` exists in the catalog, it returns a reference to the

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -290,6 +290,8 @@ pub enum PlanError {
     // Expected a constant expression that evaluates without an error to a non-null value.
     ConstantExpressionSimplificationFailed(String),
     InvalidOffset(String),
+    /// The named cursor does not exist.
+    UnknownCursor(String),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -816,6 +818,9 @@ impl fmt::Display for PlanError {
             },
             Self::ConstantExpressionSimplificationFailed(e) => write!(f, "{}", e),
             Self::InvalidOffset(e) => write!(f, "Invalid OFFSET clause: {}", e),
+            Self::UnknownCursor(name) => {
+                write!(f, "cursor {} does not exist", name.quoted())
+            }
         }
     }
 }

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -1379,17 +1379,36 @@ COMPLETE 1
 COMPLETE 0
 
 # Now declare a new cursor with the same name in a different transaction, and test that we realize that the meaning of
-# p1 has changed.
-# TODO: Currently, we have a bug here, see: https://github.com/MaterializeInc/database-issues/issues/9634
+# p1 has changed. This is a regression test for https://github.com/MaterializeInc/database-issues/issues/9634.
 simple
 BEGIN;
 DECLARE c1 CURSOR FOR (
   SELECT x, y FROM t1
 );
 EXECUTE p1;
+----
+db error: ERROR: cached plan must not change result type
+
+simple
 ROLLBACK;
 ----
-error parsing response from server: failed to fill whole buffer
+COMPLETE 0
+
+# Regression test for https://github.com/MaterializeInc/database-issues/issues/9634's portal case.
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR SELECT x, y FROM t1;
+DECLARE c2 CURSOR FOR FETCH 1 c1;
+CLOSE c1;
+DECLARE c1 CURSOR FOR SELECT x FROM t1;
+FETCH 1 c2;
+----
+db error: ERROR: cached plan must not change result type
+
+simple
+ROLLBACK;
+----
+COMPLETE 0
 
 # PREPARE FETCH with a SUBSCRIBE
 simple
@@ -1410,7 +1429,7 @@ COMPLETE 0
 COMPLETE 0
 
 # The transaction ended, so the portal is gone.
-query error db error: ERROR: portal "c1" does not exist
+query error db error: ERROR: cursor "c1" does not exist
 EXECUTE p2;
 
 # Do the same as above, but commit the transaction. Counter-intuitively, the portal disappears also if you commit the
@@ -1432,7 +1451,7 @@ COMPLETE 0
 COMPLETE 0
 COMPLETE 0
 
-query error db error: ERROR: portal "c1" does not exist
+query error db error: ERROR: cursor "c1" does not exist
 EXECUTE p3;
 
 # DECLARE CURSOR FOR FETCH

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -1353,6 +1353,104 @@ type_mod false  integer The␠packed␠type␠identifier␠of␠the␠column.
 statement ok
 COMMIT;
 
+statement ok
+CREATE TABLE t1(x text, y text);
+
+statement ok
+INSERT INTO t1 VALUES (5, 6), (7, 8);
+
+# Test PREPARE FETCH.
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR (
+  SELECT count(1) FROM t1
+  UNION ALL
+  SELECT count(1) FROM t1
+);
+PREPARE p1 AS FETCH 1 c1;
+EXECUTE p1;
+ROLLBACK;
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+2
+COMPLETE 1
+COMPLETE 0
+
+# Now declare a new cursor with the same name in a different transaction, and test that we realize that the meaning of
+# p1 has changed.
+# TODO: Currently, we have a bug here, see: https://github.com/MaterializeInc/database-issues/issues/9634
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR (
+  SELECT x, y FROM t1
+);
+EXECUTE p1;
+ROLLBACK;
+----
+error parsing response from server: failed to fill whole buffer
+
+# PREPARE FETCH with a SUBSCRIBE
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR SUBSCRIBE (
+  SELECT count(1) FROM t1
+  UNION ALL
+  SELECT count(1) FROM t1
+);
+PREPARE p2 AS FETCH 0 c1;
+EXECUTE p2;
+ROLLBACK;
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+
+# The transaction ended, so the portal is gone.
+query error db error: ERROR: portal "c1" does not exist
+EXECUTE p2;
+
+# Do the same as above, but commit the transaction. Counter-intuitively, the portal disappears also if you commit the
+# transaction.
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR SUBSCRIBE (
+  SELECT count(1) FROM t1
+  UNION ALL
+  SELECT count(1) FROM t1
+);
+PREPARE p3 AS FETCH 0 c1;
+EXECUTE p3;
+COMMIT;
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+
+query error db error: ERROR: portal "c1" does not exist
+EXECUTE p3;
+
+# DECLARE CURSOR FOR FETCH
+# (tests that `describe_fetch` is correct when called from `describe_declare`)
+simple
+BEGIN;
+DECLARE c1 CURSOR FOR SELECT count(1) FROM t1;
+DECLARE c2 CURSOR FOR FETCH 1 c1;
+FETCH 3 c2;
+ROLLBACK;
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 0
+2
+COMPLETE 1
+COMPLETE 0
+
 # Cleanup.
 
 statement ok


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/33471, because of using `PREPARE FETCH` for easier testing.

This fixes https://github.com/MaterializeInc/database-issues/issues/9634: It adds a `state_revision` field to `Session`, and uses this in `verify_statement_revision` in a similar way as `catalog_revision`. We do this for both prepared statements and portals, as the bug can manifest for both, see the added tests.

Note that the original bug was for prepared statements, but portals have the same problem. This PR fixes both. It was natural to fix in the same PR, because `verify_statement_revision` overlaps between the two code paths (`verify_prepared_statement` and `verify_portal`).

A somewhat inelegant part is `get_portal_unverified_mut`, where I needed to add a warning to callers on how not to use the returned mut ref. An alternative would be to introduce interior mutability: if we made those fields of `Portal` mutable that are currently being manipulated by the callers of `get_portal_unverified_mut`, then all these callers could work with a non-mut ref, which would make it impossible to accidentally change the sensitive fields of `Portal` (`stmt` and `desc`). I am open to making this change if a reviewer things it should be done.

The PR also adds some sanity checks in the last commit, so that we catch problems similar to the above bug before we send out malformed pgwire responses.

I've also run @antiguru's repro (the cluster-spec-sheet). What happens after the PR is that we error out those statements that become invalid, and then the client library prints "Retryable error: cached plan must not change result type, reconnecting...", and continues normally.

Nightly: https://buildkite.com/materialize/nightly/builds/13024

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
