### PR TITLE
adapter: Don't panic when COPY FROM's target table is dropped

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -775,6 +775,7 @@ impl SessionClient {
     pub async fn insert_rows(
         &mut self,
         id: CatalogItemId,
+        name: String,
         columns: Vec<ColumnIndex>,
         rows: Vec<Row>,
         ctx_extra: ExecuteContextExtra,
@@ -800,7 +801,7 @@ impl SessionClient {
             optimize::view::Optimizer::new_with_prep_no_limit(optimizer_config.clone(), None, prep);
 
         let result: Result<_, AdapterError> =
-            mz_sql::plan::plan_copy_from(&pcx, &conn_catalog, id, columns, rows)
+            mz_sql::plan::plan_copy_from(&pcx, &conn_catalog, id, name, columns, rows)
                 .err_into()
                 .and_then(|values| optimizer.optimize(values).err_into())
                 .and_then(|values| {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -272,7 +272,10 @@ pub enum ExecuteResponse {
         resp: Box<ExecuteResponse>,
     },
     CopyFrom {
+        /// Table we're copying into.
         id: CatalogItemId,
+        /// Human-readable full name of the target table.
+        name: String,
         columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'static>,
         ctx_extra: ExecuteContextExtra,

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -273,9 +273,9 @@ pub enum ExecuteResponse {
     },
     CopyFrom {
         /// Table we're copying into.
-        id: CatalogItemId,
+        target_id: CatalogItemId,
         /// Human-readable full name of the target table.
-        name: String,
+        target_name: String,
         columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'static>,
         ctx_extra: ExecuteContextExtra,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -404,6 +404,7 @@ impl Coordinator {
                         tx.send(
                             Ok(ExecuteResponse::CopyFrom {
                                 id: plan.id,
+                                name: plan.name,
                                 columns: plan.columns,
                                 params: plan.params,
                                 ctx_extra,

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -36,6 +36,7 @@ impl Coordinator {
         target_cluster: TargetCluster,
     ) {
         let plan::CopyFromPlan {
+            name: _,
             id,
             source,
             columns: _,

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -36,8 +36,8 @@ impl Coordinator {
         target_cluster: TargetCluster,
     ) {
         let plan::CopyFromPlan {
-            name: _,
-            id,
+            target_name: _,
+            target_id,
             source,
             columns: _,
             source_desc,
@@ -69,8 +69,8 @@ impl Coordinator {
         };
 
         // We check in planning that we're copying into a Table, but be defensive.
-        let Some(dest_table) = self.catalog().get_entry(&id).table() else {
-            let typ = self.catalog().get_entry(&id).item().typ();
+        let Some(dest_table) = self.catalog().get_entry(&target_id).table() else {
+            let typ = self.catalog().get_entry(&target_id).item().typ();
             let msg = format!("programming error: expected a Table found {typ:?}");
             return ctx.retire(Err(AdapterError::Unstructured(anyhow::anyhow!(msg))));
         };
@@ -190,7 +190,7 @@ impl Coordinator {
         let closure = Box::new(move |batches| {
             let _ = command_tx.send(crate::coord::Message::StagedBatches {
                 conn_id,
-                table_id: id,
+                table_id: target_id,
                 batches,
             });
         });
@@ -201,7 +201,7 @@ impl Coordinator {
             ActiveCopyFrom {
                 ingestion_id,
                 cluster_id,
-                table_id: id,
+                table_id: target_id,
                 ctx,
             },
         );

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1834,15 +1834,15 @@ where
                 };
             }
             ExecuteResponse::CopyFrom {
-                id,
-                name,
+                target_id,
+                target_name,
                 columns,
                 params,
                 ctx_extra,
             } => {
                 let row_desc =
                     row_desc.expect("missing row description for ExecuteResponse::CopyFrom");
-                self.copy_from(id, name, columns, params, row_desc, ctx_extra)
+                self.copy_from(target_id, target_name, columns, params, row_desc, ctx_extra)
                     .await
             }
             ExecuteResponse::TransactionCommitted { params }
@@ -2280,15 +2280,22 @@ where
     #[instrument(level = "debug")]
     async fn copy_from(
         &mut self,
-        id: CatalogItemId,
-        name: String,
+        target_id: CatalogItemId,
+        target_name: String,
         columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'_>,
         row_desc: RelationDesc,
         mut ctx_extra: ExecuteContextExtra,
     ) -> Result<State, io::Error> {
         let res = self
-            .copy_from_inner(id, name, columns, params, row_desc, &mut ctx_extra)
+            .copy_from_inner(
+                target_id,
+                target_name,
+                columns,
+                params,
+                row_desc,
+                &mut ctx_extra,
+            )
             .await;
         match &res {
             Ok(State::Done) => {
@@ -2317,8 +2324,8 @@ where
 
     async fn copy_from_inner(
         &mut self,
-        id: CatalogItemId,
-        name: String,
+        target_id: CatalogItemId,
+        target_name: String,
         columns: Vec<ColumnIndex>,
         params: CopyFormatParams<'_>,
         row_desc: RelationDesc,
@@ -2418,7 +2425,13 @@ where
 
         if let Err(e) = self
             .adapter_client
-            .insert_rows(id, name, columns, rows, std::mem::take(ctx_extra))
+            .insert_rows(
+                target_id,
+                target_name,
+                columns,
+                rows,
+                std::mem::take(ctx_extra),
+            )
             .await
         {
             self.adapter_client.retire_execute(

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -942,9 +942,9 @@ pub struct ShowColumnsPlan {
 #[derive(Debug)]
 pub struct CopyFromPlan {
     /// Table we're copying into.
-    pub id: CatalogItemId,
+    pub target_id: CatalogItemId,
     /// Human-readable full name of the target table.
-    pub name: String,
+    pub target_name: String,
     /// Source we're copying data from.
     pub source: CopyFromSource,
     /// How input columns map to those on the destination table.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -943,6 +943,8 @@ pub struct ShowColumnsPlan {
 pub struct CopyFromPlan {
     /// Table we're copying into.
     pub id: CatalogItemId,
+    /// Human-readable full name of the target table.
+    pub name: String,
     /// Source we're copying data from.
     pub source: CopyFromSource,
     /// How input columns map to those on the destination table.

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -292,7 +292,9 @@ pub enum PlanError {
     InvalidOffset(String),
     /// The named cursor does not exist.
     UnknownCursor(String),
-    CopyFromTargetTableDropped { name: String },
+    CopyFromTargetTableDropped {
+        target_name: String,
+    },
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -822,7 +824,7 @@ impl fmt::Display for PlanError {
             Self::UnknownCursor(name) => {
                 write!(f, "cursor {} does not exist", name.quoted())
             }
-            Self::CopyFromTargetTableDropped { name } => write!(f, "COPY FROM's target table {} was dropped", name.quoted()),
+            Self::CopyFromTargetTableDropped { target_name: name } => write!(f, "COPY FROM's target table {} was dropped", name.quoted()),
         }
     }
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -292,7 +292,7 @@ pub enum PlanError {
     InvalidOffset(String),
     /// The named cursor does not exist.
     UnknownCursor(String),
-    CopyFromTargetTableDropped,
+    CopyFromTargetTableDropped { name: String },
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -822,7 +822,7 @@ impl fmt::Display for PlanError {
             Self::UnknownCursor(name) => {
                 write!(f, "cursor {} does not exist", name.quoted())
             }
-            Self::CopyFromTargetTableDropped => write!(f, "COPY FROM's target table was dropped"),
+            Self::CopyFromTargetTableDropped { name } => write!(f, "COPY FROM's target table {} was dropped", name.quoted()),
         }
     }
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -292,6 +292,7 @@ pub enum PlanError {
     InvalidOffset(String),
     /// The named cursor does not exist.
     UnknownCursor(String),
+    CopyFromTargetTableDropped,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -821,6 +822,7 @@ impl fmt::Display for PlanError {
             Self::UnknownCursor(name) => {
                 write!(f, "cursor {} does not exist", name.quoted())
             }
+            Self::CopyFromTargetTableDropped => write!(f, "COPY FROM's target table was dropped"),
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -649,6 +649,7 @@ pub fn plan_copy_from_rows(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
+    name: String,
     columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<HirRelationExpr, PlanError> {
@@ -657,7 +658,7 @@ pub fn plan_copy_from_rows(
     // Always copy at the latest version of the table.
     let table = catalog
         .try_get_item(&id)
-        .ok_or_else(|| PlanError::CopyFromTargetTableDropped)?
+        .ok_or_else(|| PlanError::CopyFromTargetTableDropped { name })?
         .at_version(RelationVersionSelector::Latest);
     let desc = table.desc(&catalog.resolve_full_name(table.name()))?;
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -656,7 +656,8 @@ pub fn plan_copy_from_rows(
 
     // Always copy at the latest version of the table.
     let table = catalog
-        .get_item(&id)
+        .try_get_item(&id)
+        .ok_or_else(|| PlanError::CopyFromTargetTableDropped)?
         .at_version(RelationVersionSelector::Latest);
     let desc = table.desc(&catalog.resolve_full_name(table.name()))?;
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -648,8 +648,8 @@ pub fn plan_copy_from(
 pub fn plan_copy_from_rows(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
-    id: CatalogItemId,
-    name: String,
+    target_id: CatalogItemId,
+    target_name: String,
     columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<HirRelationExpr, PlanError> {
@@ -657,8 +657,8 @@ pub fn plan_copy_from_rows(
 
     // Always copy at the latest version of the table.
     let table = catalog
-        .try_get_item(&id)
-        .ok_or_else(|| PlanError::CopyFromTargetTableDropped { name })?
+        .try_get_item(&target_id)
+        .ok_or_else(|| PlanError::CopyFromTargetTableDropped { target_name })?
         .at_version(RelationVersionSelector::Latest);
     let desc = table.desc(&catalog.resolve_full_name(table.name()))?;
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -441,12 +441,12 @@ pub fn plan(
 pub fn plan_copy_from(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
-    id: CatalogItemId,
-    name: String,
+    target_id: CatalogItemId,
+    target_name: String,
     columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<super::HirRelationExpr, PlanError> {
-    query::plan_copy_from_rows(pcx, catalog, id, name, columns, rows)
+    query::plan_copy_from_rows(pcx, catalog, target_id, target_name, columns, rows)
 }
 
 /// Whether a SQL object type can be interpreted as matching the type of the given catalog item.

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -442,10 +442,11 @@ pub fn plan_copy_from(
     pcx: &PlanContext,
     catalog: &dyn SessionCatalog,
     id: CatalogItemId,
+    name: String,
     columns: Vec<ColumnIndex>,
     rows: Vec<mz_repr::Row>,
 ) -> Result<super::HirRelationExpr, PlanError> {
-    query::plan_copy_from_rows(pcx, catalog, id, columns, rows)
+    query::plan_copy_from_rows(pcx, catalog, id, name, columns, rows)
 }
 
 /// Whether a SQL object type can be interpreted as matching the type of the given catalog item.

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1562,8 +1562,8 @@ fn plan_copy_from(
     };
 
     Ok(Plan::CopyFrom(CopyFromPlan {
-        id,
-        name: table_name_string,
+        target_id: id,
+        target_name: table_name_string,
         source,
         columns,
         source_desc,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -1553,6 +1553,8 @@ fn plan_copy_from(
         bail_unsupported!("COPY FROM ... WITH (FILES ...) only supported from a URL")
     }
 
+    let table_name_string = table_name.full_name_str();
+
     let (id, source_desc, columns, maybe_mfp) = query::plan_copy_from(scx, table_name, columns)?;
 
     let Some(mfp) = maybe_mfp else {
@@ -1561,6 +1563,7 @@ fn plan_copy_from(
 
     Ok(Plan::CopyFrom(CopyFromPlan {
         id,
+        name: table_name_string,
         source,
         columns,
         source_desc,

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -846,8 +846,8 @@ fn generate_rbac_requirements(
             }
         }
         Plan::CopyFrom(plan::CopyFromPlan {
-            name: _,
-            id,
+            target_name: _,
+            target_id,
             source: _,
             columns: _,
             source_desc: _,
@@ -857,11 +857,17 @@ fn generate_rbac_requirements(
         }) => RbacRequirements {
             privileges: vec![
                 (
-                    SystemObjectId::Object(catalog.get_item(id).name().qualifiers.clone().into()),
+                    SystemObjectId::Object(
+                        catalog.get_item(target_id).name().qualifiers.clone().into(),
+                    ),
                     AclMode::USAGE,
                     role_id,
                 ),
-                (SystemObjectId::Object(id.into()), AclMode::INSERT, role_id),
+                (
+                    SystemObjectId::Object(target_id.into()),
+                    AclMode::INSERT,
+                    role_id,
+                ),
             ],
             ..Default::default()
         },

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -846,6 +846,7 @@ fn generate_rbac_requirements(
             }
         }
         Plan::CopyFrom(plan::CopyFromPlan {
+            name: _,
             id,
             source: _,
             columns: _,


### PR DESCRIPTION
It was panicking if the table was dropped at a bad moment (either while COPY FROM is reading from stdin or before the `ExecuteResponse::CopyFrom` comes back from the Coordinator).

Writing an automated test specifically for this seems complicated. I'm open to ideas, but maybe the manual testing that I did is enough, given that this is a small and straightforward change. Also, Parallel Workload would hopefully notice this again, if it regresses in the future.

(I've also manually tested (with sleeps) what happens if the table goes away after taking that catalog snapshot that the `try_get_item` looks into. In this case, the `try_get_item` still succeeds, but then we [later throw a graceful error from](https://github.com/MaterializeInc/materialize/blob/cc1d7672ff899f233badb4db65fc00168d94bb69/src/adapter/src/coord/sequencer/inner.rs#L2442) `sequence_end_transaction_inner`, which is fine. (The error msg could be improved, because now it just says `ERROR:  unknown catalog item 'u1'`, but it's probably not worth the hassle for now.))

@def-, should I add an ignore for this error msg in Parallel Workload? Or that test would fail only for a panic, and any graceful error is fine?

(Tagged Aljoscha for review, because we've been talking about similar things in the context of the frontend peek work.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9659

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
