### PR TITLE
catalog: stop using `Arbitrary` in expr_cache tests

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -126,23 +126,6 @@ impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
 }
 
 impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
-    /// Creates a new dataflow description with a human-readable name.
-    pub fn new(name: String) -> Self {
-        Self {
-            source_imports: Default::default(),
-            index_imports: Default::default(),
-            objects_to_build: Vec::new(),
-            index_exports: Default::default(),
-            sink_exports: Default::default(),
-            as_of: Default::default(),
-            until: Antichain::new(),
-            initial_storage_as_of: None,
-            refresh_schedule: None,
-            debug_name: name,
-            time_dependence: None,
-        }
-    }
-
     /// Imports a previously exported index.
     ///
     /// This method makes available an index previously exported as `id`, identified
@@ -265,6 +248,23 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
 }
 
 impl<P, S, T> DataflowDescription<P, S, T> {
+    /// Creates a new dataflow description with a human-readable name.
+    pub fn new(name: String) -> Self {
+        Self {
+            source_imports: Default::default(),
+            index_imports: Default::default(),
+            objects_to_build: Vec::new(),
+            index_exports: Default::default(),
+            sink_exports: Default::default(),
+            as_of: Default::default(),
+            until: Antichain::new(),
+            initial_storage_as_of: None,
+            refresh_schedule: None,
+            debug_name: name,
+            time_dependence: None,
+        }
+    }
+
     /// Sets the `as_of` frontier to the supplied argument.
     ///
     /// This method allows the dataflow to indicate a frontier up through
@@ -562,15 +562,6 @@ where
             debug_name: self.debug_name.clone(),
             time_dependence: self.time_dependence.clone(),
         }
-    }
-}
-
-impl Arbitrary for DataflowDescription<OptimizedMirRelationExpr, (), mz_repr::Timestamp> {
-    type Strategy = BoxedStrategy<Self>;
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any_dataflow_description(any_source_import()).boxed()
     }
 }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -1243,7 +1243,7 @@ pub struct DataflowMetainfo<Notice = RawOptimizerNotice> {
     pub index_usage_types: BTreeMap<GlobalId, Vec<IndexUsageType>>,
 }
 
-impl Default for DataflowMetainfo {
+impl<Notice> Default for DataflowMetainfo<Notice> {
     fn default() -> Self {
         DataflowMetainfo {
             optimizer_notices: Vec::new(),


### PR DESCRIPTION
This PR changes the expr_cache tests to not use `Arbitrary` and work with minimal hardcoded plans/exprs instead. The expression cache largely treats the cached expressions as opaque anyway, so generating a broad selection of them only serves to test the bincode serialization, which isn't this test's business.

Not relying on `Arbitrary` simplifies the tests a lot, since they don't have to work around proptest's slowness anymore. But more importantly, it removes the last user of `DataflowDescription`'s `Arbitrary` impl, allowing us to remove a large amount of boilerplate in a follow-up.

### Motivation

   * This PR refactors existing code.

[Relevant Slack thread.](https://materializeinc.slack.com/archives/C08A62E0751/p1755590706213029)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
