### PR TITLE
[DNM] Password auth optimization

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -208,6 +208,8 @@ pub struct AuthResponse {
     pub role_id: RoleId,
     /// If the user is a superuser.
     pub superuser: bool,
+    /// The password hash.
+    pub password_hash: String,
 }
 
 // Facile implementation for `StartupResponse`, which does not use the `allowed`


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
**Release binary password auth non optimized vs optimized:**
![release_binary_pw_optimization_difference](https://github.com/user-attachments/assets/993e7033-699d-4fb0-997b-22cb91762904)

**Release binary password auth non optimized vs optimized vs. no password auth:**
![release_binary_pw_optimization_overall](https://github.com/user-attachments/assets/ef1a5211-2b8e-409d-b00f-1f21fb93addc)

**Release binary password auth optimized QPS benchmark**
![pg_workload_bench_20250904_081529_release_binary_pw_optimized_c1-256](https://github.com/user-attachments/assets/57cff3b3-5441-4cb5-91b2-8a7c24dff2cb)

Notes:
- Query is `SELECT * FROM indexed_view LIMIT 1`
- The average QPS looks quite low, but mainly because the initial connection startup is quite slow:
```
============================================================
Run 5/9: Testing with 16 workers
============================================================

Benchmarking Workload: simple select
------------------------------------------------------------
Queries in workload: 1
Concurrency:         16 workers
Duration:            10 seconds
------------------------------------------------------------

[   3s] Workload: simple select        | Rate:  1102.1 q/s | Total:    3429 | Failed:     0 | Latency (ms): avg=   4.6 min=   2.3 max=  10.6
[   4s] Workload: simple select        | Rate:  3215.5 q/s | Total:    6645 | Failed:     0 | Latency (ms): avg=   4.9 min=   2.3 max=  19.4
[   5s] Workload: simple select        | Rate:  3234.4 q/s | Total:    9880 | Failed:     0 | Latency (ms): avg=   4.9 min=   2.6 max=  11.5
[   6s] Workload: simple select        | Rate:  3329.6 q/s | Total:   13210 | Failed:     0 | Latency (ms): avg=   4.7 min=   2.2 max=   9.7
[   7s] Workload: simple select        | Rate:  3295.4 q/s | Total:   16506 | Failed:     0 | Latency (ms): avg=   5.0 min=   2.6 max=  12.4
[   8s] Workload: simple select        | Rate:  3354.2 q/s | Total:   19861 | Failed:     0 | Latency (ms): avg=   4.7 min=   2.3 max=  11.3
[   9s] Workload: simple select        | Rate:  3133.2 q/s | Total:   22995 | Failed:     0 | Latency (ms): avg=   5.4 min=   2.8 max=  22.3
[  10s] Workload: simple select        | Rate:  3024.4 q/s | Total:   26020 | Failed:     0 | Latency (ms): avg=   5.0 min=   2.5 max=  10.8
[  11s] Workload: simple select        | Rate:  3192.4 q/s | Total:   29213 | Failed:     0 | Latency (ms): avg=   4.9 min=   2.7 max=  10.7

============================================================
Workload Summary: simple select
============================================================
Duration:             12.2 seconds
Concurrency:          16 workers
Total Queries:   32438
Failed Queries:  0
Success Rate:         100.0%
Average Rate:         2654.5 queries/second

Latency Statistics:
  Average:            4.93 ms
  Minimum:            2.05 ms
  Maximum:            27.87 ms

Latency Percentiles (ms):
----------------------------------------
  p50   :     4.39 ms
  p75   :     5.36 ms
  p90   :     7.04 ms
  p95   :     7.91 ms
  p99   :    11.88 ms
  p99.9 :    20.45 ms

Latency Distribution:
------------------------------------------------------------
      2.1 -     2.3 ms:                                              13 (  0.0%)
      2.3 -     2.7 ms:                                              70 (  0.2%)
      2.7 -     3.0 ms: █                                           442 (  1.4%)
      3.0 -     3.5 ms: ██████                                     1650 (  5.1%)
      3.5 -     3.9 ms: ██████████████████                         5063 ( 15.6%)
      3.9 -     4.5 ms: ████████████████████████████████████████  10700 ( 33.0%)
      4.5 -     5.1 ms: ████████████████████                       5485 ( 16.9%)
      5.1 -     5.8 ms: █████████                                  2643 (  8.1%)
      5.8 -     6.6 ms: ████████                                   2254 (  6.9%)
      6.6 -     7.6 ms: ███████                                    1874 (  5.8%)
      7.6 -     8.6 ms: █████                                      1361 (  4.2%)
      8.6 -     9.8 ms: █                                           318 (  1.0%)
      9.8 -    11.2 ms:                                             155 (  0.5%)
     11.2 -    12.7 ms:                                             173 (  0.5%)
     12.7 -    14.5 ms:                                              84 (  0.3%)
     14.5 -    16.5 ms:                                              69 (  0.2%)
     16.5 -    18.8 ms:                                              30 (  0.1%)
     18.8 -    21.5 ms:                                              33 (  0.1%)
     21.5 -    24.5 ms:                                              20 (  0.1%)
     24.5 -    27.9 ms:                                               0 (  0.0%)

```

as we increase the duration per test run, QPS eventually amortizes into a better one.

We see QPS and latency for the optimized / not is roughly the same:

![qps_release_binary_pw_optimized](https://github.com/user-attachments/assets/13f06e6d-9354-4ba0-890a-6a34a153f0e0)
### Motivation





<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
