### PR TITLE
MALLOC_CONF for clusterd

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -76,6 +76,7 @@ def get_minimal_system_parameters(
         # -----
         # Others (ordered by name)
         "allow_real_time_recency": "true",
+        "clusterd_malloc_conf": "thp:always",
         "constraint_based_timestamp_selection": "verify",
         "enable_compute_peek_response_stash": "true",
         "enable_0dt_deployment_panic_after_timeout": "true",

--- a/misc/python/materialize/mzcompose/services/clusterd.py
+++ b/misc/python/materialize/mzcompose/services/clusterd.py
@@ -42,6 +42,7 @@ class Clusterd(Service):
             "MZ_SOFT_ASSERTIONS=1",
             "MZ_EAT_MY_DATA=1",
             f"CLUSTERD_PERSIST_PUBSUB_URL=http://{mz_service}:6879",
+            "MALLOC_CONF=thp:always",
             *environment_extra,
         ]
 

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -68,6 +68,12 @@ pub const ENABLE_PAUSED_CLUSTER_READHOLD_DOWNGRADE: Config<bool> = Config::new(
     "Aggressively downgrade input read holds for indexes on zero-replica clusters.",
 );
 
+pub const CLUSTERD_MALLOC_CONF: Config<&str> = Config::new(
+    "clusterd_malloc_conf",
+    "",
+    "MALLOC_CONF to pass to clusterd. If empty, no MALLOC_CONF is set.",
+);
+
 /// Adds the full set of all controller `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -77,6 +83,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL)
         .add(&ENABLE_TIMELY_ZERO_COPY)
         .add(&ENABLE_TIMELY_ZERO_COPY_LGALLOC)
+        .add(&CLUSTERD_MALLOC_CONF)
         .add(&TIMELY_ZERO_COPY_LIMIT)
         .add(&ARRANGEMENT_EXERT_PROPORTIONALITY)
         .add(&ENABLE_PAUSED_CLUSTER_READHOLD_DOWNGRADE)

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -26,8 +26,9 @@ use mz_compute_client::controller::ComputeControllerTimestamp;
 use mz_compute_client::logging::LogVariant;
 use mz_compute_types::config::{ComputeReplicaConfig, ComputeReplicaLogging};
 use mz_controller_types::dyncfgs::{
-    ARRANGEMENT_EXERT_PROPORTIONALITY, CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL,
-    ENABLE_TIMELY_ZERO_COPY, ENABLE_TIMELY_ZERO_COPY_LGALLOC, TIMELY_ZERO_COPY_LIMIT,
+    ARRANGEMENT_EXERT_PROPORTIONALITY, CLUSTERD_MALLOC_CONF,
+    CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL, ENABLE_TIMELY_ZERO_COPY,
+    ENABLE_TIMELY_ZERO_COPY_LGALLOC, TIMELY_ZERO_COPY_LIMIT,
 };
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_orchestrator::NamespacedOrchestrator;
@@ -664,6 +665,10 @@ where
             });
         }
 
+        let clusterd_malloc_conf = CLUSTERD_MALLOC_CONF.get(&self.dyncfg);
+        let clusterd_malloc_conf =
+            (!clusterd_malloc_conf.is_empty()).then_some(clusterd_malloc_conf);
+
         let service = self.orchestrator.ensure_service(
             &service_name,
             ServiceConfig {
@@ -828,6 +833,7 @@ where
                 }],
                 disk_limit,
                 node_selector: location.allocation.selectors,
+                clusterd_malloc_conf,
             },
         )?;
 

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -246,6 +246,8 @@ pub struct ServiceConfig {
     pub disk_limit: Option<DiskLimit>,
     /// Node selector for this service.
     pub node_selector: BTreeMap<String, String>,
+    /// Optional jemalloc configuration.
+    pub clusterd_malloc_conf: Option<String>,
 }
 
 /// A named port associated with a service.


### PR DESCRIPTION
Exposes a feature flag `clusterd_malloc_conf` that conditionally sets the `MALLOC_CONF` environment variable for clusterd. An empty value maps to `None`, so no env symbol will be set.

This allows us to experiment with interesting settings, specifically passing `thp:always` to enable hughe pages.