### PR TITLE
[v0.147 only] cargo test: Disable test_persist_open

### DIFF
--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -472,6 +472,7 @@ async fn test_open_read_only(state_builder: TestCatalogStateBuilder) {
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+#[ignore] // doesn't work with https://github.com/MaterializeInc/materialize/commit/4b63360843dce25b4b634964c2fa35781ec990c5
 async fn test_persist_open() {
     let persist_client = PersistClient::new_for_tests().await;
     let state_builder = TestCatalogStateBuilder::new(persist_client);


### PR DESCRIPTION
My interpretation is that following
https://github.com/MaterializeInc/materialize/commit/4b63360843dce25b4b634964c2fa35781ec990c5 we have a migration even when the version number doesn't change (v74 -> v74). This test specifically tests that the catalog stays the same, but this invariant isn't true anymore with this change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
