### PR TITLE
helm-chart: Prepare weekly releases of self-managed

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -71,7 +71,7 @@ cargo update --workspace
 
 bin/bazel gen
 
-bin/helm-chart-version-bump --bump-orchestratord-version "v$version"
+bin/helm-chart-version-bump --bump-weekly-version --bump-orchestratord-version "v$version"
 
 helm_docs_version=1.14.2
 if ! helm-docs --help > /dev/null; then

--- a/doc/user/content/releases/v0.128.md
+++ b/doc/user/content/releases/v0.128.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.128"
 date: 2025-01-08
-released: false
+released: true
+patch: 1
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.143.md
+++ b/doc/user/content/releases/v0.143.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.143"
 date: 2025-04-30
-released: false
+released: true
+patch: 3
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.145.md
+++ b/doc/user/content/releases/v0.145.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.145"
 date: 2025-05-21
-released: false
+released: true
+patch: 3
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.148.md
+++ b/doc/user/content/releases/v0.148.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.148"
 date: 2025-07-02
-released: false
+released: true
+patch: 0
 _build:
   render: never
 ---

--- a/doc/user/content/releases/v0.152.md
+++ b/doc/user/content/releases/v0.152.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.152"
 date: 2025-07-30
-released: false
+released: true
+patch: 2
 _build:
   render: never
 ---

--- a/misc/helm-charts/operator-weekly/Chart.yaml
+++ b/misc/helm-charts/operator-weekly/Chart.yaml
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+apiVersion: v2
+name: materialize-operator-weekly
+description: Materialize Kubernetes Operator Helm Chart (weekly version upgrades)
+type: application
+version: v0.158.0-dev.0
+appVersion: v0.158.0-dev.0
+icon: https://materialize.com/favicon.ico
+home: https://materialize.com

--- a/misc/helm-charts/publish-weekly.sh
+++ b/misc/helm-charts/publish-weekly.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -euo pipefail
+
+. misc/shlib/shlib.bash
+
+CHARTS_DIR=misc/helm-charts
+GITHUB_PAGES_BRANCH=gh-pages
+RELEASE_DIR=.cr-release-packages
+: "${CI_DRY_RUN:=0}"
+
+run_if_not_dry() {
+  if ! is_truthy "$CI_DRY_RUN"; then
+    "$@"
+  else
+    echo "[DRY RUN] $*"
+  fi
+}
+
+VERSION=$1
+
+echo "--- Publishing Weekly Helm Chart $VERSION with Materialize $VERSION"
+rm -rf gh-pages
+git clone --branch "$GITHUB_PAGES_BRANCH" --depth 1 git@github.com:MaterializeInc/materialize.git gh-pages
+
+mkdir -p $RELEASE_DIR
+CHANGES_MADE=0
+CHART=operator-weekly
+CHART_PATH="$CHARTS_DIR/$CHART"
+echo "Processing chart: $CHART version: $VERSION"
+git checkout "origin/$VERSION"
+# Check if version already exists
+if [ -f "gh-pages/$CHART-$VERSION.tgz" ]; then
+  echo "Chart $CHART version $VERSION already exists, skipping"
+  exit 0
+fi
+# Lint chart
+if ! helm lint "$CHART_PATH"; then
+  echo "Linting failed for $CHART"
+  exit 1
+fi
+# Package chart
+helm package "$CHART_PATH" --destination $RELEASE_DIR
+CHANGES_MADE=1
+# Only proceed if we have new packages
+if [ $CHANGES_MADE -eq 1 ]; then
+  # Copy new charts to gh-pages
+  cp $RELEASE_DIR/*.tgz gh-pages/
+  # Update the repository index
+  cd gh-pages
+  REPO_URL="https://materializeinc.github.io/materialize"
+  if [ -f index.yaml ]; then
+    helm repo index . --url "$REPO_URL" --merge index.yaml
+  else
+    helm repo index . --url "$REPO_URL"
+  fi
+  # Commit and push changes
+  git add .
+  git config user.email "noreply@materialize.com"
+  git config user.name "Buildkite"
+  git commit -m "helm-charts: publish updated charts"
+  git --no-pager diff HEAD~
+  run_if_not_dry git push origin $GITHUB_PAGES_BRANCH
+  cd ..
+else
+  echo "No new chart versions to publish"
+  exit 0
+fi

--- a/misc/python/materialize/cli/helm_chart_version_bump.py
+++ b/misc/python/materialize/cli/helm_chart_version_bump.py
@@ -23,6 +23,11 @@ def main() -> int:
         description="Bump environmentd (appVersion), orchestratord and helm-chart versions in helm chart.",
     )
     parser.add_argument(
+        "--bump-weekly-version",
+        action="store_true",
+        help="Also bump the weekly Materialize operator release instead of the bi-yearly one",
+    )
+    parser.add_argument(
         "--helm-chart-version",
         type=str,
         help="Helm-chart version to bump to, no change if not set.",
@@ -55,6 +60,19 @@ def main() -> int:
             ),
         ),
     ]
+
+    if args.bump_weekly_version:
+        mods += [
+            (
+                MZ_ROOT / "misc" / "helm-charts" / "operator-weekly" / "Chart.yaml",
+                lambda docs: docs[0].update(
+                    {
+                        "version": args.environmentd_version,
+                        "appVersion": args.environmentd_version,
+                    }
+                ),
+            ),
+        ]
 
     if args.bump_orchestratord_version:
         # There are two cases that bump the version:

--- a/misc/python/materialize/release/mark_release_complete.py
+++ b/misc/python/materialize/release/mark_release_complete.py
@@ -37,6 +37,10 @@ def main():
     print(f"Pushing to {remote}...")
     spawn.runv(["git", "push", remote, "main"])
 
+    version = f"{args.release_version}.{args.patch}"
+    print(f"Releasing self-managed weekly helm-chart {version}")
+    spawn.runv(["misc/helm-charts/publish-weekly.sh", version])
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
https://www.notion.so/materialize/Weekly-cloud-Self-Managed-Release-Schedule-26913f48d37b80708ddad0dea3d62aac

Still missing: Docs for self-managed weekly
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
