### PR TITLE
derive replica capacity limit from replica size

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -423,7 +423,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "lgalloc_local_buffer_bytes",
     "lgalloc_slow_clear_bytes",
     "memory_limiter_interval",
-    "memory_limiter_usage_factor",
     "memory_limiter_usage_bias",
     "memory_limiter_burst_factor",
     "compute_server_maintenance_interval",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1335,7 +1335,6 @@ class FlipFlagsAction(Action):
             "lgalloc_local_buffer_bytes",
             "lgalloc_slow_clear_bytes",
             "memory_limiter_interval",
-            "memory_limiter_usage_factor",
             "memory_limiter_usage_bias",
             "memory_limiter_burst_factor",
             "enable_columnation_lgalloc",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -105,25 +105,18 @@ pub const MEMORY_LIMITER_INTERVAL: Config<Duration> = Config::new(
     "Interval to run the memory limiter. A zero duration disables the limiter.",
 );
 
-/// Factor of the memory limit that the process will be permitted to use before terminating the process.
-pub const MEMORY_LIMITER_USAGE_FACTOR: Config<f64> = Config::new(
-    "memory_limiter_usage_factor",
-    2.,
-    "Factor of the memory limit that the process will use before terminating the process.",
-);
-
 /// Bias to the memory limiter usage factor.
 pub const MEMORY_LIMITER_USAGE_BIAS: Config<f64> = Config::new(
     "memory_limiter_usage_bias",
     1.,
-    "Multiplicative bias to memory_limiter_usage_factor.",
+    "Multiplicative bias to the memory limiter's limit.",
 );
 
 /// Burst factor to memory limit.
 pub const MEMORY_LIMITER_BURST_FACTOR: Config<f64> = Config::new(
     "memory_limiter_burst_factor",
     0.,
-    "Multiplicative burst factor to memory limit.",
+    "Multiplicative burst factor to the memory limiter's limit.",
 );
 
 /// Enable lgalloc for columnation.
@@ -364,7 +357,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&LGALLOC_LOCAL_BUFFER_BYTES)
         .add(&LGALLOC_SLOW_CLEAR_BYTES)
         .add(&MEMORY_LIMITER_INTERVAL)
-        .add(&MEMORY_LIMITER_USAGE_FACTOR)
         .add(&MEMORY_LIMITER_USAGE_BIAS)
         .add(&MEMORY_LIMITER_BURST_FACTOR)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)

--- a/src/compute/src/memory_limiter.rs
+++ b/src/compute/src/memory_limiter.rs
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0.
 
 //! Utilities to limit memory usage.
+//!
+//! In the context of this module, "memory" refers to the sum of physical memory and swap space .
+//! Other parts of the code usually don't include swap space when talking about "memory".
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -15,7 +18,6 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use mz_compute_types::dyncfgs::{
     MEMORY_LIMITER_BURST_FACTOR, MEMORY_LIMITER_INTERVAL, MEMORY_LIMITER_USAGE_BIAS,
-    MEMORY_LIMITER_USAGE_FACTOR,
 };
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::{CastFrom, CastLossy};
@@ -79,9 +81,8 @@ impl Limiter {
             interval = Duration::MAX;
         }
 
-        let memory_limit = f64::cast_lossy(self.memory_limit)
-            * MEMORY_LIMITER_USAGE_FACTOR.get(config)
-            * MEMORY_LIMITER_USAGE_BIAS.get(config);
+        let memory_limit =
+            f64::cast_lossy(self.memory_limit) * MEMORY_LIMITER_USAGE_BIAS.get(config);
         let memory_limit = usize::cast_lossy(memory_limit);
 
         let burst_budget = f64::cast_lossy(memory_limit) * MEMORY_LIMITER_BURST_FACTOR.get(config);


### PR DESCRIPTION
To support replica sizes with different swap:memory ratios, this PR changes the way the replica memory limiter is configured. Instead of deriving the base limit from the memory limit and a dyncfg, the limit is now derived from the replica size and passed to the clusterd process as a commandline flag.

The exact logic for deriving the memory limiter limit (referred to as "capacity" here) is as follows: If swap is enabled, and the replica size definition specifies both a memory and a disk limit, the capacity limit is set to memory_limit + disk_limit. If swap is not enabled, or one of the two limits isn't set in the replica size definition, the memory limiter remains disabled.

Changing the memory limit at runtime is still possible through the remaining `memory_limiter_*` dyncfgs.

**(Note: Hold off merging until lgalloc is disabled everywhere in production.)**

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/database-issues/issues/9691

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
