### PR TITLE
Split off `determine_timestamp_for`'s `&self` part

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -194,10 +194,6 @@ impl Coordinator {
         let (_, view_id) = self.allocate_transient_id();
         let (_, sink_id) = self.allocate_transient_id();
         let conn_id = session.conn_id().clone();
-        let up_to = up_to
-            .as_ref()
-            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr.clone(), session))
-            .transpose()?;
         let debug_name = format!("subscribe-{}", sink_id);
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&self.catalog.get_cluster(cluster_id).config.features());
@@ -210,7 +206,7 @@ impl Coordinator {
             sink_id,
             Some(conn_id),
             *with_snapshot,
-            up_to,
+            *up_to,
             debug_name,
             optimizer_config,
             self.optimizer_metrics(),

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -119,8 +119,6 @@ pub enum ExprPrepStyle<'a> {
         session: &'a dyn SessionMetadata,
         catalog_state: &'a CatalogState,
     },
-    /// The expression is being prepared for evaluation in an AS OF or UP TO clause.
-    AsOfUpTo,
     /// The expression is being prepared for evaluation in a CHECK expression of a webhook source.
     WebhookValidation {
         /// Time at which this expression is being evaluated.
@@ -445,9 +443,7 @@ pub fn prep_relation_expr(
                 }
             })
         }
-        ExprPrepStyle::OneShot { .. }
-        | ExprPrepStyle::AsOfUpTo
-        | ExprPrepStyle::WebhookValidation { .. } => expr
+        ExprPrepStyle::OneShot { .. } | ExprPrepStyle::WebhookValidation { .. } => expr
             .0
             .try_visit_scalars_mut(&mut |s| prep_scalar_expr(s, style)),
     }
@@ -483,7 +479,7 @@ pub fn prep_scalar_expr(
         }),
 
         // Reject the query if it contains any unmaterializable function calls.
