### PR TITLE
Use columnar to log frontiers in compute logging

### DIFF
--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -146,13 +146,13 @@ Arrange␠Timely(Operates)  ArrangementSize  alloc::vec::Vec<alloc::rc::Rc<diffe
 Arrange␠Timely(Parks)  ArrangementSize  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 Arrange␠Timely(Reachability)  ArrangementSize  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 Compute␠Logging␠Demux  Arrange␠Compute(DataflowCurrent)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+Compute␠Logging␠Demux  Arrange␠Compute(FrontierCurrent)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  Arrange␠Compute(PeekCurrent)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::ArrangementHeapDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::ArrangementHeapDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::ArrangementHeapDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::DataflowGlobalDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::ErrorCountDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::FrontierDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::HydrationTimeDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::ImportFrontierDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  FlatMap  alloc::vec::Vec<(mz_compute::logging::compute::PeekDurationDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
@@ -187,7 +187,6 @@ FlatMap  Arrange␠Compute(ArrangementHeapCapacity)  alloc::vec::Vec<((mz_repr::
 FlatMap  Arrange␠Compute(ArrangementHeapSize)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Arrange␠Compute(DataflowGlobal)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Arrange␠Compute(ErrorCount)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-FlatMap  Arrange␠Compute(FrontierCurrent)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Arrange␠Compute(HydrationTime)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Arrange␠Compute(ImportFrontierCurrent)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FlatMap  Arrange␠Compute(LirMapping)  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
@@ -243,7 +242,6 @@ GROUP BY type;
 1  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 1  alloc::vec::Vec<(mz_compute::logging::compute::DataflowGlobalDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<(mz_compute::logging::compute::ErrorCountDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-1  alloc::vec::Vec<(mz_compute::logging::compute::FrontierDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<(mz_compute::logging::compute::HydrationTimeDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<(mz_compute::logging::compute::ImportFrontierDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<(mz_compute::logging::compute::PeekDurationDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
@@ -257,8 +255,8 @@ GROUP BY type;
 1  mz_timely_util::columnar::Column<((mz_compute::logging::timely::ChannelDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  mz_timely_util::columnar::Column<(core::time::Duration,␠mz_compute::logging::compute::ComputeEvent)>
 1  mz_timely_util::columnar::Column<(mz_compute::logging::compute::LirMappingDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-11  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-20  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+10  alloc::vec::Vec<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+21  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 3  alloc::vec::Vec<(mz_compute::logging::compute::ArrangementHeapDatum,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 31  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 4  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>


### PR DESCRIPTION
Same as #33527, but for frontier logging.
