### PR TITLE
`prep_relation_expr` earlier in peek sequencing

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -300,6 +300,25 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
         // Set the `as_of` and `until` timestamps for the dataflow.
         df_desc.set_as_of(timestamp_ctx.antichain());
 
+        // Get the single timestamp representing the `as_of` time.
+        let as_of = df_desc
+            .as_of
+            .clone()
+            .expect("as_of antichain")
+            .into_option()
+            .expect("unique as_of element");
+
+        // Resolve all unmaterializable function calls including mz_now().
+        let style = ExprPrepStyle::OneShot {
+            logical_time: EvalTime::Time(as_of),
+            session,
+            catalog_state: self.catalog.state(),
+        };
+        df_desc.visit_children(
+            |r| prep_relation_expr(r, style),
+            |s| prep_scalar_expr(s, style),
+        )?;
+
         // Use the opportunity to name an `until` frontier that will prevent
         // work we needn't perform. By default, `until` will be
         // `Antichain::new()`, which prevents no updates and is safe.
@@ -335,25 +354,6 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             // Collect the list of indexes used by the dataflow at this point.
             trace_plan!(at: "global", &df_meta.used_indexes(&df_desc));
         }
-
-        // Get the single timestamp representing the `as_of` time.
-        let as_of = df_desc
-            .as_of
-            .clone()
-            .expect("as_of antichain")
-            .into_option()
-            .expect("unique as_of element");
-
-        // Resolve all unmaterializable function calls including mz_now().
-        let style = ExprPrepStyle::OneShot {
-            logical_time: EvalTime::Time(as_of),
-            session,
-            catalog_state: self.catalog.state(),
-        };
-        df_desc.visit_children(
-            |r| prep_relation_expr(r, style),
-            |s| prep_scalar_expr(s, style),
-        )?;
 
         // Ensure all expressions are normalized before finalizing.
         for build in df_desc.objects_to_build.iter_mut() {

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -25,14 +25,17 @@ CREATE TABLE events (
     delete_ms numeric
 );
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv1 AS
 SELECT count(*)
 FROM events
 WHERE mz_now() >= insert_ms
   AND mz_now() < delete_ms;
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv1
 ----
-Explained Query:
+materialize.public.mv1:
   With
     cte l0 =
       Reduce aggregates=[count(*)]
@@ -58,17 +61,20 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv2 AS
 SELECT content, insert_ms
 FROM events
 -- The event should appear in only one interval of duration `10000`.
 -- The interval begins here ...
 WHERE mz_now() >= 10000 * (insert_ms / 10000)
 -- ... and ends here.
-  AND mz_now() < 10000 * (1 + insert_ms / 10000)
+  AND mz_now() < 10000 * (1 + insert_ms / 10000);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv2
 ----
-Explained Query:
+materialize.public.mv2:
   Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3))))
       Map ((#1{insert_ms} / 10000))
@@ -83,17 +89,20 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv3 AS
 SELECT content, insert_ms
 FROM events
 -- The event should appear in `6` intervals each of width `10000`.
 -- The interval begins here ...
 WHERE mz_now() >= 10000 * (insert_ms / 10000)
 -- ... and ends here.
-  AND mz_now() < 6 * (10000 + insert_ms / 10000)
+  AND mz_now() < 6 * (10000 + insert_ms / 10000);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv3
 ----
-Explained Query:
+materialize.public.mv3:
   Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3))))
       Map ((#1{insert_ms} / 10000))
@@ -108,8 +117,8 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv4 AS
 SELECT content, insert_ms
 FROM events
 -- The event should appear inside the interval that begins at
@@ -117,9 +126,12 @@ FROM events
 -- The interval begins here ..
 WHERE mz_now() >= insert_ms
 -- ... and ends here.
-  AND mz_now() < insert_ms + 30000
+  AND mz_now() < insert_ms + 30000;
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv4
 ----
-Explained Query:
+materialize.public.mv4:
   Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp((#1{insert_ms} + 30000)))
       ReadStorage materialize.public.events
@@ -132,14 +144,17 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv5 AS
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() >= insert_ms + 60000
   AND mz_now() < delete_ms + 60000;
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv5
 ----
-Explained Query:
+materialize.public.mv5:
   Filter (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((#1{insert_ms} + 60000)))
     ReadStorage materialize.public.events
 
@@ -156,13 +171,16 @@ EOF
 # can push down are also associative, so this is moot. Let's at least check that an associative
 # function _does_ report pushdown even when the argument list is long.
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv6 AS
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE COALESCE(delete_ms, insert_ms) < mz_now();
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv6
 ----
-Explained Query:
+materialize.public.mv6:
   Filter (mz_now() > numeric_to_mz_timestamp(coalesce(#2{delete_ms}, #1{insert_ms})))
     ReadStorage materialize.public.events
 
@@ -174,8 +192,8 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv7 AS
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() < delete_ms + 10000
@@ -187,8 +205,11 @@ WHERE mz_now() < delete_ms + 10000
   AND mz_now() < delete_ms + 70000
   AND mz_now() < delete_ms + 80000
   AND mz_now() < delete_ms + 90000;
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv7
 ----
-Explained Query:
+materialize.public.mv7:
   Filter (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 90000)))
     ReadStorage materialize.public.events
 
@@ -229,13 +250,16 @@ EOF
 # Verify that try_parse_monotonic_iso8601_timestamp gets pushdown (the whole
 # point of that func)
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv8 AS
 SELECT content, inserted_at
 FROM events_timestamped
 WHERE mz_now() < try_parse_monotonic_iso8601_timestamp(content);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, filter pushdown) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv8
 ----
-Explained Query:
+materialize.public.mv8:
   Project (#0{content}, #1{inserted_at})
     Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0{content})))
       ReadStorage materialize.public.events_timestamped
@@ -308,15 +332,18 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv9 AS
 with cte as (
   select x, t, case when x=0 then t - INTERVAL '1' day else t - INTERVAL '2' day end as case_statement from t
 )
 select x, t from cte
 where case_statement < mz_now();
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv9
 ----
-Explained Query:
+materialize.public.mv9:
   Filter (mz_now() > timestamp_to_mz_timestamp((#1{t} - case when (#0{x} = 0) then 1 day else 2 days end)))
     ReadStorage materialize.public.t
 
@@ -334,8 +361,8 @@ EOF
 statement ok
 CREATE TABLE items(id int, ship_time timestamp);
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv10 AS
 SELECT * from items
 WHERE mz_now() <= date_trunc(
     'month',
@@ -345,9 +372,12 @@ WHERE mz_now() <= date_trunc(
         + CASE WHEN EXTRACT(MONTH FROM ship_time) >= 6 THEN EXTRACT(MONTH FROM ship_time) - 6 ELSE 0 END
     )
     * INTERVAL '1 months'
-)
+);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv10
 ----
-Explained Query:
+materialize.public.mv10:
   Project (#0{id}, #1{ship_time})
     Filter (mz_now() <= timestamp_to_mz_timestamp(date_trunc_month_ts((#1{ship_time} - (1 month * numeric_to_double((case when (#2 < 6) then (extract_month_ts(#1{ship_time}) + 6) else 0 end + case when (#2 >= 6) then (extract_month_ts(#1{ship_time}) - 6) else 0 end)))))))
       Map (extract_month_ts(#1{ship_time}))
@@ -361,12 +391,15 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv11 AS
 SELECT * from items
 WHERE CASE WHEN id = 10 THEN EXTRACT(MONTH FROM ship_time) ELSE 0 END < mz_now();
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv11
 ----
-Explained Query:
+materialize.public.mv11:
   Filter (mz_now() > numeric_to_mz_timestamp(case when (#0{id} = 10) then extract_month_ts(#1{ship_time}) else 0 end))
     ReadStorage materialize.public.items
 
@@ -377,12 +410,15 @@ Target cluster: quickstart
 
 EOF
 
-query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR
+statement ok
+CREATE MATERIALIZED VIEW mv12 AS
 SELECT * from items
 WHERE CASE WHEN EXTRACT(MONTH FROM ship_time) >= 6 THEN 12 ELSE 0 END < mz_now();
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(filter pushdown, humanized expressions) AS VERBOSE TEXT FOR MATERIALIZED VIEW mv12
 ----
-Explained Query:
+materialize.public.mv12:
   Filter (mz_now() > integer_to_mz_timestamp(case when (extract_month_ts(#1{ship_time}) >= 6) then 12 else 0 end))
     ReadStorage materialize.public.items
 

--- a/test/sqllogictest/mztimestamp.slt
+++ b/test/sqllogictest/mztimestamp.slt
@@ -23,10 +23,9 @@ true
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR SELECT 1::mz_timestamp = mz_now()
 ----
-Explained Query:
-  Map ((1 = mz_now())) // { arity: 1 }
-    Constant // { arity: 0 }
-      - ()
+Explained Query (fast path):
+  Constant
+    - (false)
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -195,15 +195,15 @@ EOF
 # an arbitrary number of records to find one that matches.
 
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers WHERE value > mz_now() LIMIT 10;
+EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT * from numbers WHERE value > mz_now()::text::int8 / 100000000000000 LIMIT 10;
 ----
 Explained Query:
   Finish limit=10 output=[#0]
-    Filter (mz_now() < integer_to_mz_timestamp(#0{value}))
+    Filter (integer_to_bigint(#0{value}) > 0)
       ReadStorage materialize.public.numbers
 
 Source materialize.public.numbers
-  filter=((mz_now() < integer_to_mz_timestamp(#0{value})))
+  filter=((integer_to_bigint(#0{value}) > 0))
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -406,3 +406,18 @@ WHERE ts + INTERVAL '60' minutes >= mz_now();
 
 statement ok
 SELECT * FROM mv5;
+
+# Regression test for https://github.com/MaterializeInc/database-issues/issues/9645
+statement ok
+CREATE TABLE t(export_id text, worker_id int, dataflow_id int);
+
+statement ok
+CREATE DEFAULT INDEX ON t;
+
+statement ok
+SELECT subq_2.c2 AS c5,
+       mz_catalog.mz_now() AS c7
+FROM (SELECT CAST('62143-12-31' AS date) + '200000 YEARS' AS c2
+      FROM (SELECT
+            FROM (SELECT FROM t) AS subq_0) AS subq_1
+      WHERE pg_catalog."current_timestamp"() = pg_catalog.pg_postmaster_start_time()) AS subq_2;


### PR DESCRIPTION
This is fixing https://github.com/MaterializeInc/database-issues/issues/9645 by moving unmaterializable function evaluation (`prep_relation_expr`/`prep_scalar_expr`) earlier in peek sequencing. It also does the same move in COPY TO sequencing. Even though fast path is not a thing there, so the above issue can't occur, we'd still like to avoid unnecessary divergence between the peek sequencing and the COPY TO sequencing codes.

Also note that even independently from https://github.com/MaterializeInc/database-issues/issues/9645, it seems generally better to do `mz_now()` (and other unmaterializable func) evaluation before optimization, because constants are easier to work with during optimization than function calls. This is demonstrated by a few (somewhat contrived) tests flipping from slow path to fast path peeks.

The cause of https://github.com/MaterializeInc/database-issues/issues/9645 was a somewhat weird interaction between various things:
1. `create_fast_path_plan` is able to handle an MFP on top of a Get, but is not able to handle an MFP on top of a Constant. This limitation is understandable, give that we usually expect FoldConstants to make an MFP on top of a Constant disappear.
2. In the above issue, an MFP on top of a Constant was not disappearing, because it was containing an unmaterializable function call, which FoldConstants can't handle.
3. We have a special fast path optimizer, which we use during peek sequencing when a peek looks like a fast path peek between local and global optimization, so that we don't have to run the full global optimization pipeline. The soft assert that was tripped in the above issue is meant to verify that if a peek looked like a fast path peek before running the fast path optimizer, then we continue to be able to plan the peek as fast path also after running the fast path optimizer. The reason this got violated here is because the plan was an MFP on top of a Get before running the fast path optimizer, but was an MFP on top of a Constant after running the fast path optimizer.

After the PR moved unmaterializable function evaluation before (global or fast path) optimization, the fast path optimizer now doesn't leave the MFP on top of the Constant, because the MFP no longer has an unmaterializable function call at that point, so FoldConstants folds away the MFP. (The MFP's result is folded into a new Constant node.)

(Philosophically, the above 1. is a _non-monotonicity_ in the optimizer, which is not good: Generally, it's good if optimization code has the behavior that if `plan'` is a better plan than `plan`, then `optimize(plan')` is a better plan than `optimize(plan)`. As per 1., `create_fast_path_plan` is an optimization that doesn't have this property: an MFP on top of a constant is a better plan than an MFP on top of a Get, but `create_fast_path_plan` makes the former into a worse plan than the latter. Such non-monotonicities in the optimizer often lead to unpleasant surprises: if optimization `O2` has a non-monotonicity, and we have an optimizer pipeline `O1 -> O2`, and we make a change to `O1`, then even if that change is a strict improvement _locally_ for `O1`, the change can still regress the `O1 -> O2` pipeline. So, it would be good to eliminate the non-monotonicity here by making `create_fast_path_plan` able to handle an MFP on top of a Constant, but I consider this out of scope for this PR. I opened a separate issue: https://github.com/MaterializeInc/database-issues/issues/9665)

This PR has a slightly annoying side-effect on slt testing: if an slt has an EXPLAIN OPTIMIZED PLAN on a peek that involves mz_now, the explain output will now show the evaluation result of the mz_now. This is a problem in tests, because mz_now changes at every slt run. I worked around this problem in two ways:
1. Made some tests create a materialize view instead of a peek. `mz_now` is not evaluated in materialized view plans. (`filter-pushdown.slt`)
2. Added a division to `mz_now` by 100000000000000 to make it always 0. I used this workaround instead of 1. in `persist-fast-path.slt`, because it was essential here for the test to remain a peek, since persist fast path is not relevant for materialized views.

@bkirwi may I ask you to check the test changes in `filter-pushdown.slt` and `persist-fast-path.slt` (explained in the previous paragraph) that I didn't accidentally invalidate any tests there?

@aljoscha, I tagged you for the overall PR review, because it's a peek sequencing thing. But if you'd like to avoid delving into optimization stuff at this moment, then let me know, and then I'll tag Michael instead.

Nightly: https://buildkite.com/materialize/nightly/builds/13207
New Nightly after fixing the problem in the 4-replica slt: https://buildkite.com/materialize/nightly/builds/13209

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9645

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
