### PR TITLE
also check credit consumption limit on environmentd startup

### DIFF
--- a/misc/python/materialize/cli/orchestratord.py
+++ b/misc/python/materialize/cli/orchestratord.py
@@ -64,6 +64,7 @@ def main():
         "--environment-name",
         default="12345678-1234-1234-1234-123456789012",
     )
+    parser_environment.add_argument("--environment-id", required=False)
     parser_environment.add_argument("--postgres-url", default=DEFAULT_POSTGRES)
     parser_environment.add_argument("--s3-bucket", default=DEFAULT_MINIO)
     parser_environment.add_argument("--license-key-file")
@@ -206,7 +207,10 @@ def environment(args: argparse.Namespace):
             cluster=args.kind_cluster_name,
         )
 
-    environment_id = str(uuid4())
+    if args.environment_id is None:
+        environment_id = str(uuid4())
+    else:
+        environment_id = args.environment_id
 
     def root_psql(cmd: str):
         env_kubectl(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -108,7 +108,9 @@ use mz_compute_client::controller::error::InstanceMissing;
 use mz_compute_types::ComputeInstanceId;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
-use mz_controller::clusters::{ClusterConfig, ClusterEvent, ClusterStatus, ProcessId};
+use mz_controller::clusters::{
+    ClusterConfig, ClusterEvent, ClusterStatus, ProcessId, ReplicaLocation,
+};
 use mz_controller::{ControllerConfig, Readiness};
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
 use mz_expr::{MapFilterProject, OptimizedMirRelationExpr, RowSetFinishing};
@@ -129,6 +131,7 @@ use mz_ore::{
 use mz_persist_client::PersistClient;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
+use mz_repr::adt::numeric::Numeric;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::optimize::OptimizerFeatures;
@@ -145,7 +148,7 @@ use mz_sql::plan::{
     OnTimeoutAction, Params, QueryWhen,
 };
 use mz_sql::session::user::User;
-use mz_sql::session::vars::SystemVars;
+use mz_sql::session::vars::{MAX_CREDIT_CONSUMPTION_RATE, SystemVars, Var};
 use mz_sql_parser::ast::ExplainStage;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::client::TableData;
@@ -1868,6 +1871,18 @@ impl Coordinator {
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller.update_configuration(dyncfg_updates);
+
+        self.validate_resource_limit_numeric(
+            Numeric::zero(),
+            self.current_credit_consumption_rate(),
+            |system_vars| {
+                self.license_key
+                    .max_credit_consumption_rate()
+                    .map_or_else(|| system_vars.max_credit_consumption_rate(), Numeric::from)
+            },
+            "cluster replica",
+            MAX_CREDIT_CONSUMPTION_RATE.name(),
+        )?;
 
         let mut policies_to_set: BTreeMap<CompactionWindow, CollectionIdBundle> =
             Default::default();
@@ -3874,6 +3889,24 @@ impl Coordinator {
             // main thread has shut down.
             let _ = internal_cmd_tx.send(Message::StorageUsagePrune(expired));
         });
+    }
+
+    fn current_credit_consumption_rate(&self) -> Numeric {
+        self.catalog()
+            .user_cluster_replicas()
+            .filter_map(|replica| match &replica.config.location {
+                ReplicaLocation::Managed(location) => Some(location.size_for_billing()),
+                ReplicaLocation::Unmanaged(_) => None,
+            })
+            .map(|size| {
+                self.catalog()
+                    .cluster_replica_sizes()
+                    .0
+                    .get(size)
+                    .expect("location size is validated against the cluster replica sizes")
+                    .credits_per_hour
+            })
+            .sum()
     }
 }
 


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/database-issues/issues/9708

### Tips for reviewer

not sure if there are other limits we want to check on startup, but this one is an important one to start with

we probably also want tests for this, but i'm about to head out for vacation for a week, so figured i would at least get this up before i left

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
