### PR TITLE
compute-types: remove remaining proptest boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,8 +6059,6 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "mz-storage-types",
- "proptest",
- "proptest-derive",
  "serde",
  "timely",
  "tracing",

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -19,8 +19,6 @@ mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["tracing", "metrics"] }
 mz-repr = { path = "../repr", features = ["tracing"] }
 mz-storage-types = { path = "../storage-types" }
-proptest = { version = "1.7.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.5.1", features = ["boxed_union"] }
 serde = { version = "1.0.219", features = ["derive"] }
 timely = "0.24.0"
 tracing = "0.1.37"

--- a/src/compute-types/src/plan/join.rs
+++ b/src/compute-types/src/plan/join.rs
@@ -31,8 +31,6 @@ use std::collections::BTreeMap;
 
 use mz_expr::{MapFilterProject, MirScalarExpr};
 use mz_repr::{Datum, Row, RowArena};
-use proptest::prelude::*;
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 pub mod delta_join;
@@ -42,7 +40,7 @@ pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
 /// A complete enumeration of possible join plans to render.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum JoinPlan {
     /// A join implemented by a linear join.
     Linear(LinearJoinPlan),
@@ -62,23 +60,6 @@ pub struct JoinClosure {
     pub ready_equivalences: Vec<Vec<MirScalarExpr>>,
     /// TODO(database-issues#7533): Add documentation.
     pub before: mz_expr::SafeMfpPlan,
-}
-
-impl Arbitrary for JoinClosure {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (
-            prop::collection::vec(prop::collection::vec(any::<MirScalarExpr>(), 0..3), 0..3),
-            any::<mz_expr::SafeMfpPlan>(),
-        )
-            .prop_map(|(ready_equivalences, before)| JoinClosure {
-                ready_equivalences,
-                before,
-            })
-            .boxed()
-    }
 }
 
 impl JoinClosure {

--- a/src/compute-types/src/plan/join/linear_join.rs
+++ b/src/compute-types/src/plan/join/linear_join.rs
@@ -13,9 +13,6 @@ use mz_expr::{
     JoinInputCharacteristics, MapFilterProject, MirScalarExpr, join_permutations,
     permutation_for_arrangement,
 };
-use proptest::prelude::*;
-use proptest::result::Probability;
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::plan::AvailableCollections;
@@ -43,39 +40,12 @@ pub struct LinearJoinPlan {
     pub final_closure: Option<JoinClosure>,
 }
 
-impl Arbitrary for LinearJoinPlan {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (
-            any::<usize>(),
-            any_with::<Option<Vec<MirScalarExpr>>>((Probability::default(), ((0..3).into(), ()))),
-            any::<Option<JoinClosure>>(),
-            prop::collection::vec(any::<LinearStagePlan>(), 0..3),
-            any::<Option<JoinClosure>>(),
-        )
-            .prop_map(
-                |(source_relation, source_key, initial_closure, stage_plans, final_closure)| {
-                    LinearJoinPlan {
-                        source_relation,
-                        source_key,
-                        initial_closure,
-                        stage_plans,
-                        final_closure,
-                    }
-                },
-            )
-            .boxed()
-    }
-}
-
 /// A plan for the execution of one stage of a linear join.
 ///
 /// Each stage is a binary join between the current accumulated
 /// join results, and a new collection. The former is referred to
 /// as the "stream" and the latter the "lookup".
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LinearStagePlan {
     /// The index of the relation into which we will look up.
     pub lookup_relation: usize,

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -24,13 +24,12 @@
 //!     if a potential downstream operator does not expect its input to be arranged.
 
 use mz_expr::{MirScalarExpr, permutation_for_arrangement};
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::plan::AvailableCollections;
 
 /// A plan describing how to compute a threshold operation.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ThresholdPlan {
     /// Basic threshold maintains all positive inputs.
     Basic(BasicThresholdPlan),
@@ -54,7 +53,7 @@ impl ThresholdPlan {
 }
 
 /// A plan to maintain all inputs with positive counts.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BasicThresholdPlan {
     /// Description of how the input has been arranged, and how to arrange the output
     pub ensure_arrangement: (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>),

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -18,13 +18,12 @@
 //! * A [BasicTopKPlan] maintains up to K rows per key and can handle retractions.
 
 use mz_expr::ColumnOrder;
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::plan::bucketing_of_expected_group_size;
 
 /// A plan encapsulating different variants to compute a TopK operation.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum TopKPlan {
     /// A plan for Top1 for monotonic inputs.
     MonotonicTop1(MonotonicTop1Plan),
@@ -166,7 +165,7 @@ impl TopKPlan {
 /// differential's semantics. (2) is especially interesting because Kafka is
 /// monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
 /// Materialize and commonly used by users.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MonotonicTop1Plan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -183,7 +182,7 @@ pub struct MonotonicTop1Plan {
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MonotonicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -205,7 +204,7 @@ pub struct MonotonicTopKPlan {
 }
 
 /// A plan for generic TopKs that don't fit any more specific category.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BasicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -13,8 +13,6 @@ use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{CatalogItemId, GlobalId, RelationDesc, Timestamp};
 use mz_storage_types::connections::aws::AwsConnection;
 use mz_storage_types::sinks::S3UploadInfo;
-use proptest::prelude::{Arbitrary, BoxedStrategy, Strategy, any};
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
 
@@ -37,47 +35,8 @@ pub struct ComputeSinkDesc<S: 'static = (), T = Timestamp> {
     pub refresh_schedule: Option<RefreshSchedule>,
 }
 
-impl Arbitrary for ComputeSinkDesc<(), Timestamp> {
-    type Strategy = BoxedStrategy<Self>;
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (
-            any::<GlobalId>(),
-            any::<RelationDesc>(),
-            any::<ComputeSinkConnection<()>>(),
-            any::<bool>(),
-            proptest::collection::vec(any::<Timestamp>(), 1..4),
-            proptest::collection::vec(any::<usize>(), 0..4),
-            proptest::option::of(any::<RefreshSchedule>()),
-        )
-            .prop_map(
-                |(
-                    from,
-                    from_desc,
-                    connection,
-                    with_snapshot,
-                    up_to_frontier,
-                    non_null_assertions,
-                    refresh_schedule,
-                )| {
-                    ComputeSinkDesc {
-                        from,
-                        from_desc,
-                        connection,
-                        with_snapshot,
-                        up_to: Antichain::from(up_to_frontier),
-                        non_null_assertions,
-                        refresh_schedule,
-                    }
-                },
-            )
-            .boxed()
-    }
-}
-
 /// TODO(database-issues#7533): Add documentation.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ComputeSinkConnection<S: 'static = ()> {
     /// TODO(database-issues#7533): Add documentation.
     Subscribe(SubscribeSinkConnection),
