### PR TITLE
revert use of --sbom while debug

### DIFF
--- a/misc/python/materialize/release/cut_release.py
+++ b/misc/python/materialize/release/cut_release.py
@@ -55,7 +55,7 @@ def main():
         print(f"Checking out SHA {args.sha}")
         checkout(args.sha)
         print(f"Bumping version to {version}")
-        spawn.runv([MZ_ROOT / "bin" / "bump-version", version, "--sbom"])
+        spawn.runv([MZ_ROOT / "bin" / "bump-version", version])
         print("Tagging version")
         tag_annotated(version)
         print("Pushing tag to Materialize repo")


### PR DESCRIPTION

The new SBOM functionality can error in the release cut process. Revert the use of the `--sbom` flag while we debug this.

