### PR TITLE
Switch to binary func trait for some variants

### DIFF
--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -26,7 +26,7 @@ use mz_compute_types::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
 };
 use mz_expr::func::CastUint64ToInt64;
-use mz_expr::{BinaryFunc, EvalError, MirScalarExpr, UnaryFunc};
+use mz_expr::{BinaryFunc, EvalError, MirScalarExpr, UnaryFunc, func};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::{Datum, DatumVec, Diff, Row, SharedRow, SqlScalarType};
@@ -296,7 +296,7 @@ where
                             SqlScalarType::UInt64,
                         )
                         .call_unary(UnaryFunc::CastUint64ToInt64(CastUint64ToInt64)),
-                        BinaryFunc::AddInt64,
+                        BinaryFunc::AddInt64(func::AddInt64),
                     );
                 }
             }

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -719,7 +719,7 @@ mod relation {
 /// Support for parsing [mz_expr::MirScalarExpr].
 mod scalar {
     use mz_expr::{
-        BinaryFunc, ColumnOrder, MirScalarExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc,
+        BinaryFunc, ColumnOrder, MirScalarExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc, func,
     };
     use mz_repr::{AsColumnType, Datum, Row, RowArena, SqlScalarType};
 
@@ -781,7 +781,7 @@ mod scalar {
                     Op::Unr(mz_expr::UnaryFunc::IsFalse(_)) => Some(13),
                     Op::Neg(mz_expr::UnaryFunc::IsFalse(_)) => Some(13),
                     // 14: addition, subtraction
-                    Op::Bin(mz_expr::BinaryFunc::AddInt64) => Some(14),
+                    Op::Bin(mz_expr::BinaryFunc::AddInt64(_)) => Some(14),
                     // 14: multiplication, division, modulo
                     Op::Bin(mz_expr::BinaryFunc::MulInt64) => Some(15),
                     Op::Bin(mz_expr::BinaryFunc::DivInt64) => Some(15),
@@ -832,7 +832,7 @@ mod scalar {
                     Op::Bin(mz_expr::BinaryFunc::Lt)
                 } else if input.eat(syn::Token![+]) {
                     exp_opd = true;
-                    Op::Bin(mz_expr::BinaryFunc::AddInt64) // TODO: fix placeholder
+                    Op::Bin(mz_expr::BinaryFunc::AddInt64(func::AddInt64)) // TODO: fix placeholder
                 } else if input.eat(syn::Token![*]) {
                     exp_opd = true;
                     Op::Bin(mz_expr::BinaryFunc::MulInt64) // TODO: fix placeholder

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1770,7 +1770,7 @@ mod tests {
             func: BinaryFunc::Gte,
             expr1: Box::new(MirScalarExpr::column(0)),
             expr2: Box::new(MirScalarExpr::CallBinary {
-                func: BinaryFunc::AddInt64,
+                func: BinaryFunc::AddInt64(AddInt64),
                 expr1: Box::new(MirScalarExpr::column(1)),
                 expr2: Box::new(MirScalarExpr::CallUnary {
                     func: UnaryFunc::NegInt64(NegInt64),

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -447,6 +447,7 @@ impl JoinInputMapper {
 mod tests {
     use mz_repr::{Datum, SqlScalarType};
 
+    use crate::scalar::func;
     use crate::{BinaryFunc, MirScalarExpr, UnaryFunc};
 
     use super::*;
@@ -489,7 +490,7 @@ mod tests {
             expr: Box::new(MirScalarExpr::column(1)),
         };
         let key21 = MirScalarExpr::CallBinary {
-            func: BinaryFunc::AddInt32,
+            func: BinaryFunc::AddInt32(func::AddInt32),
             expr1: Box::new(MirScalarExpr::column(2)),
             expr2: Box::new(MirScalarExpr::literal(
                 Ok(Datum::Int32(4)),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -93,112 +93,94 @@ pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "i16",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_int16<'a>(a: i16, b: i16) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b)
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int16(a: i16, b: i16) -> Result<i16, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "i32",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_int32<'a>(a: i32, b: i32) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b)
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int32(a: i32, b: i32) -> Result<i32, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "i64",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_int64<'a>(a: i64, b: i64) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b)
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int64(a: i64, b: i64) -> Result<i64, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "u16",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_uint16<'a>(a: u16, b: u16) -> Result<Datum<'a>, EvalError> {
+fn add_uint16(a: u16, b: u16) -> Result<u16, EvalError> {
     a.checked_add(b)
         .ok_or_else(|| EvalError::UInt16OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "u32",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_uint32<'a>(a: u32, b: u32) -> Result<Datum<'a>, EvalError> {
+fn add_uint32(a: u32, b: u32) -> Result<u32, EvalError> {
     a.checked_add(b)
         .ok_or_else(|| EvalError::UInt32OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "u64",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_uint64()
-        .checked_add(b.unwrap_uint64())
+fn add_uint64(a: u64, b: u64) -> Result<u64, EvalError> {
+    a.checked_add(b)
         .ok_or_else(|| EvalError::UInt64OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "f32",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_float32<'a>(a: f32, b: f32) -> Result<Datum<'a>, EvalError> {
+fn add_float32(a: f32, b: f32) -> Result<f32, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)
     } else {
-        Ok(Datum::from(sum))
+        Ok(sum)
     }
 }
 
 #[sqlfunc(
     is_monotone = "(true, true)",
-    output_type = "f64",
     is_infix_op = true,
     sqlname = "+",
     propagates_nulls = true
 )]
-fn add_float64<'a>(a: f64, b: f64) -> Result<Datum<'a>, EvalError> {
+fn add_float64(a: f64, b: f64) -> Result<f64, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)
     } else {
-        Ok(Datum::from(sum))
+        Ok(sum)
     }
 }
 
@@ -4103,6 +4085,9 @@ impl BinaryFunc {
             BinaryFunc::AddUInt64(s) => s.negate(),
             BinaryFunc::AddFloat32(s) => s.negate(),
             BinaryFunc::AddFloat64(s) => s.negate(),
+
+            // The following functions are specifically declared for legacy reasons.
+            // TODO: Pending conversion to `LazyBinaryFunc`, these can be removed.
             BinaryFunc::Eq => Some(BinaryFunc::NotEq),
             BinaryFunc::NotEq => Some(BinaryFunc::Eq),
             BinaryFunc::Lt => Some(BinaryFunc::Gte),

--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -476,6 +476,7 @@ mod test {
                 old.output_type(column_a_ty.clone(), column_b_ty.clone()),
                 "{new:?} output_type mismatch"
             );
+            assert_eq!(new.negate(), old.negate(), "{new:?} negate mismatch");
             assert_eq!(
                 format!("{}", new),
                 format!("{}", old),
@@ -513,14 +514,54 @@ mod test {
         //   which works because most don't look at the type. We should fix this
         //   and pass expected column types.
 
-        check(func::AddInt16, BF::AddInt16, &i32_ty, &i32_ty);
-        check(func::AddInt32, BF::AddInt32, &i32_ty, &i32_ty);
-        check(func::AddInt64, BF::AddInt64, &i32_ty, &i32_ty);
-        check(func::AddUint16, BF::AddUInt16, &i32_ty, &i32_ty);
-        check(func::AddUint32, BF::AddUInt32, &i32_ty, &i32_ty);
-        check(func::AddUint64, BF::AddUInt64, &i32_ty, &i32_ty);
-        check(func::AddFloat32, BF::AddFloat32, &i32_ty, &i32_ty);
-        check(func::AddFloat64, BF::AddFloat64, &i32_ty, &i32_ty);
+        check(
+            func::AddInt16,
+            BF::AddInt16(func::AddInt16),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddInt32,
+            BF::AddInt32(func::AddInt32),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddInt64,
+            BF::AddInt64(func::AddInt64),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddUint16,
+            BF::AddUInt16(func::AddUint16),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddUint32,
+            BF::AddUInt32(func::AddUint32),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddUint64,
+            BF::AddUInt64(func::AddUint64),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddFloat32,
+            BF::AddFloat32(func::AddFloat32),
+            &i32_ty,
+            &i32_ty,
+        );
+        check(
+            func::AddFloat64,
+            BF::AddFloat64(func::AddFloat64),
+            &i32_ty,
+            &i32_ty,
+        );
         check(func::AddDateTime, BF::AddDateTime, &i32_ty, &i32_ty);
         check(func::AddDateInterval, BF::AddDateInterval, &i32_ty, &i32_ty);
         check(

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"f32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float32<'a>(a: f32, b: f32) -> Result<Datum<'a>, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float32(a: f32, b: f32) -> Result<f32, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(sum)\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddFloat32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat32 {
     type Input1 = f32;
     type Input2 = f32;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<f32, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat32 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <f32>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat32 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <f32 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,11 +61,11 @@ impl std::fmt::Display for AddFloat32 {
         f.write_str("+")
     }
 }
-fn add_float32<'a>(a: f32, b: f32) -> Result<Datum<'a>, EvalError> {
+fn add_float32(a: f32, b: f32) -> Result<f32, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)
     } else {
-        Ok(Datum::from(sum))
+        Ok(sum)
     }
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f32,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float32();\n    let b = b.unwrap_float32();\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"f32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float32<'a>(a: f32, b: f32) -> Result<Datum<'a>, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f32,
 )]
 pub struct AddFloat32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat32 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = f32;
+    type Input2 = f32;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,7 @@ impl std::fmt::Display for AddFloat32 {
         f.write_str("+")
     }
 }
-fn add_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let a = a.unwrap_float32();
-    let b = b.unwrap_float32();
+fn add_float32<'a>(a: f32, b: f32) -> Result<Datum<'a>, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f64,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    let a = a.unwrap_float64();\n    let b = b.unwrap_float64();\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"f64\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float64<'a>(a: f64, b: f64) -> Result<Datum<'a>, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = f64,
 )]
 pub struct AddFloat64;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat64 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = f64;
+    type Input2 = f64;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,7 @@ impl std::fmt::Display for AddFloat64 {
         f.write_str("+")
     }
 }
-fn add_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    let a = a.unwrap_float64();
-    let b = b.unwrap_float64();
+fn add_float64<'a>(a: f64, b: f64) -> Result<Datum<'a>, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_float64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"f64\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float64<'a>(a: f64, b: f64) -> Result<Datum<'a>, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(Datum::from(sum))\n    }\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_float64(a: f64, b: f64) -> Result<f64, EvalError> {\n    let sum = a + b;\n    if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {\n        Err(EvalError::FloatOverflow)\n    } else {\n        Ok(sum)\n    }\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddFloat64;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat64 {
     type Input1 = f64;
     type Input2 = f64;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<f64, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat64 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <f64>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddFloat64 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <f64 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,11 +61,11 @@ impl std::fmt::Display for AddFloat64 {
         f.write_str("+")
     }
 }
-fn add_float64<'a>(a: f64, b: f64) -> Result<Datum<'a>, EvalError> {
+fn add_float64(a: f64, b: f64) -> Result<f64, EvalError> {
     let sum = a + b;
     if sum.is_infinite() && !a.is_infinite() && !b.is_infinite() {
         Err(EvalError::FloatOverflow)
     } else {
-        Ok(Datum::from(sum))
+        Ok(sum)
     }
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int16<'a>(a: i16, b: i16) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int16(a: i16, b: i16) -> Result<i16, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddInt16;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt16 {
     type Input1 = i16;
     type Input2 = i16;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<i16, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt16 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <i16>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt16 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <i16 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,6 +61,6 @@ impl std::fmt::Display for AddInt16 {
         f.write_str("+")
     }
 }
-fn add_int16<'a>(a: i16, b: i16) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
+fn add_int16(a: i16, b: i16) -> Result<i16, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i16,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int16()\n        .checked_add(b.unwrap_int16())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i16\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int16<'a>(a: i16, b: i16) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i16,
 )]
 pub struct AddInt16;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt16 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = i16;
+    type Input2 = i16;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,6 @@ impl std::fmt::Display for AddInt16 {
         f.write_str("+")
     }
 }
-fn add_int16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_int16()
-        .checked_add(b.unwrap_int16())
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int16<'a>(a: i16, b: i16) -> Result<Datum<'a>, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int32<'a>(a: i32, b: i32) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int32(a: i32, b: i32) -> Result<i32, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddInt32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt32 {
     type Input1 = i32;
     type Input2 = i32;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<i32, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt32 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <i32>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt32 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <i32 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,6 +61,6 @@ impl std::fmt::Display for AddInt32 {
         f.write_str("+")
     }
 }
-fn add_int32<'a>(a: i32, b: i32) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
+fn add_int32(a: i32, b: i32) -> Result<i32, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i32,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int32()\n        .checked_add(b.unwrap_int32())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int32<'a>(a: i32, b: i32) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i32,
 )]
 pub struct AddInt32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt32 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = i32;
+    type Input2 = i32;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,6 @@ impl std::fmt::Display for AddInt32 {
         f.write_str("+")
     }
 }
-fn add_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_int32()
-        .checked_add(b.unwrap_int32())
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int32<'a>(a: i32, b: i32) -> Result<Datum<'a>, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int64<'a>(a: i64, b: i64) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int64(a: i64, b: i64) -> Result<i64, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddInt64;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt64 {
     type Input1 = i64;
     type Input2 = i64;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<i64, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt64 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <i64>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt64 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <i64 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,6 +61,6 @@ impl std::fmt::Display for AddInt64 {
         f.write_str("+")
     }
 }
-fn add_int64<'a>(a: i64, b: i64) -> Result<Datum<'a>, EvalError> {
-    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
+fn add_int64(a: i64, b: i64) -> Result<i64, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_int64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i64,\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_int64()\n        .checked_add(b.unwrap_int64())\n        .ok_or(EvalError::NumericFieldOverflow)\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"i64\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_int64<'a>(a: i64, b: i64) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i64,
 )]
 pub struct AddInt64;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddInt64 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = i64;
+    type Input2 = i64;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,6 @@ impl std::fmt::Display for AddInt64 {
         f.write_str("+")
     }
 }
-fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_int64()
-        .checked_add(b.unwrap_int64())
-        .ok_or(EvalError::NumericFieldOverflow)
-        .map(Datum::from)
+fn add_int64<'a>(a: i64, b: i64) -> Result<Datum<'a>, EvalError> {
+    a.checked_add(b).ok_or(EvalError::NumericFieldOverflow).map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint16()\n        .checked_add(b.unwrap_uint16())\n        .ok_or_else(|| EvalError::UInt16OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint16<'a>(a: u16, b: u16) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt16OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = 
 )]
 pub struct AddUint16;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint16 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = u16;
+    type Input2 = u16;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,8 @@ impl std::fmt::Display for AddUint16 {
         f.write_str("+")
     }
 }
-fn add_uint16<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_uint16()
-        .checked_add(b.unwrap_uint16())
+fn add_uint16<'a>(a: u16, b: u16) -> Result<Datum<'a>, EvalError> {
+    a.checked_add(b)
         .ok_or_else(|| EvalError::UInt16OutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint16.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint16.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u16\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint16<'a>(a: u16, b: u16) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt16OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint16(a: u16, b: u16) -> Result<u16, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt16OutOfRange(format!(\"{a} + {b}\").into()))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddUint16;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint16 {
     type Input1 = u16;
     type Input2 = u16;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<u16, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint16 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <u16>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint16 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <u16 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,8 +61,7 @@ impl std::fmt::Display for AddUint16 {
         f.write_str("+")
     }
 }
-fn add_uint16<'a>(a: u16, b: u16) -> Result<Datum<'a>, EvalError> {
+fn add_uint16(a: u16, b: u16) -> Result<u16, EvalError> {
     a.checked_add(b)
         .ok_or_else(|| EvalError::UInt16OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint32()\n        .checked_add(b.unwrap_uint32())\n        .ok_or_else(|| EvalError::UInt32OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint32<'a>(a: u32, b: u32) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt32OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,8 +17,8 @@ expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = 
 )]
 pub struct AddUint32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint32 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
+    type Input1 = u32;
+    type Input2 = u32;
     type Output = Result<Datum<'a>, EvalError>;
     fn call(
         &self,
@@ -64,9 +64,8 @@ impl std::fmt::Display for AddUint32 {
         f.write_str("+")
     }
 }
-fn add_uint32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_uint32()
-        .checked_add(b.unwrap_uint32())
+fn add_uint32<'a>(a: u32, b: u32) -> Result<Datum<'a>, EvalError> {
+    a.checked_add(b)
         .ok_or_else(|| EvalError::UInt32OutOfRange(format!("{a} + {b}").into()))
         .map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint32.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint32.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u32\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint32<'a>(a: u32, b: u32) -> Result<Datum<'a>, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt32OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint32(a: u32, b: u32) -> Result<u32, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt32OutOfRange(format!(\"{a} + {b}\").into()))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -19,7 +19,7 @@ pub struct AddUint32;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint32 {
     type Input1 = u32;
     type Input2 = u32;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Output = Result<u32, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint32 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <u32>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint32 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <u32 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,8 +61,7 @@ impl std::fmt::Display for AddUint32 {
         f.write_str("+")
     }
 }
-fn add_uint32<'a>(a: u32, b: u32) -> Result<Datum<'a>, EvalError> {
+fn add_uint32(a: u32, b: u32) -> Result<u32, EvalError> {
     a.checked_add(b)
         .ok_or_else(|| EvalError::UInt32OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint64.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__add_uint64.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"u64\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {\n    a.unwrap_uint64()\n        .checked_add(b.unwrap_uint64())\n        .ok_or_else(|| EvalError::UInt64OutOfRange(format!(\"{a} + {b}\").into()))\n        .map(Datum::from)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    is_infix_op = true,\n    sqlname = \"+\",\n    propagates_nulls = true\n)]\nfn add_uint64(a: u64, b: u64) -> Result<u64, EvalError> {\n    a.checked_add(b)\n        .ok_or_else(|| EvalError::UInt64OutOfRange(format!(\"{a} + {b}\").into()))\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -17,9 +17,9 @@ expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = 
 )]
 pub struct AddUint64;
 impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint64 {
-    type Input1 = Datum<'a>;
-    type Input2 = Datum<'a>;
-    type Output = Result<Datum<'a>, EvalError>;
+    type Input1 = u64;
+    type Input2 = u64;
+    type Output = Result<u64, EvalError>;
     fn call(
         &self,
         a: Self::Input1,
@@ -34,7 +34,7 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint64 {
         input_type_b: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
-        let output = <u64>::as_column_type();
+        let output = Self::Output::as_column_type();
         let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
             self,
         );
@@ -45,9 +45,6 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for AddUint64 {
                     || (propagates_nulls
                         && (input_type_a.nullable || input_type_b.nullable)),
             )
-    }
-    fn introduces_nulls(&self) -> bool {
-        <u64 as ::mz_repr::DatumType<'_, ()>>::nullable()
     }
     fn is_infix_op(&self) -> bool {
         true
@@ -64,9 +61,7 @@ impl std::fmt::Display for AddUint64 {
         f.write_str("+")
     }
 }
-fn add_uint64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    a.unwrap_uint64()
-        .checked_add(b.unwrap_uint64())
+fn add_uint64(a: u64, b: u64) -> Result<u64, EvalError> {
+    a.checked_add(b)
         .ok_or_else(|| EvalError::UInt64OutOfRange(format!("{a} + {b}").into()))
-        .map(Datum::from)
 }

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__eq.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"=\",\n    propagates_nulls = true\n)]\nfn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a == b)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"=\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::NotEq)\"\n)]\nfn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a == b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,6 +51,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Eq {
     }
     fn is_infix_op(&self) -> bool {
         true
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::NotEq)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gt.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gt.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">\",\n    propagates_nulls = true\n)]\nfn gt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a > b)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::Lte)\"\n)]\nfn gt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a > b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -54,6 +54,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Gt {
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::Lte)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__gte.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">=\",\n    propagates_nulls = true\n)]\nfn gte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a >= b)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \">=\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::Lt)\"\n)]\nfn gte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a >= b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -54,6 +54,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Gte {
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::Lt)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lt.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lt.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<\",\n    propagates_nulls = true\n)]\nfn lt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a < b)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::Gte)\"\n)]\nfn lt<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a < b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -54,6 +54,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Lt {
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::Gte)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lte.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__lte.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<=\",\n    propagates_nulls = true\n)]\nfn lte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a <= b)\n}\n"
+expression: "#[sqlfunc(\n    is_monotone = \"(true, true)\",\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"<=\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::Gt)\"\n)]\nfn lte<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a <= b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -54,6 +54,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for Lte {
     }
     fn is_monotone(&self) -> (bool, bool) {
         (true, true)
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::Gt)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
+++ b/src/expr/src/scalar/snapshots/mz_expr__scalar__func__not_eq.snap
@@ -1,6 +1,6 @@
 ---
 source: src/expr/src/scalar/func.rs
-expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"!=\",\n    propagates_nulls = true\n)]\nfn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a != b)\n}\n"
+expression: "#[sqlfunc(\n    output_type = \"bool\",\n    is_infix_op = true,\n    sqlname = \"!=\",\n    propagates_nulls = true,\n    negate = \"Some(BinaryFunc::Eq)\"\n)]\nfn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {\n    Datum::from(a != b)\n}\n"
 ---
 #[derive(
     proptest_derive::Arbitrary,
@@ -51,6 +51,9 @@ impl<'a> crate::func::binary::EagerBinaryFunc<'a> for NotEq {
     }
     fn is_infix_op(&self) -> bool {
         true
+    }
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        Some(BinaryFunc::Eq)
     }
     fn propagates_nulls(&self) -> bool {
         true

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4499,14 +4499,14 @@ pub static OP_IMPLS: LazyLock<BTreeMap<&'static str, Func>> = LazyLock::new(|| {
                 // to coerce unknown-type arguments as `Float64`.
                 typeconv::plan_coerce(ecx, exprs.into_element(), &SqlScalarType::Float64)
             }) => Any, oid::OP_UNARY_PLUS_OID;
