### PR TITLE
catalog: remove unneeded division in `mz_console_cluster_utilization_overview`

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -12374,15 +12374,8 @@ max_memory_and_disk AS (
         CASE
           WHEN disk_bytes IS NULL
           AND memory_bytes IS NULL THEN NULL
-          ELSE (
-            (
-              COALESCE(disk_bytes, 0) + COALESCE(memory_bytes, 0)
-            ) / total_memory_bytes
-          ) / (
-            (
-              total_disk_bytes::numeric + total_memory_bytes::numeric
-            ) / total_memory_bytes
-          )
+          ELSE (COALESCE(disk_bytes, 0) + COALESCE(memory_bytes, 0))
+               / (total_disk_bytes::numeric + total_memory_bytes::numeric)
         END AS memory_and_disk_percent
       FROM replica_utilization_history_binned
     ) AS max_memory_and_disk_inner


### PR DESCRIPTION
According to my high school maths knowledge, these two divisions cancel out, but I might be missing something!

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
