### PR TITLE
Downgrade numpy to 2.2.6

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -27,7 +27,8 @@ matplotlib==3.10.1
 matplotlib-stubs==0.3.4
 networkx==3.4.2
 networkx-stubs==0.0.1
-numpy==2.3.3
+# Keep on 2.2.6 for Python 3.10 compatibility
+numpy==2.2.6
 pandas==2.3.2
 pandas-stubs==2.2.3.250308
 parameterized==0.9.0


### PR DESCRIPTION
Noticed by @teskje  in https://materializeinc.slack.com/archives/C01LKF361MZ/p1758207197866599
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
