### PR TITLE
Fix capacity and allocation logging

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -1168,7 +1168,9 @@ impl<A: Scheduler> DemuxHandler<'_, '_, A> {
             .state
             .pack_arrangement_heap_capacity_update(operator_id);
         let diff = Diff::cast_from(delta_capacity);
-        self.output.arrangement_heap_size.give((datum, ts, diff));
+        self.output
+            .arrangement_heap_capacity
+            .give((datum, ts, diff));
     }
 
     /// Update the allocation count for an arrangement.
@@ -1190,7 +1192,9 @@ impl<A: Scheduler> DemuxHandler<'_, '_, A> {
             .state
             .pack_arrangement_heap_allocations_update(operator_id);
         let diff = Diff::cast_from(delta_allocations);
-        self.output.arrangement_heap_size.give((datum, ts, diff));
+        self.output
+            .arrangement_heap_allocations
+            .give((datum, ts, diff));
     }
 
     /// Indicate that a new arrangement exists, start maintaining the heap size state.

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9684 is fixed
-$ skip-if
-SELECT true
-
 $ set-sql-timeout duration=300s
 $ set-arg-default default-replica-size=scale=1,workers=1
 


### PR DESCRIPTION
We were using wrong outputs for capacity and allocation counts, causing both to show up as size when inserting, and partially retracted when dropping the operators. The fix is to use the correct outputs.

Fixes https://github.com/MaterializeInc/database-issues/issues/9684
