### PR TITLE
Fix kafka source logging when failing to commit offsets

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -509,10 +509,10 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                     offset_commit_metrics.offset_commit_failures.inc();
                     tracing::warn!(
                         %e,
-                        "timely-{} source({}) failed to commit offsets: resume_upper={}",
-                        config.worker_id,
-                        config.id,
-                        resume_upper.pretty()
+                        "timely-{worker_id} source({source_id}) failed to commit offsets: resume_upper={upper}",
+                        worker_id = config.worker_id,
+                        source_id = config.id,
+                        upper = resume_upper.pretty()
                     );
                 }
             }
@@ -524,10 +524,10 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                         offset_commit_metrics.offset_commit_failures.inc();
                         tracing::warn!(
                             %e,
-                            "timely-{} source({}) failed to commit offsets: resume_upper={}",
-                            config.worker_id,
-                            config.id,
-                            frontier.pretty()
+                            "timely-{worker_id} source({source_id}) failed to commit offsets: resume_upper={upper}",
+                            worker_id = config.worker_id,
+                            source_id = config.id,
+                            upper = frontier.pretty()
                         );
                     }
                 }


### PR DESCRIPTION
Fix the order of config.id and worker_id

### Motivation

reducing global entropy

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
