### PR TITLE
Update defaults of `enable_reduce_reduction` and `enable_mz_join_core_v2`

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -24,7 +24,7 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
 /// Whether rendering should use `mz_join_core_v2` rather than DD's `JoinCore::join_core`.
 pub const ENABLE_MZ_JOIN_CORE_V2: Config<bool> = Config::new(
     "enable_mz_join_core_v2",
-    false,
+    true,
     "Whether compute should use `mz_join_core_v2` rather than DD's `JoinCore::join_core` to render \
      linear joins.",
 );

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1434,7 +1434,7 @@ pub static ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: VarDefinition = VarDefinition:
 
 pub static ENABLE_REDUCE_REDUCTION: VarDefinition = VarDefinition::new(
     "enable_reduce_reduction",
-    value!(bool; false),
+    value!(bool; true),
     "split complex reductions in to simpler ones and a join (Materialize).",
     true,
 );

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -96,9 +96,14 @@ EXPLAIN OPTIMIZED PLAN WITH(arity, humanized expressions) AS VERBOSE TEXT FOR
 SELECT sum(e * f), max(f) FROM v GROUP BY mod(e, 5)
 ----
 Explained Query:
-  Project (#1{sum}, #2{max_f}) // { arity: 2 }
-    Reduce group_by=[(#0{e} % 5)] aggregates=[sum((#0{e} * #1{f})), max(#1{f})] // { arity: 3 }
-      ReadStorage materialize.public.v // { arity: 2 }
+  Project (#3{sum}, #1{max_f}) // { arity: 2 }
+    Join on=(#0 = #2) type=differential // { arity: 4 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Reduce group_by=[(#0{e} % 5)] aggregates=[max(#1{f})] // { arity: 2 }
+          ReadStorage materialize.public.v // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Reduce group_by=[(#0{e} % 5)] aggregates=[sum((#0{e} * #1{f}))] // { arity: 2 }
+          ReadStorage materialize.public.v // { arity: 2 }
 
 Source materialize.public.v
 

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -73,9 +73,16 @@ Explained Query:
   Threshold // { types: "(bigint?, text?, date?)" }
     Union // { types: "(bigint?, text?, date?)" }
       Negate // { types: "(bigint?, text?, date?)" }
-        Project (#1{sum_a}, #2{max_b}, #0{c}) // { types: "(bigint?, text?, date?)" }
-          Reduce group_by=[#2{c}] aggregates=[sum(#0{a}), max(#1{b})] // { types: "(date?, bigint?, text?)" }
-            ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+        Project (#3{sum_a}, #1{max_b}, #0{c}) // { types: "(bigint?, text?, date?)" }
+          Join on=(#0{c} = #2{c}) type=differential // { types: "(date?, text?, date?, bigint?)" }
+            ArrangeBy keys=[[#0{c}]] // { types: "(date?, text?)" }
+              Reduce group_by=[#1{c}] aggregates=[max(#0{b})] // { types: "(date?, text?)" }
+                Project (#1{b}, #2{c}) // { types: "(text?, date?)" }
+                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+            ArrangeBy keys=[[#0{c}]] // { types: "(date?, bigint?)" }
+              Reduce group_by=[#1{c}] aggregates=[sum(#0{a})] // { types: "(date?, bigint?)" }
+                Project (#0{a}, #2{c}) // { types: "(integer?, date?)" }
+                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
       Constant // { types: "(bigint, text, date?)" }
         - (1, "hello", null)
 
@@ -133,30 +140,40 @@ EXPLAIN OPTIMIZED PLAN WITH(types, humanized expressions) AS VERBOSE TEXT FOR
 (SELECT null::boolean as f1, 10 as f2) EXCEPT (SELECT min(f), count(*) FROM v WHERE (select d::double FROM u) = v.e GROUP BY e LIMIT 1)
 ----
 Explained Query:
-  Threshold // { types: "(boolean?, bigint)" }
-    Union // { types: "(boolean?, bigint)" }
-      Negate // { types: "(boolean?, bigint)" }
-        TopK limit=1 // { types: "(boolean?, bigint)" }
-          Project (#1{min_f}, #2{count}) // { types: "(boolean?, bigint)" }
-            Reduce group_by=[#0{e}] aggregates=[min(#1{f}), count(*)] // { types: "(double precision, boolean?, bigint)" }
-              Project (#0{e}, #1{f}) // { types: "(double precision, boolean?)" }
-                Join on=(#0{e} = #2) type=differential // { types: "(double precision, boolean?, double precision)" }
-                  ArrangeBy keys=[[#0{e}]] // { types: "(double precision, boolean?)" }
-                    Filter (#0{e}) IS NOT NULL // { types: "(double precision, boolean?)" }
-                      ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
-                  ArrangeBy keys=[[#0]] // { types: "(double precision?)" }
-                    Union // { types: "(double precision?)" }
-                      Project (#1) // { types: "(double precision?)" }
-                        Filter (#0{d}) IS NOT NULL // { types: "(integer, double precision?)" }
-                          Map (integer_to_double(#0{d})) // { types: "(integer?, double precision?)" }
-                            ReadStorage materialize.public.u // { types: "(integer?)" }
-                      Project (#1) // { types: "(double precision)" }
-                        FlatMap guard_subquery_size(#0{count}) // { types: "(bigint, double precision)" }
-                          Reduce aggregates=[count(*)] // { types: "(bigint)" }
-                            Project () // { types: "()" }
-                              ReadStorage materialize.public.u // { types: "(integer?)" }
-      Constant // { types: "(boolean?, bigint)" }
-        - (null, 10)
+  With
+    cte l0 =
+      Project (#0{e}, #1{f}) // { types: "(double precision, boolean?)" }
+        Join on=(#0{e} = #2) type=differential // { types: "(double precision, boolean?, double precision)" }
+          ArrangeBy keys=[[#0{e}]] // { types: "(double precision, boolean?)" }
+            Filter (#0{e}) IS NOT NULL // { types: "(double precision, boolean?)" }
+              ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
+          ArrangeBy keys=[[#0]] // { types: "(double precision?)" }
+            Union // { types: "(double precision?)" }
+              Project (#1) // { types: "(double precision?)" }
+                Filter (#0{d}) IS NOT NULL // { types: "(integer, double precision?)" }
+                  Map (integer_to_double(#0{d})) // { types: "(integer?, double precision?)" }
+                    ReadStorage materialize.public.u // { types: "(integer?)" }
+              Project (#1) // { types: "(double precision)" }
+                FlatMap guard_subquery_size(#0{count}) // { types: "(bigint, double precision)" }
+                  Reduce aggregates=[count(*)] // { types: "(bigint)" }
+                    Project () // { types: "()" }
+                      ReadStorage materialize.public.u // { types: "(integer?)" }
+  Return // { types: "(boolean?, bigint)" }
+    Threshold // { types: "(boolean?, bigint)" }
+      Union // { types: "(boolean?, bigint)" }
+        Negate // { types: "(boolean?, bigint)" }
+          TopK limit=1 // { types: "(boolean?, bigint)" }
+            Project (#1{min_f}, #3{count}) // { types: "(boolean?, bigint)" }
+              Join on=(#0{e} = #2{e}) type=differential // { types: "(double precision, boolean?, double precision, bigint)" }
+                ArrangeBy keys=[[#0{e}]] // { types: "(double precision, boolean?)" }
+                  Reduce group_by=[#0{e}] aggregates=[min(#1{f})] // { types: "(double precision, boolean?)" }
+                    Get l0 // { types: "(double precision, boolean?)" }
+                ArrangeBy keys=[[#0{e}]] // { types: "(double precision, bigint)" }
+                  Reduce group_by=[#0{e}] aggregates=[count(*)] // { types: "(double precision, bigint)" }
+                    Project (#0{e}) // { types: "(double precision)" }
+                      Get l0 // { types: "(double precision, boolean?)" }
+        Constant // { types: "(boolean?, bigint)" }
+          - (null, 10)
 
 Source materialize.public.u
 Source materialize.public.v

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -306,8 +306,8 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Project (#0{l_partkey}..=#4{min_l_orderkey}, #3{min_c_nationkey}) // { arity: 6 }
-    Reduce group_by=[#1{l_partkey}, #2{c_nationkey}] aggregates=[count(*), min(#2{c_nationkey}), min(#0{l_orderkey})] // { arity: 5 }
+  With
+    cte l0 =
       Project (#0{l_orderkey}, #1{l_partkey}, #28{c_nationkey}) // { arity: 3 }
         Filter (#10{l_shipdate} <= 1995-11-14) AND (#30{c_acctbal} <= 12907776) AND (#10{l_shipdate} >= 1995-04-19) AND (#30{c_acctbal} >= #5{l_extendedprice}) // { arity: 33 }
           Join on=(#0{l_orderkey} = #16{o_orderkey} AND #17{o_custkey} = #25{c_custkey}) type=delta // { arity: 33 }
@@ -321,6 +321,18 @@ Explained Query:
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join lookup] // { arity: 8 }
+  Return // { arity: 6 }
+    Project (#0{l_partkey}, #1{c_nationkey}, #6{count}, #2{min_c_nationkey}, #3{min_l_orderkey}, #2{min_c_nationkey}) // { arity: 6 }
+      Join on=(#0{l_partkey} = #4{l_partkey} AND #1{c_nationkey} = #5{c_nationkey}) type=differential // { arity: 7 }
+        implementation
+          %0[#0, #1]UKKA » %1[#0, #1]UKKA
+        ArrangeBy keys=[[#0{l_partkey}, #1{c_nationkey}]] // { arity: 4 }
+          Reduce group_by=[#1{l_partkey}, #2{c_nationkey}] aggregates=[min(#2{c_nationkey}), min(#0{l_orderkey})] // { arity: 4 }
+            Get l0 // { arity: 3 }
+        ArrangeBy keys=[[#0{l_partkey}, #1{c_nationkey}]] // { arity: 3 }
+          Reduce group_by=[#0{l_partkey}, #1{c_nationkey}] aggregates=[count(*)] // { arity: 3 }
+            Project (#1{l_partkey}, #2{c_nationkey}) // { arity: 2 }
+              Get l0 // { arity: 3 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join lookup)
@@ -610,8 +622,8 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Project (#0{o_custkey}, #0{o_custkey}..=#2{count}) // { arity: 4 }
-    Reduce group_by=[#1{o_custkey}] aggregates=[min(#0{o_orderkey}), count(*)] // { arity: 3 }
+  With
+    cte l0 =
       Project (#2{o_orderkey}, #3{o_custkey}) // { arity: 2 }
         Filter (#1{l_shipdate} < #5{o_orderdate}) AND (#11{c_acctbal} > #4{o_totalprice}) AND (#11{c_acctbal} >= #0{l_extendedprice}) // { arity: 14 }
           Join on=(#3{o_custkey} = #6{c_custkey}) type=delta // { arity: 14 }
@@ -628,6 +640,18 @@ Explained Query:
                 ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
             ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join lookup] // { arity: 8 }
+  Return // { arity: 4 }
+    Project (#0{o_custkey}, #0{o_custkey}, #1{min_o_orderkey}, #3{count}) // { arity: 4 }
+      Join on=(#0{o_custkey} = #2{o_custkey}) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 2 }
+          Reduce group_by=[#1{o_custkey}] aggregates=[min(#0{o_orderkey})] // { arity: 2 }
+            Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 2 }
+          Reduce group_by=[#0{o_custkey}] aggregates=[count(*)] // { arity: 2 }
+            Project (#1{o_custkey}) // { arity: 1 }
+              Get l0 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (delta join lookup)

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -375,7 +375,6 @@ query T
 SELECT mdo.name FROM mz_introspection.mz_arrangement_sharing mash JOIN mz_introspection.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
 ----
 AccumulableErrorCheck
-Arrange ReduceCollation
 Arrange ReduceMinsMaxes
 Arrange ReduceMinsMaxes
 Arrange ReduceMinsMaxes
@@ -411,8 +410,6 @@ Distinct recursive err
 DistinctBy
 DistinctByErrorCheck
 ReduceAccumulable
-ReduceCollation
-ReduceCollation Errors
 ReduceMinsMaxes
 ReduceMinsMaxes
 ReduceMinsMaxes
@@ -864,16 +861,16 @@ SELECT mdo.name FROM mz_introspection.mz_arrangement_sharing mash JOIN mz_intros
 AccumulableErrorCheck
 AccumulableErrorCheck
 AccumulableErrorCheck
-Arrange ReduceCollation
 Arrange ReduceMinsMaxes
 Arrange ReduceMinsMaxes
-Arrange bundle err
 ArrangeAccumulable [val: empty]
 ArrangeAccumulable [val: empty]
 ArrangeAccumulable [val: empty]
 ArrangeBy[[CallBinary(ModInt64, Column(0, "data"), Literal(Ok(Row{[Int64(2)]}), ColumnType { scalar_type: Int64, nullable: false }))]]
 ArrangeBy[[CallUnary(CastInt32ToInt64(CastInt32ToInt64), Column(0, "id"))]]
 ArrangeBy[[Column(0)]]
+ArrangeBy[[Column(0, "data")]]
+ArrangeBy[[Column(0, "data")]]-errors
 ArrangeBy[[Column(0, "id")]]
 ArrangeBy[[Column(0, "id")]]-errors
 ArrangeBy[[Column(0, "max")]]
@@ -893,7 +890,6 @@ Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
 Arranged MinsMaxesHierarchical input
-Arranged ReduceFuseBasic input
 Arranged ReduceInaccumulable
 Arranged ReduceInaccumulable
 Arranged TopK input
@@ -907,11 +903,9 @@ Arranged TopK input
 ReduceAccumulable
 ReduceAccumulable
 ReduceAccumulable
-ReduceCollation
-ReduceCollation Errors
-ReduceFuseBasic
 ReduceInaccumulable
 ReduceInaccumulable
+ReduceInaccumulable Error Check
 ReduceInaccumulable Error Check
 ReduceMinsMaxes
 ReduceMinsMaxes
@@ -985,7 +979,6 @@ GROUP BY mdod.name
 ORDER BY mdod.name;
 ----
 AccumulableErrorCheck  11
-Arrange␠ReduceCollation  1
 Arrange␠ReduceMinsMaxes  3
 Arrange␠export␠iterative  2
 Arrange␠export␠iterative␠err  2
@@ -1118,8 +1111,6 @@ Distinct␠recursive␠err  3
 DistinctBy  49
 DistinctByErrorCheck  49
 ReduceAccumulable  11
-ReduceCollation  1
-ReduceCollation␠Errors  1
 ReduceInaccumulable  3
 ReduceInaccumulable␠Error␠Check  3
 ReduceMinsMaxes  3
@@ -1228,12 +1219,9 @@ GROUP BY mdod.name
 ORDER BY mdod.name
 ----
 AccumulableErrorCheck  2
-Arrange␠ReduceCollation  1
 Arrange␠ReduceMinsMaxes  1
 ArrangeAccumulable␠[val:␠empty]  2
 ReduceAccumulable  2
-ReduceCollation  1
-ReduceCollation␠Errors  1
 ReduceMinsMaxes  1
 ReduceMinsMaxes␠Error␠Check  1
 

--- a/test/sqllogictest/explain/aggregates.slt
+++ b/test/sqllogictest/explain/aggregates.slt
@@ -37,8 +37,16 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), array_agg(c) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), array_agg[order_by=[]](row(array[#2{c}]))]
-    ReadStorage materialize.public.t
+  Project (#0{a}, #1{array_agg}, #3{array_agg})
+    Join on=(#0{a} = #2{a}) type=differential
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+          Project (#0{a}, #1{b})
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{c}]))]
+          Project (#0{a}, #2{c})
+            ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -50,8 +58,16 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), string_agg(c, ',') FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), string_agg[order_by=[]](row(row(#2{c}, ",")))]
-    ReadStorage materialize.public.t
+  Project (#0{a}, #1{array_agg}, #3{string_agg})
+    Join on=(#0{a} = #2{a}) type=differential
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+          Project (#0{a}, #1{b})
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[string_agg[order_by=[]](row(row(#1{c}, ",")))]
+          Project (#0{a}, #2{c})
+            ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -63,8 +79,15 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), string_agg(c, ',' ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), string_agg[order_by=[#0{a} desc nulls_first]](row(row(#2{c}, ","), #1{b}))]
-    ReadStorage materialize.public.t
+  Project (#0{a}, #1{array_agg}, #3{string_agg})
+    Join on=(#0{a} = #2{a}) type=differential
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+          Project (#0{a}, #1{b})
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0{a}]]
+        Reduce group_by=[#0{a}] aggregates=[string_agg[order_by=[#0{a} desc nulls_first]](row(row(#2{c}, ","), #1{b}))]
+          ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -76,9 +99,21 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), max(#2{c})]
-    Filter (#2{c} != "x")
-      ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Filter (#2{c} != "x")
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #3{array_agg}, #1{max_c})
+      Join on=(#0{a} = #2{a}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[max(#1{c})]
+            Project (#0{a}, #2{c})
+              Get l0
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+            Project (#0{a}, #1{b})
+              Get l0
 
 Source materialize.public.t
   filter=((#2{c} != "x"))
@@ -91,11 +126,24 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
-  Project (#0{a}..=#2{max_b})
-    Filter (#3{count} > 1)
-      Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), max(#1{b}), count(*)]
-        Project (#0{a}, #1{b})
-          ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #5{array_agg}, #1{max_b})
+      Filter (#3{count} > 1)
+        Join on=(#0{a} = #2{a} = #4{a}) type=delta
+          ArrangeBy keys=[[#0{a}]]
+            Reduce group_by=[#0{a}] aggregates=[max(#1{b})]
+              Get l0
+          ArrangeBy keys=[[#0{a}]]
+            Reduce group_by=[#0{a}] aggregates=[count(*)]
+              Project (#0{a})
+                ReadStorage materialize.public.t
+          ArrangeBy keys=[[#0{a}]]
+            Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+              Get l0
 
 Source materialize.public.t
 
@@ -121,9 +169,19 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} asc nulls_last]](row(array[#1{b}], #1{b})), array_agg[order_by=[#0{a} desc nulls_first]](row(array[#1{b}], #1{b}))]
-    Project (#0{a}, #1{b})
-      ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #1{array_agg}, #3{array_agg})
+      Join on=(#0{a} = #2{a}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} asc nulls_last]](row(array[#1{b}], #1{b}))]
+            Get l0
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} desc nulls_first]](row(array[#1{b}], #1{b}))]
+            Get l0
 
 Source materialize.public.t
 
@@ -137,19 +195,31 @@ EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[array_agg[order_by=[#0{b} asc nulls_last]](row(array[#0{b}], #0{b})), array_agg[order_by=[#0{b} desc nulls_first]](row(array[#0{b}], #0{b})), sum(1)]
-        Project (#1{b})
-          ReadStorage materialize.public.t
+      Project (#1{b})
+        ReadStorage materialize.public.t
+    cte l1 =
+      CrossJoin type=delta
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(1)]
+            Project ()
+              ReadStorage materialize.public.t
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0{b} asc nulls_last]](row(array[#0{b}], #0{b}))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0{b} desc nulls_first]](row(array[#0{b}], #0{b}))]
+            Get l0
   Return
     Project (#0{array_agg}, #1{array_agg}, #3)
       Map ((#2{sum} > 0))
         Union
-          Get l0
+          Project (#1{array_agg}, #2{array_agg}, #0{sum})
+            Get l1
           Map (null, null, null)
             Union
               Negate
                 Project ()
-                  Get l0
+                  Get l1
               Constant
                 - ()
 
@@ -192,18 +262,29 @@ EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT s
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(#0{a}), jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#1{b}))), array_agg[order_by=[]](row(array[#1{b}]))]
-        Project (#0{a}, #1{b})
-          ReadStorage materialize.public.t
+      Project (#1{b})
+        ReadStorage materialize.public.t
+    cte l1 =
+      CrossJoin type=delta
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(#0{a})]
+            Project (#0{a})
+              ReadStorage materialize.public.t
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#0{b})))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[]](row(array[#0{b}]))]
+            Get l0
   Return
     Project (#0{sum_a}..=#2{array_agg}, #2{array_agg})
       Union
-        Get l0
+        Get l1
         Map (null, null, null)
           Union
             Negate
               Project ()
-                Get l0
+                Get l1
             Constant
               - ()
 
@@ -217,11 +298,19 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
-  Project (#0{a}, #1{array_agg})
-    Filter (#1{array_agg} = #2{array_agg})
-      Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} asc nulls_last]](row(array[#1{b}], #1{b})), array_agg[order_by=[#0{a} desc nulls_first]](row(array[#1{b}], #1{b}))]
-        Project (#0{a}, #1{b})
-          ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #1{array_agg})
+      Join on=(#0{a} = #2{a} AND #1{array_agg} = #3{array_agg}) type=differential
+        ArrangeBy keys=[[#0{a}, #1{array_agg}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} asc nulls_last]](row(array[#1{b}], #1{b}))]
+            Get l0
+        ArrangeBy keys=[[#0{a}, #1{array_agg}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[#0{a} desc nulls_first]](row(array[#1{b}], #1{b}))]
+            Get l0
 
 Source materialize.public.t
 
@@ -234,9 +323,19 @@ EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a
 
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), array_agg[order_by=[]](row(array[digest(text_to_bytea(#1{b}), "sha256")]))]
-    Project (#0{a}, #1{b})
-      ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #3{array_agg}, #1{array_agg})
+      Join on=(#0{a} = #2{a}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[digest(text_to_bytea(#1{b}), "sha256")]))]
+            Get l0
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+            Get l0
 
 Source materialize.public.t
 
@@ -249,9 +348,19 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH (humanized expressions) AS VERBOSE TEXT FOR SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}])), array_agg[order_by=[]](row(array[case when (#0{a} = 1) then "ooo" else #1{b} end]))]
-    Project (#0{a}, #1{b})
-      ReadStorage materialize.public.t
+  With
+    cte l0 =
+      Project (#0{a}, #1{b})
+        ReadStorage materialize.public.t
+  Return
+    Project (#0{a}, #1{array_agg}, #3{array_agg})
+      Join on=(#0{a} = #2{a}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[#1{b}]))]
+            Get l0
+        ArrangeBy keys=[[#0{a}]]
+          Reduce group_by=[#0{a}] aggregates=[array_agg[order_by=[]](row(array[case when (#0{a} = 1) then "ooo" else #1{b} end]))]
+            Get l0
 
 Source materialize.public.t
 

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -44,18 +44,31 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), array_agg(c) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[#2{c}])))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1{b}]), row(array[#2{c}]))
-    Get::PassArrangements materialize.public.t
-      raw=true
-
-Source materialize.public.t
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(array[#1{b}]))
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1{c}])))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(array[#1{c}]))
+      Get::Collection materialize.public.t
+        project=(#0, #2)
+        raw=true
 
 Target cluster: quickstart
 
@@ -65,18 +78,31 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), string_agg(c, ',') FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row(#2{c}, ","))))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1{b}]), row(row(#2{c}, ",")))
-    Get::PassArrangements materialize.public.t
-      raw=true
-
-Source materialize.public.t
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(array[#1{b}]))
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row(#1{c}, ","))))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row(#1{c}, ",")))
+      Get::Collection materialize.public.t
+        project=(#0, #2)
+        raw=true
 
 Target cluster: quickstart
 
@@ -86,16 +112,30 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), string_agg(c, ',' ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    aggrs[1]=(1, string_agg[order_by=[#0 desc nulls_first]](row(row(#2{c}, ","), #1{b})))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1{b}]), row(row(#2{c}, ","), #1{b}))
-    Get::PassArrangements materialize.public.t
-      raw=true
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(array[#1{b}]))
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[#0 desc nulls_first]](row(row(#2{c}, ","), #1{b})))
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#3)
+        map=(row(row(#2{c}, ","), #1{b}))
+      Get::PassArrangements materialize.public.t
+        raw=true
 
 Source materialize.public.t
 
@@ -107,22 +147,40 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[b, h]
-    hierarchical
-      aggr_funcs=[max]
-      skips=[1]
-      monotonic
-      must_consolidate
-    basic
-      aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #2)
-      map=(row(array[#1{b}]))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        closure
+          project=(#0, #2, #1)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Hierarchical
+        aggr_funcs=[max]
+        skips=[0]
+        monotonic
+        must_consolidate
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#1)
+        Get::Collection l0
+          project=(#0, #2)
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}]))
+        Get::Collection l0
+          project=(#0, #1)
+          raw=true
 
 Source materialize.public.t
   filter=((#2{c} != "x"))
@@ -135,27 +193,80 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[b, h, a]
-    accumulable
-      simple_aggrs[0]=(0, 2, count(*))
-    hierarchical
-      aggr_funcs=[max]
-      skips=[1]
-      monotonic
-      must_consolidate
-    basic
-      aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#2, #1, #3)
-      map=(row(array[#1{b}]), true)
-    mfp_after
-      project=(#0..=#2)
-      filter=((#3 > 1))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Delta
+      plan_path[0]
+        delta_stage[1]
+          closure
+            project=(#0, #2, #1)
+          lookup={ relation=2, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1)
+            filter=((#2 > 1))
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        source={ relation=0, key=[#0] }
+      plan_path[1]
+        delta_stage[1]
+          closure
+            project=(#1, #3, #2)
+          lookup={ relation=2, key=[#0] }
+          stream={ key=[#2], thinning=(#0, #1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1, #0)
+          lookup={ relation=0, key=[#0] }
+          stream={ key=[#0], thinning=() }
+        initial_closure
+          project=(#0)
+          filter=((#1 > 1))
+        source={ relation=1, key=[#0] }
+      plan_path[2]
+        delta_stage[1]
+          lookup={ relation=0, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1)
+            filter=((#2 > 1))
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        source={ relation=2, key=[#0] }
+      Reduce::Hierarchical
+        aggr_funcs=[max]
+        skips=[0]
+        monotonic
+        must_consolidate
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#1)
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, count(*))
+        key_plan=id
+        val_plan
+          project=(#1)
+          map=(true)
+        Get::Collection materialize.public.t
+          project=(#0)
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}]))
+        Get::PassArrangements l0
+          raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -191,16 +302,34 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1{b}], #1{b})))
-    aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#1{b}], #1{b})))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#2, #2)
-      map=(row(array[#1{b}], #1{b}))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1{b}], #1{b})))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}], #1{b}))
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#1{b}], #1{b})))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}], #1{b}))
+        Get::PassArrangements l0
+          raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -215,41 +344,83 @@ EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT array_agg(b ORDER BY b ASC), ar
 Explained Query:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[b, b, a]
-        accumulable
-          simple_aggrs[0]=(0, 2, sum(1))
-        basic
-          aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#0{b}], #0{b})))
-          aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#0{b}], #0{b})))
-        key_plan
-          project=()
-        val_plan
-          project=(#1, #1, #2)
-          map=(row(array[#0{b}], #0{b}), 1)
-        Get::Collection materialize.public.t
-          raw=true
+      Get::Collection materialize.public.t
+        raw=true
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #2, #1)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(0, 0, sum(1))
+          key_plan=id
+          val_plan
+            project=(#0)
+            map=(1)
+          Get::Collection materialize.public.t
+            project=()
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#0{b}], #0{b})))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(array[#0{b}], #0{b}))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#0{b}], #0{b})))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(array[#0{b}], #0{b}))
+          Get::PassArrangements l0
+            raw=true
   Return
     Mfp
       project=(#0, #1, #3)
       map=((#2 > 0))
       Union
-        ArrangeBy
-          input_key=[]
+        Get::Collection l1
+          project=(#1, #2, #0)
           raw=true
-          Get::PassArrangements l0
-            raw=false
-            arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
         Mfp
           project=(#0..=#2)
           map=(null, null, null)
           Union consolidate_output=true
             Negate
-              Get::Arrangement l0
+              Get::Collection l1
                 project=()
-                key=
-                raw=false
-                arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
+                raw=true
             Constant
               - ()
 
@@ -312,40 +483,81 @@ EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT sum(a), jsonb_agg(b), array_agg
 Explained Query:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, b]
-        accumulable
+      Get::Collection materialize.public.t
+        project=(#1)
+        raw=true
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #2, #1)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
           simple_aggrs[0]=(0, 0, sum(#0{a}))
-        basic
-          aggrs[0]=(1, jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#1{b}))))
-          aggrs[1]=(2, array_agg[order_by=[]](row(array[#1{b}])))
-        key_plan
-          project=()
-        val_plan
-          project=(#0, #2, #3)
-          map=(row(jsonbable_to_jsonb(#1{b})), row(array[#1{b}]))
-        Get::Collection materialize.public.t
-          raw=true
+          key_plan
+            project=()
+          val_plan=id
+          Get::Collection materialize.public.t
+            project=(#0)
+            raw=true
+        Reduce::Basic
+          aggr=(0, jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#0{b}))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(jsonbable_to_jsonb(#0{b})))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[]](row(array[#0{b}])))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(array[#0{b}]))
+          Get::PassArrangements l0
+            raw=true
   Return
     Mfp
       project=(#0..=#2, #2)
       Union
-        ArrangeBy
-          input_key=[]
+        Get::PassArrangements l1
           raw=true
-          Get::PassArrangements l0
-            raw=false
-            arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
         Mfp
           project=(#0..=#2)
           map=(null, null, null)
           Union consolidate_output=true
             Negate
-              Get::Arrangement l0
+              Get::Collection l1
                 project=()
-                key=
-                raw=false
-                arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
+                raw=true
             Constant
               - ()
 
@@ -360,19 +572,42 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1{b}], #1{b})))
-    aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#1{b}], #1{b})))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#2, #2)
-      map=(row(array[#1{b}], #1{b}))
-    mfp_after
-      project=(#0, #1)
-      filter=((#1 = #2))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0, #1] }
+        stream={ key=[#0, #1], thinning=() }
+      source={ relation=0, key=[#0, #1] }
+      ArrangeBy
+        input_key=[#0]
+        raw=false
+        arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1{b}], #1{b})))
+          key_plan
+            project=(#0)
+          val_plan
+            project=(#2)
+            map=(row(array[#1{b}], #1{b}))
+          Get::PassArrangements l0
+            raw=true
+      ArrangeBy
+        input_key=[#0]
+        raw=false
+        arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#1{b}], #1{b})))
+          key_plan
+            project=(#0)
+          val_plan
+            project=(#2)
+            map=(row(array[#1{b}], #1{b}))
+          Get::PassArrangements l0
+            raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -386,16 +621,36 @@ EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), array_agg(sha2
 
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[digest(text_to_bytea(#1{b}), "sha256")])))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#2, #3)
-      map=(row(array[#1{b}]), row(array[digest(text_to_bytea(#1{b}), "sha256")]))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        closure
+          project=(#0, #2, #1)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[digest(text_to_bytea(#1{b}), "sha256")])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[digest(text_to_bytea(#1{b}), "sha256")]))
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}]))
+        Get::PassArrangements l0
+          raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -409,16 +664,34 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1{b}])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[case when (#0{a} = 1) then "ooo" else #1{b} end])))
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#2, #3)
-      map=(row(array[#1{b}]), row(array[case when (#0{a} = 1) then "ooo" else #1{b} end]))
-    Get::Collection materialize.public.t
-      raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1{b}])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[#1{b}]))
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[case when (#0{a} = 1) then "ooo" else #1{b} end])))
+        key_plan
+          project=(#0)
+        val_plan
+          project=(#2)
+          map=(row(array[case when (#0{a} = 1) then "ooo" else #1{b} end]))
+        Get::PassArrangements l0
+          raw=true
 
 Source materialize.public.t
   project=(#0, #1)

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -3080,700 +3080,164 @@ GROUP BY a
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 5,
         "node": {
-          "Reduce": {
-            "input_key": [
+          "Join": {
+            "inputs": [
               {
-                "Column": [
-                  0,
-                  "a"
-                ]
-              }
-            ],
-            "input": {
-              "lir_id": 1,
-              "node": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": [
-                              0,
-                              "a"
-                            ]
-                          }
-                        ],
-                        [
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
                           0,
-                          1
-                        ],
-                        [
-                          1
-                        ]
-                      ]
-                    ]
-                  },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
-                          "Column": [
-                            1,
-                            "b"
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
+                          "a"
                         ]
                       }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    3,
-                    4
-                  ],
-                  "input_arity": 2
-                }
-              }
-            },
-            "plan": {
-              "Basic": {
-                "Multiple": [
-                  [
-                    0,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
+                    ],
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
                             }
                           },
-                          "exprs": [
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
                             {
                               "CallVariadic": {
                                 "func": {
                                   "RecordCreate": {
                                     "field_names": [
-                                      "value",
-                                      "sep"
+                                      ""
                                     ]
                                   }
                                 },
                                 "exprs": [
                                   {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": [
-                                              1,
-                                              "b"
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
                                           ]
                                         }
                                       },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  [
-                    1,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": [
-                                              1,
-                                              "b"
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
                                               ]
                                             }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
                                           }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
                                           ]
                                         }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   }
                                 ]
                               }
                             }
-                          ]
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
                         }
-                      },
-                      "distinct": false
-                    }
-                  ]
-                ]
-              }
-            },
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2
-              ],
-              "input_arity": 3
-            }
-          }
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Basic (global aggregate).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  STRING_AGG(b::text || '1',  ','),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "lir_id": 11,
-        "node": {
-          "Let": {
-            "id": 0,
-            "value": {
-              "lir_id": 2,
-              "node": {
-                "Reduce": {
-                  "input_key": null,
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [
-                                {
-                                  "Column": [
-                                    0,
-                                    "a"
-                                  ]
-                                }
-                              ],
-                              [
-                                0,
-                                1
-                              ],
-                              [
-                                1
-                              ]
-                            ]
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": [
-                                  0,
-                                  "a"
-                                ]
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
                       }
                     },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "predicates": [],
-                        "projection": [
-                          2,
-                          3
-                        ],
-                        "input_arity": 1
-                      }
-                    }
-                  },
-                  "plan": {
-                    "Basic": {
-                      "Multiple": [
-                        [
-                          0,
-                          {
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
                             "func": {
                               "StringAgg": {
                                 "order_by": []
@@ -3810,7 +3274,7 @@ FROM t
                                                 },
                                                 "expr": {
                                                   "Column": [
-                                                    0,
+                                                    1,
                                                     "b"
                                                   ]
                                                 }
@@ -3859,11 +3323,177 @@ FROM t
                               }
                             },
                             "distinct": false
-                          }
-                        ],
-                        [
-                          1,
-                          {
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
                             "func": {
                               "StringAgg": {
                                 "order_by": []
@@ -3900,7 +3530,7 @@ FROM t
                                                 },
                                                 "expr": {
                                                   "Column": [
-                                                    0,
+                                                    1,
                                                     "b"
                                                   ]
                                                 }
@@ -3949,199 +3579,787 @@ FROM t
                               }
                             },
                             "distinct": false
-                          }
-                        ]
-                      ]
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
                     }
-                  },
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Linear": {
+                "source_relation": 0,
+                "source_key": [
+                  {
+                    "Column": [
                       0,
+                      null
+                    ]
+                  }
+                ],
+                "initial_closure": null,
+                "stage_plans": [
+                  {
+                    "lookup_relation": 1,
+                    "stream_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "stream_thinning": [
                       1
                     ],
-                    "input_arity": 2
+                    "lookup_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    }
+                  }
+                ],
+                "final_closure": null
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Basic (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+SELECT
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 15,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": [
+                              0,
+                              "a"
+                            ]
+                          }
+                        ],
+                        [
+                          0,
+                          1
+                        ],
+                        [
+                          1
+                        ]
+                      ]
+                    ]
+                  },
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": [
+                            0,
+                            "a"
+                          ]
+                        }
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 14,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input_key": [],
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 6,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
                             "node": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
                                 },
-                                "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      [
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Linear": {
+                            "source_relation": 0,
+                            "source_key": [],
+                            "initial_closure": null,
+                            "stage_plans": [
+                              {
+                                "lookup_relation": 1,
+                                "stream_key": [],
+                                "stream_thinning": [
+                                  0
+                                ],
+                                "lookup_key": [],
+                                "closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
                                         0,
                                         1
                                       ],
-                                      [
-                                        0,
-                                        1
-                                      ]
-                                    ]
-                                  ]
+                                      "input_arity": 2
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "final_closure": null
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "body": {
+                    "lir_id": 13,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 7,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "keys": {
+                                  "raw": true,
+                                  "arranged": []
                                 },
                                 "plan": "PassArrangements"
                               }
                             }
                           },
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1
-                            ],
-                            "input_arity": 2
-                          },
-                          "forms": {
-                            "raw": true,
-                            "arranged": []
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
-                            "lir_id": 7,
+                          {
+                            "lir_id": 12,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 11,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 9,
                                           "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    [
-                                                      0,
-                                                      1
-                                                    ],
-                                                    [
-                                                      0,
-                                                      1
-                                                    ]
-                                                  ]
-                                                ]
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 2
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 8,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
+                                                    },
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": []
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 2
+                                                      }
+                                                    }
                                                   }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 10,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
                                                 ]
                                               }
                                             }
                                           }
                                         }
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
-                                        }
-                                      }
+                                      ],
+                                      "consolidate_output": true
                                     }
                                   }
-                                ],
-                                "consolidate_output": true
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
                               }
                             }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
-                        }
+                          }
+                        ],
+                        "consolidate_output": false
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  }
                 }
               }
             }
@@ -4164,523 +4382,1407 @@ MATERIALIZED VIEW collated_group_by_mv
     {
       "id": "materialize.public.collated_group_by_mv",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 9,
         "node": {
-          "Reduce": {
-            "input_key": [
+          "Join": {
+            "inputs": [
               {
-                "Column": [
-                  0,
-                  "a"
-                ]
-              }
-            ],
-            "input": {
-              "lir_id": 1,
-              "node": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": [
-                              0,
-                              "a"
-                            ]
-                          }
-                        ],
-                        [
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
                           0,
-                          1
-                        ],
-                        [
-                          1
+                          "a"
                         ]
-                      ]
-                    ]
-                  },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
-                          "Column": [
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
                             1,
-                            "b"
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Hierarchical": {
+                        "Bucketed": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            0,
+                            0
+                          ],
+                          "buckets": [
+                            268435456,
+                            16777216,
+                            1048576,
+                            65536,
+                            4096,
+                            256,
+                            16
                           ]
                         }
                       }
                     },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
                             }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": [
+                                1,
+                                "b"
+                              ]
+                            },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": [
+                                1,
+                                "b"
+                              ]
+                            },
+                            "distinct": false
                           }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            1,
+                            {
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": [
+                                  1,
+                                  "b"
+                                ]
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
+                            {
+                              "func": "Count",
+                              "expr": {
+                                "Column": [
+                                  1,
+                                  "b"
+                                ]
+                              },
+                              "distinct": true
+                            }
+                          ]
                         ]
                       }
                     },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 6,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 5,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
                             ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
                                         {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
                                           }
                                         },
                                         {
-                                          "scalar_type": "String",
-                                          "nullable": false
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
                                         }
                                       ]
                                     }
                                   }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
+                                ]
+                              }
                             }
-                          }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 8,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
                         ]
                       }
+                    ],
+                    "input": {
+                      "lir_id": 7,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
                     }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    1,
-                    3,
-                    1,
-                    1,
-                    1,
-                    4
-                  ],
-                  "input_arity": 2
+                  }
                 }
               }
-            },
+            ],
             "plan": {
-              "Collation": {
-                "accumulable": {
-                  "full_aggrs": [
-                    {
-                      "func": "Count",
-                      "expr": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
                         "Column": [
-                          1,
-                          "b"
+                          0,
+                          null
                         ]
-                      },
-                      "distinct": true
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
                     },
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": [
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
                           1,
-                          "b"
-                        ]
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
                       },
-                      "distinct": false
-                    }
-                  ],
-                  "simple_aggrs": [
-                    [
-                      1,
-                      4,
                       {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": [
-                            1,
-                            "b"
-                          ]
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ],
-                  "distinct_aggrs": [
-                    [
-                      0,
-                      0,
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5
+                              ],
+                              "input_arity": 6
+                            }
+                          }
+                        }
+                      },
                       {
-                        "func": "Count",
-                        "expr": {
-                          "Column": [
-                            1,
-                            "b"
-                          ]
-                        },
-                        "distinct": true
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                5,
+                                1,
+                                2,
+                                4,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
                       }
-                    ]
-                  ]
-                },
-                "hierarchical": {
-                  "Bucketed": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
                     ],
-                    "skips": [
-                      2,
-                      0
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
                     ],
-                    "buckets": [
-                      268435456,
-                      16777216,
-                      1048576,
-                      65536,
-                      4096,
-                      256,
-                      16
-                    ]
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                4,
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                0,
+                                4,
+                                5,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              5,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 3,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              5,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                7,
+                                2,
+                                3,
+                                5,
+                                6
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
                   }
-                },
-                "basic": {
-                  "Multiple": [
-                    [
-                      1,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": [
-                                                1,
-                                                "b"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  49
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    [
-                      5,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": [
-                                                1,
-                                                "b"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  50
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ]
-                },
-                "aggregate_types": [
-                  "Accumulable",
-                  "Basic",
-                  "Hierarchical",
-                  "Hierarchical",
-                  "Accumulable",
-                  "Basic"
                 ]
               }
-            },
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6
-              ],
-              "input_arity": 7
             }
           }
         }
@@ -4701,18 +5803,1424 @@ SELECT * FROM collated_group_by
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 9,
         "node": {
-          "Reduce": {
-            "input_key": [
+          "Join": {
+            "inputs": [
               {
-                "Column": [
-                  0,
-                  "a"
-                ]
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Hierarchical": {
+                        "Monotonic": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            0,
+                            0
+                          ],
+                          "must_consolidate": true
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": [
+                                1,
+                                "b"
+                              ]
+                            },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": [
+                                1,
+                                "b"
+                              ]
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            1,
+                            {
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": [
+                                  1,
+                                  "b"
+                                ]
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
+                            {
+                              "func": "Count",
+                              "expr": {
+                                "Column": [
+                                  1,
+                                  "b"
+                                ]
+                              },
+                              "distinct": true
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 6,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 5,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 8,
+                "node": {
+                  "Reduce": {
+                    "input_key": [
+                      {
+                        "Column": [
+                          0,
+                          "a"
+                        ]
+                      }
+                    ],
+                    "input": {
+                      "lir_id": 7,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": [
+                                      0,
+                                      "a"
+                                    ]
+                                  }
+                                ],
+                                [
+                                  0,
+                                  1
+                                ],
+                                [
+                                  1
+                                ]
+                              ]
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": [
+                                                    1,
+                                                    "b"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
               }
             ],
-            "input": {
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5
+                              ],
+                              "input_arity": 6
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                5,
+                                1,
+                                2,
+                                4,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                4,
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                0,
+                                4,
+                                5,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              5,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 3,
+                    "source_key": [
+                      {
+                        "Column": [
+                          0,
+                          null
+                        ]
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              3,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": [
+                              5,
+                              null
+                            ]
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": [
+                              0,
+                              null
+                            ]
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                7,
+                                2,
+                                3,
+                                5,
+                                6
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Collated (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+MATERIALIZED VIEW collated_global_mv
+----
+{
+  "plans": [
+    {
+      "id": "materialize.public.collated_global_mv",
+      "plan": {
+        "lir_id": 19,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
               "lir_id": 1,
               "node": {
                 "Get": {
@@ -4743,1289 +7251,1305 @@ SELECT * FROM collated_group_by
                       ]
                     ]
                   },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
                           "Column": [
-                            1,
-                            "b"
+                            0,
+                            "a"
                           ]
                         }
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": [
-                                        2,
-                                        null
-                                      ]
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    1,
-                    3,
-                    1,
-                    1,
-                    1,
-                    4
-                  ],
-                  "input_arity": 2
-                }
-              }
-            },
-            "plan": {
-              "Collation": {
-                "accumulable": {
-                  "full_aggrs": [
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": [
-                          1,
-                          "b"
-                        ]
-                      },
-                      "distinct": true
-                    },
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": [
-                          1,
-                          "b"
-                        ]
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  "simple_aggrs": [
-                    [
-                      1,
-                      4,
+                      ],
+                      null,
                       {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": [
-                            1,
-                            "b"
-                          ]
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ],
-                  "distinct_aggrs": [
-                    [
-                      0,
-                      0,
-                      {
-                        "func": "Count",
-                        "expr": {
-                          "Column": [
-                            1,
-                            "b"
-                          ]
-                        },
-                        "distinct": true
-                      }
-                    ]
-                  ]
-                },
-                "hierarchical": {
-                  "Monotonic": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
-                    ],
-                    "skips": [
-                      2,
-                      0
-                    ],
-                    "must_consolidate": true
-                  }
-                },
-                "basic": {
-                  "Multiple": [
-                    [
-                      1,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": [
-                                                1,
-                                                "b"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  49
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    [
-                      5,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": [
-                                                1,
-                                                "b"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  50
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ]
-                },
-                "aggregate_types": [
-                  "Accumulable",
-                  "Basic",
-                  "Hierarchical",
-                  "Hierarchical",
-                  "Accumulable",
-                  "Basic"
-                ]
-              }
-            },
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6
-              ],
-              "input_arity": 7
-            }
-          }
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Collated (global aggregate).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-MATERIALIZED VIEW collated_global_mv
-----
-{
-  "plans": [
-    {
-      "id": "materialize.public.collated_global_mv",
-      "plan": {
-        "lir_id": 11,
-        "node": {
-          "Let": {
-            "id": 0,
-            "value": {
-              "lir_id": 2,
-              "node": {
-                "Reduce": {
-                  "input_key": null,
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [
-                                {
-                                  "Column": [
-                                    0,
-                                    "a"
-                                  ]
-                                }
-                              ],
-                              [
-                                0,
-                                1
-                              ],
-                              [
-                                1
-                              ]
-                            ]
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": [
-                                  0,
-                                  "a"
-                                ]
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
                         "expressions": [],
                         "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
-                      }
-                    },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "predicates": [],
                         "projection": [
-                          0,
-                          2,
-                          0,
-                          0,
-                          0,
-                          3
+                          1
                         ],
-                        "input_arity": 1
+                        "input_arity": 2
                       }
-                    }
-                  },
-                  "plan": {
-                    "Collation": {
-                      "accumulable": {
-                        "full_aggrs": [
-                          {
-                            "func": "Count",
-                            "expr": {
-                              "Column": [
-                                0,
-                                "b"
-                              ]
-                            },
-                            "distinct": true
-                          },
-                          {
-                            "func": "SumInt32",
-                            "expr": {
-                              "Column": [
-                                0,
-                                "b"
-                              ]
-                            },
-                            "distinct": false
-                          }
-                        ],
-                        "simple_aggrs": [
-                          [
-                            1,
-                            4,
-                            {
-                              "func": "SumInt32",
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ],
-                        "distinct_aggrs": [
-                          [
-                            0,
-                            0,
-                            {
-                              "func": "Count",
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              },
-                              "distinct": true
-                            }
-                          ]
-                        ]
-                      },
-                      "hierarchical": {
-                        "Bucketed": {
-                          "aggr_funcs": [
-                            "MinInt32",
-                            "MaxInt32"
-                          ],
-                          "skips": [
-                            2,
-                            0
-                          ],
-                          "buckets": [
-                            268435456,
-                            16777216,
-                            1048576,
-                            65536,
-                            4096,
-                            256,
-                            16
-                          ]
-                        }
-                      },
-                      "basic": {
-                        "Multiple": [
-                          [
-                            1,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": [
-                                                      0,
-                                                      "b"
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        49
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ],
-                          [
-                            5,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": [
-                                                      0,
-                                                      "b"
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        50
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ]
-                      },
-                      "aggregate_types": [
-                        "Accumulable",
-                        "Basic",
-                        "Hierarchical",
-                        "Hierarchical",
-                        "Accumulable",
-                        "Basic"
-                      ]
-                    }
-                  },
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      1,
-                      2,
-                      3,
-                      4,
-                      5
-                    ],
-                    "input_arity": 6
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 18,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input_key": [],
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 10,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
                             "node": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
                                 },
-                                "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      [
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
                                         0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
+                                        0
                                       ],
-                                      [
-                                        0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
-                                      ]
-                                    ]
-                                  ]
+                                      "input_arity": 1
+                                    }
+                                  }
                                 },
-                                "plan": "PassArrangements"
+                                "plan": {
+                                  "Hierarchical": {
+                                    "Bucketed": {
+                                      "aggr_funcs": [
+                                        "MinInt32",
+                                        "MaxInt32"
+                                      ],
+                                      "skips": [
+                                        0,
+                                        0
+                                      ],
+                                      "buckets": [
+                                        268435456,
+                                        16777216,
+                                        1048576,
+                                        65536,
+                                        4096,
+                                        256,
+                                        16
+                                      ]
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
                               }
                             }
                           },
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 6
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Accumulable": {
+                                    "full_aggrs": [
+                                      {
+                                        "func": "Count",
+                                        "expr": {
+                                          "Column": [
+                                            0,
+                                            "b"
+                                          ]
+                                        },
+                                        "distinct": true
+                                      },
+                                      {
+                                        "func": "SumInt32",
+                                        "expr": {
+                                          "Column": [
+                                            0,
+                                            "b"
+                                          ]
+                                        },
+                                        "distinct": false
+                                      }
+                                    ],
+                                    "simple_aggrs": [
+                                      [
+                                        1,
+                                        1,
+                                        {
+                                          "func": "SumInt32",
+                                          "expr": {
+                                            "Column": [
+                                              0,
+                                              "b"
+                                            ]
+                                          },
+                                          "distinct": false
+                                        }
+                                      ]
+                                    ],
+                                    "distinct_aggrs": [
+                                      [
+                                        0,
+                                        0,
+                                        {
+                                          "func": "Count",
+                                          "expr": {
+                                            "Column": [
+                                              0,
+                                              "b"
+                                            ]
+                                          },
+                                          "distinct": true
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
+                              }
+                            }
                           },
-                          "forms": {
-                            "raw": true,
-                            "arranged": []
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
+                          {
                             "lir_id": 7,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
-                                          "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ],
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ]
-                                                  ]
-                                                ]
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 6
-                                                  }
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 6,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
                                                 ]
                                               }
-                                            }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
                                           }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 9,
+                            "node": {
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 8,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Delta": {
+                            "path_plans": [
+                              {
+                                "source_relation": 0,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3
+                                          ],
+                                          "input_arity": 4
                                         }
                                       }
                                     }
                                   },
                                   {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
                                         }
                                       }
                                     }
                                   }
                                 ],
-                                "consolidate_output": true
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 1,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            2,
+                                            3,
+                                            0,
+                                            1
+                                          ],
+                                          "input_arity": 4
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 2,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 3,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            5,
+                                            4
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
                               }
-                            }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        49
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": false
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
+                            ]
+                          }
                         }
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  },
+                  "body": {
+                    "lir_id": 17,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 11,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "keys": {
+                                  "raw": true,
+                                  "arranged": []
+                                },
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [],
+                                    "projection": [
+                                      2,
+                                      4,
+                                      0,
+                                      1,
+                                      3,
+                                      5
+                                    ],
+                                    "input_arity": 6
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 16,
+                            "node": {
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 15,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 13,
+                                          "node": {
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 12,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
+                                                    },
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": []
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 6
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 14,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "consolidate_output": true
+                                    }
+                                  }
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
+                              }
+                            }
+                          }
+                        ],
+                        "consolidate_output": false
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6048,794 +8572,1332 @@ SELECT * FROM collated_global
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 11,
+        "lir_id": 19,
         "node": {
           "Let": {
             "id": 0,
             "value": {
-              "lir_id": 2,
+              "lir_id": 1,
               "node": {
-                "Reduce": {
-                  "input_key": null,
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [
-                                {
-                                  "Column": [
-                                    0,
-                                    "a"
-                                  ]
-                                }
-                              ],
-                              [
-                                0,
-                                1
-                              ],
-                              [
-                                1
-                              ]
-                            ]
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": [
-                                  0,
-                                  "a"
-                                ]
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        }
-                      }
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
                     }
                   },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
-                      }
-                    },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
                           {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": [
-                                              1,
-                                              null
-                                            ]
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
+                            "Column": [
+                              0,
+                              "a"
+                            ]
                           }
                         ],
-                        "predicates": [],
-                        "projection": [
+                        [
                           0,
-                          2,
-                          0,
-                          0,
-                          0,
-                          3
+                          1
                         ],
-                        "input_arity": 1
-                      }
-                    }
+                        [
+                          1
+                        ]
+                      ]
+                    ]
                   },
                   "plan": {
-                    "Collation": {
-                      "accumulable": {
-                        "full_aggrs": [
-                          {
-                            "func": "Count",
-                            "expr": {
-                              "Column": [
-                                0,
-                                "b"
-                              ]
-                            },
-                            "distinct": true
-                          },
-                          {
-                            "func": "SumInt32",
-                            "expr": {
-                              "Column": [
-                                0,
-                                "b"
-                              ]
-                            },
-                            "distinct": false
-                          }
-                        ],
-                        "simple_aggrs": [
-                          [
-                            1,
-                            4,
-                            {
-                              "func": "SumInt32",
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ],
-                        "distinct_aggrs": [
-                          [
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": [
                             0,
-                            0,
-                            {
-                              "func": "Count",
-                              "expr": {
-                                "Column": [
-                                  0,
-                                  "b"
-                                ]
-                              },
-                              "distinct": true
-                            }
+                            "a"
                           ]
-                        ]
-                      },
-                      "hierarchical": {
-                        "Monotonic": {
-                          "aggr_funcs": [
-                            "MinInt32",
-                            "MaxInt32"
-                          ],
-                          "skips": [
-                            2,
-                            0
-                          ],
-                          "must_consolidate": true
                         }
-                      },
-                      "basic": {
-                        "Multiple": [
-                          [
-                            1,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": [
-                                                      0,
-                                                      "b"
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        49
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ],
-                          [
-                            5,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": [
-                                                      0,
-                                                      "b"
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        50
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ]
-                      },
-                      "aggregate_types": [
-                        "Accumulable",
-                        "Basic",
-                        "Hierarchical",
-                        "Hierarchical",
-                        "Accumulable",
-                        "Basic"
-                      ]
-                    }
-                  },
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      1,
-                      2,
-                      3,
-                      4,
-                      5
-                    ],
-                    "input_arity": 6
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 18,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input_key": [],
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 10,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
                             "node": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
                                 },
-                                "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      [
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
                                         0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
+                                        0
                                       ],
-                                      [
-                                        0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
-                                      ]
-                                    ]
-                                  ]
+                                      "input_arity": 1
+                                    }
+                                  }
                                 },
-                                "plan": "PassArrangements"
+                                "plan": {
+                                  "Hierarchical": {
+                                    "Monotonic": {
+                                      "aggr_funcs": [
+                                        "MinInt32",
+                                        "MaxInt32"
+                                      ],
+                                      "skips": [
+                                        0,
+                                        0
+                                      ],
+                                      "must_consolidate": true
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
                               }
                             }
                           },
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 6
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Accumulable": {
+                                    "full_aggrs": [
+                                      {
+                                        "func": "Count",
+                                        "expr": {
+                                          "Column": [
+                                            0,
+                                            "b"
+                                          ]
+                                        },
+                                        "distinct": true
+                                      },
+                                      {
+                                        "func": "SumInt32",
+                                        "expr": {
+                                          "Column": [
+                                            0,
+                                            "b"
+                                          ]
+                                        },
+                                        "distinct": false
+                                      }
+                                    ],
+                                    "simple_aggrs": [
+                                      [
+                                        1,
+                                        1,
+                                        {
+                                          "func": "SumInt32",
+                                          "expr": {
+                                            "Column": [
+                                              0,
+                                              "b"
+                                            ]
+                                          },
+                                          "distinct": false
+                                        }
+                                      ]
+                                    ],
+                                    "distinct_aggrs": [
+                                      [
+                                        0,
+                                        0,
+                                        {
+                                          "func": "Count",
+                                          "expr": {
+                                            "Column": [
+                                              0,
+                                              "b"
+                                            ]
+                                          },
+                                          "distinct": true
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
+                              }
+                            }
                           },
-                          "forms": {
-                            "raw": true,
-                            "arranged": []
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
+                          {
                             "lir_id": 7,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
-                                          "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ],
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ]
-                                                  ]
-                                                ]
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 6
-                                                  }
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 6,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
                                                 ]
                                               }
-                                            }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
                                           }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 9,
+                            "node": {
+                              "Reduce": {
+                                "input_key": null,
+                                "input": {
+                                  "lir_id": 8,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": []
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": [
+                                                                0,
+                                                                "b"
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Delta": {
+                            "path_plans": [
+                              {
+                                "source_relation": 0,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3
+                                          ],
+                                          "input_arity": 4
                                         }
                                       }
                                     }
                                   },
                                   {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
                                         }
                                       }
                                     }
                                   }
                                 ],
-                                "consolidate_output": true
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 1,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            2,
+                                            3,
+                                            0,
+                                            1
+                                          ],
+                                          "input_arity": 4
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 2,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 3,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            5,
+                                            4
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
                               }
-                            }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        49
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": false
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
+                            ]
+                          }
                         }
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  },
+                  "body": {
+                    "lir_id": 17,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 11,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "keys": {
+                                  "raw": true,
+                                  "arranged": []
+                                },
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [],
+                                    "projection": [
+                                      2,
+                                      4,
+                                      0,
+                                      1,
+                                      3,
+                                      5
+                                    ],
+                                    "input_arity": 6
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 16,
+                            "node": {
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 15,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 13,
+                                          "node": {
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 12,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
+                                                    },
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": []
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 6
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 14,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "consolidate_output": true
+                                    }
+                                  }
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
+                              }
+                            }
+                          }
+                        ],
+                        "consolidate_output": false
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -674,18 +674,33 @@ FROM t
 GROUP BY a
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "1"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "2"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -705,37 +720,47 @@ FROM t
 Explained Query:
   With
     cte l0 =
-      Reduce::Basic
-        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
-        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
-        key_plan
-          project=()
-        val_plan
-          project=(#2, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "1"), ",")))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "2"), ",")))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::PassArrangements l1
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
       Mfp
         project=(#0, #1)
         map=(null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+              raw=true
           Constant
             - ()
 
@@ -752,27 +777,116 @@ EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
 MATERIALIZED VIEW collated_group_by_mv
 ----
 materialize.public.collated_group_by_mv:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1{b}))
-      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
-    hierarchical
+  Join::Delta
+    plan_path[0]
+      delta_stage[2]
+        closure
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #0, #4..=#6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1{b}))
+      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "1"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "2"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -787,28 +901,117 @@ EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
 SELECT * FROM collated_group_by
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1{b}))
-      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
-    hierarchical
+  Join::Delta
+    plan_path[0]
+      delta_stage[2]
+        closure
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #0, #4..=#6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       monotonic
       must_consolidate
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1{b}))
+      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "1"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "1"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || "2"), ","))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || "2"), ",")))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -825,46 +1028,119 @@ MATERIALIZED VIEW collated_global_mv
 materialize.public.collated_global_mv:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0{b}))
-          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
-        hierarchical
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
-        key_plan
-          project=()
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0{b}))
+          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "1"), ",")))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "2"), ",")))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
 
@@ -883,47 +1159,120 @@ SELECT * FROM collated_global
 Explained Query:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0{b}))
-          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
-        hierarchical
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           monotonic
           must_consolidate
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
-        key_plan
-          project=()
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0{b}))
+          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "1"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "1"), ",")))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || "2"), ","))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || "2"), ",")))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
 

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -659,18 +659,33 @@ FROM t
 GROUP BY a
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#3, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -690,37 +705,47 @@ FROM t
 Explained Query:
   With
     cte l0 =
-      Reduce::Basic
-        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-        key_plan
-          project=()
-        val_plan
-          project=(#2, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::PassArrangements l1
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
       Mfp
         project=(#0, #1)
         map=(█, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+              raw=true
           Constant
             - ()
 
@@ -737,27 +762,116 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS VERBOSE TEXT FOR
 MATERIALIZED VIEW collated_group_by_mv
 ----
 materialize.public.collated_group_by_mv:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1{b}))
-      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
-    hierarchical
+  Join::Delta
+    plan_path[0]
+      delta_stage[2]
+        closure
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #0, #4..=#6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1{b}))
+      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -772,28 +886,117 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS VERBOSE TEXT FOR
 SELECT * FROM collated_group_by
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1{b}))
-      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
-    hierarchical
+  Join::Delta
+    plan_path[0]
+      delta_stage[2]
+        closure
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #0, #4..=#6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       monotonic
       must_consolidate
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
-    input_key=#0{a}
-    key_plan
-      project=(#0)
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1{b}), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1{b}))
+      distinct_aggrs[0]=(0, 0, count(distinct #1{b}))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#1, #1)
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1{b}) || █), █))))
+      input_key=#0{a}
+      key_plan
+        project=(#0)
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1{b}) || █), █)))
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -810,46 +1013,119 @@ MATERIALIZED VIEW collated_global_mv
 materialize.public.collated_global_mv:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0{b}))
-          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
-        hierarchical
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-        key_plan
-          project=()
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0{b}))
+          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(█, █, █, █, █, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
 
@@ -868,47 +1144,120 @@ SELECT * FROM collated_global
 Explained Query:
   With
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0{b}))
-          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
-        hierarchical
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0{a}
+        raw=false
+        arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           monotonic
           must_consolidate
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
-        key_plan
-          project=()
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0{b}), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0{a}
-          raw=false
-          arrangements[0]={ key=[#0{a}], permutation=id, thinning=(#1) }
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0{b}))
+          distinct_aggrs[0]=(0, 0, count(distinct #0{b}))
+          key_plan
+            project=()
+          val_plan
+            project=(#0, #0)
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0{b}) || █), █))))
+          key_plan
+            project=()
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0{b}) || █), █)))
+          Get::PassArrangements l0
+            raw=true
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(█, █, █, █, █, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
 

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -9,6 +9,8 @@
 
 mode cockroach
 
+reset-server
+
 # Test contents of introspection relations
 
 statement ok

--- a/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
+++ b/test/sqllogictest/introspection/singlereplica_attribution_sources.slt
@@ -554,7 +554,7 @@ SELECT mlm.global_id AS global_id, lir_id, parent_lir_id, REPEAT(' ', nesting * 
              mlm.operator_id_start <= megsa.region_id AND megsa.region_id < mlm.operator_id_end)
 ORDER BY mlm.global_id, lir_id DESC;
 ----
-u26  2  NULL  Non-monotonic␠TopK  8  7  3808  15.000
+u26  2  NULL  Non-monotonic␠TopK  NULL  NULL  NULL  NULL
 u26  1  2  ␠␠Stream␠u25  NULL  NULL  NULL  NULL
 u27  4  NULL  Arrange␠(#0{x})  NULL  NULL  NULL  NULL
 u27  3  4  ␠␠Stream␠u26  NULL  NULL  NULL  NULL
@@ -1061,7 +1061,7 @@ EXPLAIN ANALYZE HINTS FOR INDEX v2_idx_x;
 ----
 Arrange␠(#0{x})  NULL  NULL  NULL  NULL
 ␠␠Stream␠u26  NULL  NULL  NULL  NULL
-Non-monotonic␠TopK  8  7  15  3808␠bytes
+Non-monotonic␠TopK  NULL  NULL  NULL  NULL
 ␠␠Stream␠u25  NULL  NULL  NULL  NULL
 
 query T multiline

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -319,19 +319,29 @@ EXPLAIN OPTIMIZED PLAN WITH(types, no fast path, humanized expressions) AS VERBO
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[min(#0{col_not_null}), max(#0{col_not_null}), sum(#0{col_not_null}), count(*), sum((integer_to_numeric(#0{col_not_null}) * integer_to_numeric(#0{col_not_null}))), sum(integer_to_numeric(#0{col_not_null})), count(integer_to_numeric(#0{col_not_null})), list_agg[order_by=[]](row(list[#0{col_not_null}]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
-        Project (#1{col_not_null}) // { types: "(integer)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+      Project (#1{col_not_null}) // { types: "(integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      CrossJoin type=delta // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+        ArrangeBy keys=[[]] // { types: "(integer, integer)" }
+          Reduce aggregates=[min(#0{col_not_null}), max(#0{col_not_null})] // { types: "(integer, integer)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+          Reduce aggregates=[sum(#0{col_not_null}), count(*), sum((integer_to_numeric(#0{col_not_null}) * integer_to_numeric(#0{col_not_null}))), sum(integer_to_numeric(#0{col_not_null})), count(integer_to_numeric(#0{col_not_null}))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer list)" }
+          Reduce aggregates=[list_agg[order_by=[]](row(list[#0{col_not_null}]))] // { types: "(integer list)" }
+            Get l0 // { types: "(integer)" }
   Return // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
     Project (#0{min_col_not_null}, #1{max_col_not_null}, #8, #9, #7{list_agg}) // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
       Map ((bigint_to_numeric(#2{sum_col_not_null}) / bigint_to_numeric(case when (#3{count} = 0) then null else #3{count} end)), sqrtnumeric(case when ((#4{sum}) IS NULL OR (#5{sum}) IS NULL OR (case when (#6{count} = 0) then null else #6{count} end) IS NULL OR (case when (0 = (#6{count} - 1)) then null else (#6{count} - 1) end) IS NULL) then null else greatest(((#4{sum} - ((#5{sum} * #5{sum}) / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end))) / bigint_to_numeric(case when (0 = (#6{count} - 1)) then null else (#6{count} - 1) end)), 0) end)) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?, numeric?, numeric?)" }
         Union // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
-          Get l0 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+          Get l1 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
           Map (null, null, null, 0, null, null, 0, null) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
             Union // { types: "()" }
               Negate // { types: "()" }
                 Project () // { types: "()" }
-                  Get l0 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+                  Get l1 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
               Constant // { types: "()" }
                 - ()
 

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -494,12 +494,22 @@ LIMIT 10;
 ----
 Explained Query:
   Finish order_by=[#0{max} desc nulls_first] limit=10 output=[#0..=#2]
-    Project (#1{max}, #0{error}, #2{count})
-      Reduce group_by=[#1{error}] aggregates=[max((extract_epoch_tstz(#0{occurred_at}) * 1000)), count(*)]
+    With
+      cte l0 =
         Project (#0{occurred_at}, #3{error})
           Filter (#7 <= 100) AND (#7 >= 0) AND (#3{error}) IS NOT NULL
             Map (timestamp_tz_to_mz_timestamp(#0{occurred_at}))
               ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
+    Return
+      Project (#1{max}, #0{error}, #3{count})
+        Join on=(#0{error} = #2{error}) type=differential
+          ArrangeBy keys=[[#0{error}]]
+            Reduce group_by=[#1{error}] aggregates=[max((extract_epoch_tstz(#0{occurred_at}) * 1000))]
+              Get l0
+          ArrangeBy keys=[[#0{error}]]
+            Reduce group_by=[#0{error}] aggregates=[count(*)]
+              Project (#1{error})
+                Get l0
 
 Used Indexes:
   - mz_internal.mz_source_status_history_ind (lookup)

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -126,8 +126,7 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               Filter (#0{f1}) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
-  Return // { arity: 9 }
-    Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), max(#2{f1}), min(#2{f1}), count(#1{f2}), sum(#1{f2}), min(#1{f2}), max(#1{f2})] // { arity: 9 }
+    cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
           Union // { arity: 2 }
@@ -144,6 +143,17 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0{f1}, #1{f2}, #0{f1}) // { arity: 3 }
           Get l1 // { arity: 2 }
+  Return // { arity: 9 }
+    Project (#0{f1}, #6{count_f1}, #7{sum_f1}, #1{max_f1}, #2{min_f1}, #8{count_f2}, #9{sum_f2}, #3{min_f2}, #4{max_f2}) // { arity: 9 }
+      Join on=(#0{f1} = #5{f1}) type=differential // { arity: 10 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#2{f1}), min(#2{f1}), min(#1{f2}), max(#1{f2})] // { arity: 5 }
+            Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+          Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), count(#1{f2}), sum(#1{f2})] // { arity: 5 }
+            Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -172,25 +182,35 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               Filter (#0{f1}) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0{f1}, #1{f2}) // { arity: 2 }
+                Join on=(#0{f1} = #2{f1}) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0{f1}]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+                    Distinct project=[#0{f1}] // { arity: 1 }
+                      Project (#0{f1}) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0{f1}, #1{f2}, #0{f1}) // { arity: 3 }
+          Get l1 // { arity: 2 }
   Return // { arity: 9 }
-    Filter (#6{sum_f2} >= 0) // { arity: 9 }
-      Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), max(#2{f1}), min(#2{f1}), count(#1{f2}), sum(#1{f2}), min(#1{f2}), max(#1{f2})] // { arity: 9 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0{f1}, #1{f2}) // { arity: 2 }
-                  Join on=(#0{f1} = #2{f1}) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0{f1}]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-                      Distinct project=[#0{f1}] // { arity: 1 }
-                        Project (#0{f1}) // { arity: 1 }
-                          Get l1 // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0{f1}, #1{f2}, #0{f1}) // { arity: 3 }
-            Get l1 // { arity: 2 }
+    Project (#0{f1}, #6{count_f1}, #7{sum_f1}, #1{max_f1}, #2{min_f1}, #8{count_f2}, #9{sum_f2}, #3{min_f2}, #4{max_f2}) // { arity: 9 }
+      Filter (#9{sum_f2} >= 0) // { arity: 10 }
+        Join on=(#0{f1} = #5{f1}) type=differential // { arity: 10 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#2{f1}), min(#2{f1}), min(#1{f2}), max(#1{f2})] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+            Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), count(#1{f2}), sum(#1{f2})] // { arity: 5 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -219,25 +239,35 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               Filter (#0{f1}) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0{f1}, #1{f2}) // { arity: 2 }
+                Join on=(#0{f1} = #2{f1}) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0{f1}]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+                    Distinct project=[#0{f1}] // { arity: 1 }
+                      Project (#0{f1}) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0{f1}, #1{f2}, #0{f1}) // { arity: 3 }
+          Get l1 // { arity: 2 }
   Return // { arity: 9 }
-    Filter (#2{sum_f1} >= 0) // { arity: 9 }
-      Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), max(#2{f1}), min(#2{f1}), count(#1{f2}), sum(#1{f2}), min(#1{f2}), max(#1{f2})] // { arity: 9 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0{f1}, #1{f2}) // { arity: 2 }
-                  Join on=(#0{f1} = #2{f1}) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0{f1}]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-                      Distinct project=[#0{f1}] // { arity: 1 }
-                        Project (#0{f1}) // { arity: 1 }
-                          Get l1 // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0{f1}, #1{f2}, #0{f1}) // { arity: 3 }
-            Get l1 // { arity: 2 }
+    Project (#0{f1}, #6{count_f1}, #7{sum_f1}, #1{max_f1}, #2{min_f1}, #8{count_f2}, #9{sum_f2}, #3{min_f2}, #4{max_f2}) // { arity: 9 }
+      Filter (#7{sum_f1} >= 0) // { arity: 10 }
+        Join on=(#0{f1} = #5{f1}) type=differential // { arity: 10 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#2{f1}), min(#2{f1}), min(#1{f2}), max(#1{f2})] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 5 }
+            Reduce group_by=[#0{f1}] aggregates=[count(#2{f1}), sum(#2{f1}), count(#1{f2}), sum(#1{f2})] // { arity: 5 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -280,19 +310,31 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1}), max(#0{f1})] // { arity: 3 }
-    Project (#0{f1}) // { arity: 1 }
-      Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+  With
+    cte l0 =
+      Project (#0{f1}) // { arity: 1 }
+        Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+          implementation
+            %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              Filter (#0{f1} >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              Filter (#0{f1} >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum_f1}, #1{max_f1}) // { arity: 3 }
+      Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
         implementation
-          %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
-        ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-          Project (#0{f1}) // { arity: 1 }
-            Filter (#0{f1} >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-          Project (#0{f1}) // { arity: 1 }
-            Filter (#0{f1} >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#0{f1})] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1})] // { arity: 2 }
+            Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0{f1} >= 0))
@@ -308,8 +350,8 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#1{sum_f1} >= 0) // { arity: 3 }
-    Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1}), max(#0{f1})] // { arity: 3 }
+  With
+    cte l0 =
       Project (#0{f1}) // { arity: 1 }
         Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
           implementation
@@ -322,6 +364,18 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               Filter (#0{f1} >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum_f1}, #1{max_f1}) // { arity: 3 }
+      Filter (#3{sum_f1} >= 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#0{f1})] // { arity: 2 }
+              Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1})] // { arity: 2 }
+              Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0{f1} >= 0))
@@ -352,26 +406,38 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
-  Return // { arity: 3 }
-    Filter (#2{max_f1} >= 0) // { arity: 3 }
-      Reduce group_by=[#0{f1}] aggregates=[sum(#2{f2}), max(#1{f1})] // { arity: 3 }
-        Union // { arity: 3 }
-          Map (null, null) // { arity: 3 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{f1}) // { arity: 1 }
-                  Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0{f1}]K
-                    Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-                      Distinct project=[#0{f1}] // { arity: 1 }
-                        Project (#0{f1}) // { arity: 1 }
-                          Get l1 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null, null) // { arity: 3 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
               Project (#0{f1}) // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0{f1}, #0{f1}, #1{f2}) // { arity: 3 }
-            Get l1 // { arity: 2 }
+                Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0{f1}]K
+                  Get l0 // { arity: 1 }
+                  ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+                    Distinct project=[#0{f1}] // { arity: 1 }
+                      Project (#0{f1}) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            Project (#0{f1}) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0{f1}, #0{f1}, #1{f2}) // { arity: 3 }
+          Get l1 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum_f2}, #1{max_f1}) // { arity: 3 }
+      Filter (#1{max_f1} >= 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#1{f1})] // { arity: 2 }
+              Project (#0{f1}, #1{f1}) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[sum(#1{f2})] // { arity: 2 }
+              Project (#0{f1}, #2{f2}) // { arity: 2 }
+                Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -386,18 +452,31 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0{f1}] aggregates=[sum((#0{f1} + #1{f2})), max(#0{f1})] // { arity: 3 }
-    Project (#0{f1}, #2{f2}) // { arity: 2 }
-      Join on=(#0{f1} = #1{f1}) type=differential // { arity: 3 }
-        implementation
-          %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
-        ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-          Project (#0{f1}) // { arity: 1 }
+  With
+    cte l0 =
+      Project (#0{f1}, #2{f2}) // { arity: 2 }
+        Join on=(#0{f1} = #1{f1}) type=differential // { arity: 3 }
+          implementation
+            %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              Filter (#0{f1} >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1} >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum}, #1{max_f1}) // { arity: 3 }
+      Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
-          Filter (#0{f1} >= 0) // { arity: 2 }
-            ReadStorage materialize.public.t2 // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#0{f1})] // { arity: 2 }
+            Project (#0{f1}) // { arity: 1 }
+              Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[sum((#0{f1} + #1{f2}))] // { arity: 2 }
+            Get l0 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0{f1} >= 0))
@@ -413,19 +492,31 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0{f1}] aggregates=[sum((#0{f1} + #0{f1})), max(#0{f1})] // { arity: 3 }
-    Project (#0{f1}) // { arity: 1 }
-      Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+  With
+    cte l0 =
+      Project (#0{f1}) // { arity: 1 }
+        Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+          implementation
+            %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              Filter (#0{f1} >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              Filter (#0{f1} >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum}, #1{max_f1}) // { arity: 3 }
+      Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
         implementation
-          %0:t1[#0{f1}]Kif » %1:t2[#0{f1}]Kiif
-        ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-          Project (#0{f1}) // { arity: 1 }
-            Filter (#0{f1} >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-          Project (#0{f1}) // { arity: 1 }
-            Filter (#0{f1} >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#0{f1})] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[sum((#0{f1} + #0{f1}))] // { arity: 2 }
+            Get l0 // { arity: 1 }
 
 Source materialize.public.t1
   filter=((#0{f1} >= 0))
@@ -457,25 +548,36 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               Filter (#0{f1}) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
-  Return // { arity: 3 }
-    Filter (#2{max_f1} >= 0) // { arity: 3 }
-      Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1}), max(#1{f1})] // { arity: 3 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0{f1}) // { arity: 1 }
-                  Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0{f1}]K
-                    Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
-                      Distinct project=[#0{f1}] // { arity: 1 }
-                        Get l1 // { arity: 1 }
+    cte l2 =
+      Union // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
               Project (#0{f1}) // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0{f1}, #0{f1}) // { arity: 2 }
-            Get l1 // { arity: 1 }
+                Join on=(#0{f1} = #1{f1}) type=differential // { arity: 2 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0{f1}]K
+                  Get l0 // { arity: 1 }
+                  ArrangeBy keys=[[#0{f1}]] // { arity: 1 }
+                    Distinct project=[#0{f1}] // { arity: 1 }
+                      Get l1 // { arity: 1 }
+            Project (#0{f1}) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0{f1}, #0{f1}) // { arity: 2 }
+          Get l1 // { arity: 1 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{sum_f1}, #1{max_f1}) // { arity: 3 }
+      Filter (#1{max_f1} >= 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#1{f1})] // { arity: 2 }
+              Get l2 // { arity: 2 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[sum(#0{f1})] // { arity: 2 }
+              Project (#0{f1}) // { arity: 1 }
+                Get l2 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -552,8 +654,7 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
-  Return // { arity: 3 }
-    Reduce group_by=[#0{f1}] aggregates=[count(#1{f2}), max(#1{f2})] // { arity: 3 }
+    cte l2 =
       Union // { arity: 2 }
         Map (null) // { arity: 2 }
           Union // { arity: 1 }
@@ -570,6 +671,17 @@ Explained Query:
             Project (#0{f1}) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{count_f2}, #1{max_f2}) // { arity: 3 }
+      Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#1{f2})] // { arity: 2 }
+            Get l2 // { arity: 2 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[count(#1{f2})] // { arity: 2 }
+            Get l2 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -584,8 +696,8 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f2) > 0;
 ----
 Explained Query:
-  Filter (#2{max_f2} > 0) // { arity: 3 }
-    Reduce group_by=[#0{f1}] aggregates=[count(#1{f2}), max(#1{f2})] // { arity: 3 }
+  With
+    cte l0 =
       Project (#0{f1}, #2{f2}) // { arity: 2 }
         Join on=(#0{f1} = #1{f1}) type=differential // { arity: 3 }
           implementation
@@ -597,6 +709,18 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{count_f2}, #1{max_f2}) // { arity: 3 }
+      Filter (#1{max_f2} > 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#1{f2})] // { arity: 2 }
+              Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[count(#1{f2})] // { arity: 2 }
+              Get l0 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0{f1}) IS NOT NULL)
@@ -612,8 +736,8 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t1.f1 + t2.f2) > 0;
 ----
 Explained Query:
-  Filter (#1{max} > 0) // { arity: 3 }
-    Reduce group_by=[#0{f1}] aggregates=[max((#0{f1} + #2{f2})), sum((#1{f2} + #2{f2}))] // { arity: 3 }
+  With
+    cte l0 =
       Project (#0{f1}, #1{f2}, #3{f2}) // { arity: 3 }
         Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
           implementation
@@ -624,6 +748,19 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #1{max}, #3{sum}) // { arity: 3 }
+      Filter (#1{max} > 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max((#0{f1} + #1{f2}))] // { arity: 2 }
+              Project (#0{f1}, #2{f2}) // { arity: 2 }
+                Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[sum((#1{f2} + #2{f2}))] // { arity: 2 }
+              Get l0 // { arity: 3 }
 
 Source materialize.public.t1
   filter=((#0{f1}) IS NOT NULL)
@@ -681,8 +818,7 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
-  Return // { arity: 3 }
-    Reduce group_by=[#0{f1}] aggregates=[count(#1{f2}), max(#2{f2})] // { arity: 3 }
+    cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
           Union // { arity: 2 }
@@ -698,6 +834,19 @@ Explained Query:
                         Get l1 // { arity: 3 }
             ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0{f1}, #3{count_f2}, #1{max_f2}) // { arity: 3 }
+      Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[max(#1{f2})] // { arity: 2 }
+            Project (#0{f1}, #2{f2}) // { arity: 2 }
+              Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+          Reduce group_by=[#0{f1}] aggregates=[count(#1{f2})] // { arity: 2 }
+            Project (#0{f1}, #1{f2}) // { arity: 2 }
+              Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -725,24 +874,36 @@ Explained Query:
           ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
             Filter (#0{f1}) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0{f1}, #1{f2}) // { arity: 2 }
+                Join on=(#1{f2} = #2{f2}) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#1{f2}]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0{f2}]] // { arity: 1 }
+                    Distinct project=[#0{f2}] // { arity: 1 }
+                      Project (#1{f2}) // { arity: 1 }
+                        Get l1 // { arity: 3 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Get l1 // { arity: 3 }
   Return // { arity: 3 }
-    Filter (#2{max_f2} > 0) // { arity: 3 }
-      Reduce group_by=[#0{f1}] aggregates=[count(#1{f2}), max(#2{f2})] // { arity: 3 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0{f1}, #1{f2}) // { arity: 2 }
-                  Join on=(#1{f2} = #2{f2}) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#1{f2}]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0{f2}]] // { arity: 1 }
-                      Distinct project=[#0{f2}] // { arity: 1 }
-                        Project (#1{f2}) // { arity: 1 }
-                          Get l1 // { arity: 3 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Get l1 // { arity: 3 }
+    Project (#0{f1}, #3{count_f2}, #1{max_f2}) // { arity: 3 }
+      Filter (#1{max_f2} > 0) // { arity: 4 }
+        Join on=(#0{f1} = #2{f1}) type=differential // { arity: 4 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[max(#1{f2})] // { arity: 2 }
+              Project (#0{f1}, #2{f2}) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0{f1}]] // { arity: 2 }
+            Reduce group_by=[#0{f1}] aggregates=[count(#1{f2})] // { arity: 2 }
+              Project (#0{f1}, #1{f2}) // { arity: 2 }
+                Get l2 // { arity: 3 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -871,36 +1032,44 @@ Explained Query:
           Project (#0{f1}) // { arity: 1 }
             Filter (#1{f2} = 6) // { arity: 2 }
               ReadStorage materialize.public.t3 // { arity: 2 }
+    cte l1 =
+      Union // { arity: 1 }
+        Project (#0{f2}) // { arity: 1 }
+          Get l0 // { arity: 2 }
+        Project (#4) // { arity: 1 }
+          Map (null) // { arity: 5 }
+            Join on=(#0{f1} = #2{f1} AND #1{f2} = #3{f2}) type=differential // { arity: 4 }
+              implementation
+                %0[#0, #1]KK » %1:t3[#0, #1]KK
+              ArrangeBy keys=[[#0{f1}, #1{f2}]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Map (6) // { arity: 2 }
+                      Distinct project=[#0{f1}] // { arity: 1 }
+                        Project (#1{f1}) // { arity: 1 }
+                          Get l0 // { arity: 2 }
+                  Distinct project=[#0{f1}, #1{f2}] // { arity: 2 }
+                    ReadStorage materialize.public.t3 // { arity: 2 }
+              ArrangeBy keys=[[#0{f1}, #1{f2}]] // { arity: 2 }
+                ReadStorage materialize.public.t3 // { arity: 2 }
   Return // { arity: 1 }
-    Project (#1{count}) // { arity: 1 }
-      Join on=(#0{f2} = #2{max_f2}) type=differential // { arity: 3 }
+    Project (#2{count}) // { arity: 1 }
+      Join on=(#0{f2} = #1{max_f2}) type=delta // { arity: 3 }
         implementation
-          %1[#1{agg2}]UK » %0:t1[#0{f2}]K
+          %0:t1 » %1[#0{agg2}]UK » %2[×]UA
+          %1 » %2[×]UA » %0:t1[#0{f2}]K
+          %2 » %1[×]UA » %0:t1[#0{f2}]K
         ArrangeBy keys=[[#0{f2}]] // { arity: 1 }
           Project (#1{f2}) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#1{max_f2}]] // { arity: 2 }
-          Filter (#1{max_f2}) IS NOT NULL // { arity: 2 }
-            Reduce aggregates=[count(*), max(#0{f2})] // { arity: 2 }
-              Union // { arity: 1 }
-                Project (#0{f2}) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Project (#4) // { arity: 1 }
-                  Map (null) // { arity: 5 }
-                    Join on=(#0{f1} = #2{f1} AND #1{f2} = #3{f2}) type=differential // { arity: 4 }
-                      implementation
-                        %0[#0, #1]KK » %1:t3[#0, #1]KK
-                      ArrangeBy keys=[[#0{f1}, #1{f2}]] // { arity: 2 }
-                        Union // { arity: 2 }
-                          Negate // { arity: 2 }
-                            Map (6) // { arity: 2 }
-                              Distinct project=[#0{f1}] // { arity: 1 }
-                                Project (#1{f1}) // { arity: 1 }
-                                  Get l0 // { arity: 2 }
-                          Distinct project=[#0{f1}, #1{f2}] // { arity: 2 }
-                            ReadStorage materialize.public.t3 // { arity: 2 }
-                      ArrangeBy keys=[[#0{f1}, #1{f2}]] // { arity: 2 }
-                        ReadStorage materialize.public.t3 // { arity: 2 }
+        ArrangeBy keys=[[], [#0{max_f2}]] // { arity: 1 }
+          Filter (#0{max_f2}) IS NOT NULL // { arity: 1 }
+            Reduce aggregates=[max(#0{f2})] // { arity: 1 }
+              Get l1 // { arity: 1 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Get l1 // { arity: 1 }
 
 Source materialize.public.t1
 Source materialize.public.t2

--- a/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
@@ -55,19 +55,27 @@ FROM t_using_dataflow_rendering;
 Explained Query:
   With
     cte l0 =
-      Reduce aggregates=[sum(#0{real1}), sum(#1{double1}), sum(#2{numeric1}), sum((#0{real1} + #0{real1})), sum((#1{double1} + #1{double1})), sum((#2{numeric1} + #2{numeric1})), min(#0{real1}), min(#1{double1}), min(#2{numeric1}), min((#0{real1} + #0{real1})), min((#1{double1} + #1{double1})), min((#2{numeric1} + #2{numeric1})), max(#0{real1}), max(#1{double1}), max(#2{numeric1}), max((#0{real1} + #0{real1})), max((#1{double1} + #1{double1})), max((#2{numeric1} + #2{numeric1})), count(#0{real1}), count(#1{double1}), count(#2{numeric1}), count((#0{real1} + #0{real1})), count((#1{double1} + #1{double1})), count((#2{numeric1} + #2{numeric1}))]
-        Project (#0{real1}..=#2{numeric1})
-          ReadStorage materialize.public.t_using_dataflow_rendering
+      Project (#0{real1}..=#2{numeric1})
+        ReadStorage materialize.public.t_using_dataflow_rendering
+    cte l1 =
+      CrossJoin type=differential
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[min(#0{real1}), min(#1{double1}), min(#2{numeric1}), min((#0{real1} + #0{real1})), min((#1{double1} + #1{double1})), min((#2{numeric1} + #2{numeric1})), max(#0{real1}), max(#1{double1}), max(#2{numeric1}), max((#0{real1} + #0{real1})), max((#1{double1} + #1{double1})), max((#2{numeric1} + #2{numeric1}))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(#0{real1}), sum(#1{double1}), sum(#2{numeric1}), sum((#0{real1} + #0{real1})), sum((#1{double1} + #1{double1})), sum((#2{numeric1} + #2{numeric1})), count(#0{real1}), count(#1{double1}), count(#2{numeric1}), count((#0{real1} + #0{real1})), count((#1{double1} + #1{double1})), count((#2{numeric1} + #2{numeric1}))]
+            Get l0
   Return
     Project (#0{sum_real1}..=#17{max}, #24..=#29)
       Map ((#0{sum_real1} / bigint_to_real(case when (#18{count_real1} = 0) then null else #18{count_real1} end)), (#1{sum_double1} / bigint_to_double(case when (#19{count_double1} = 0) then null else #19{count_double1} end)), (#2{sum_numeric1} / bigint_to_numeric(case when (#20{count_numeric1} = 0) then null else #20{count_numeric1} end)), (#3{sum} / bigint_to_real(case when (#21{count} = 0) then null else #21{count} end)), (#4{sum} / bigint_to_double(case when (#22{count} = 0) then null else #22{count} end)), (#5{sum} / bigint_to_numeric(case when (#23{count} = 0) then null else #23{count} end)))
         Union
-          Get l0
+          Project (#12{sum_real1}..=#17{sum}, #0{min_real1}..=#11{max}, #18{count_real1}..=#23{count})
+            Get l1
           Map (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 0, 0, 0, 0, 0, 0)
             Union
               Negate
                 Project ()
-                  Get l0
+                  Get l1
               Constant
                 - ()
 

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -32,7 +32,7 @@ emit_plan_insights_notice                off                     "Boolean flag i
 emit_timestamp_notice                    off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                     off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 enable_rbac_checks                       on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
-enable_reduce_reduction                  off                     "split complex reductions in to simpler ones and a join (Materialize)."
+enable_reduce_reduction                  on                      "split complex reductions in to simpler ones and a join (Materialize)."
 enable_session_rbac_checks               off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 extra_float_digits                       3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                               <omitted>               "Allows failpoints to be dynamically activated."


### PR DESCRIPTION
These were recently [turned on](https://materializeinc.slack.com/archives/CTESPM7FU/p1756222692313869) in prod. This PR updates their defaults, so that the next self-managed release can pick up the change.

(The diff is big because of the EXPLAIN changes in slts, especially the json EXPLAINs. But the code change is just the 2 lines that change the defaults of the flags.)

Additionally, I've put a `reset-server` in `introspection/relations.slt` to make object ids in the expected outputs not depend on which other slts have been run before this one. This is unrelated to the feature flags, it's just that the object ids were making the slt auto-rewriting do the wrong thing. (cc @antiguru)

### Motivation


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
