### PR TITLE
sql server tests: Reenable failing ones

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2746,9 +2746,8 @@ ddl_action_list = ActionList(
         # (DropMySqlSourceAction, 4),
         (CreatePostgresSourceAction, 4),
         (DropPostgresSourceAction, 4),
-        # TODO: Reenable when database-issues#9620 is fixed
-        # (CreateSqlServerSourceAction, 4),
-        # (DropSqlServerSourceAction, 4),
+        (CreateSqlServerSourceAction, 4),
+        (DropSqlServerSourceAction, 4),
         (GrantPrivilegesAction, 4),
         (RevokePrivilegesAction, 1),
         (ReconnectAction, 1),

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -37,6 +37,7 @@ from materialize.zippy.sql_server_actions import (
     CreateSqlServerTable,
     SqlServerDML,
     SqlServerStart,
+    SqlServerRestart,
 )
 from materialize.zippy.sql_server_cdc_actions import CreateSqlServerCdcTable
 from materialize.zippy.mz_actions import (
@@ -252,8 +253,7 @@ class SqlServerCdc(Scenario):
             KillClusterd: 5,
             StoragedKill: 5,
             StoragedStart: 5,
-            # TODO: Reenable when database-issues#9624 is fixed
-            # SqlServerRestart: 10,
+            SqlServerRestart: 10,
             CreateViewParameterized(): 10,
             ValidateView: 20,
             SqlServerDML: 100,

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -19,6 +19,7 @@ from materialize import buildkite
 from materialize.data_ingest.executor import (
     KafkaExecutor,
     MySqlExecutor,
+    SqlServerExecutor,
 )
 from materialize.data_ingest.workload import *  # noqa: F401 F403
 from materialize.data_ingest.workload import WORKLOADS, execute_workload
@@ -118,8 +119,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     # TODO: Reenable KafkaRoundtripExecutor when database-issues#8657 is fixed
-    # TODO: Reenable SqlServerExecutor when database-issues#9618 is fixed
-    executor_classes = [MySqlExecutor, KafkaExecutor]
+    executor_classes = [MySqlExecutor, KafkaExecutor, SqlServerExecutor]
 
     with c.override(
         # Fixed port so that we keep the same port after restarting Mz in disruptions


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
