### PR TITLE
Mark some interval-related functions as non-monotone

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -494,7 +494,7 @@ fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalEr
 }
 
 #[sqlfunc(
-    is_monotone = "(true, true)",
+    is_monotone = "(false, false)",
     output_type = "CheckedTimestamp<chrono::DateTime<Utc>>",
     is_infix_op = true,
     sqlname = "+",
@@ -1333,7 +1333,7 @@ fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalEr
 }
 
 #[sqlfunc(
-    is_monotone = "(true, true)",
+    is_monotone = "(false, false)",
     output_type = "chrono::NaiveTime",
     is_infix_op = true,
     sqlname = "-",
@@ -1493,7 +1493,7 @@ fn mul_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(true, true)",
+    is_monotone = "(false, false)",
     output_type = "Interval",
     is_infix_op = true,
     sqlname = "*",
@@ -1689,7 +1689,7 @@ fn div_numeric<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 #[sqlfunc(
-    is_monotone = "(true, false)",
+    is_monotone = "(false, false)",
     output_type = "Interval",
     is_infix_op = true,
     sqlname = "/",
@@ -4566,8 +4566,9 @@ impl BinaryFunc {
             | BinaryFunc::AddTimestampTzInterval
             | BinaryFunc::AddDateInterval
             | BinaryFunc::AddDateTime
-            | BinaryFunc::AddTimeInterval
             | BinaryFunc::AddNumeric => (true, true),
+            // <time> + <interval> wraps!
+            BinaryFunc::AddTimeInterval => (false, false),
             BinaryFunc::BitAndInt16
             | BinaryFunc::BitAndInt32
             | BinaryFunc::BitAndInt64
@@ -4615,8 +4616,9 @@ impl BinaryFunc {
             | BinaryFunc::SubDate
             | BinaryFunc::SubDateInterval
             | BinaryFunc::SubTime
-            | BinaryFunc::SubTimeInterval
             | BinaryFunc::SubNumeric => (true, true),
+            // <time> - <interval> wraps!
+            BinaryFunc::SubTimeInterval => (false, false),
             BinaryFunc::MulInt16
             | BinaryFunc::MulInt32
             | BinaryFunc::MulInt64
@@ -4625,8 +4627,8 @@ impl BinaryFunc {
             | BinaryFunc::MulUInt64
             | BinaryFunc::MulFloat32
             | BinaryFunc::MulFloat64
-            | BinaryFunc::MulNumeric
-            | BinaryFunc::MulInterval => (true, true),
+            | BinaryFunc::MulNumeric => (true, true),
+            BinaryFunc::MulInterval => (false, false),
             BinaryFunc::DivInt16
             | BinaryFunc::DivInt32
             | BinaryFunc::DivInt64
@@ -4635,8 +4637,8 @@ impl BinaryFunc {
             | BinaryFunc::DivUInt64
             | BinaryFunc::DivFloat32
             | BinaryFunc::DivFloat64
-            | BinaryFunc::DivNumeric
-            | BinaryFunc::DivInterval => (true, false),
+            | BinaryFunc::DivNumeric => (true, false),
+            BinaryFunc::DivInterval => (false, false),
             BinaryFunc::ModInt16
             | BinaryFunc::ModInt32
             | BinaryFunc::ModInt64

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_time_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_time_interval.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = \"CheckedTimestamp<chrono::DateTime<Utc>>\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let time = a.unwrap_time();\n    let interval = b.unwrap_interval();\n    let (t, _) = time.overflowing_add_signed(interval.duration_as_chrono());\n    Datum::Time(t)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"CheckedTimestamp<chrono::DateTime<Utc>>\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let time = a.unwrap_time();\n    let interval = b.unwrap_interval();\n    let (t, _) = time.overflowing_add_signed(interval.duration_as_chrono());\n    Datum::Time(t)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -55,7 +55,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddTimeInterval {
         true
     }
     fn is_monotone(&self) -> (bool, bool) {
-        (true, true)
+        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__div_interval.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, false)\",\n    output_type = \"Interval\",\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_interval()\n            .checked_div(b)\n            .ok_or_else(|| EvalError::IntervalOutOfRange(format!(\"{a} / {b}\").into()))\n            .map(Datum::from)\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Interval\",\n    is_infix_op = true,\n    sqlname = \"/\",\n    propagates_nulls = true\n)]\nfn div_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let b = b.unwrap_float64();\n    if b == 0.0 {\n        Err(EvalError::DivisionByZero)\n    } else {\n        a.unwrap_interval()\n            .checked_div(b)\n            .ok_or_else(|| EvalError::IntervalOutOfRange(format!(\"{a} / {b}\").into()))\n            .map(Datum::from)\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -53,7 +53,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for DivInterval {
         true
     }
     fn is_monotone(&self) -> (bool, bool) {
-        (true, false)
+        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__mul_interval.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"Interval\",\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_interval()\n        .checked_mul(b.unwrap_float64())\n        .ok_or_else(|| EvalError::IntervalOutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"Interval\",\n    is_infix_op = true,\n    sqlname = \"*\",\n    propagates_nulls = true\n)]\nfn mul_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_interval()\n        .checked_mul(b.unwrap_float64())\n        .ok_or_else(|| EvalError::IntervalOutOfRange(format!(\"{a} * {b}\").into()))\n        .map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -53,7 +53,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for MulInterval {
         true
     }
     fn is_monotone(&self) -> (bool, bool) {
-        (true, true)
+        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time_interval.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__sub_time_interval.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = \"chrono::NaiveTime\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let time = a.unwrap_time();\n    let interval = b.unwrap_interval();\n    let (t, _) = time.overflowing_sub_signed(interval.duration_as_chrono());\n    Datum::Time(t)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(false, false)\",\n    output_type = \"chrono::NaiveTime\",\n    is_infix_op = true,\n    sqlname = \"-\",\n    propagates_nulls = true\n)]\nfn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    let time = a.unwrap_time();\n    let interval = b.unwrap_interval();\n    let (t, _) = time.overflowing_sub_signed(interval.duration_as_chrono());\n    Datum::Time(t)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -53,7 +53,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for SubTimeInterval {
         true
     }
     fn is_monotone(&self) -> (bool, bool) {
-        (true, true)
+        (false, false)
     }
     fn propagates_nulls(&self) -> bool {
         true


### PR DESCRIPTION
### Motivation

See https://github.com/MaterializeInc/database-issues/issues/9301 for a long description of the trouble with multiplication and division.

See https://github.com/MaterializeInc/database-issues/issues/9656 for a probably-related CI failure with adding times and intervals.

### Tips for reviewer

I haven't reproduced the second issue above, so I haven't proved that this change fixes it. But time+interval is definitely non-monotone, and it does seem to come up in the linked PR...

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
