### PR TITLE
update sql server statistics test to expect null stats on new replica

### DIFF
--- a/test/sql-server-cdc-old-syntax/statistics.td
+++ b/test/sql-server-cdc-old-syntax/statistics.td
@@ -160,7 +160,7 @@ SELECT cr.id
 $ unset-regex
 
 # Ensure the snapshot stats stay there, and don't change for the original replica
-# and the new replica has reset stats
+# and the new replica has no snapshot stats as no snapshots needed.
 > SELECT
     s.name,
     u.replica_id,
@@ -174,7 +174,7 @@ $ unset-regex
   GROUP BY s.name, u.replica_id
   ORDER BY s.name, u.replica_id
 mz_source "${old_replica_id}" false true 2 2
-mz_source "${replica_id}" true true 0 0
+mz_source "${replica_id}" true true <null> <null>
 
 $ sql-server-execute name=sql-server
 CREATE TABLE alt (f1 VARCHAR(128));


### PR DESCRIPTION
Fixes an incorrect expectation in the test.  The snapshot statistics on a new replica that's never performed a snapshot are null.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