@@ -112,11 +71,11 @@ impl<S> ComputeSinkConnection<S> {
 }
 
 /// TODO(database-issues#7533): Add documentation.
-#[derive(Arbitrary, Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SubscribeSinkConnection {}
 
 /// Connection attributes required to do a oneshot copy to s3.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CopyToS3OneshotSinkConnection {
     /// Information specific to the upload.
     pub upload_info: S3UploadInfo,
@@ -131,7 +90,7 @@ pub struct CopyToS3OneshotSinkConnection {
 }
 
 /// TODO(database-issues#7533): Add documentation.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MaterializedViewSinkConnection<S> {
     /// TODO(database-issues#7533): Add documentation.
     pub value_desc: RelationDesc,
@@ -141,7 +100,7 @@ pub struct MaterializedViewSinkConnection<S> {
 
 /// ContinualTask-specific information necessary for rendering a ContinualTask
 /// sink. (Shared-sink information is instead stored on ComputeSinkConnection.)
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ContinualTaskConnection<S> {
     /// The id of the (for now) single input to this CT.
     //

--- a/src/compute-types/src/sources.rs
+++ b/src/compute-types/src/sources.rs
@@ -10,7 +10,6 @@
 //! Types for describing dataflow sources.
 
 use mz_repr::SqlRelationType;
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 /// A description of an instantiation of a source.
@@ -18,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// This includes a description of the source, but additionally any
 /// context-dependent options like the ability to apply filtering and
 /// projection to the records as they emerge.
-#[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceInstanceDesc<M> {
     /// Arguments for this instantiation of the source.
     pub arguments: SourceInstanceArguments,
@@ -29,7 +28,7 @@ pub struct SourceInstanceDesc<M> {
 }
 
 /// Per-source construction arguments.
-#[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceInstanceArguments {
     /// Linear operators to be applied record-by-record.
     pub operators: Option<mz_expr::MapFilterProject>,


### PR DESCRIPTION
(First commit is from https://github.com/MaterializeInc/materialize/pull/33638 and can be ignored here.)

Now that the expr_cache tests don't rely on these `Arbitrary` impls anymore, they can be deleted.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