-        ExprPrepStyle::Maintained | ExprPrepStyle::AsOfUpTo => {
+        ExprPrepStyle::Maintained => {
             let mut last_observed_unmaterializable_func = None;
             expr.visit_mut_post(&mut |e| {
                 if let MirScalarExpr::CallUnmaterializable(f) = e {
@@ -494,10 +490,6 @@ pub fn prep_scalar_expr(
             if let Some(f) = last_observed_unmaterializable_func {
                 let err = match style {
                     ExprPrepStyle::Maintained => OptimizerError::UnmaterializableFunction(f),
-                    ExprPrepStyle::AsOfUpTo => OptimizerError::UncallableFunction {
-                        func: f,
-                        context: "AS OF or UP TO",
-                    },
                     _ => unreachable!(),
                 };
                 return Err(err);

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -17,8 +17,7 @@ use mz_adapter::catalog::CatalogState;
 use mz_adapter::session::Session;
 use mz_adapter::{CollectionIdBundle, TimelineContext, TimestampProvider};
 use mz_compute_types::ComputeInstanceId;
-use mz_expr::MirScalarExpr;
-use mz_repr::{Datum, GlobalId, SqlScalarType, Timestamp};
+use mz_repr::{GlobalId, Timestamp};
 use mz_sql::plan::QueryWhen;
 use mz_sql::session::vars::IsolationLevel;
 use mz_sql_parser::ast::TransactionIsolationLevel;
@@ -177,11 +176,10 @@ fn parse_query_when(s: &str) -> QueryWhen {
     let s = s.to_lowercase();
     match s.split_once(':') {
         Some((when, ts)) => {
-            let ts: i64 = ts.parse().unwrap();
-            let expr = MirScalarExpr::literal_ok(Datum::Int64(ts), SqlScalarType::Int64);
+            let ts = ts.parse().unwrap();
             match when {
-                "attimestamp" => QueryWhen::AtTimestamp(expr),
-                "atleasttimestamp" => QueryWhen::AtLeastTimestamp(expr),
+                "attimestamp" => QueryWhen::AtTimestamp(ts),
+                "atleasttimestamp" => QueryWhen::AtLeastTimestamp(ts),
                 _ => panic!("bad when {s}"),
             }
         }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -893,7 +893,7 @@ pub struct SubscribePlan {
     pub from: SubscribeFrom,
     pub with_snapshot: bool,
     pub when: QueryWhen,
-    pub up_to: Option<MirScalarExpr>,
+    pub up_to: Option<Timestamp>,
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
     pub output: SubscribeOutput,
@@ -1846,15 +1846,15 @@ pub enum QueryWhen {
     /// expression.
     ///
     /// The expression may have any type.
-    AtTimestamp(MirScalarExpr),
+    AtTimestamp(Timestamp),
     /// Same as Immediately, but will also advance to at least the specified
     /// expression.
-    AtLeastTimestamp(MirScalarExpr),
+    AtLeastTimestamp(Timestamp),
 }
 
 impl QueryWhen {
     /// Returns a timestamp to which the candidate must be advanced.
-    pub fn advance_to_timestamp(&self) -> Option<MirScalarExpr> {
+    pub fn advance_to_timestamp(&self) -> Option<Timestamp> {
         match self {
             QueryWhen::AtTimestamp(t) | QueryWhen::AtLeastTimestamp(t) => Some(t.clone()),
             QueryWhen::Immediately | QueryWhen::FreshestTableWrite => None,

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -287,7 +287,7 @@ pub enum PlanError {
     Replan(String),
     NetworkPolicyLockoutError,
     NetworkPolicyInUse,
-    // Expected a constant expression that evaluates without an error to a non-null value.
+    /// Expected a constant expression that evaluates without an error to a non-null value.
     ConstantExpressionSimplificationFailed(String),
     InvalidOffset(String),
     /// The named cursor does not exist.
@@ -295,6 +295,8 @@ pub enum PlanError {
     CopyFromTargetTableDropped {
         target_name: String,
     },
+    /// AS OF or UP TO should be an expression that is castable and simplifiable to a non-null mz_timestamp value.
+    InvalidAsOfUpTo,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -825,6 +827,7 @@ impl fmt::Display for PlanError {
                 write!(f, "cursor {} does not exist", name.quoted())
             }
             Self::CopyFromTargetTableDropped { target_name: name } => write!(f, "COPY FROM's target table {} was dropped", name.quoted()),
+            Self::InvalidAsOfUpTo => write!(f, "AS OF or UP TO should be castable to a (non-null) mz_timestamp value")
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1033,32 +1033,6 @@ where
     Ok(expr.map(map_exprs).project(project_key))
 }
 
-/// Plans an expression in the `UP TO` position of a `SUBSCRIBE` statement.
-pub fn plan_up_to(
-    scx: &StatementContext,
-    mut up_to: Expr<Aug>,
-) -> Result<MirScalarExpr, PlanError> {
-    let scope = Scope::empty();
-    let desc = RelationDesc::empty();
-    // Even though this is part of a SUBSCRIBE, we need a QueryLifetime::OneShot (instead of
-    // QueryLifetime::Subscribe), because the UP TO is evaluated only once.
-    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
-    transform_ast::transform(scx, &mut up_to)?;
-    let ecx = &ExprContext {
-        qcx: &qcx,
-        name: "UP TO",
-        scope: &scope,
-        relation_type: desc.typ(),
-        allow_aggregates: false,
-        allow_subqueries: false,
-        allow_parameters: false,
-        allow_windows: false,
-    };
-    plan_expr(ecx, &up_to)?
-        .type_as_any(ecx)?
-        .lower_uncorrelated()
-}
-
 /// Plans an expression in the AS OF position of a `SELECT` or `SUBSCRIBE`, or `CREATE MATERIALIZED
 /// VIEW` statement.
 pub fn plan_as_of(
@@ -1067,34 +1041,57 @@ pub fn plan_as_of(
 ) -> Result<QueryWhen, PlanError> {
     match as_of {
         None => Ok(QueryWhen::Immediately),
-        Some(mut as_of) => match as_of {
-            AsOf::At(ref mut expr) | AsOf::AtLeast(ref mut expr) => {
-                let scope = Scope::empty();
-                let desc = RelationDesc::empty();
-                // Even for a SUBSCRIBE, we need QueryLifetime::OneShot, because the AS OF is
-                // evaluated only once.
-                let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
-                transform_ast::transform(scx, expr)?;
-                let ecx = &ExprContext {
-                    qcx: &qcx,
-                    name: "AS OF",
-                    scope: &scope,
-                    relation_type: desc.typ(),
-                    allow_aggregates: false,
-                    allow_subqueries: false,
-                    allow_parameters: false,
-                    allow_windows: false,
-                };
-                let expr = plan_expr(ecx, expr)?
-                    .type_as_any(ecx)?
-                    .lower_uncorrelated()?;
-                match as_of {
-                    AsOf::At(_) => Ok(QueryWhen::AtTimestamp(expr)),
-                    AsOf::AtLeast(_) => Ok(QueryWhen::AtLeastTimestamp(expr)),
-                }
-            }
+        Some(as_of) => match as_of {
+            AsOf::At(expr) => Ok(QueryWhen::AtTimestamp(plan_as_of_or_up_to(scx, expr)?)),
+            AsOf::AtLeast(expr) => Ok(QueryWhen::AtLeastTimestamp(plan_as_of_or_up_to(scx, expr)?)),
         },
     }
+}
+
+/// Plans and evaluates a scalar expression in a OneShot context to a non-null MzTimestamp.
+///
+/// Produces [`PlanError::InvalidAsOfUpTo`] if the expression is
+/// - not a constant,
+/// - not castable to MzTimestamp,
+/// - is null,
+/// - contains an unmaterializable function,
+/// - some other evaluation error occurs, e.g., a division by 0,
+/// - contains aggregates, subqueries, parameters, or window function calls.
+pub fn plan_as_of_or_up_to(
+    scx: &StatementContext,
+    mut expr: Expr<Aug>,
+) -> Result<mz_repr::Timestamp, PlanError> {
+    let scope = Scope::empty();
+    let desc = RelationDesc::empty();
+    // (Even for a SUBSCRIBE, we need QueryLifetime::OneShot, because the AS OF or UP TO is
+    // evaluated only once.)
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
+    transform_ast::transform(scx, &mut expr)?;
+    let ecx = &ExprContext {
+        qcx: &qcx,
+        name: "AS OF or UP TO",
+        scope: &scope,
+        relation_type: desc.typ(),
+        allow_aggregates: false,
+        allow_subqueries: false,
+        allow_parameters: false,
+        allow_windows: false,
+    };
+    let hir =
+        plan_expr(ecx, &expr)?.cast_to(ecx, CastContext::Implicit, &SqlScalarType::MzTimestamp)?;
+    if hir.contains_unmaterializable() {
+        bail_unsupported!("calling an unmaterializable function in AS OF or UP TO");
+    }
+    // At this point, we definitely have a constant expression:
+    // - it can't contain any unmaterializable functions;
+    // - it can't refer to any columns.
+    // But the following can still fail due to a variety of reasons: most commonly, the cast can
+    // fail, but also a null might appear, or some other evaluation error can happen, e.g., a
+    // division by 0.
+    let timestamp = hir
+        .into_literal_mz_timestamp()
+        .ok_or_else(|| PlanError::InvalidAsOfUpTo)?;
+    Ok(timestamp)
 }
 
 /// Plans an expression in the AS position of a `CREATE SECRET`.

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -51,7 +51,9 @@ use crate::ast::{
 use crate::catalog::CatalogItemType;
 use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
-use crate::plan::query::{ExprContext, QueryLifetime, offset_into_value, plan_expr, plan_up_to};
+use crate::plan::query::{
+    ExprContext, QueryLifetime, offset_into_value, plan_as_of_or_up_to, plan_expr,
+};
 use crate::plan::scope::Scope;
 use crate::plan::statement::show::ShowSelect;
 use crate::plan::statement::{StatementContext, StatementDesc, ddl};
@@ -1216,7 +1218,9 @@ pub fn plan_subscribe(
     };
 
     let when = query::plan_as_of(scx, as_of)?;
-    let up_to = up_to.map(|up_to| plan_up_to(scx, up_to)).transpose()?;
+    let up_to = up_to
+        .map(|up_to| plan_as_of_or_up_to(scx, up_to))
+        .transpose()?;
 
     let qcx = QueryContext::root(scx, QueryLifetime::Subscribe);
     let ecx = ExprContext {

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -24,8 +24,14 @@ SELECT * FROM data
 2 1
 3 1
 
-query error cannot call current_timestamp in AS OF
+query error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
 SELECT * FROM data AS OF now()
+
+query error db error: ERROR: AS OF or UP TO does not support implicitly casting from text to mz_timestamp
+SELECT * FROM data AS OF current_database()
+
+query error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
+SELECT * FROM data AS OF current_database()::mz_timestamp
 
 query II
 SELECT * FROM data ORDER BY a, b AS OF AT LEAST 1
@@ -46,20 +52,32 @@ SELECT * FROM data AS OF 192741824E4::numeric;
 2 1
 3 1
 
-query error out of range integral type conversion attempted
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT * FROM data AS OF -1;
 
-query error decimal cannot be expressed in target primitive type
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT * FROM data AS OF -1::numeric;
 
-query error decimal cannot be expressed in target primitive type
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT * FROM data AS OF 1E38;
 
-query error decimal cannot be expressed in target primitive type
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT * FROM data AS OF 1.2;
 
-query error cannot call mz_now in AS OF
+query error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
 SELECT * FROM data AS OF mz_now();
+
+query error db error: ERROR: column "a" does not exist
+SELECT * FROM data AS OF a;
+
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SELECT * FROM data AS OF 'xxx';
+
+query error db error: ERROR: AS OF or UP TO does not support implicitly casting from integer list to mz_timestamp
+SELECT * FROM data AS OF LIST[7,8,9];
+
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SELECT * FROM data AS OF 7/0;
 
 statement ok
 CREATE TABLE t (i INT);
@@ -86,13 +104,13 @@ SELECT count(*) = 2 FROM t AS OF AT LEAST 1
 ----
 false
 
-query error can't use null as a mz_timestamp for AS OF
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT 1 AS OF NULL::timestamp;
 
-query error can't use null as a mz_timestamp for AS OF
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SELECT * FROM data AS OF NULL::numeric;
 
-query error can't use null as a mz_timestamp for AS OF
+query error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
 SUBSCRIBE (SELECT 1) AS OF NULL::timestamptz;
 
 # Test that timestamps are used for constant queries with temporal filters

--- a/test/sqllogictest/subscribe_error.slt
+++ b/test/sqllogictest/subscribe_error.slt
@@ -61,3 +61,31 @@ FETCH 1 c
 
 statement ok
 ROLLBACK
+
+# Test that invalid UP TO expressions are rejected.
+# (`SUBSCRIBE ... AS OF ... UP TO` is also tested in `as_of.slt` and in some cargo tests:
+# test_empty_subscribe_error, test_empty_subscribe_notice, test_subscribe_basic)
+
+statement error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SUBSCRIBE mv UP TO -1;
+
+statement error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SUBSCRIBE mv UP TO null;
+
+statement error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SUBSCRIBE mv UP TO null::mz_timestamp;
+
+statement error db error: ERROR: AS OF or UP TO should be castable to a \(non\-null\) mz_timestamp value
+SUBSCRIBE mv UP TO 'xxx';
+
+statement error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
+SUBSCRIBE mv UP TO now();
+
+statement error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
+SUBSCRIBE mv UP TO mz_now();
+
+statement error db error: ERROR: AS OF or UP TO does not support implicitly casting from text to mz_timestamp
+SUBSCRIBE mv UP TO current_database();
+
+statement error db error: ERROR: calling an unmaterializable function in AS OF or UP TO not yet supported
+SUBSCRIBE mv UP TO current_database()::mz_timestamp;

--- a/test/testdrive/fetch-tail-as-of.td
+++ b/test/testdrive/fetch-tail-as-of.td
@@ -23,7 +23,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > DECLARE c CURSOR FOR SUBSCRIBE t1 AS OF -1;
 
 ! FETCH 1 c;
-contains:out of range integral type conversion attempted
+contains:AS OF or UP TO should be castable to a (non-null) mz_timestamp value
 
 > COMMIT
 


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/33647.

This is another preparatory refactoring for the big peek sequencing PR, as discussed with @aljoscha. In the old peek sequencing, `TimestampProvider` is implemented by the `Coordinator`. In the frontend peek sequencing we won't have access to the Coordinator, and would like to avoid writing another implementation of `TimestampProvider`. This is because it has several methods that are irrelevant in the frontend peek sequencing (and also because there is an asyncness mismatch, due to the thin controller clients having to send messages to the compute controller, which is avoided in the old peek sequencing by the cached frontiers in the fat clients).

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
