### PR TITLE
parallel-workload: Use more interesting expressions in SELECT, views and conditions; support COPY FROM STDIN; prepared statements; run 10x faster

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -188,6 +188,8 @@ case "$cmd" in
         docker_command=()
 
         detach_container=false
+        interactive=false
+        tty=false
         container_name_param=""
 
         while [[ $# -gt 0 ]]; do
@@ -200,6 +202,14 @@ case "$cmd" in
                     container_name_param="$2"
                     shift # past argument
                     shift # past value
+                    ;;
+                --interactive)
+                    interactive=true
+                    shift # past argument
+                    ;;
+                --tty)
+                    tty=true
+                    shift # past argument
                     ;;
                 *)
                     docker_command+=("$1")
@@ -275,6 +285,14 @@ case "$cmd" in
 
         if [[ $detach_container == "true" ]]; then
             args+=("--detach")
+        fi
+
+        if [[ $interactive == "true" ]]; then
+            args+=("--interactive")
+        fi
+
+        if [[ $tty == "true" ]]; then
+            args+=("--tty")
         fi
 
         if [[ -n "$container_name_param" ]]; then

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1811,11 +1811,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=read, --threads=16]
+              args: [--runtime=1500, --complexity=read, --threads=16]
 
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
@@ -1823,11 +1823,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=dml, --threads=16]
+              args: [--runtime=1500, --complexity=dml, --threads=16]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1839,7 +1839,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --threads=8]
+              args: [--runtime=1500, --threads=8]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1847,11 +1847,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=ddl-only, --threads=2]
+              args: [--runtime=1500, --complexity=ddl-only, --threads=2]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1860,11 +1860,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           # Sporadic OoM otherwise
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --threads=100]
+              args: [--runtime=1500, --threads=100]
         skip: "Too unstable at the moment"
 
       - id: parallel-workload-rename-naughty
@@ -1877,7 +1877,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=rename, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1889,7 +1889,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=rename, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --threads=16]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1897,11 +1897,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=cancel, --threads=16]
+              args: [--runtime=1500, --scenario=cancel, --threads=16]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1909,11 +1909,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=kill, --threads=8]
+              args: [--runtime=1500, --scenario=kill, --threads=8]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1922,11 +1922,11 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: hetzner-x86-64-8cpu-16gb
+          queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=backup-restore, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1938,7 +1938,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=0dt-deploy, --threads=16]
+              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1812,10 +1812,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=read, --threads=16]
+              args: [--runtime=1500, --complexity=read, --threads=8]
 
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
@@ -1824,10 +1825,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=dml, --threads=16]
+              args: [--runtime=1500, --complexity=dml, --threads=8]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1836,10 +1838,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=16]
+              args: [--runtime=1500, --threads=8]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1848,10 +1851,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=ddl-only, --threads=16]
+              args: [--runtime=1500, --complexity=ddl-only, --threads=8]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1861,10 +1865,11 @@ steps:
         agents:
           # Sporadic OoM otherwise
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=16]
+              args: [--runtime=1500, --threads=8]
         skip: "Too unstable at the moment"
 
       - id: parallel-workload-rename-naughty
@@ -1874,10 +1879,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=8]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1886,10 +1892,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --threads=8]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1898,10 +1905,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=cancel, --threads=16]
+              args: [--runtime=1500, --scenario=cancel, --threads=8]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1910,10 +1918,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill, --threads=16]
+              args: [--runtime=1500, --scenario=kill, --threads=8]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1923,10 +1932,11 @@ steps:
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
           queue: hetzner-x86-64-16cpu-32gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=8]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1935,10 +1945,11 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
+        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
+              args: [--runtime=1500, --scenario=0dt-deploy, --threads=8]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1812,7 +1812,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1825,7 +1824,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1838,7 +1836,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1851,7 +1848,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1865,7 +1861,6 @@ steps:
         agents:
           # Sporadic OoM otherwise
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1879,7 +1874,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1892,7 +1886,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1905,7 +1898,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1918,7 +1910,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1932,7 +1923,6 @@ steps:
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
           queue: hetzner-x86-64-16cpu-32gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1945,7 +1935,6 @@ steps:
         timeout_in_minutes: 90
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
-        parallelism: 10
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1815,7 +1815,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=read, --threads=100]
+              args: [--runtime=1500, --complexity=read, --threads=16]
 
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
@@ -1827,7 +1827,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=dml, --threads=100]
+              args: [--runtime=1500, --complexity=dml, --threads=16]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1839,7 +1839,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --threads=100]
+              args: [--runtime=1500, --threads=16]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1851,7 +1851,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --complexity=ddl-only, --threads=100]
+              args: [--runtime=1500, --complexity=ddl-only, --threads=16]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1864,7 +1864,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --threads=100]
+              args: [--runtime=1500, --threads=16]
         skip: "Too unstable at the moment"
 
       - id: parallel-workload-rename-naughty
@@ -1877,7 +1877,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=rename, --naughty-identifiers, --threads=100]
+              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1889,7 +1889,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=rename, --threads=100]
+              args: [--runtime=1500, --scenario=rename, --threads=16]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1901,7 +1901,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=cancel, --threads=100]
+              args: [--runtime=1500, --scenario=cancel, --threads=16]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1913,7 +1913,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=kill, --threads=100]
+              args: [--runtime=1500, --scenario=kill, --threads=16]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1926,7 +1926,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=backup-restore, --naughty-identifiers, --threads=100]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1938,7 +1938,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=3000, --scenario=0dt-deploy, --threads=100]
+              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1805,6 +1805,18 @@ steps:
   - group: "Parallel Workload"
     key: parallel-workload
     steps:
+      - id: parallel-workload-read-only
+        label: "Parallel Workload (Read-Only)"
+        depends_on: build-x86_64
+        artifact_paths: [parallel-workload-queries.log.zst]
+        timeout_in_minutes: 90
+        agents:
+          queue: hetzner-x86-64-8cpu-16gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=3000, --complexity=read, --threads=16]
+
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
         depends_on: build-x86_64
@@ -1815,20 +1827,19 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=dml, --threads=16]
+              args: [--runtime=3000, --complexity=dml, --threads=16]
 
       - id: parallel-workload-ddl
-        label: "Parallel Workload (DDL) with :azure: blob store"
+        label: "Parallel Workload (DDL)"
         depends_on: build-x86_64
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          # Azure blob store uses more memory
           queue: hetzner-x86-64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=8, --azurite]
+              args: [--runtime=3000, --threads=8]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1840,7 +1851,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=ddl-only, --threads=2]
+              args: [--runtime=3000, --complexity=ddl-only, --threads=2]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1853,7 +1864,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=100]
+              args: [--runtime=3000, --threads=100]
         skip: "Too unstable at the moment"
 
       - id: parallel-workload-rename-naughty
@@ -1866,10 +1877,10 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
+              args: [--runtime=3000, --scenario=rename, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-rename
-        label: "Parallel Workload (rename) with :azure: blob store"
+        label: "Parallel Workload (rename)"
         depends_on: build-x86_64
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
@@ -1878,7 +1889,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --threads=16, --azurite]
+              args: [--runtime=3000, --scenario=rename, --threads=16]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1890,7 +1901,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=cancel, --threads=16]
+              args: [--runtime=3000, --scenario=cancel, --threads=16]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1902,7 +1913,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill, --threads=8]
+              args: [--runtime=3000, --scenario=kill, --threads=8]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1915,7 +1926,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
+              args: [--runtime=3000, --scenario=backup-restore, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1927,7 +1938,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
+              args: [--runtime=3000, --scenario=0dt-deploy, --threads=16]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1815,7 +1815,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=read, --threads=100]
+              args: [--runtime=3000, --complexity=read, --threads=100]
 
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
@@ -1827,7 +1827,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=dml, --threads=100]
+              args: [--runtime=3000, --complexity=dml, --threads=100]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1839,7 +1839,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=100]
+              args: [--runtime=3000, --threads=100]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1851,7 +1851,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=ddl-only, --threads=100]
+              args: [--runtime=3000, --complexity=ddl-only, --threads=100]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1864,7 +1864,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=100]
+              args: [--runtime=3000, --threads=100]
         skip: "Too unstable at the moment"
 
       - id: parallel-workload-rename-naughty
