### PR TITLE
adapter: remove `force_swap_for_cc_sizes` flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -567,7 +567,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "persist_enable_incremental_compaction",
     "storage_statistics_retention_duration",
     "enable_paused_cluster_readhold_downgrade",
-    "force_swap_for_cc_sizes",
 ]
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1517,7 +1517,6 @@ class FlipFlagsAction(Action):
             "storage_statistics_retention_duration",
             "enable_paused_cluster_readhold_downgrade",
             "enable_mz_join_core_v2",
-            "force_swap_for_cc_sizes",
             "enable_with_ordinality_legacy_fallback",
         ]
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -131,15 +131,6 @@ pub const PERSIST_FAST_PATH_ORDER: Config<bool> = Config::new(
     "If set, send queries with a compatible literal constraint or ordering clause down the Persist fast path.",
 );
 
-/// This flag exists solely to facilitate the slow rollout of swap for cc replica sizes. The plan
-/// is to remove it once the rollout is complete and the cc replica size definitions have been
-/// adjusted to enable swap directly.
-pub const FORCE_SWAP_FOR_CC_SIZES: Config<bool> = Config::new(
-    "force_swap_for_cc_sizes",
-    false,
-    "Whether to enable swap for all cc replica sizes.",
-);
-
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -160,5 +151,4 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_PASSWORD_AUTH)
         .add(&CONSTRAINT_BASED_TIMESTAMP_SELECTION)
         .add(&PERSIST_FAST_PATH_ORDER)
-        .add(&FORCE_SWAP_FOR_CC_SIZES)
 }


### PR DESCRIPTION
This PR removes the dyncfg flag to patch cc sizes to use swap. It was added to enable a slow rollout of swap, and now that that is complete we can update the replica size definitions directly.

### Motivation

   * This PR refactors existing code.

Removes an unused feature flag.

### Tips for reviewer

PRs to update the replica size definitions:
* staging: https://github.com/MaterializeInc/cloud/pull/11607
* prod: https://github.com/MaterializeInc/cloud/pull/11614

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
