### PR TITLE
Select labels passed to environmentd for clusterd services

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -583,10 +583,14 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         // `StatefulSet` is created is not permitted by Kubernetes, and we're
         // not yet smart enough to handle deleting and recreating the
         // `StatefulSet`.
-        let match_labels = btreemap! {
+        let mut match_labels = btreemap! {
             "environmentd.materialize.cloud/namespace".into() => self.namespace.clone(),
             "environmentd.materialize.cloud/service-id".into() => id.into(),
         };
+        for (key, value) in &self.config.service_labels {
+            match_labels.insert(key.clone(), value.clone());
+        }
+
         let mut labels = match_labels.clone();
         for (key, value) in labels_in {
             labels.insert(self.make_label_key(&key), value);
@@ -599,9 +603,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 format!("environmentd.materialize.cloud/port-{}", port.name),
                 "true".into(),
             );
-        }
-        for (key, value) in &self.config.service_labels {
-            labels.insert(key.clone(), value.clone());
         }
         let mut limits = BTreeMap::new();
         let mut requests = BTreeMap::new();


### PR DESCRIPTION
Have the service also match labels passed in to environmentd for all services.

### Motivation

  * This PR fixes a recognized bug.
https://github.com/MaterializeInc/cloud/issues/11527
Previously, services could select pods from different Materialize instances if they are in the same namespace and have the same service id (very likely when initially created).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
