### PR TITLE
Persist: clarify `reduced` semantics to refer only to spine structure

### DIFF
--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1744,16 +1744,22 @@ impl<T: Timestamp + Lattice> Spine<T> {
         self.introduce_batch(batch, usize::cast_from(index.trailing_zeros()), log);
     }
 
-    /// True iff there is at most one HollowBatch in `self.merging`.
+    /// True iff there is at most one SpineBatch across all layers.
     ///
-    /// When true, there is no maintenance work to perform in the trace, other
-    /// than compaction. We do not yet have logic in place to determine if
-    /// compaction would improve a trace, so for now we are ignoring that.
+    /// When true, there is no structural merge work to perform in the trace.
+    /// Spine merges operate on SpineBatches (the per-layer structural units),
+    /// not on the inner HollowBatch parts within a single SpineBatch. With
+    /// incremental compaction it is common to have a single SpineBatch that
+    /// contains many inner parts (some possibly empty). We intentionally
+    /// consider this state "reduced" to avoid repeatedly injecting synthetic
+    /// empty batches when only intra-batch compaction remains.
     fn reduced(&self) -> bool {
-        self.spine_batches()
-            .flat_map(|b| b.parts.as_slice())
-            .count()
-            < 2
+        // Consider the trace "reduced" when there is at most one SpineBatch across all
+        // layers, regardless of how many inner hollow parts that batch contains. Inner
+        // parts can be cleaned up by compaction, which we intentionally ignore here to
+        // avoid repeatedly injecting empty batches when only structure-level compaction
+        // remains.
+        self.spine_batches().count() < 2
     }
 
     /// Describes the merge progress of layers in the trace.


### PR DESCRIPTION
The exert function is called exclusively by the catalog force compaction code path. In the case that there was only one spine batch with multiple hollow batches, the exert function would incorrectly introduce empty SpineBatches. The behavior of the `reduced` function was always using the number of HollowBatches as a proxy for the structural shape of the spine. With incremental compaction, there might be only one run with a number of empty HollowBatches. This is totally legal, and not a reason to try and force structural merges.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
