### PR TITLE
Early exit from `StorageCollections::acquire_read_holds` and `collections_frontiers`

### DIFF
--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1442,6 +1442,10 @@ where
         &self,
         ids: Vec<GlobalId>,
     ) -> Result<Vec<CollectionFrontiers<Self::Timestamp>>, StorageError<Self::Timestamp>> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+
         let collections = self.collections.lock().expect("lock poisoned");
 
         let res = ids
@@ -2499,6 +2503,10 @@ where
         &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError> {
+        if desired_holds.is_empty() {
+            return Ok(vec![]);
+        }
+
         let mut collections = self.collections.lock().expect("lock poisoned");
 
         let mut advanced_holds = Vec::new();


### PR DESCRIPTION
This is just a minor optimization that I noticed while working on the peek sequencing. These methods lock `self.collections`, plus `StorageCollections::acquire_read_holds` does lots of other things. We can avoid all this when the input vec of collection ids is empty.

An example situation when there are no ids is when `Coordinator::acquire_read_holds` is used in a fast path peek, in which case `desired_storage_holds` will be empty, so `StorageCollections::acquire_read_holds` is called with an empty vec.

### Motivation

   * This PR does a minor optimization.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
