### PR TITLE
cut-release: Reenable sbom generation

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -17,27 +17,31 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-if [[ $# -ne 1 && $# -ne 2 ]]; then
+if [[ $# -lt 1 ]]; then
     die "usage: $0 VERSION [--no-commit] [--sbom]"
 fi
 
 commit=true
 sbom=false
-if [[ $# -eq 2 ]]; then
-    if [[ "$2" == "--no-commit" ]]; then
+
+version=${1#v}
+shift
+
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--no-commit" ]]; then
         commit=false
-    elif [[ "$2" == "--sbom" ]]; then
+        shift
+    elif [[ "$1" == "--sbom" ]]; then
         sbom=true
+        shift
     else
         die "invalid flag: $2, only --no-commit and --sbom are supported"
     fi
-fi
+done
 
 if ! run git diff HEAD --compact-summary --exit-code; then
     die "cannot begin bump with uncommitted content"
 fi
-
-version=${1#v}
 
 sed -i.bak \
     "s/^version = .*/version = \"$version\"/" \
@@ -98,6 +102,7 @@ if $sbom; then
     rm -rf sbom
     mkdir sbom
     find . -type f -name "Dockerfile" -exec sed -i 's/MZFROM/FROM/g' {} +
+    mkdir -p ~/.inspector-sbomgen
     inspector-sbomgen directory --path . --skip-files test --outfile "sbom/materialize.$version.cdx.json" --disable-progress-bar
     git ls-files | grep 'Dockerfile$' | xargs git checkout --
     git add sbom

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -216,6 +216,7 @@ case "$cmd" in
             --volume "$(pwd)/target-xcompile:/mnt/build"
             --volume "$(pwd):$(pwd)"
             --workdir "$(pwd)"
+            --env XDG_CACHE_HOME=/mnt/build/cache
             --env AWS_ACCESS_KEY_ID
             --env AWS_DEFAULT_REGION
             --env AWS_SECRET_ACCESS_KEY

--- a/misc/python/materialize/release/cut_release.py
+++ b/misc/python/materialize/release/cut_release.py
@@ -55,7 +55,19 @@ def main():
         print(f"Checking out SHA {args.sha}")
         checkout(args.sha)
         print(f"Bumping version to {version}")
-        spawn.runv([MZ_ROOT / "bin" / "bump-version", version])
+        spawn.runv(
+            [
+                MZ_ROOT / "bin" / "ci-builder",
+                "run",
+                "stable",
+                MZ_ROOT / "bin" / "bump-version",
+                version,
+                "--no-commit",
+                "--sbom",
+            ]
+        )
+        # Commit here instead of in bump-version so we have access to the correct git author
+        spawn.runv(["git", "commit", "-am", f"release: bump to version {version}"])
         print("Tagging version")
         tag_annotated(version)
         print("Pushing tag to Materialize repo")


### PR DESCRIPTION
Verified locally on macOS with `bin/cut-release --sha HEAD --version v0.157.1 --remote origin`
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