-            params!(Int16, Int16) => AddInt16 => Int16, 550;
-            params!(Int32, Int32) => AddInt32 => Int32, 551;
-            params!(Int64, Int64) => AddInt64 => Int64, 684;
-            params!(UInt16, UInt16) => AddUInt16 => UInt16, oid::FUNC_ADD_UINT16;
-            params!(UInt32, UInt32) => AddUInt32 => UInt32, oid::FUNC_ADD_UINT32;
-            params!(UInt64, UInt64) => AddUInt64 => UInt64, oid::FUNC_ADD_UINT64;
-            params!(Float32, Float32) => AddFloat32 => Float32, 586;
-            params!(Float64, Float64) => AddFloat64 => Float64, 591;
+            params!(Int16, Int16) => AddInt16(func::AddInt16) => Int16, 550;
+            params!(Int32, Int32) => AddInt32(func::AddInt32) => Int32, 551;
+            params!(Int64, Int64) => AddInt64(func::AddInt64) => Int64, 684;
+            params!(UInt16, UInt16) => AddUInt16(func::AddUint16) => UInt16, oid::FUNC_ADD_UINT16;
+            params!(UInt32, UInt32) => AddUInt32(func::AddUint32) => UInt32, oid::FUNC_ADD_UINT32;
+            params!(UInt64, UInt64) => AddUInt64(func::AddUint64) => UInt64, oid::FUNC_ADD_UINT64;
+            params!(Float32, Float32) => AddFloat32(func::AddFloat32) => Float32, 586;
+            params!(Float64, Float64) => AddFloat64(func::AddFloat64) => Float64, 591;
             params!(Interval, Interval) => AddInterval => Interval, 1337;
             params!(Timestamp, Interval) => AddTimestampInterval => Timestamp, 2066;
             params!(Interval, Timestamp) => {

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -490,7 +490,9 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                                 "func": "Gt",
                                 "expr1": {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         0,
@@ -570,7 +572,9 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
               },
               {
                 "CallBinary": {
-                  "func": "AddInt32",
+                  "func": {
+                    "AddInt32": null
+                  },
                   "expr1": {
                     "Column": [
                       0,
@@ -6584,7 +6588,9 @@ WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
                     "scalars": [
                       {
                         "CallBinary": {
-                          "func": "AddInt32",
+                          "func": {
+                            "AddInt32": null
+                          },
                           "expr1": {
                             "Column": [
                               0,

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -159,7 +159,9 @@ SELECT 1, a + b as c FROM t WHERE a > 0 and b < 0 and a + b > 0
               "expressions": [
                 {
                   "CallBinary": {
-                    "func": "AddInt32",
+                    "func": {
+                      "AddInt32": null
+                    },
                     "expr1": {
                       "Column": [
                         0,
@@ -336,7 +338,9 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                   "scalars": [
                     {
                       "CallBinary": {
-                        "func": "AddInt32",
+                        "func": {
+                          "AddInt32": null
+                        },
                         "expr1": {
                           "Column": [
                             0,
@@ -533,7 +537,9 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                 "func": "Gt",
                 "expr1": {
                   "CallBinary": {
-                    "func": "AddInt32",
+                    "func": {
+                      "AddInt32": null
+                    },
                     "expr1": {
                       "Column": [
                         0,

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -321,7 +321,9 @@ SELECT a + b, 1 FROM t
                   "expressions": [
                     {
                       "CallBinary": {
-                        "func": "AddInt32",
+                        "func": {
+                          "AddInt32": null
+                        },
                         "expr1": {
                           "Column": [
                             0,
@@ -418,7 +420,9 @@ SELECT c + d, 1 FROM u
         "expressions": [
           {
             "CallBinary": {
-              "func": "AddInt32",
+              "func": {
+                "AddInt32": null
+              },
               "expr1": {
                 "Column": [
                   0,
@@ -1107,7 +1111,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                 "expressions": [
                                   {
                                     "CallBinary": {
-                                      "func": "AddInt32",
+                                      "func": {
+                                        "AddInt32": null
+                                      },
                                       "expr1": {
                                         "Column": [
                                           0,
@@ -10162,7 +10168,9 @@ WHERE a = c AND d = e AND b + d > 42
                               "expressions": [
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         1,
@@ -10179,7 +10187,9 @@ WHERE a = c AND d = e AND b + d > 42
                                 },
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         0,
@@ -10344,7 +10354,9 @@ WHERE a = c AND d = e AND b + d > 42
                               "expressions": [
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         2,
@@ -10361,7 +10373,9 @@ WHERE a = c AND d = e AND b + d > 42
                                 },
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         0,
@@ -10559,7 +10573,9 @@ WHERE a = c AND d = e AND b + d > 42
                               "expressions": [
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         2,
@@ -10576,7 +10592,9 @@ WHERE a = c AND d = e AND b + d > 42
                                 },
                                 {
                                   "CallBinary": {
-                                    "func": "AddInt32",
+                                    "func": {
+                                      "AddInt32": null
+                                    },
                                     "expr1": {
                                       "Column": [
                                         0,

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -101,7 +101,9 @@ SELECT a + 1, b, 4 FROM mv WHERE a > 0
         "scalars": [
           {
             "CallBinary": {
-              "func": "AddInt32",
+              "func": {
+                "AddInt32": null
+              },
               "expr1": {
                 "Column": [
                   {


### PR DESCRIPTION
Switch some variants of `BinaryFunc` to use the `LazyBinaryFunc` trait's implementation.

Adds missing `negate` properties to negatable binary functions.
