### PR TITLE
ci: Move cargo doc test back to test pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -107,21 +107,6 @@ steps:
           queue: hetzner-aarch64-4cpu-8gb
         sanitizer: skip
 
-      - id: lint-cargo-doc-test
-        label: Cargo doc tests
-        command: bin/ci-builder run stable ci/test/lint-cargo-doc-test.sh
-        inputs:
-          - Cargo.lock
-          - Cargo.toml
-          - "**/Cargo.toml"
-          - "**/*.rs"
-        depends_on: []
-        timeout_in_minutes: 40
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        coverage: skip
-        sanitizer: skip
-
       - id: sbomgen
         timeout_in_minutes: 30
         label: Generate SBOM and upload to AWS

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -240,6 +240,22 @@ steps:
         coverage: skip
         sanitizer: skip
 
+      - id: lint-cargo-doc-test
+        label: Cargo doc tests
+        command: bin/ci-builder run stable ci/test/lint-cargo-doc-test.sh
+        inputs:
+          - Cargo.lock
+          - Cargo.toml
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        depends_on: []
+        timeout_in_minutes: 40
+        agents:
+          queue: hetzner-x86-64-dedi-32cpu-128gb-cargo-test
+        coverage: skip
+        sanitizer: skip
+
+
   - id: cargo-test
     label: ":rust: Cargo test"
     timeout_in_minutes: 60


### PR DESCRIPTION
and use the dedicated agents. Depends on https://github.com/MaterializeInc/i2/pull/2841

For https://materializeinc.slack.com/archives/C01LKF361MZ/p1758285899379379

Fixes: https://github.com/MaterializeInc/database-issues/issues/9717
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
