### PR TITLE
ci: Fix nightly failures (2025-09-06)

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -141,4 +141,5 @@ known_errors = [
     "The fast_path_optimizer shouldn't make a fast path plan slow path.",  # TODO: Remove when database-issues#9645 is fixed
     "Window function performance issue: `reduce_unnest_list_fusion` failed",  # TODO: Remove when database-issues#9644 is fixed
     "WITH ORDINALITY or ROWS FROM with pg_catalog.regexp_split_to_table not yet supported",
+    "invalid normalization form",  # Expected with https://github.com/MaterializeInc/materialize/pull/33507
 ]

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -269,8 +269,16 @@ trufflehog_jq_filter_common() {
       .Raw != "d3aa325086974cdfb3912f28e5a8c168" and
       .Raw != "jdbc:postgresql://postgres:5432/postgres" and
       .Raw != "RPSsql12345" and
+      .Raw != "RPSsql1234" and
+      .Raw != "RPSsql123" and
+      .Raw != "RPSsql12" and
+      .Raw != "RPSsql1" and
       .Raw != "RPSsql" and
-      .Raw != "RPSsq"
+      .Raw != "RPSsq" and
+      .Raw != "RPSs" and
+      .Raw != "RPS" and
+      .Raw != "RP" and
+      .Raw != "R"
     )'
 }
 


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/13173

Test run: https://buildkite.com/materialize/nightly/builds/13195

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
