### PR TITLE
Make `REFRESH` scheduling handle it gracefully when the cluster is in a graceful reconfig

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -245,6 +245,8 @@ pub enum AdapterError {
     /// enumerate users by spraying login attempts and differentiating
     /// between a "no such user" and "incorrect password" error.
     AuthenticationError,
+    /// An ALTER CLUSTER was attempted while a graceful cluster reconfiguration was in progress.
+    AlterClusterWhilePendingReplicas,
 }
 
 impl AdapterError {
@@ -577,6 +579,7 @@ impl AdapterError {
             AdapterError::ReadOnly => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::AlterClusterTimeout => SqlState::QUERY_CANCELED,
             AdapterError::AuthenticationError => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
+            AdapterError::AlterClusterWhilePendingReplicas => SqlState::OBJECT_IN_USE,
         }
     }
 
@@ -823,6 +826,9 @@ impl fmt::Display for AdapterError {
                     )?;
                 }
                 Ok(())
+            }
+            AdapterError::AlterClusterWhilePendingReplicas => {
+                write!(f, "cannot alter clusters with pending updates")
             }
         }
     }


### PR DESCRIPTION
This fixes  https://github.com/MaterializeInc/database-issues/issues/9710. It does the 2. approach from the issue.

(We could make these feature interact in a nicer way, but REFRESH is probably getting deprecated, so I'd like to avoid putting more effort into this now.)

Btw., @jubrad, is it expected that the error does _not_ occur with `wait for`; it only occurs with `wait until`. (Also, there is no test for this error.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/database-issues/issues/9710

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
