### PR TITLE
clean up balancer and console resources if they are disabled

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -96,9 +96,18 @@ def run(args: argparse.Namespace):
         dev=args.dev,
         cluster=args.kind_cluster_name,
     )
+
+    try:
+        subprocess.check_output(
+            ["helm", "status", "orchestratord", f"--namespace={args.namespace}"]
+        )
+        command = "upgrade"
+    except:
+        command = "install"
+
     helm_args = [
         "helm",
-        "install",
+        command,
         "orchestratord",
         "misc/helm-charts/operator",
         "--atomic",


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9639

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
