### PR TITLE
sqlsmith: Update version & run in parallel-workload again

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2467,7 +2467,7 @@ read_action_list = ActionList(
     [
         (SelectAction, 100),
         (SelectOneAction, 1),
-        # (SQLsmithAction, 30),  # Questionable use
+        (SQLsmithAction, 30),
         (CopyToS3Action, 100),
         # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (CommitRollbackAction, 30),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -1156,17 +1156,16 @@ class Database:
         for relation in self:
             relation.create(exe)
 
-        if False:  # Questionable use
-            result = composition.run(
-                "sqlsmith",
-                "--target=host=materialized port=6875 dbname=materialize user=materialize",
-                "--exclude-catalog",
-                "--dump-state",
-                capture=True,
-                capture_stderr=True,
-                rm=True,
-            )
-            self.sqlsmith_state = result.stdout
+        result = composition.run(
+            "sqlsmith",
+            "--target=host=materialized port=6875 dbname=materialize user=materialize",
+            "--exclude-catalog",
+            "--dump-state",
+            capture=True,
+            capture_stderr=True,
+            rm=True,
+        )
+        self.sqlsmith_state = result.stdout
 
     def drop(self, exe: Executor) -> None:
         for db in self.dbs:
@@ -1183,16 +1182,15 @@ class Database:
             src.executor.mz_conn.close()
 
     def update_sqlsmith_state(self, composition: Composition) -> None:
-        if False:  # Questionable use
-            result = composition.run(
-                "sqlsmith",
-                "--target=host=materialized port=6875 dbname=materialize user=materialize",
-                "--exclude-catalog",
-                "--read-state",
-                "--dump-state",
-                stdin=self.sqlsmith_state,
-                capture=True,
-                capture_stderr=True,
-                rm=True,
-            )
-            self.sqlsmith_state = result.stdout
+        result = composition.run(
+            "sqlsmith",
+            "--target=host=materialized port=6875 dbname=materialize user=materialize",
+            "--exclude-catalog",
+            "--read-state",
+            "--dump-state",
+            stdin=self.sqlsmith_state,
+            capture=True,
+            capture_stderr=True,
+            rm=True,
+        )
+        self.sqlsmith_state = result.stdout

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -121,6 +121,7 @@ class Executor:
         explainable: bool = False,
         http: Http = Http.NO,
         fetch: bool = False,
+        cluster_replica: str | None = None,
     ) -> None:
         is_http = (
             http == Http.RANDOM and self.rng.choice([True, False])
@@ -142,6 +143,10 @@ class Executor:
                         raise QueryError(str(e), query)
                 else:
                     try:
+                        if cluster_replica:
+                            self.cur.execute(
+                                f"SET cluster_replica = {cluster_replica}".encode()
+                            )
                         if query == "commit;":
                             self.log("commit")
                             self.cur.connection.commit()
@@ -232,3 +237,5 @@ class Executor:
                     raise
         finally:
             self.last_status = "finished"
+            if cluster_replica:
+                self.cur.execute("RESET cluster_replica")

--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -81,7 +81,8 @@ known_errors = [
     "Expected right parenthesis, found left parenthesis",  # Should fix, but only happens rarely with cast+coalesce
     "invalid selection: operation may only refer to user-defined tables",  # Seems expected when using catalog tables
     "Unsupported temporal predicate",  # Expected, see https://github.com/MaterializeInc/database-issues/issues/5288
-    "Unsupported temporal operatrion: NotEq",
+    "Unsupported temporal operation: NotEq",
+    "Unsupported binary temporal operation: NotEq",
     "OneShot plan has temporal constraints",  # Expected, see https://github.com/MaterializeInc/database-issues/issues/5288
     "internal error: cannot evaluate unmaterializable function",  # Currently expected, see https://github.com/MaterializeInc/database-issues/issues/4083
     "string is not a valid identifier:",  # Expected in parse_ident & quote_ident

--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -81,6 +81,7 @@ known_errors = [
     "Expected right parenthesis, found left parenthesis",  # Should fix, but only happens rarely with cast+coalesce
     "invalid selection: operation may only refer to user-defined tables",  # Seems expected when using catalog tables
     "Unsupported temporal predicate",  # Expected, see https://github.com/MaterializeInc/database-issues/issues/5288
+    "Unsupported temporal operatrion: NotEq",
     "OneShot plan has temporal constraints",  # Expected, see https://github.com/MaterializeInc/database-issues/issues/5288
     "internal error: cannot evaluate unmaterializable function",  # Currently expected, see https://github.com/MaterializeInc/database-issues/issues/4083
     "string is not a valid identifier:",  # Expected in parse_ident & quote_ident
@@ -136,4 +137,6 @@ known_errors = [
     "key cannot be null",  # expected, see PR materialize#25941
     "regexp_extract must specify at least one capture group",
     "array_fill with arrays not yet supported",
+    "The fast_path_optimizer shouldn't make a fast path plan slow path.",  # TODO: Remove when database-issues#9645 is fixed
+    "Window function performance issue: `reduce_unnest_list_fusion` failed",  # TODO: Remove when database-issues#9644 is fixed
 ]

--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -30,7 +30,7 @@ ADD https://api.github.com/repos/MaterializeInc/sqlsmith/git/refs/heads/master v
 # Build SQLsmith
 RUN git clone --single-branch --branch=master https://github.com/MaterializeInc/sqlsmith \
     && cd sqlsmith \
-    && git checkout 5b0448c3c8c9f87654302d12c893fe173f97cbb9 \
+    && git checkout 8d0bd7fe57d875bab70ca0c6f5a8bbc9f36d4bfb \
     && rm -rf .git \
     && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ . \
     && cmake --build . -j `nproc`

--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -30,7 +30,7 @@ ADD https://api.github.com/repos/MaterializeInc/sqlsmith/git/refs/heads/master v
 # Build SQLsmith
 RUN git clone --single-branch --branch=master https://github.com/MaterializeInc/sqlsmith \
     && cd sqlsmith \
-    && git checkout 8d0bd7fe57d875bab70ca0c6f5a8bbc9f36d4bfb \
+    && git checkout 198f13b36415d38164ab6ad094d2e8b91a9f5419 \
     && rm -rf .git \
     && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ . \
     && cmake --build . -j `nproc`


### PR DESCRIPTION
Motivated by https://materializeinc.slack.com/archives/CU7ELJ6E9/p1756852503595199

Finds two mz_now bugs reliably now.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
