### PR TITLE
disable license key checks in the emulator

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -693,7 +693,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else if matches!(args.orchestrator, OrchestratorKind::Kubernetes) {
         bail!("--license-key is required when running in Kubernetes");
     } else {
-        ValidatedLicenseKey::default()
+        // license key checks are optional for the emulator
+        ValidatedLicenseKey::disabled()
     };
 
     // Configure testing options.

--- a/src/license-keys/src/lib.rs
+++ b/src/license-keys/src/lib.rs
@@ -66,7 +66,6 @@ impl ValidatedLicenseKey {
         }
     }
 
-    // TODO: temporary until we get the rest of the infrastructure in place
     pub fn disabled() -> Self {
         Self {
             id: "".to_string(),
@@ -100,7 +99,6 @@ impl ValidatedLicenseKey {
 
 impl Default for ValidatedLicenseKey {
     fn default() -> Self {
-        // this is used for the emulator if no license key is provided
         Self {
             id: "".to_string(),
             organization: "".to_string(),


### PR DESCRIPTION
### Motivation

https://materializeinc.slack.com/archives/CU7ELJ6E9/p1758216047458169

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
