### PR TITLE
docker: Upgrade base images to Ubuntu 25.04

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -10,7 +10,7 @@
 # Stage 1: Build a minimum CI Builder image that we can use for the initial
 # steps like `mkpipeline` and `Build`, as well as any tests that are self
 # contained and use other Docker images.
-FROM ubuntu:noble-20250805 AS ci-builder-min
+FROM ubuntu:plucky-20250730 AS ci-builder-min
 
 WORKDIR /workdir
 
@@ -47,7 +47,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     libxml2 \
     pigz \
     python3 \
-    python3.12-venv \
+    python3.13-venv \
     zstd \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -24,10 +24,10 @@ kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
 launchdarkly-api==17.2.0
 matplotlib==3.10.1
-matplotlib-stubs==0.2.0
+matplotlib-stubs==0.3.4
 networkx==3.4.2
 networkx-stubs==0.0.1
-numpy==1.26.4
+numpy==2.3.3
 pandas==2.3.2
 pandas-stubs==2.2.3.250308
 parameterized==0.9.0

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -99,7 +99,7 @@ all set.
 
 If you are just testing Materialize locally and don't care about data loss you can run environmentd with `eatmydata environmentd`, which will disable fsync calls.
 
-Similarly postgres as the metadata store can be instructed to eat your data using `echo LD_PRELOAD=libeatmydata.so > /etc/postgresql/16/main/environment`, and then restarting it.
+Similarly postgres as the metadata store can be instructed to eat your data using `echo LD_PRELOAD=libeatmydata.so > /etc/postgresql/17/main/environment`, and then restarting it.
 
 On my Linux system without `eatmydata` for both Materialize and Postgres, running with `bin/environmentd --reset --optimized --no-default-features --postgres=postgres://deen@%2Fvar%2Frun%2Fpostgresql`:
 ```

--- a/misc/images/materialized-base/postgresql.conf
+++ b/misc/images/materialized-base/postgresql.conf
@@ -10,7 +10,7 @@
 data_directory = '/mzdata/postgres'
 hba_file = '/etc/postgresql/pg_hba.conf'
 ident_file = '/mzdata/postgres/pg_ident.conf'
-external_pid_file = '/var/run/postgresql/16-main.pid'
+external_pid_file = '/var/run/postgresql/17-main.pid'
 listen_addresses = '*'
 port = 26257
 max_connections = 5000
@@ -22,7 +22,7 @@ max_wal_size = 1GB
 min_wal_size = 80MB
 log_line_prefix = '%m [%p] %q%u@%d '
 log_timezone = UTC
-cluster_name = '16/main'
+cluster_name = '17/main'
 datestyle = 'iso, mdy'
 timezone = UTC
 lc_messages = 'C.UTF-8'

--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:noble-20250805
+FROM ubuntu:plucky-20250730
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -199,20 +199,20 @@ class Owners(Check):
             + dedent(
                 """
                 $ psql-execute command="\\l owner_db*"
-                \\                                                   List of databases
-                    Name    |     Owner     | Encoding | Locale Provider | Collate | Ctype | ICU Locale | ICU Rules | Access privileges
-                ------------+---------------+----------+-----------------+---------+-------+------------+-----------+-------------------
-                 owner_db1  | owner_role_01 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db10 | owner_role_02 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db11 | owner_role_03 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db2  | other_owner   | UTF8     | libc            | C       | C     |            |           |
-                 owner_db3  | owner_role_01 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db4  | other_owner   | UTF8     | libc            | C       | C     |            |           |
-                 owner_db5  | owner_role_01 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db6  | other_owner   | UTF8     | libc            | C       | C     |            |           |
-                 owner_db7  | owner_role_02 | UTF8     | libc            | C       | C     |            |           |
-                 owner_db8  | other_owner   | UTF8     | libc            | C       | C     |            |           |
-                 owner_db9  | owner_role_01 | UTF8     | libc            | C       | C     |            |           |
+                \\                                                 List of databases
+                    Name    |     Owner     | Encoding | Locale Provider | Collate | Ctype | Locale | ICU Rules | Access privileges
+                ------------+---------------+----------+-----------------+---------+-------+--------+-----------+-------------------
+                 owner_db1  | owner_role_01 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db10 | owner_role_02 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db11 | owner_role_03 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db2  | other_owner   | UTF8     | libc            | C       | C     |        |           |
+                 owner_db3  | owner_role_01 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db4  | other_owner   | UTF8     | libc            | C       | C     |        |           |
+                 owner_db5  | owner_role_01 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db6  | other_owner   | UTF8     | libc            | C       | C     |        |           |
+                 owner_db7  | owner_role_02 | UTF8     | libc            | C       | C     |        |           |
+                 owner_db8  | other_owner   | UTF8     | libc            | C       | C     |        |           |
+                 owner_db9  | owner_role_01 | UTF8     | libc            | C       | C     |        |           |
 
 
                 $ psql-execute command="\\dn owner_schema*"

--- a/misc/python/materialize/optbench/util.py
+++ b/misc/python/materialize/optbench/util.py
@@ -10,8 +10,12 @@
 from collections.abc import Callable
 from pathlib import Path
 from re import match
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
+
+if TYPE_CHECKING:
+    pass
 
 from . import Scenario
 
@@ -33,7 +37,7 @@ def duration_to_timedelta(duration: str) -> np.timedelta64 | None:
         return None
     else:
         unit = "us" if m.group("unit") == "µs" else m.group("unit")
-        time = np.timedelta64(m.group("time"), unit)
+        time = np.timedelta64(m.group("time"), cast("np._TimeUnitSpec", unit))
         frac = np.timedelta64(frac_to_ns[unit](m.group("frac") or "0"), "ns")
         return time + frac
 

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -18,6 +18,6 @@ RUN ln -s /usr/local/bin/materialized /usr/local/bin/environmentd \
 
 USER materialize
 
-RUN /usr/lib/postgresql/16/bin/initdb -D /mzdata/postgres -U root --auth-local=trust
+RUN /usr/lib/postgresql/17/bin/initdb -D /mzdata/postgres -U root --auth-local=trust
 
 ENTRYPOINT ["tini", "--", "entrypoint.sh"]

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -63,12 +63,12 @@ if ! is_truthy "${MZ_NO_BUILTIN_POSTGRES:-0}"; then
   # Should exist already, but /mzdata might be overwritten with a fresh volume
   if [ ! -f $PGDATA/PG_VERSION ]; then
     mkdir -p $PGDATA
-    /usr/lib/postgresql/16/bin/initdb -D $PGDATA -U $PGUSER --auth-local=trust
+    /usr/lib/postgresql/17/bin/initdb -D $PGDATA -U $PGUSER --auth-local=trust
   fi
 
   # Might have been killed hard
   rm -f $PGDATA/postmaster.pid
-  /usr/lib/postgresql/16/bin/postgres -D $PGDATA \
+  /usr/lib/postgresql/17/bin/postgres -D $PGDATA \
       -c listen_addresses='*' \
       -c unix_socket_directories=/var/run/postgresql \
       -c config_file=/etc/postgresql/postgresql.conf &
@@ -76,7 +76,7 @@ if ! is_truthy "${MZ_NO_BUILTIN_POSTGRES:-0}"; then
 
   trap 'kill -INT $PGPID; wait $PGPID' SIGTERM SIGINT
 
-  until /usr/lib/postgresql/16/bin/pg_isready > /dev/null 2>&1; do
+  until /usr/lib/postgresql/17/bin/pg_isready > /dev/null 2>&1; do
     sleep 0.01
   done
 

--- a/test/chbench/chbench/Dockerfile
+++ b/test/chbench/chbench/Dockerfile
@@ -52,7 +52,7 @@ RUN ls build
 
 MZFROM ubuntu-base
 
-RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y libconfig++9v5 libmysqlclient21 libpqxx-7.8 unixodbc && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y libconfig++11 libmysqlclient24 libpqxx-7.10 unixodbc && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY odbc.ini /etc/odbc.ini
 COPY mz-default-postgres.cfg /etc/chbenchmark/mz-default-postgres.cfg

--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -22,7 +22,11 @@ if ! kind get clusters | grep -q "$K8S_CLUSTER_NAME"; then
 
     run kind create cluster --name="$K8S_CLUSTER_NAME" --config="${CLUSTER_YAML}" --wait=60s
 
+    run kind get kubeconfig --name="$K8S_CLUSTER_NAME" > "$KUBECONFIG"
+
     run kubectl --context="$K8S_CONTEXT" taint nodes --selector=environmentd=true "environmentd=true:NoSchedule"
+else
+    run kind get kubeconfig --name="$K8S_CLUSTER_NAME" > "$KUBECONFIG"
 fi
 
 for f in misc/kind/configmaps/*; do

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -341,7 +341,7 @@ def report(
         if num_plots > 1:
             title += f"\n(part {i+1}/{num_plots})"
         plt.title(title)
-        plt.legend(loc="best")
+        plt.legend(loc="best")  # type: ignore
         plt.grid(True)
         plt.ylim(bottom=0)
         plot_path = f"plots/{scenario_name}_{suffix}_{i}_timeline.png"
@@ -365,7 +365,7 @@ def report(
             (uniqu_durations, counts) = numpy.unique(durations, return_counts=True)
             counts = numpy.cumsum(counts)
             plt.plot(uniqu_durations, 1 - counts / counts.max(), label=key)
-        plt.legend(loc="best")
+        plt.legend(loc="best")  # type: ignore
 
         plot_path = f"plots/{scenario_name}_{suffix}_ccdf.png"
         plt.savefig(MZ_ROOT / plot_path, dpi=300)

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -147,11 +147,11 @@ materialize ""
 
 # ...and also in `\l`
 $ psql-execute command="\l"
-\                                                   List of databases
-    Name     |    Owner    | Encoding | Locale Provider | Collate | Ctype | ICU Locale | ICU Rules | Access privileges
--------------+-------------+----------+-----------------+---------+-------+------------+-----------+-------------------
- d           | materialize | UTF8     | libc            | C       | C     |            |           |
- materialize | mz_system   | UTF8     | libc            | C       | C     |            |           |
+\                                                 List of databases
+    Name     |    Owner    | Encoding | Locale Provider | Collate | Ctype | Locale | ICU Rules | Access privileges
+-------------+-------------+----------+-----------------+---------+-------+--------+-----------+-------------------
+ d           | materialize | UTF8     | libc            | C       | C     |        |           |
+ materialize | mz_system   | UTF8     | libc            | C       | C     |        |           |
 
 
 


### PR DESCRIPTION
I still think we should go to a higher version, not lower, but merged the previous PR since it's faster to get working. This is some more effort.

Follow-up to https://github.com/MaterializeInc/materialize/pull/33575

Test run: https://buildkite.com/materialize/nightly/builds/13398
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
