### PR TITLE
docker: Use Ubuntu 24.04 as base images instead

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -10,7 +10,7 @@
 # Stage 1: Build a minimum CI Builder image that we can use for the initial
 # steps like `mkpipeline` and `Build`, as well as any tests that are self
 # contained and use other Docker images.
-FROM ubuntu:oracular-20250619 AS ci-builder-min
+FROM ubuntu:noble-20250805 AS ci-builder-min
 
 WORKDIR /workdir
 

--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:oracular-20250619
+FROM ubuntu:noble-20250805
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1

--- a/test/chbench/chbench/Dockerfile
+++ b/test/chbench/chbench/Dockerfile
@@ -52,7 +52,7 @@ RUN ls build
 
 MZFROM ubuntu-base
 
-RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y libconfig++9v5 libmysqlclient21 libpqxx-7.9 unixodbc && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y libconfig++9v5 libmysqlclient21 libpqxx-7.8 unixodbc && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY odbc.ini /etc/odbc.ini
 COPY mz-default-postgres.cfg /etc/chbenchmark/mz-default-postgres.cfg


### PR DESCRIPTION
To address https://materializeinc.slack.com/archives/CTESPM7FU/p1757685343686539
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
