### PR TITLE
zippy: Add forgotten SqlServerCdcLarge scenario

### DIFF
--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -465,3 +465,22 @@ class MySqlCdcLarge(Scenario):
             ValidateView: 20,
             MySqlDML: 100,
         }
+
+
+class SqlServerCdcLarge(Scenario):
+    """A Zippy test using MS SQL Server CDC exclusively (SQL Server not killed)."""
+
+    def bootstrap(self) -> list[ActionOrFactory]:
+        return super().bootstrap() + [SqlServerStart]
+
+    def actions_with_weight(self) -> dict[ActionOrFactory, float]:
+        return {
+            CreateSqlServerTable: 10,
+            CreateSqlServerCdcTable: 10,
+            KillClusterd: 5,
+            StoragedKill: 5,
+            StoragedStart: 5,
+            CreateViewParameterized(): 10,
+            ValidateView: 20,
+            SqlServerDML: 100,
+        }


### PR DESCRIPTION
Noticed in https://buildkite.com/materialize/release-qualification/builds/937#019917d9-e07f-4172-bcf7-9a7c97a67137

Follow-up to https://github.com/MaterializeInc/materialize/pull/33414

Test run: https://buildkite.com/materialize/release-qualification/builds/938

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
