### PR TITLE
Envd ed25519

### DIFF
--- a/src/orchestratord/src/controller/materialize/balancer.rs
+++ b/src/orchestratord/src/controller/materialize/balancer.rs
@@ -32,7 +32,8 @@ use crate::{
     k8s::{apply_resource, delete_resource, get_resource},
 };
 use mz_cloud_resources::crd::{
-    generated::cert_manager::certificates::Certificate, materialize::v1alpha1::Materialize,
+    generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
+    materialize::v1alpha1::Materialize,
 };
 use mz_ore::instrument;
 
@@ -131,6 +132,8 @@ fn create_balancerd_external_certificate(
         mz.balancerd_external_certificate_name(),
         mz.balancerd_external_certificate_secret_name(),
         None,
+        CertificatePrivateKeyAlgorithm::Rsa,
+        Some(4096),
     )
 }
 

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -34,7 +34,8 @@ use crate::{
     k8s::{apply_resource, delete_resource},
 };
 use mz_cloud_resources::crd::{
-    generated::cert_manager::certificates::Certificate, materialize::v1alpha1::Materialize,
+    generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
+    materialize::v1alpha1::Materialize,
 };
 
 pub struct Resources {
@@ -198,6 +199,8 @@ fn create_console_external_certificate(
         mz.console_external_certificate_name(),
         mz.console_external_certificate_secret_name(),
         None,
+        CertificatePrivateKeyAlgorithm::Rsa,
+        Some(4096),
     )
 }
 

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -50,7 +50,9 @@ use super::matching_image_from_environmentd_image_ref;
 use crate::controller::materialize::tls::{create_certificate, issuer_ref_defined};
 use crate::k8s::{apply_resource, delete_resource, get_resource};
 use mz_cloud_provider::CloudProvider;
-use mz_cloud_resources::crd::generated::cert_manager::certificates::Certificate;
+use mz_cloud_resources::crd::generated::cert_manager::certificates::{
+    Certificate, CertificatePrivateKeyAlgorithm,
+};
 use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::instrument;
@@ -893,6 +895,8 @@ fn create_environmentd_certificate(
             mz.environmentd_service_name(),
             mz.environmentd_service_internal_fqdn(),
         ]),
+        CertificatePrivateKeyAlgorithm::Ed25519,
+        None,
     )
 }
 

--- a/src/orchestratord/src/controller/materialize/tls.rs
+++ b/src/orchestratord/src/controller/materialize/tls.rs
@@ -20,6 +20,8 @@ pub fn create_certificate(
     cert_name: String,
     secret_name: String,
     additional_dns_names: Option<Vec<String>>,
+    algorithm: CertificatePrivateKeyAlgorithm,
+    size: Option<i64>,
 ) -> Option<Certificate> {
     let default_spec = default_spec.unwrap_or_else(MaterializeCertSpec::default);
     let mz_cert_spec = mz_cert_spec.unwrap_or_else(MaterializeCertSpec::default);
@@ -52,10 +54,10 @@ pub fn create_certificate(
             duration: mz_cert_spec.duration.or(default_spec.duration),
             issuer_ref,
             private_key: Some(CertificatePrivateKey {
-                algorithm: Some(CertificatePrivateKeyAlgorithm::Rsa),
+                algorithm: Some(algorithm),
                 encoding: Some(CertificatePrivateKeyEncoding::Pkcs8),
                 rotation_policy: Some(CertificatePrivateKeyRotationPolicy::Always),
-                size: Some(4096),
+                size,
             }),
             renew_before: mz_cert_spec.renew_before.or(default_spec.renew_before),
             secret_name,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
I think this will improve CPS and lower ENVD CPU. Since public comms should go through balancer this shouldn't have compatibility issues. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
