### PR TITLE
storage,0dt: include source exports (aka. subsources) in hydration checks

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -260,7 +260,7 @@ impl Coordinator {
         let storage_frontiers = self
             .controller
             .storage
-            .active_ingestions(cluster.id)
+            .active_ingestion_exports(cluster.id)
             .copied()
             .filter(|id| !id.is_transient() && !exclude_collections.contains(id))
             .map(|id| {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -359,8 +359,10 @@ pub trait StorageController: Debug {
     /// capabilties.
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
-    /// Returns the IDs of all active ingestions for the given storage instance.
-    fn active_ingestions(
+    /// Returns the IDs of ingestion exports running on the given instance. This
+    /// includes the ingestion itself, if any, and running source tables (aka.
+    /// subsources).
+    fn active_ingestion_exports(
         &self,
         instance_id: StorageInstanceId,
     ) -> Box<dyn Iterator<Item = &GlobalId> + '_>;

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -254,9 +254,17 @@ where
         }
     }
 
-    /// Returns the ingestions running on this instance.
+    /// Returns ingestions running on this instance. This _only_ includes the
+    /// "toplevel" ingestions, not any of their source tables (aka. subsources).
     pub fn active_ingestions(&self) -> impl Iterator<Item = &GlobalId> {
         self.active_ingestions.keys()
+    }
+
+    /// Returns ingestion exports running on this instance. This includes the
+    /// ingestion itself, if any, and running source tables (aka. subsources).
+    pub fn active_ingestion_exports(&self) -> impl Iterator<Item = &GlobalId> {
+        let ingestion_exports = self.ingestion_exports.keys();
+        self.active_ingestions.keys().chain(ingestion_exports)
     }
 
     /// Returns the exports running on this instance.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -503,11 +503,11 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
-    fn active_ingestions(
+    fn active_ingestion_exports(
         &self,
         instance_id: StorageInstanceId,
     ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
-        Box::new(self.instances[&instance_id].active_ingestions())
+        Box::new(self.instances[&instance_id].active_ingestion_exports())
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {


### PR DESCRIPTION
Before, we were erroneously only including the "root" ingestion objects and not any of their subsource/tables in hydration checks.

@def-  I believe this should fix https://github.com/MaterializeInc/database-issues/issues/9687, but I haven't yet tried running that using the `--release` nightly config.