### PR TITLE
Fix balancerd tests after sni fastpath

### DIFF
--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -1318,13 +1318,13 @@ impl Resolver {
                             port,
                         }),
                     ) => {
-                        debug!("Found sni servername: {servername:?} (pgwire)");
                         let sni_addr = sni_addr_template.replace("{}", servername);
                         let tenant = stub_resolver.tenant(&sni_addr).await;
-                        debug!("sni_addr tenant lookup {:?} - {:?}", sni_addr, tenant);
                         let sni_addr = format!("{sni_addr}:{port}");
-                        debug!("sni_addr backend lookup {sni_addr}");
                         let addr = lookup(&sni_addr).await?;
+                        if tenant.is_some() {
+                            debug!("SNI header found for tenant {:?}", tenant);
+                        }
                         ResolvedAddr {
                             addr,
                             password: None,
@@ -1354,10 +1354,9 @@ impl Resolver {
                             addr_template.replace("{}", &auth_session.tenant_id().to_string());
                         let addr = lookup(&addr).await?;
                         let tenant = Some(auth_session.tenant_id().to_string());
-                        debug!(
-                            "No sni header found for tenant connection {:?}, used frontegg",
-                            tenant
-                        );
+                        if tenant.is_some() {
+                            debug!("SNI header NOT found for tenant {:?}", tenant);
+                        }
                         ResolvedAddr {
                             addr,
                             password: Some(password),


### PR DESCRIPTION
- don't use fastpath when tenant resolution is required sni fastpath, like http, does not support tenant resolution in docker compose

- fix workflow_user test to close connection before looking at writes

- add more logging for man_connections


https://github.com/MaterializeInc/database-issues/issues/9700


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
