### PR TITLE
testdrive: Bump SQL timeout for wallclock-lag.td

### DIFF
--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -12,7 +12,7 @@
 # These tests rely on testdrive's retry feature, as `mz_wallclock_lag_history`
 # is only refreshed periodically, so data is likely not immediately available.
 
-$ set-sql-timeout duration=60s
+$ set-sql-timeout duration=120s
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/13062#0199100a-be78-46ef-b59b-0f9451a8f912/25203

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
