### PR TITLE
[persist] Improve debug logging for persist stats

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -9,7 +9,7 @@
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::str::FromStr;
@@ -1601,9 +1601,17 @@ impl RustType<proto_hollow_batch_part::Format> for BatchColumnarFormat {
 ///
 /// These are "lazy" in the sense that we don't decode them (or even validate
 /// the encoded version) until they're used.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LazyPartStats {
     key: LazyProto<ProtoStructStats>,
+}
+
+impl Debug for LazyPartStats {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("LazyPartStats")
+            .field(&self.decode())
+            .finish()
+    }
 }
 
 impl LazyPartStats {


### PR DESCRIPTION
This decodes the proto when debugging stats (improving readability) and applies redaction to just user data without including non-private metadata.

### Motivation

Spotted while doing some investigation into CI flakes this week.