### PR TITLE
Call `prep_scalar_expr` on `RETURNING`

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -84,7 +84,6 @@ known_errors = [
     "Unsupported temporal operation: NotEq",
     "Unsupported binary temporal operation: NotEq",
     "OneShot plan has temporal constraints",  # Expected, see https://github.com/MaterializeInc/database-issues/issues/5288
-    "internal error: cannot evaluate unmaterializable function",  # Currently expected, see https://github.com/MaterializeInc/database-issues/issues/4083
     "string is not a valid identifier:",  # Expected in parse_ident & quote_ident
     "invalid datepart",
     "pg_cancel_backend in this position not yet supported",

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2946,7 +2946,7 @@ impl Coordinator {
             selection,
             mut assignments,
             finishing,
-            returning,
+            mut returning,
         } = plan;
 
         // Read then writes can be queued, so re-verify the id exists.
@@ -3125,11 +3125,11 @@ impl Coordinator {
             }
 
             let style = ExprPrepStyle::OneShot {
-                logical_time: EvalTime::NotAvailable,
+                logical_time: EvalTime::NotAvailable, // We already errored out on mz_now above.
                 session: ctx.session(),
                 catalog_state: catalog.state(),
             };
-            for expr in assignments.values_mut() {
+            for expr in assignments.values_mut().chain(returning.iter_mut()) {
                 return_if_err!(prep_scalar_expr(expr, style.clone()), ctx);
             }
 

--- a/test/sqllogictest/returning.slt
+++ b/test/sqllogictest/returning.slt
@@ -115,7 +115,7 @@ UPDATE t SET a = 0 RETURNING b
 statement error Expected end of statement, found RETURNING
 DELETE FROM t AS t RETURNING *
 
-statement error cannot evaluate unmaterializable function
+statement ok
 INSERT INTO t VALUES (7, 8) RETURNING now()
 
 statement error db error: ERROR: calls to mz_now in write statements are not supported
@@ -130,6 +130,7 @@ SELECT * FROM t ORDER BY a, b
 3  4
 5  6
 7  8
+7  8
 9  10
 10  0
 10  11
@@ -137,3 +138,8 @@ SELECT * FROM t ORDER BY a, b
 100  11
 NULL  10
 NULL  11
+
+# Regression test for https://github.com/MaterializeInc/database-issues/issues/9657, i.e., that we call
+# `prep_scalar_expr` on RETURNING.
+statement ok
+INSERT INTO t VALUES (1, 1) RETURNING mz_version();


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/9657, that is, instead of `RETURNING` producing an internal error when it has any unmaterializable function, now it actually evaluates them (except `mz_now`, see https://github.com/MaterializeInc/database-issues/issues/4083).

I've also removed the ignore in SQLsmith. We'll see how this goes. SQLsmith run: https://buildkite.com/materialize/nightly/builds/13213

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9657

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
