### PR TITLE
TopK: avoid mapping errors when limit is constant

### DIFF
--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -126,6 +126,32 @@ impl TopKPlan {
             }
         }
     }
+
+    /// Return the limit of the TopK, if any.
+    pub fn limit(&self) -> Option<&mz_expr::MirScalarExpr> {
+        match self {
+            TopKPlan::MonotonicTop1(MonotonicTop1Plan {
+                group_key: _,
+                order_key: _,
+                must_consolidate: _,
+            }) => None,
+            TopKPlan::MonotonicTopK(MonotonicTopKPlan {
+                limit,
+                arity: _,
+                must_consolidate: _,
+                group_key: _,
+                order_key: _,
+            }) => limit.as_ref(),
+            TopKPlan::Basic(BasicTopKPlan {
+                limit,
+                group_key: _,
+                order_key: _,
+                arity: _,
+                offset: _,
+                buckets: _,
+            }) => limit.as_ref(),
+        }
+    }
 }
 
 impl RustType<ProtoTopKPlan> for TopKPlan {


### PR DESCRIPTION
We used to always render an operator to map the error collection, even if we could determine that the limit expression could never error. This change adjusts rendering to only render error handling if the expression is not a literal, or evaluates to an error itself.
