### PR TITLE
storage: enable multi_replica sources by default

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -108,7 +108,7 @@ pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
 /// Whether we allow sources in multi-replica clusters.
 pub const ENABLE_MULTI_REPLICA_SOURCES: Config<bool> = Config::new(
     "enable_multi_replica_sources",
-    false,
+    true,
     "Enable multi-replica sources.",
 );
 


### PR DESCRIPTION
This flag has been on in cloud for quite a while, so match that now in the default. This will also make sure that it's on in self-managed.