@@ -1877,7 +1877,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=100]
+              args: [--runtime=3000, --scenario=rename, --naughty-identifiers, --threads=100]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1889,7 +1889,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --threads=100]
+              args: [--runtime=3000, --scenario=rename, --threads=100]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1901,7 +1901,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=cancel, --threads=100]
+              args: [--runtime=3000, --scenario=cancel, --threads=100]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1913,7 +1913,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill, --threads=100]
+              args: [--runtime=3000, --scenario=kill, --threads=100]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1926,7 +1926,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=100]
+              args: [--runtime=3000, --scenario=backup-restore, --naughty-identifiers, --threads=100]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1938,7 +1938,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=0dt-deploy, --threads=100]
+              args: [--runtime=3000, --scenario=0dt-deploy, --threads=100]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1839,7 +1839,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=8]
+              args: [--runtime=1500, --threads=16]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1913,7 +1913,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill, --threads=8]
+              args: [--runtime=1500, --scenario=kill, --threads=16]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1815,7 +1815,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=read, --threads=16]
+              args: [--runtime=1500, --complexity=read, --threads=100]
 
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
@@ -1827,7 +1827,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=dml, --threads=16]
+              args: [--runtime=1500, --complexity=dml, --threads=100]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1839,7 +1839,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --threads=16]
+              args: [--runtime=1500, --threads=100]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1851,7 +1851,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=ddl-only, --threads=2]
+              args: [--runtime=1500, --complexity=ddl-only, --threads=100]
 
       - id: parallel-workload-many-threads
         label: "Parallel Workload (many threads)"
@@ -1877,7 +1877,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=100]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1889,7 +1889,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --threads=16]
+              args: [--runtime=1500, --scenario=rename, --threads=100]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1901,7 +1901,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=cancel, --threads=16]
+              args: [--runtime=1500, --scenario=cancel, --threads=100]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1913,7 +1913,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill, --threads=16]
+              args: [--runtime=1500, --scenario=kill, --threads=100]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1926,7 +1926,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=100]
 
       - id: parallel-workload-0dt
         label: "Parallel Workload (0dt deploy)"
@@ -1938,7 +1938,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
+              args: [--runtime=1500, --scenario=0dt-deploy, --threads=100]
 
   - group: Slow cluster tests
     key: slow-cluster

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -15,16 +15,16 @@ set -euo pipefail
 
 builder=${BUILDKITE_PLUGIN_MZCOMPOSE_CI_BUILDER:-min}
 
