### PR TITLE
Inline BytesBatch::index

### DIFF
--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -507,6 +507,7 @@ mod bytes_container {
                 false
             }
         }
+        #[inline]
         fn index(&self, index: usize) -> &[u8] {
             let lower = self.offsets.index(index);
             let upper = self.offsets.index(index + 1);


### PR DESCRIPTION
Noticed in performance profiles that it didn't get inlined where I'd expect it to.
