### PR TITLE
mz emulator: Improved handling of Postgres exiting

### DIFF
--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -66,13 +66,15 @@ if ! is_truthy "${MZ_NO_BUILTIN_POSTGRES:-0}"; then
     /usr/lib/postgresql/16/bin/initdb -D $PGDATA -U $PGUSER --auth-local=trust
   fi
 
+  # Might have been killed hard
+  rm -f $PGDATA/postmaster.pid
   /usr/lib/postgresql/16/bin/postgres -D $PGDATA \
       -c listen_addresses='*' \
       -c unix_socket_directories=/var/run/postgresql \
       -c config_file=/etc/postgresql/postgresql.conf &
   PGPID=$!
 
-  trap 'kill -INT $PGPID; wait $PGPID' SIGTERM SIGINT EXIT
+  trap 'kill -INT $PGPID; wait $PGPID' SIGTERM SIGINT
 
   until /usr/lib/postgresql/16/bin/pg_isready > /dev/null 2>&1; do
     sleep 0.01


### PR DESCRIPTION
Seen in
https://buildkite.com/materialize/test/builds/109203#01993955-459b-4090-abaf-e5e242d5a7b3 and
https://buildkite.com/materialize/test/builds/109206#01993958-c090-4329-bfe1-cf83f4c31d0f I think

Follow-up to https://github.com/MaterializeInc/materialize/pull/33548
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