+if is_truthy "${CI_HEAP_PROFILES:-}"; then
+  builder=stable
+fi
+
 mzcompose() {
     stdbuf --output=L --error=L bin/ci-builder run "$builder" bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
 kubectl() {
     bin/ci-builder run stable kubectl --context="$K8S_CONTEXT" "$@"
-}
-
-faketty() {
-    script -qfc "$(printf "%q " "$@")" /dev/null
 }
 
 service=${BUILDKITE_PLUGIN_MZCOMPOSE_RUN:-default}
@@ -67,13 +67,13 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     chmod 777 coverage/
 fi
 
+STOP_RUNNING=false
+
 if is_truthy "${CI_HEAP_PROFILES:-}"; then
-    (while true; do
-        sleep 5
-        # faketty because otherwise docker will complain about not being inside
-        # of a TTY when run in a background job
-        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
-    done
+    (while [ "$STOP_RUNNING" != "true" ]; do
+         sleep 30
+         bin/ci-builder run stable --detach bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
+     done
     ) &
 fi
 
@@ -220,10 +220,14 @@ cleanup() {
   mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml' -printf '%P\n'; find . -maxdepth 1 -name 'mz_debug_*.log' -printf '%P\n'; find . -maxdepth 1 -name 'slt*.diff' -printf '%P\n')
   artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 
-  ci_unimportant_heading "Running trufflehog to scan artifacts for secrets & uploading artifacts"
-  {
-    bin/ci-builder run "$builder" trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio,uplead,tatumio filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
-  } &
+  if is_truthy "${CI_HEAP_PROFILES:-}"; then
+      STOP_RUNNING=true
+  else
+      ci_unimportant_heading "Running trufflehog to scan artifacts for secrets & uploading artifacts"
+      {
+        bin/ci-builder run "$builder" trufflehog --no-update --no-verification --json --exclude-detectors=coda,dockerhub,box,npmtoken,github,snykkey,eightxeight,sumologickey,miro,fmfw,logzio,qase,cannyio,uplead,tatumio filesystem "${artifacts[@]}" | trufflehog_jq_filter_logs > trufflehog.log
+      } &
+  fi
 
   unset CI_EXTRA_ARGS # We don't want extra args for the annotation
   # Continue even if ci-annotate-errors fails

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -125,7 +125,7 @@ Operation | Computes
 [`date`](../types/date) `+` [`interval`](../types/interval) | [`timestamp`](../types/timestamp)
 [`date`](../types/date) `-` [`interval`](../types/interval) | [`timestamp`](../types/timestamp)
 [`date`](../types/date) `+` [`time`](../types/time) | [`timestamp`](../types/timestamp)
-[`date`](../types/date) `-` [`date`](../types/date) | [`interval`](../types/interval)
+[`date`](../types/date) `-` [`date`](../types/date) | [`integer`](../types/integer)
 [`timestamp`](../types/timestamp) `+` [`interval`](../types/interval) | [`timestamp`](../types/timestamp)
 [`timestamp`](../types/timestamp) `-` [`interval`](../types/interval) | [`timestamp`](../types/timestamp)
 [`timestamp`](../types/timestamp) `-` [`timestamp`](../types/timestamp) | [`interval`](../types/interval)

--- a/doc/user/content/sql/functions/cast.md
+++ b/doc/user/content/sql/functions/cast.md
@@ -80,7 +80,6 @@ Source type                                | Return type                        
 [`interval`](../../types/interval/)        | [`text`](../../types/text/)                   | Assignment
 [`interval`](../../types/interval/)        | [`time`](../../types/time/)                   | Assignment
 [`jsonb`](../../types/jsonb/)              | [`bigint`](../../types/integer/)              | Explicit
-[`jsonb`](../../types/jsonb/)              | [`bool`](../../types/boolean/)                | Explicit
 [`jsonb`](../../types/jsonb/)              | [`float`](../../types/float/)                 | Explicit
 [`jsonb`](../../types/jsonb/)              | [`int`](../../types/integer/)                 | Explicit
 [`jsonb`](../../types/jsonb/)              | [`real`](../../types/real/)                   | Explicit

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -150,16 +150,16 @@
   - signature: 'cbrt(x: double precision) -> double precision'
     description: The cube root of `x`.
 
-  - signature: 'ceil(x: N) -> N'
+  - signature: 'ceil(x: N) -> double precision'
     description: The smallest integer >= `x`.
 
-  - signature: 'ceiling(x: N) -> N'
+  - signature: 'ceiling(x: N) -> double precision'
     description: "Alias of `ceil`."
 
-  - signature: 'exp(x: N) -> N'
+  - signature: 'exp(x: N) -> double precision'
     description: Exponential of `x` (e raised to the given power)
 
-  - signature: 'floor(x: N) -> N'
+  - signature: 'floor(x: N) -> double precision'
     description: The largest integer <= `x`.
 
   - signature: 'ln(x: double precision) -> double precision'
@@ -198,7 +198,7 @@
   - signature: 'power(x: numeric, y: numeric) -> numeric'
     description: "`x` raised to the power of `y`."
 
-  - signature: 'round(x: N) -> N'
+  - signature: 'round(x: N) -> double precision'
     description: |
       `x` rounded to the nearest whole number.
       If `N` is `real` or `double precision`, rounds ties to the nearest even number.
@@ -214,7 +214,7 @@
   - signature: 'sqrt(x: double precision) -> double precision'
     description: The square root of `x`.
 
-  - signature: 'trunc(x: N) -> N'
+  - signature: 'trunc(x: N) -> double precision'
     description: "`x` truncated toward zero to a whole number."
 
 - type: Trigonometric
@@ -276,7 +276,7 @@
   - signature: 'btrim(s: str, c: str) -> str'
     description: Trim any character in `c` from both sides of `s`.
 
-  - signature: 'bit_count(b: bytea) -> int'
+  - signature: 'bit_count(b: bytea) -> bigint'
     description: Returns the number of bits set in the bit string (aka _popcount_).
 
   - signature: 'bit_length(s: str) -> int'
@@ -1122,3 +1122,4 @@
         the `current_role` is assumed.
     - signature: 'mz_is_superuser() -> bool'
       description: Reports whether the `current_role` is a superuser.
+      unmaterializable: true

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -86,14 +86,16 @@ class SmallInt(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::smallint" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::smallint" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -122,14 +124,16 @@ class Int(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::int" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::int" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -158,14 +162,16 @@ class Long(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::bigint" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::bigint" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -192,14 +198,16 @@ class UInt2(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::uint2" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::uint2" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -232,14 +240,16 @@ class UInt4(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::uint4" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::uint4" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -274,14 +284,16 @@ class UInt8(DataType):
             raise ValueError(f"Unexpected record size {record_size}")
 
         if rng.randrange(10) == 0:
-            return min
-        if rng.randrange(10) == 0:
-            return max
-        return rng.randint(min, max)
+            value = min
+        elif rng.randrange(10) == 0:
+            value = max
+        else:
+            value = rng.randint(min, max)
+        return f"{value}::uint8" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::uint8" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -305,24 +317,24 @@ class Float(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(10) == 0:
-            return 1.0
-        if rng.randrange(10) == 0:
-            return 0.0
-
-        if record_size == RecordSize.TINY:
-            return rng.random()
+            value = 1.0
+        elif rng.randrange(10) == 0:
+            value = 0.0
+        elif record_size == RecordSize.TINY:
+            value = rng.random()
         elif record_size == RecordSize.SMALL:
-            return rng.uniform(-100, 100)
+            value = rng.uniform(-100, 100)
         elif record_size == RecordSize.MEDIUM:
-            return rng.uniform(-1_000_000, 1_000_000)
+            value = rng.uniform(-1_000_000, 1_000_000)
         elif record_size == RecordSize.LARGE:
-            return rng.uniform(-1_000_000_000, 1_000_000_000_00)
+            value = rng.uniform(-1_000_000_000, 1_000_000_000_00)
         else:
             raise ValueError(f"Unexpected record size {record_size}")
+        return f"{value}::float4" if in_query else value
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return num
+        return f"{num}::float4" if in_query else num
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -336,7 +348,33 @@ class Float(DataType):
             return "float4"
 
 
-class Double(Float):
+class Double(DataType):
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if rng.randrange(10) == 0:
+            value = 1.0
+        elif rng.randrange(10) == 0:
+            value = 0.0
+        elif record_size == RecordSize.TINY:
+            value = rng.random()
+        elif record_size == RecordSize.SMALL:
+            value = rng.uniform(-100, 100)
+        elif record_size == RecordSize.MEDIUM:
+            value = rng.uniform(-1_000_000, 1_000_000)
+        elif record_size == RecordSize.LARGE:
+            value = rng.uniform(-1_000_000_000, 1_000_000_000_00)
+        else:
+            raise ValueError(f"Unexpected record size {record_size}")
+        return f"{value}::float8" if in_query else value
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        return f"{num}::float8" if in_query else num
+
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
         if backend == Backend.AVRO:
@@ -349,7 +387,33 @@ class Double(Float):
             return "float8"
 
 
-class Numeric(Float):
+class Numeric(DataType):
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if rng.randrange(10) == 0:
+            value = 1.0
+        elif rng.randrange(10) == 0:
+            value = 0.0
+        elif record_size == RecordSize.TINY:
+            value = rng.random()
+        elif record_size == RecordSize.SMALL:
+            value = rng.uniform(-100, 100)
+        elif record_size == RecordSize.MEDIUM:
+            value = rng.uniform(-1_000_000, 1_000_000)
+        elif record_size == RecordSize.LARGE:
+            value = rng.uniform(-1_000_000_000, 1_000_000_000_00)
+        else:
+            raise ValueError(f"Unexpected record size {record_size}")
+        return f"{value}::numeric" if in_query else value
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        return f"{num}::numeric" if in_query else num
+
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
         if backend == Backend.AVRO:
@@ -360,7 +424,33 @@ class Numeric(Float):
             return "numeric"
 
 
-class Numeric383(Float):
+class Numeric383(DataType):
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if rng.randrange(10) == 0:
+            value = 1.0
+        elif rng.randrange(10) == 0:
+            value = 0.0
+        elif record_size == RecordSize.TINY:
+            value = rng.random()
+        elif record_size == RecordSize.SMALL:
+            value = rng.uniform(-100, 100)
+        elif record_size == RecordSize.MEDIUM:
+            value = rng.uniform(-1_000_000, 1_000_000)
+        elif record_size == RecordSize.LARGE:
+            value = rng.uniform(-1_000_000_000, 1_000_000_000_00)
+        else:
+            raise ValueError(f"Unexpected record size {record_size}")
+        return f"{value}::numeric(38,3)" if in_query else value
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        return f"{num}::numeric(38,3)" if in_query else num
+
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
         if backend == Backend.AVRO:

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -623,18 +623,20 @@ class Timestamp(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(100) == 0:
-            return "TIMESTAMP '1-01-01'"
-        if rng.randrange(100) == 0:
-            return "TIMESTAMP '99999-12-31'"
-
-        return f"TIMESTAMP '{rng.randrange(1, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}'"
+            result = "1-01-01"
+        elif rng.randrange(100) == 0:
+            result = "99999-12-31"
+        else:
+            result = f"{rng.randrange(1, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}"
+        return f"TIMESTAMP '{result}'" if in_query else str(result)
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
         day = num % 28
         month = num // 28 % 12
         year = num // 336
-        return f"TIMESTAMP '{year}-{month}-{day}'"
+        result = f"{year}-{month}-{day}"
+        return f"TIMESTAMP '{result}'" if in_query else str(result)
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -656,18 +658,20 @@ class MzTimestamp(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(100) == 0:
-            return "MZ_TIMESTAMP '1970-01-01'"
-        if rng.randrange(100) == 0:
-            return "MZ_TIMESTAMP '99999-12-31'"
-
-        return f"MZ_TIMESTAMP '{rng.randrange(1970, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}'"
+            result = "1970-01-01"
+        elif rng.randrange(100) == 0:
+            result = "99999-12-31"
+        else:
+            result = f"{rng.randrange(1970, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}"
+        return f"MZ_TIMESTAMP '{result}'" if in_query else result
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
         day = num % 28
         month = num // 28 % 12
         year = 1970 + (num // 336)
-        return f"MZ_TIMESTAMP '{year}-{month}-{day}'"
+        result = f"{year}-{month}-{day}"
+        return f"MZ_TIMESTAMP '{result}'" if in_query else result
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -684,18 +688,20 @@ class Date(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(100) == 0:
-            return "DATE '1-01-01'"
-        if rng.randrange(100) == 0:
-            return "DATE '99999-12-31'"
-
-        return f"DATE '{rng.randrange(1, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}'"
+            result = "1-01-01"
+        elif rng.randrange(100) == 0:
+            result = "99999-12-31"
+        else:
+            result = f"{rng.randrange(1, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}"
+        return f"DATE '{result}'" if in_query else result
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
         day = num % 28
         month = num // 28 % 12
         year = num // 336
-        return f"TIME '{year}-{month}-{day}'"
+        result = f"{year}-{month}-{day}"
+        return f"DATE '{result}'" if in_query else result
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -715,18 +721,20 @@ class Time(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(100) == 0:
-            return "TIME '00:00:00'"
-        if rng.randrange(100) == 0:
-            return "TIME '23:59:59.999999'"
-
-        return f"TIME '{rng.randrange(0, 24)}:{rng.randrange(0, 60)}:{rng.randrange(0, 60)}.{rng.randrange(0, 1000000)}'"
+            result = "00:00:00"
+        elif rng.randrange(100) == 0:
+            result = "23:59:59.999999"
+        else:
+            result = f"{rng.randrange(0, 24)}:{rng.randrange(0, 60)}:{rng.randrange(0, 60)}.{rng.randrange(0, 1000000)}"
+        return f"TIME '{result}'" if in_query else result
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
         seconds = num % 60
         minutes = num // 60 % 60
         hours = num // 3600
-        return f"TIME '{hours}:{minutes}:{seconds}'"
+        result = f"{hours}:{minutes}:{seconds}"
+        return f"TIME '{result}'" if in_query else result
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
@@ -746,24 +754,26 @@ class Interval(DataType):
         in_query: bool = False,
     ) -> Any:
         if rng.randrange(100) == 0:
-            return "INTERVAL '-178956970 years -8 months -2147483648 days -2562047788:00:54.775808'"
-        if rng.randrange(100) == 0:
-            return "INTERVAL '178956970 years 7 months 2147483647 days 2562047788:00:54.775807'"
-
-        if record_size == RecordSize.TINY:
-            return f"INTERVAL '{rng.random():.0f}' MINUTE"
+            result = (
+                "-178956970 years -8 months -2147483648 days -2562047788:00:54.775808"
+            )
+        elif rng.randrange(100) == 0:
+            result = "178956970 years 7 months 2147483647 days 2562047788:00:54.775807"
+        elif record_size == RecordSize.TINY:
+            result = f"{rng.random():.0f} MINUTE"
         elif record_size == RecordSize.SMALL:
-            return f"INTERVAL '{rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds'"
+            result = f"{rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds"
         elif record_size == RecordSize.MEDIUM:
-            return f"INTERVAL '{rng.uniform(-100, 100):.0f} years {rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds'"
+            result = f"{rng.uniform(-100, 100):.0f} years {rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds"
         elif record_size == RecordSize.LARGE:
-            return f"INTERVAL '{rng.uniform(-178956970, 178956970):.0f} years {rng.uniform(-365, 365):.0f} days {rng.uniform(-1000000000, 1000000000):.0f} seconds'"
+            result = f"{rng.uniform(-178956970, 178956970):.0f} years {rng.uniform(-365, 365):.0f} days {rng.uniform(-1000000000, 1000000000):.0f} seconds"
         else:
             raise ValueError(f"Unexpected record size {record_size}")
+        return f"INTERVAL '{result}'" if in_query else result
 
     @staticmethod
     def numeric_value(num: int, in_query: bool = False) -> Any:
-        return f"INTERVAL '{num}' MINUTE"
+        return f"INTERVAL '{num}' MINUTE" if in_query else str(num)
 
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -648,6 +648,34 @@ class Timestamp(DataType):
             return "timestamp"
 
 
+class MzTimestamp(DataType):
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if rng.randrange(100) == 0:
+            return "MZ_TIMESTAMP '1970-01-01'"
+        if rng.randrange(100) == 0:
+            return "MZ_TIMESTAMP '99999-12-31'"
+
+        return f"MZ_TIMESTAMP '{rng.randrange(1970, 100000)}-{rng.randrange(1, 13)}-{rng.randrange(1, 29)}'"
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        day = num % 28
+        month = num // 28 % 12
+        year = 1970 + (num // 336)
+        return f"MZ_TIMESTAMP '{year}-{month}-{day}'"
+
+    @staticmethod
+    def name(backend: Backend = Backend.MATERIALIZE) -> str:
+        if backend != Backend.MATERIALIZE:
+            raise ValueError("Unsupported")
+        return "mz_timestamp"
+
+
 class Date(DataType):
     @staticmethod
     def random_value(

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -751,13 +751,13 @@ class Interval(DataType):
             return "INTERVAL '178956970 years 7 months 2147483647 days 2562047788:00:54.775807'"
 
         if record_size == RecordSize.TINY:
-            return f"INTERVAL '{rng.random()}' MINUTE"
+            return f"INTERVAL '{rng.random():.0f}' MINUTE"
         elif record_size == RecordSize.SMALL:
-            return f"INTERVAL '{rng.uniform(-100, 100)} days {rng.uniform(-100, 100)} seconds'"
+            return f"INTERVAL '{rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds'"
         elif record_size == RecordSize.MEDIUM:
-            return f"INTERVAL '{rng.uniform(-100, 100)} years {rng.uniform(-100, 100)} days {rng.uniform(-100, 100)} seconds'"
+            return f"INTERVAL '{rng.uniform(-100, 100):.0f} years {rng.uniform(-100, 100):.0f} days {rng.uniform(-100, 100):.0f} seconds'"
         elif record_size == RecordSize.LARGE:
-            return f"INTERVAL '{rng.uniform(-178956970, 178956970)} years {rng.uniform(-365, 365)} days {rng.uniform(-1000000000, 1000000000)} seconds'"
+            return f"INTERVAL '{rng.uniform(-178956970, 178956970):.0f} years {rng.uniform(-365, 365):.0f} days {rng.uniform(-1000000000, 1000000000):.0f} seconds'"
         else:
             raise ValueError(f"Unexpected record size {record_size}")
 
@@ -806,6 +806,7 @@ DATA_TYPES_FOR_AVRO = sorted(
             Time,
             Date,
             Timestamp,
+            MzTimestamp,
             Oid,
             Numeric,
             Numeric383,
@@ -863,6 +864,7 @@ DATA_TYPES_FOR_SQL_SERVER = sorted(
             Date,
             Time,
             Timestamp,
+            MzTimestamp,
             Float,
             Double,
         }

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -79,7 +79,7 @@ class Executor:
                 else "materialized"
             )
         self.mz_conn = psycopg.connect(
-            host="localhost",
+            host="127.0.0.1",
             port=self.ports[mz_service],
             user="materialize",
             dbname=self.database,
@@ -202,7 +202,7 @@ class KafkaExecutor(Executor):
             ],
         }
 
-        kafka_conf = {"bootstrap.servers": f"localhost:{self.ports['kafka']}"}
+        kafka_conf = {"bootstrap.servers": f"127.0.0.1:{self.ports['kafka']}"}
 
         a = AdminClient(kafka_conf)
         fs = a.create_topics(
@@ -220,7 +220,7 @@ class KafkaExecutor(Executor):
         topic = list(fs.keys())[0]
 
         schema_registry_conf = {
-            "url": f"http://localhost:{self.ports['schema-registry']}"
+            "url": f"http://127.0.0.1:{self.ports['schema-registry']}"
         }
         registry = SchemaRegistryClient(schema_registry_conf)
 
@@ -485,7 +485,7 @@ class MySqlExecutor(Executor):
     def create(self, logging_exe: Any | None = None) -> None:
         self.logging_exe = logging_exe
         self.mysql_conn = pymysql.connect(
-            host="localhost",
+            host="127.0.0.1",
             user="root",
             password=MySql.DEFAULT_ROOT_PASSWORD,
             database="mysql",
@@ -616,7 +616,7 @@ class PgExecutor(Executor):
     def create(self, logging_exe: Any | None = None) -> None:
         self.logging_exe = logging_exe
         self.pg_conn = psycopg.connect(
-            host="localhost",
+            host="127.0.0.1",
             user="postgres",
             password="postgres",
             port=self.ports["postgres"],

--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -325,7 +325,7 @@ def execute_workload(
 
     # Reconnect as Mz disruptions may have destroyed the previous connection
     conn = psycopg.connect(
-        host="localhost",
+        host="127.0.0.1",
         port=ports[workload.mz_service],
         user="materialize",
         dbname="materialize",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -157,9 +157,6 @@ class Action:
             "out of range",
             "is only defined for finite arguments",
             "Window function performance issue",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9644 is fixed
-            "Negative multiplicities in TopK",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
-            "Non-positive multiplicity in DistinctBy",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
-            "Invalid data in source errors, saw retractions",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9670 is fixed
         ]
         if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -157,7 +157,6 @@ class Action:
             "out of range",
             "is only defined for finite arguments",
             "Window function performance issue",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9644 is fixed
-            "Invalid data in source, saw retractions",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
             "Negative multiplicities in TopK",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
             "Non-positive multiplicity in DistinctBy",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
             "Invalid data in source errors, saw retractions",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9670 is fixed

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -28,8 +28,6 @@ import materialize.parallel_workload.database
 from materialize.data_ingest.data_type import (
     NUMBER_TYPES,
     Boolean,
-    IntArray,
-    IntList,
     Text,
     TextTextMap,
 )
@@ -2671,7 +2669,10 @@ read_action_list = ActionList(
         (SelectAction, 100),
         (SelectOneAction, 1),
         # (SQLsmithAction, 30),  # Questionable use
-        (CopyToS3Action, 100),  # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9661 is fixed
+        (
+            CopyToS3Action,
+            100,
+        ),  # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9661 is fixed
         (SetClusterAction, 1),
         (CommitRollbackAction, 30),
         (ReconnectAction, 1),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -279,6 +279,7 @@ class SelectAction(Action):
                 "in the same timedomain",
                 'is not allowed from the "mz_catalog_server" cluster',
                 "timed out before ingesting the source's visible frontier when real-time-recency query issued",
+                "unexpected panic during query optimization: The fast_path_optimizer shouldn't make a fast path plan slow path",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9645 is fixed
             ]
         )
         if exe.db.complexity == Complexity.DDL:

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -611,7 +611,7 @@ class CopyFromStdinAction(Action):
         if exe.db.complexity == Complexity.DDL:
             result.extend(
                 [
-                    "COPY FROM's target table was dropped",
+                    "COPY FROM's target table",
                 ]
             )
         return result
@@ -1689,7 +1689,7 @@ class CreateClusterAction(Action):
             managed=self.rng.choice([True, False]),
             size=self.rng.choice(["1", "2"]),
             replication_factor=self.rng.choice([1, 2]),
-            introspection_interval=self.rng.choice(["0", "1s", "10s"]),
+            introspection_interval="1s",
         )
         cluster.create(exe)
         exe.db.clusters.append(cluster)

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -71,6 +71,7 @@ from materialize.parallel_workload.database import (
     WebhookSource,
 )
 from materialize.parallel_workload.executor import Executor, Http
+from materialize.parallel_workload.expression import expression
 from materialize.parallel_workload.settings import Complexity, Scenario
 from materialize.sqlsmith import known_errors
 
@@ -262,6 +263,10 @@ class SelectAction(Action):
                 "in the same timedomain",
                 'is not allowed from the "mz_catalog_server" cluster',
                 "timed out before ingesting the source's visible frontier when real-time-recency query issued",
+                "timestamp out of range",
+                "numeric field overflow",
+                "division by zero",
+                "out of range",
             ]
         )
         if exe.db.complexity == Complexity.DDL:
@@ -293,10 +298,10 @@ class SelectAction(Action):
 
         if self.rng.choice([True, False]):
             expressions = ", ".join(
-                str(column)
-                for column in self.rng.sample(
-                    all_columns, k=self.rng.randint(1, len(all_columns))
-                )
+                [
+                    expression(self.rng.choice(list(DATA_TYPES)), all_columns, self.rng)
+                    for i in range(self.rng.randint(1, 10))
+                ]
             )
             if self.rng.choice([True, False]):
                 column1 = self.rng.choice(all_columns)
@@ -315,6 +320,9 @@ class SelectAction(Action):
         if join:
             column2 = self.rng.choice(columns)
             query += f"JOIN {obj2_name} ON {column} = {column2}"
+
+        if self.rng.choice([True, False]):
+            query = f"{query} UNION ALL {query}"
 
         query += " LIMIT 1"
 
@@ -1387,6 +1395,7 @@ class FlipFlagsAction(Action):
 
 class CreateViewAction(Action):
     def run(self, exe: Executor) -> bool:
+        # TODO: Use expressions
         with exe.db.lock:
             if len(exe.db.views) >= MAX_VIEWS:
                 return False

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -515,6 +515,16 @@ class InsertAction(Action):
 
 
 class CopyFromStdinAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        if exe.db.complexity == Complexity.DDL:
+            result.extend(
+                [
+                    "COPY FROM's target table was dropped",
+                ]
+            )
+        return result
+
     def run(self, exe: Executor) -> bool:
         table = None
         if exe.insert_table is not None:

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -25,7 +25,14 @@ from psycopg import Connection
 from psycopg.errors import OperationalError
 
 import materialize.parallel_workload.database
-from materialize.data_ingest.data_type import NUMBER_TYPES, Boolean, Text, TextTextMap
+from materialize.data_ingest.data_type import (
+    NUMBER_TYPES,
+    Boolean,
+    IntArray,
+    IntList,
+    Text,
+    TextTextMap,
+)
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.mzcompose import get_default_system_parameters
@@ -148,9 +155,12 @@ class Action:
             "numeric field overflow",
             "division by zero",
             "out of range",
-            "cannot evaluate unmaterializable function",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9657 is fixed
+            "is only defined for finite arguments",
             "Window function performance issue",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9644 is fixed
             "Invalid data in source, saw retractions",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
+            "Negative multiplicities in TopK",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
+            "Non-positive multiplicity in DistinctBy",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9668 is fixed
+            "Invalid data in source errors, saw retractions",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9670 is fixed
         ]
         if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(
@@ -253,11 +263,33 @@ class Action:
                 column1 = self.rng.choice(all_columns)
                 column2 = self.rng.choice(all_columns)
                 column3 = self.rng.choice(all_columns)
-                fns = ["COUNT"]
+                fns = [
+                    "COUNT({})",
+                    "LIST_AGG({})",
+                    "JSONB_AGG({})",
+                ]
+                if column1.data_type == Text:
+                    fns.extend(["STRING_AGG({}, ',')"])
+                if column1.data_type not in [TextTextMap, IntArray, IntList]:
+                    fns.extend(["ARRAY_AGG({})"])
                 if column1.data_type in NUMBER_TYPES:
-                    fns.extend(["SUM", "AVG", "MAX", "MIN"])
+                    fns.extend(
+                        [
+                            "SUM({})",
+                            "AVG({})",
+                            "MAX({})",
+                            "MIN({})",
+                            "STDDEV({})",
+                            "STDDEV_POP({})",
+                            "STDDEV_SAMP({})",
+                            "VAR_SAMP({})",
+                            "VAR_POP({})",
+                        ]
+                    )
+                elif column1.data_type == Boolean:
+                    fns.extend(["BOOL_AND({})", "BOOL_OR({})"])
                 window_fn = self.rng.choice(fns)
-                expressions += f", {window_fn}({column1}) OVER (PARTITION BY {column2} ORDER BY {column3})"
+                expressions += f", {window_fn.format(column1)} OVER (PARTITION BY {column2} ORDER BY {column3})"
         else:
             expressions = "*"
 
@@ -319,6 +351,7 @@ class FetchAction(Action):
                 [
                     "does not exist",
                     "subscribe has been terminated because underlying relation",
+                    "subscribe has been terminated because underlying cluster",
                 ]
             )
         return result
@@ -380,7 +413,6 @@ class SelectAction(Action):
                 "in the same timedomain",
                 'is not allowed from the "mz_catalog_server" cluster',
                 "timed out before ingesting the source's visible frontier when real-time-recency query issued",
-                "unexpected panic during query optimization: The fast_path_optimizer shouldn't make a fast path plan slow path",  # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9645 is fixed
             ]
         )
         if exe.db.complexity == Complexity.DDL:
@@ -493,6 +525,7 @@ class CopyToS3Action(Action):
                 "Cannot encode the following columns/types",
                 "timeout: error trying to connect",
                 "cannot represent decimal value",  # parquet limitation
+                "Cannot represent special numeric value",  # parquet limitation
             ]
         )
         if exe.db.complexity == Complexity.DDL:
@@ -716,9 +749,20 @@ class SourceInsertAction(Action):
 
 class UpdateAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
-        return [
-            "canceling statement due to statement timeout",
-        ] + super().errors_to_ignore(exe)
+        result = super().errors_to_ignore(exe)
+        result.extend(
+            [
+                "canceling statement due to statement timeout",
+            ]
+        )
+
+        if exe.db.complexity == Complexity.DDL:
+            result.extend(
+                [
+                    "does not exist",
+                ]
+            )
+        return result
 
     def run(self, exe: Executor) -> bool:
         table = None
@@ -2631,7 +2675,7 @@ read_action_list = ActionList(
         (SelectAction, 100),
         (SelectOneAction, 1),
         # (SQLsmithAction, 30),  # Questionable use
-        # (CopyToS3Action, 100),  # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9661 is fixed
+        (CopyToS3Action, 100),  # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9661 is fixed
         (SetClusterAction, 1),
         (CommitRollbackAction, 30),
         (ReconnectAction, 1),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2538,7 +2538,7 @@ read_action_list = ActionList(
         (SelectAction, 100),
         (SelectOneAction, 1),
         # (SQLsmithAction, 30),  # Questionable use
-        (CopyToS3Action, 100),
+        # (CopyToS3Action, 100),  # TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9661 is fixed
         # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (CommitRollbackAction, 30),
         (ReconnectAction, 1),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -265,13 +265,13 @@ class Action:
                 column3 = self.rng.choice(all_columns)
                 fns = [
                     "COUNT({})",
-                    "LIST_AGG({})",
-                    "JSONB_AGG({})",
+                    # "LIST_AGG({})",
+                    # "JSONB_AGG({})",
                 ]
-                if column1.data_type == Text:
-                    fns.extend(["STRING_AGG({}, ',')"])
-                if column1.data_type not in [TextTextMap, IntArray, IntList]:
-                    fns.extend(["ARRAY_AGG({})"])
+                # if column1.data_type == Text:
+                #     fns.extend(["STRING_AGG({}, ',')"])
+                # if column1.data_type not in [TextTextMap, IntArray, IntList]:
+                #     fns.extend(["ARRAY_AGG({})"])
                 if column1.data_type in NUMBER_TYPES:
                     fns.extend(
                         [

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import copy
 import datetime
 import json
 import random
@@ -72,7 +73,11 @@ from materialize.parallel_workload.database import (
 )
 from materialize.parallel_workload.executor import Executor, Http
 from materialize.parallel_workload.expression import ExprKind, expression
-from materialize.parallel_workload.settings import Complexity, Scenario
+from materialize.parallel_workload.settings import (
+    ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS,
+    Complexity,
+    Scenario,
+)
 from materialize.sqlsmith import known_errors
 
 if TYPE_CHECKING:
@@ -1944,11 +1949,7 @@ class KillAction(Action):
     ):
         super().__init__(rng, composition)
         self.system_param_fn = system_param_fn
-        self.system_parameters = {
-            "memory_limiter_interval": "0",
-            # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
-            "persist_stats_audit_percent": "0",
-        }
+        self.system_parameters = copy.deepcopy(ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS)
         self.azurite = azurite
         self.sanity_restart = sanity_restart
 
@@ -2016,11 +2017,7 @@ class ZeroDowntimeDeployAction(Action):
                 healthcheck=LEADER_STATUS_HEALTHCHECK,
                 metadata_store="cockroach",
                 default_replication_factor=1,
-                additional_system_parameter_defaults={
-                    "memory_limiter_interval": "0",
-                    # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
-                    "persist_stats_audit_percent": "0",
-                },
+                additional_system_parameter_defaults=ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS,
             ),
         ):
             self.composition.up(mz_service, detach=True)

--- a/misc/python/materialize/parallel_workload/column.py
+++ b/misc/python/materialize/parallel_workload/column.py
@@ -1,0 +1,170 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import TYPE_CHECKING
+
+from pg8000.native import identifier
+
+from materialize.data_ingest.data_type import (
+    DataType,
+)
+from materialize.util import naughty_strings
+
+if TYPE_CHECKING:
+    from materialize.parallel_workload.database import DBObject
+
+
+NAUGHTY_IDENTIFIERS = False
+
+
+def naughtify(name: str) -> str:
+    """Makes a string into a naughty identifier, always returns the same
+    identifier when called with the same input."""
+    global NAUGHTY_IDENTIFIERS
+
+    if not NAUGHTY_IDENTIFIERS:
+        return name
+
+    strings = naughty_strings()
+    # This rng is just to get a more interesting integer for the name
+    index = sum([10**i * c for i, c in enumerate(name.encode())]) % len(strings)
+    # Keep them short so we can combine later with other identifiers, 255 char limit
+    return f"{name}_{strings[index].encode('utf-8')[:16].decode('utf-8', 'ignore')}"
+
+
+class Column:
+    column_id: int
+    data_type: type[DataType]
+    db_object: "DBObject"
+    nullable: bool
+    default: str | None
+    raw_name: str
+
+    def __init__(
+        self,
+        rng: random.Random,
+        column_id: int,
+        data_type: type[DataType],
+        db_object: "DBObject",
+    ):
+        self.column_id = column_id
+        self.data_type = data_type
+        self.db_object = db_object
+        self.nullable = rng.choice([True, False])
+        self.default = rng.choice(
+            [None, str(data_type.random_value(rng, in_query=True))]
+        )
+        self.raw_name = f"c-{self.column_id}-{self.data_type.name()}"
+
+    def name(self, in_query: bool = False) -> str:
+        return (
+            identifier(naughtify(self.raw_name))
+            if in_query
+            else naughtify(self.raw_name)
+        )
+
+    def __str__(self) -> str:
+        return f"{self.db_object}.{self.name(True)}"
+
+    def value(self, rng: random.Random, in_query: bool = False) -> str:
+        return str(self.data_type.random_value(rng, in_query=in_query))
+
+    def create(self) -> str:
+        result = f"{self.name(True)} {self.data_type.name()}"
+        if self.default:
+            result += f" DEFAULT {self.default}"
+        if not self.nullable:
+            result += " NOT NULL"
+        return result
+
+
+class WebhookColumn(Column):
+    def __init__(
+        self,
+        name: str,
+        data_type: type[DataType],
+        nullable: bool,
+        db_object: "DBObject",
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name
+
+
+class KafkaColumn(Column):
+    def __init__(
+        self,
+        name: str,
+        data_type: type[DataType],
+        nullable: bool,
+        db_object: "DBObject",
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name
+
+
+class MySqlColumn(Column):
+    def __init__(
+        self,
+        name: str,
+        data_type: type[DataType],
+        nullable: bool,
+        db_object: "DBObject",
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name
+
+
+class PostgresColumn(Column):
+    def __init__(
+        self,
+        name: str,
+        data_type: type[DataType],
+        nullable: bool,
+        db_object: "DBObject",
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name
+
+
+class SqlServerColumn(Column):
+    def __init__(
+        self,
+        name: str,
+        data_type: type[DataType],
+        nullable: bool,
+        db_object: "DBObject",
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -915,7 +915,7 @@ class Database:
                     ["scale=1,workers=1", "scale=1,workers=4", "scale=2,workers=2"]
                 ),
                 replication_factor=1,
-                introspection_interval=rng.choice(["0", "1s", "10s"]),
+                introspection_interval="1s",
             )
             for i in range(rng.randint(1, MAX_INITIAL_CLUSTERS))
         ]

--- a/misc/python/materialize/parallel_workload/expression.py
+++ b/misc/python/materialize/parallel_workload/expression.py
@@ -49,6 +49,7 @@ class ExprKind(Enum):
     ALL = 1
     WRITE = 2
     MATERIALIZABLE = 3
+    NONE = 4
 
 
 class FuncOp:

--- a/misc/python/materialize/parallel_workload/expression.py
+++ b/misc/python/materialize/parallel_workload/expression.py
@@ -1,0 +1,197 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+
+from materialize.data_ingest.data_type import (
+    DATA_TYPES,
+    Boolean,
+    Bytea,
+    DataType,
+    Date,
+    Double,
+    Float,
+    Int,
+    IntArray,
+    Interval,
+    IntList,
+    Jsonb,
+    Long,
+    MzTimestamp,
+    Numeric,
+    Numeric383,
+    RecordSize,
+    Text,
+    TextTextMap,
+    Time,
+    Timestamp,
+    UInt2,
+    UInt4,
+    UInt8,
+)
+from materialize.parallel_workload.database import (
+    Column,
+    KafkaColumn,
+    MySqlColumn,
+    PostgresColumn,
+    SqlServerColumn,
+)
+
+
+class FuncOp:
+    def __init__(self, text: str, params: list, materializable: bool = True):
+        self.text = text
+        self.params = params
+        self.materializable = materializable
+
+
+FUNC_OPS: dict[type[DataType], list[FuncOp]] = {dt: [] for dt in DATA_TYPES}
+
+for dt in DATA_TYPES:
+    FUNC_OPS[Boolean] += [
+        FuncOp("{} IS NULL", [dt]),
+        FuncOp("{} IS NOT NULL", [dt]),
+    ]
+
+    if dt != Bytea:
+        FUNC_OPS[Text] += [FuncOp("cast({} as text)", [dt])]
+
+    if dt not in (IntList, IntArray, TextTextMap, Bytea, Jsonb, Text):
+        FUNC_OPS[Text] += [
+            FuncOp("{} || {}", [dt, Text]),
+            FuncOp("{} || {}", [Text, dt]),
+        ]
+
+    if dt not in (IntList, IntArray, TextTextMap, Bytea, Jsonb):
+        FUNC_OPS[Boolean] += [
+            FuncOp("{} > {}", [dt, dt]),
+            FuncOp("{} < {}", [dt, dt]),
+            FuncOp("{} >= {}", [dt, dt]),
+            FuncOp("{} <= {}", [dt, dt]),
+            FuncOp("{} = {}", [dt, dt]),
+            FuncOp("{} != {}", [dt, dt]),
+        ]
+
+INT_TYPES = [Int, Long]
+UINT_TYPES = [UInt2, UInt4, UInt8]
+FLOAT_TYPES = [Float, Double, Numeric, Numeric383]
+
+for dt in INT_TYPES + UINT_TYPES + FLOAT_TYPES:
+    FUNC_OPS[dt] += [
+        FuncOp("{} + {}", [dt, dt]),
+        FuncOp("{} - {}", [dt, dt]),
+        FuncOp("{} * {}", [dt, dt]),
+        FuncOp("{} / {}", [dt, dt]),
+        FuncOp("abs{}", [dt]),
+    ]
+
+FUNC_OPS[Long] += [FuncOp(f"cast({{}} as {Long.name()})", [Int])]
+
+for i, dt in enumerate(UINT_TYPES):
+    for dt2 in UINT_TYPES[i + 1 :]:
+        FUNC_OPS[dt2] += [FuncOp(f"cast({{}} as {dt2.name()})", [dt])]
+
+for dt in FLOAT_TYPES:
+    for dt2 in FLOAT_TYPES:
+        if dt2 == dt:
+            continue
+        FUNC_OPS[dt2] += [FuncOp(f"cast({{}} as {dt2.name()})", [dt])]
+
+FUNC_OPS[Boolean] += [
+    FuncOp("{} AND {}", [Boolean, Boolean]),
+    FuncOp("{} OR {}", [Boolean, Boolean]),
+    FuncOp("NOT {}", [Boolean]),
+    FuncOp("{} @> {}", [IntList, IntList]),
+    FuncOp("{} <@ {}", [IntList, IntList]),
+    FuncOp("{} @> {}", [TextTextMap, TextTextMap]),
+    FuncOp("{} <@ {}", [TextTextMap, TextTextMap]),
+]
+
+FUNC_OPS[Text] += [
+    FuncOp("lower{}", [Text]),
+    FuncOp("upper{}", [Text]),
+    FuncOp("md5{}", [Text]),
+    FuncOp("{} || {}", [Text, Text]),
+    FuncOp("reverse{}", [Text]),
+    FuncOp("{} -> {}", [TextTextMap, Text]),
+    FuncOp("mz_environment_id()", [], materializable=False),
+    FuncOp("mz_version()", [], materializable=False),
+    FuncOp("current_database()", [], materializable=False),
+    FuncOp("current_catalog()", [], materializable=False),
+    FuncOp("current_user()", [], materializable=False),
+    FuncOp("current_role()", [], materializable=False),
+    FuncOp("session_user()", [], materializable=False),
+    FuncOp("current_schema()", [], materializable=False),
+]
+
+FUNC_OPS[Int] += [
+    FuncOp("bit_count{}", [Bytea]),
+    FuncOp("bit_length{}", [Bytea]),
+    FuncOp("bit_length{}", [Text]),
+    FuncOp("ascii{}", [Text]),
+    FuncOp("position({} in {})", [Text, Text]),
+    FuncOp("length{}", [Text]),
+    FuncOp("mz_version_num()", [], materializable=False),
+    FuncOp("{} - {}", [Date, Date]),
+]
+
+FUNC_OPS[Timestamp] += [
+    FuncOp("{} + {}", [Date, Interval]),
+    FuncOp("{} - {}", [Date, Interval]),
+    FuncOp("{} + {}", [Date, Time]),
+    FuncOp("{} + {}", [Timestamp, Interval]),
+    FuncOp("{} - {}", [Timestamp, Interval]),
+    FuncOp("now()", [], materializable=False),
+    FuncOp("current_timestamp()", [], materializable=False),
+    FuncOp("cast({} as Timestamp)", [MzTimestamp]),
+]
+
+FUNC_OPS[MzTimestamp] += [
+    FuncOp("mz_now()", [], materializable=False),
+]
+
+FUNC_OPS[Interval] += [
+    FuncOp("{} - {}", [Timestamp, Timestamp]),
+    FuncOp("{} - {}", [Time, Time]),
+]
+
+FUNC_OPS[Time] += [
+    FuncOp("{} + {}", [Time, Interval]),
+    FuncOp("{} - {}", [Time, Interval]),
+]
+
+FUNC_OPS[IntList] += [FuncOp("{} || {}", [IntList, IntList])]
+
+
+def expression(
+    data_type: type[DataType],
+    columns: list[Column] | (
+        list[MySqlColumn]
+        | (list[PostgresColumn] | (list[SqlServerColumn] | list[KafkaColumn]))
+    ),
+    rng: random.Random,
+    level: int = 0,
+) -> str:
+    if level < 120:
+        if FUNC_OPS[data_type] and rng.random() < 0.3:
+            fnop = rng.choice(FUNC_OPS[data_type])
+            exprs = [
+                f"({expression(dt, columns, rng, level + 1)})" for dt in fnop.params
+            ]
+            return fnop.text.format(*exprs)
+
+        if rng.random() < 0.9:
+            for col in random.sample(columns, len(columns)):
+                if col.data_type == data_type:
+                    return str(col)
+
+    record_size = rng.choice(
+        [RecordSize.TINY, RecordSize.SMALL, RecordSize.MEDIUM, RecordSize.LARGE]
+    )
+    return str(data_type.random_value(rng, record_size=record_size, in_query=True))

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -507,7 +507,7 @@ def main() -> int:
         description="Run a parallel workload against Materialize",
     )
 
-    parser.add_argument("--host", default="localhost", type=str)
+    parser.add_argument("--host", default="127.0.0.1", type=str)
     parser.add_argument("--port", default=6875, type=int)
     parser.add_argument("--system-port", default=6877, type=int)
     parser.add_argument("--http-port", default=6876, type=int)

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -359,7 +359,7 @@ def run(
             worker.end_time = time.time()
 
     stopping_time = (
-        datetime.datetime.now() + datetime.timedelta(seconds=300)
+        datetime.datetime.now() + datetime.timedelta(seconds=600)
     ).timestamp()
     while time.time() < stopping_time:
         for thread in threads:
@@ -379,9 +379,9 @@ def run(
         if scenario == scenario.ZeroDowntimeDeploy:
             # With 0dt deploys connections against the currently-fenced-out
             # environmentd will be stuck forever, the promoted environmentd can
-            # take > 5 minutes to become responsive as well
+            # take > 10 minutes to become responsive as well
             os._exit(0)
-        print("Threads have not stopped within 5 minutes, exiting hard")
+        print("Threads have not stopped within 10 minutes, exiting hard")
         os._exit(1)
 
     try:

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -42,4 +42,6 @@ ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS = {
     "memory_limiter_interval": "0",
     # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9660 is fixed
     "log_filter": "warn",
+    # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
+    "persist_stats_filter_enabled": "false",
 }

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -35,3 +35,13 @@ class Scenario(Enum):
     def _missing_(cls, value):
         if value == "random":
             return cls(random.choice([elem.value for elem in cls]))
+
+
+ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS = {
+    # Uses a lot of memory, hard to predict how much
+    "memory_limiter_interval": "0",
+    # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9660 is fixed
+    "log_filter": "warn",
+    # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
+    "persist_stats_audit_percent": "0",
+}

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -42,6 +42,4 @@ ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS = {
     "memory_limiter_interval": "0",
     # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9660 is fixed
     "log_filter": "warn",
-    # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
-    "persist_stats_audit_percent": "0",
 }

--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -137,6 +137,7 @@ known_errors = [
     "key cannot be null",  # expected, see PR materialize#25941
     "regexp_extract must specify at least one capture group",
     "array_fill with arrays not yet supported",
+    "not yet supported",
     "Window function performance issue: `reduce_unnest_list_fusion` failed",  # TODO: Remove when database-issues#9644 is fixed
     "WITH ORDINALITY or ROWS FROM with ",
     "invalid normalization form",  # Expected with https://github.com/MaterializeInc/materialize/pull/33507

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -40,7 +40,11 @@ from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.parallel_workload.parallel_workload import parse_common_args, run
-from materialize.parallel_workload.settings import Complexity, Scenario
+from materialize.parallel_workload.settings import (
+    ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS,
+    Complexity,
+    Scenario,
+)
 
 SERVICES = [
     Cockroach(setup_materialize=True, in_memory=True),
@@ -111,11 +115,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ports=["6975:6875", "6976:6876", "6977:6877"],
             sanity_restart=sanity_restart,
             default_replication_factor=1,
-            additional_system_parameter_defaults={
-                "memory_limiter_interval": "0",
-                # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
-                "persist_stats_audit_percent": "0",
-            },
+            additional_system_parameter_defaults=ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS,
         ),
         Toxiproxy(seed=random.randrange(2**63)),
     ):

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -106,7 +106,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             sanity_restart=sanity_restart,
             metadata_store="cockroach",
             default_replication_factor=2,
-            additional_system_parameter_defaults={"memory_limiter_interval": "0"},
+            additional_system_parameter_defaults={
+                "memory_limiter_interval": "0",
+                # TODO: Remove when https://github.com/MaterializeInc/database-issues/issues/9656 is fixed
+                "persist_stats_audit_percent": "0",
+            },
         ),
         Toxiproxy(seed=random.randrange(2**63)),
     ):

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -140,6 +140,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 '{"key": "value"}',
                 '550e8400-e29b-41d4-a716-446655440000'
             );
+
+            CREATE MATERIALIZED VIEW mv3 AS SELECT * FROM t2;
             """,
             service=mz_server,
         )


### PR DESCRIPTION
Motivated by https://materializeinc.slack.com/archives/CU7ELJ6E9/p1756852503595199

I always knew we'd need more general expressions, so finally got around to implementing them (and removing all the TODO comments).

That reproduces the original issue easily in 4/9 runs: https://buildkite.com/materialize/nightly/builds/13133

> +++ [worker_8] Query failed: INSERT INTO "db-pw-1757078559-0"."s-0"."t-1" ("c-0-bigint", "c-1-mz_timestamp") VALUES (-1154873474221047172, MZ_TIMESTAMP '19317-9-27'), (-9223372036854775808, MZ_TIMESTAMP '66822-9-13'), (9223372036854775807, MZ_TIMESTAMP '17235-10-21'), (-4665962949847538769, MZ_TIMESTAMP '69332-6-15'), (8444606562024686967, MZ_TIMESTAMP '71526-12-6'), (6100859744477175015, MZ_TIMESTAMP '96494-10-12'), (-9223372036854775808, MZ_TIMESTAMP '59117-4-1'), (119013262017748147, MZ_TIMESTAMP '78394-6-22'), (-6428999613294955046, MZ_TIMESTAMP '69507-9-2'), (214639980754110942, MZ_TIMESTAMP '70046-11-5'), (-9223372036854775808, MZ_TIMESTAMP '93346-6-14') RETURNING 94, abs(-22.491346699927163), abs(6921), current_timestamp(), TIME '6:7:10.991542', '{-93}'::int[], -36.12842768411257, '{"key0": "-33", "key1": "-71", "key2": "84", "key3": "-43", "key4": "-1", "key5": "85", "key6": "8", "key7": "13", "key8": "68", "key9": "6"}'::jsonb, cast((DATE '58327-7-20') as text), 1523333707; HTTP XX000: internal error: cannot evaluate unmaterializable function: CurrentTimestamp

This also found an unrelated bug: https://github.com/MaterializeInc/database-issues/issues/9656

New run with https://github.com/MaterializeInc/materialize/pull/33500 included should show us if it's fixed: https://buildkite.com/materialize/nightly/builds/13136
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
