### PR TITLE
storage: report statistics only for ingestion exports

### DIFF
--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -286,7 +286,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 source_resume_uppers,
                 remap_metadata: description.remap_metadata.clone(),
                 persist_clients: Arc::clone(&storage_state.persist_clients),
-                statistics: storage_state.aggregated_statistics.get_local_source_stats(),
+                statistics: storage_state
+                    .aggregated_statistics
+                    .get_ingestion_stats(&primary_source_id),
                 shared_remap_upper: Rc::clone(
                     &storage_state.source_uppers[&description.remap_collection_id],
                 ),

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -252,7 +252,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         Box::pin(SignaledFuture::new(busy_signal, async move {
             let id = config.id;
             let worker_id = config.worker_id;
-            let source_statistics = config.source_statistics();
             let [
                 data_cap_set,
                 rewind_cap_set,
@@ -430,12 +429,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 })
                 .collect();
 
-            let snapshot_total =
-                fetch_snapshot_size(&client, worker_tables, metrics, &config).await?;
-
-            let mut snapshot_staged_total = 0;
-            source_statistics.set_snapshot_records_known(snapshot_total);
-            source_statistics.set_snapshot_records_staged(0);
+            report_snapshot_size(&client, worker_tables, metrics, &config).await?;
 
             for (&oid, outputs) in reader_table_info.iter() {
                 let mut table_name = None;
@@ -501,12 +495,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                         raw_handle.give_fueled(&data_cap_set[0], &update).await;
                     }
                     snapshot_staged += 1;
-                    snapshot_staged_total += u64::cast_from(output_indexes.len());
                     if snapshot_staged % 1000 == 0 {
                         for export_stat in export_statistics.get(&oid).unwrap() {
                             export_stat.set_snapshot_records_staged(snapshot_staged);
                         }
-                        source_statistics.set_snapshot_records_staged(snapshot_staged_total);
                     }
                 }
                 // final update for snapshot_staged, using the staged values as the total is an estimate
@@ -530,9 +522,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 }
             }
             *rewind_cap_set = CapabilitySet::new();
-
-            source_statistics.set_snapshot_records_known(snapshot_staged_total);
-            source_statistics.set_snapshot_records_staged(snapshot_staged_total);
 
             // Failure scenario after we have produced the snapshot, but before a successful COMMIT
             fail::fail_point!("pg_snapshot_failure", |_| Err(
@@ -707,27 +696,25 @@ fn decode_copy_row(data: &[u8], col_len: usize, row: &mut Row) -> Result<(), Def
 }
 
 /// Record the sizes of the tables being snapshotted in `PgSnapshotMetrics` and emit snapshot statistics for each export.
-async fn fetch_snapshot_size(
+async fn report_snapshot_size(
     client: &Client,
     // The table names, oids, number of outputs, and export_ids for this table owned by this worker.
     tables: Vec<(String, Oid, usize, &Vec<SourceStatistics>)>,
     metrics: PgSnapshotMetrics,
     config: &RawSourceCreationConfig,
-) -> Result<u64, anyhow::Error> {
+) -> Result<(), anyhow::Error> {
     // TODO(guswynn): delete unused configs
     let snapshot_config = config.config.parameters.pg_snapshot_config;
 
-    let mut total = 0;
-    for (table, oid, output_count, export_stats) in tables {
+    for (table, oid, _, export_stats) in tables {
         let stats = collect_table_statistics(client, snapshot_config, &table, oid).await?;
         metrics.record_table_count_latency(table, stats.count_latency);
         for export_stat in export_stats {
             export_stat.set_snapshot_records_known(stats.count);
             export_stat.set_snapshot_records_staged(0);
         }
-        total += stats.count * u64::cast_from(output_count);
     }
-    Ok(total)
+    Ok(())
 }
 
 #[derive(Default)]

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -153,13 +153,6 @@ impl RawSourceCreationConfig {
     pub fn responsible_for<P: Hash>(&self, partition: P) -> bool {
         self.responsible_worker(partition) == self.worker_id
     }
-
-    /// Returns a `SourceStatistics` for the source.
-    pub fn source_statistics(&self) -> &SourceStatistics {
-        self.statistics
-            .get(&self.id)
-            .expect("statistics exist for the source")
-    }
 }
 
 /// Creates a source dataflow operator graph from a source connection. The type of SourceConnection
@@ -309,7 +302,6 @@ where
 {
     let source_id = config.id;
     let worker_id = config.worker_id;
-    let source_statistics = config.source_statistics().clone();
     let now_fn = config.now_fn.clone();
     let timestamp_interval = config.timestamp_interval;
 
@@ -352,7 +344,11 @@ where
         export_collections.insert(id, new_export.as_collection());
 
         let bytes_read_counter = config.metrics.source_defs.bytes_read.clone();
-        let source_statistics = source_statistics.clone();
+        let source_statistics = config
+            .statistics
+            .get(&id)
+            .expect("statistics initialized")
+            .clone();
 
         builder.build(move |mut caps| {
             let mut health_cap = Some(caps.remove(0));

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -682,6 +682,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     let resume_upper = resume_uppers[export_id].clone();
                     self.storage_state.aggregated_statistics.initialize_source(
                         *export_id,
+                        ingestion_id,
                         resume_upper.clone(),
                         || {
                             SourceStatistics::new(

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -75,7 +75,7 @@ two
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
 remote1 true true 2 2
@@ -84,7 +84,7 @@ remote2 true true 2 2
 > SELECT s.name,
   SUM(u.updates_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
   GROUP BY s.id, s.name
 webhook_text 1

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -27,7 +27,7 @@ two
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
 remote1 true true 2 2
@@ -36,7 +36,7 @@ remote2 true true 2 2
 > SELECT s.name,
   SUM(u.updates_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
   GROUP BY s.id, s.name
 webhook_text 1
@@ -64,7 +64,7 @@ three
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
 remote1 true true 3 3
@@ -73,7 +73,7 @@ remote2 true true 3 3
 > SELECT s.name,
   SUM(u.updates_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
   GROUP BY s.id, s.name
 webhook_text 2

--- a/test/cluster/storage/04-after-clusterd-restart.td
+++ b/test/cluster/storage/04-after-clusterd-restart.td
@@ -46,7 +46,7 @@ five
   SUM(u.offset_known),
   SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
 remote1 5 5

--- a/test/mysql-cdc-old-syntax/statistics.td
+++ b/test/mysql-cdc-old-syntax/statistics.td
@@ -51,7 +51,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -68,7 +68,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -83,7 +83,7 @@ SELECT cr.id
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 1 1
 
@@ -91,7 +91,7 @@ $ set-from-sql var=previous-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 
@@ -105,7 +105,7 @@ INSERT INTO t1 VALUES ('two');
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 1 1
 
@@ -113,7 +113,7 @@ $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -131,7 +131,7 @@ INSERT INTO t1 VALUES ('three');
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 1 1
 
@@ -140,7 +140,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -154,7 +154,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -171,7 +171,7 @@ SELECT cr.id
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true <null> <null>
 

--- a/test/mysql-cdc/statistics.td
+++ b/test/mysql-cdc/statistics.td
@@ -54,7 +54,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -71,7 +71,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -86,18 +86,18 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-from-sql var=previous-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 
@@ -111,18 +111,18 @@ INSERT INTO t1 VALUES ('two');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -140,19 +140,19 @@ INSERT INTO t1 VALUES ('three');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-regex match=u\d+ replacement="<REPLICAID>"
 > SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -166,7 +166,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -183,7 +183,7 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
 mz_source true true <null> <null>
@@ -208,20 +208,20 @@ true
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 2 2
-t1 false true 0 0
-t2 false true 2 2
+t1 true true 0 0
+t2 true true 2 2
 
 # Ensure subsource stats show up, and then are removed when we drop subsources.
 > SELECT
     t.name,
     SUM(u.updates_committed) > 0
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('t1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name
@@ -233,7 +233,7 @@ t2 true
 > SELECT
     t.name, count(*)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('t1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name

--- a/test/pg-cdc-old-syntax/statistics.td
+++ b/test/pg-cdc-old-syntax/statistics.td
@@ -56,7 +56,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -73,7 +73,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -88,7 +88,7 @@ SELECT cr.id
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 2 2
 
@@ -96,7 +96,7 @@ $ set-from-sql var=previous-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 
@@ -111,7 +111,7 @@ INSERT INTO t1 VALUES ('three');
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 2 2
 
@@ -119,7 +119,7 @@ $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -137,7 +137,7 @@ INSERT INTO t1 VALUES ('four');
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true 2 2
 
@@ -146,7 +146,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -160,7 +160,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -177,7 +177,7 @@ SELECT cr.id
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source true true <null> <null>
 
@@ -198,7 +198,7 @@ true
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source 1 1
 
@@ -207,7 +207,7 @@ mz_source 1 1
     u.snapshot_records_known,
     u.snapshot_records_staged
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 mz_source 1 1
 
@@ -216,7 +216,7 @@ mz_source 1 1
     s.name,
     u.updates_committed > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('alt') AND u.replica_id = '${replica_id}'
 alt true
 
@@ -225,7 +225,7 @@ alt true
 > SELECT
     count(*)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('alt')
 0
 

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -59,7 +59,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -76,7 +76,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -91,18 +91,18 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 2 2
-t1 false true 2 2
+t1 true true 2 2
 
 $ set-from-sql var=previous-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 
@@ -116,18 +116,18 @@ INSERT INTO t1 VALUES ('three');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 2 2
-t1 false true 2 2
+t1 true true 2 2
 
 $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -145,19 +145,19 @@ INSERT INTO t1 VALUES ('four');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 2 2
-t1 false true 2 2
+t1 true true 2 2
 
 $ set-regex match=u\d+ replacement="<REPLICAID>"
 > SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -171,7 +171,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -188,7 +188,7 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
 mz_source true true <null> <null>
@@ -210,7 +210,7 @@ true
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1', 'alt') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
@@ -223,7 +223,7 @@ t1 0 0
     t.name,
     SUM(u.updates_committed) > 0
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('alt', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name
@@ -235,7 +235,7 @@ t1 true
 > SELECT
     t.name, count(*)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('alt', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name

--- a/test/sql-server-cdc-old-syntax/statistics.td
+++ b/test/sql-server-cdc-old-syntax/statistics.td
@@ -56,7 +56,7 @@ true
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
@@ -66,7 +66,7 @@ $ set-from-sql var=previous-offset-committed
 SELECT
     (SUM(u.offset_committed))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source')
 
 $ sql-server-execute name=sql-server
@@ -79,7 +79,7 @@ INSERT INTO t1 VALUES ('three');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
@@ -89,7 +89,7 @@ $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (SUM(u.offset_committed))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source')
 
 # capture the current replica_id for the source statistics
@@ -98,7 +98,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -112,7 +112,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -135,7 +135,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -149,7 +149,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -169,7 +169,7 @@ $ unset-regex
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name, u.replica_id
   ORDER BY s.name, u.replica_id
@@ -192,7 +192,7 @@ true
      SUM(u.snapshot_records_known),
      SUM(u.snapshot_records_staged)
    FROM mz_sources s
-   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
    WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
    GROUP BY s.name
    ORDER BY s.name
@@ -203,7 +203,7 @@ true
     s.name,
     SUM(u.updates_committed) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('alt') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
@@ -214,6 +214,6 @@ alt true
 > SELECT
     count(*)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('alt') AND u.replica_id = '${replica_id}'
 0

--- a/test/sql-server-cdc/statistics.td
+++ b/test/sql-server-cdc/statistics.td
@@ -61,7 +61,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -75,7 +75,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -107,7 +107,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -124,7 +124,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -139,18 +139,18 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-from-sql var=previous-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 $ sql-server-execute name=sql-server
@@ -163,18 +163,18 @@ INSERT INTO t1 VALUES ('two');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (u.offset_committed)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -192,19 +192,19 @@ INSERT INTO t1 VALUES ('three');
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 1 1
-t1 false true 1 1
+t1 true true 1 1
 
 $ set-regex match=u\d+ replacement="<REPLICAID>"
 > SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -218,7 +218,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -235,7 +235,7 @@ SELECT cr.id
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
 mz_source true true <null> <null>
@@ -272,20 +272,20 @@ true
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('mz_source', 't1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY s.name
   ORDER BY s.name
 mz_source true true 2 2
-t1 false true 0 0
-t2 false true 2 2
+t1 true true 0 0
+t2 true true 2 2
 
 # Ensure subsource stats show up, and then are removed when we drop subsources.
 > SELECT
     t.name,
     SUM(u.updates_committed) > 0
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('t1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name
@@ -297,7 +297,7 @@ t2 true
 > SELECT
     t.name, count(*)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('t1', 't2') AND u.replica_id = '${replica_id}'
   GROUP BY t.name
   ORDER BY t.name

--- a/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
+++ b/test/testdrive-old-kafka-src-syntax/pr-24663-regression.td
@@ -120,7 +120,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
@@ -139,7 +139,7 @@ id creature
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name
@@ -158,7 +158,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('dbz_no_before')
   GROUP BY s.name
   ORDER BY s.name

--- a/test/testdrive-old-kafka-src-syntax/snapshot-source-statistics.td
+++ b/test/testdrive-old-kafka-src-syntax/snapshot-source-statistics.td
@@ -81,7 +81,7 @@ mammalmore    moose   2
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -91,7 +91,7 @@ $ set-from-sql var=previous-offset-known
 SELECT
     (SUM(u.offset_known))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 
@@ -105,7 +105,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -117,7 +117,7 @@ $ set-from-sql var=pre-restart-offset-committed
 SELECT
     (SUM(u.offset_committed))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 > ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
@@ -137,7 +137,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name

--- a/test/testdrive-old-kafka-src-syntax/source-statistics.td
+++ b/test/testdrive-old-kafka-src-syntax/source-statistics.td
@@ -106,7 +106,7 @@ $ set-sql-timeout duration=2minutes
   bool_and(u.snapshot_committed),
   SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
@@ -114,18 +114,17 @@ metrics_test_source true 2 2 2 true true
 
 > DROP SOURCE metrics_test_source CASCADE
 
-# Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
 # jitter on when metrics are produced for each sub-source.
 > SELECT s.name,
   bool_and(u.snapshot_committed),
   SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house_in_source_statistics_td', 'auctions', 'bids', 'organizations', 'users')
   GROUP BY s.name
   ORDER BY s.name
-auction_house_in_source_statistics_td true true false false true true
+auction_house_in_source_statistics_td true true true true true true
 
 
 # Assert that the codepath that ensures a 0-value as the first value in `mz_source_statistics` occurs, using a `SUBSCRIBE`.
@@ -165,7 +164,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
     SUM(u.records_indexed),
     bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -179,7 +178,7 @@ $ set-from-sql var=updates-committed
 SELECT
     (SUM(u.updates_committed) + 1)::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 $ set-from-sql var=state-bytes
@@ -201,7 +200,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
     SUM(u.bytes_indexed) < ${state-bytes},
     SUM(u.records_indexed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name

--- a/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-deletion.td
@@ -94,13 +94,13 @@ sink_cluster 1 1 true true
 > SELECT s.name,
   SUM(u.updates_committed) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
   GROUP BY s.id, s.name
 upsert_size true
 upsert_cluster true
-s false
-s false
+s true
+s true
 
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id

--- a/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
+++ b/test/testdrive-old-kafka-src-syntax/statistics-maintenance.td
@@ -55,7 +55,7 @@ sink1 1 1 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true 1
@@ -75,7 +75,7 @@ sink1 1 1 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true 1
@@ -99,7 +99,7 @@ sink1 2 2 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true 2

--- a/test/testdrive-old-kafka-src-syntax/steady-state-source-statistics.td
+++ b/test/testdrive-old-kafka-src-syntax/steady-state-source-statistics.td
@@ -82,7 +82,7 @@ mammalmore    moose   2
     SUM(u.offset_known) > 0,
     SUM(u.offset_known) = SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -93,7 +93,7 @@ upsert true true
     SUM(u.offset_known) > 0,
     SUM(u.offset_committed) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('counter')
   GROUP BY s.name
   ORDER BY s.name
@@ -103,7 +103,7 @@ $ set-from-sql var=previous-offset-known
 SELECT
     (SUM(u.offset_known))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 
@@ -121,7 +121,7 @@ birdmore      geese   56
     SUM(u.offset_known) > ${previous-offset-known},
     SUM(u.offset_known) = SUM(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name

--- a/test/testdrive/load-generator-key-value.td
+++ b/test/testdrive/load-generator-key-value.td
@@ -339,8 +339,8 @@ true
   LEFT JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('kv_snapshot', 'kv_up', 'kv_none')
   ORDER BY s.name;
-kv_snapshot 3 3 true true true 0
-kv_up 0 0 true true false 16
+kv_snapshot 3 3 true true true 16
+kv_up 3 3 true true false 16
 
 > CREATE TABLE kv_none FROM SOURCE kv_snapshot INCLUDE KEY ENVELOPE NONE;
 
@@ -360,9 +360,9 @@ kv_up 0 0 true true false 16
   LEFT JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('kv_snapshot', 'kv_up', 'kv_none')
   ORDER BY s.name;
-kv_none 0 0 true true false 0
-kv_snapshot 3 3 true true true 0
-kv_up 0 0 false false false 16
+kv_none 3 3 true true false 0
+kv_snapshot 3 3 true true true 16
+kv_up 3 3 false false false 16
 
 > DROP SOURCE kv_snapshot CASCADE;
 
@@ -403,8 +403,8 @@ kv_up 0 0 false false false 16
   LEFT JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('kv_snapshot', 'kv_up', 'kv_none')
   ORDER BY s.name;
-kv_none 0 0 0 0 false 0
-kv_snapshot 6 6 0 0 true 0
-kv_up 0 0 0 0 false 16
+kv_none 6 6 0 0 false 0
+kv_snapshot 6 6 0 0 true 16
+kv_up 6 6 0 0 false 16
 
 > DROP SOURCE kv_snapshot CASCADE;

--- a/test/testdrive/pr-24663-regression.td
+++ b/test/testdrive/pr-24663-regression.td
@@ -124,7 +124,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('dbz_no_before_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -144,7 +144,7 @@ id creature
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('dbz_no_before_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -163,7 +163,7 @@ $ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keys
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('dbz_no_before_tbl')
   GROUP BY t.name
   ORDER BY t.name

--- a/test/testdrive/snapshot-source-statistics.td
+++ b/test/testdrive/snapshot-source-statistics.td
@@ -85,18 +85,18 @@ mammalmore    moose   2
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert', 'upsert_tbl')
   GROUP BY s.name
   ORDER BY s.name
-upsert 9 9
+upsert 18 18
 upsert_tbl 9 9
 
 $ set-from-sql var=previous-offset-known
 SELECT
-    (SUM(u.offset_known))::text
+    (MAX(u.offset_known))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 
@@ -106,24 +106,24 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
 # Snapshot counts don't move...
 > SELECT
     s.name,
-    SUM(u.offset_known) > ${previous-offset-known},
+    MAX(u.offset_known) > ${previous-offset-known},
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged)
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert', 'upsert_tbl')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 9 9
-upsert_tbl false 9 9
+upsert true 18 18
+upsert_tbl true 9 9
 
 # ...even if we restart.
 
 $ set-from-sql var=pre-restart-offset-committed
 SELECT
-    (SUM(u.offset_committed))::text
+    (MAX(u.offset_committed))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 
@@ -132,7 +132,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -152,7 +152,7 @@ $ set-regex match=u\d+ replacement="<REPLICAID>"
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -168,7 +168,7 @@ SELECT cr.id
   FROM
     mz_clusters c,
     mz_cluster_replicas cr,
-    mz_internal.mz_source_statistics_raw u,
+    mz_internal.mz_source_statistics u,
     mz_sources s
   WHERE
     c.name = 'stats_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
@@ -184,19 +184,19 @@ $ unset-regex
 # for the previous replica may include that event.
 > SELECT
     s.name,
-    SUM(u.offset_committed) >= ${pre-restart-offset-committed},
+    MAX(u.offset_committed) >= ${pre-restart-offset-committed},
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged),
     u.replica_id
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert', 'upsert_tbl')
   GROUP BY s.name, u.replica_id
   ORDER BY s.name, u.replica_id
-upsert true 9 9 ${old_replica_id}
-upsert_tbl false 9 9 ${old_replica_id}
+upsert true 18 18 ${old_replica_id}
+upsert_tbl true 9 9 ${old_replica_id}
 upsert true <null> <null> ${new_replica_id}
-upsert_tbl false <null> <null> ${new_replica_id}
+upsert_tbl true <null> <null> ${new_replica_id}
 
 > CREATE TABLE append_tbl FROM SOURCE upsert (REFERENCE "testdrive-upsert-${testdrive.seed}")
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -218,19 +218,19 @@ moose  100
 
 > SELECT
     s.name,
-    SUM(u.offset_committed) >= ${pre-restart-offset-committed},
+    MAX(u.offset_committed) >= ${pre-restart-offset-committed},
     SUM(u.snapshot_records_known),
     SUM(u.snapshot_records_staged),
     u.replica_id
   FROM mz_internal.mz_source_statuses s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert', 'upsert_tbl', 'append_tbl')
   GROUP BY s.name, u.replica_id
   ORDER BY s.name, u.replica_id
-append_tbl false 11 11 ${new_replica_id}
-upsert true 9 9 ${old_replica_id}
+append_tbl true 11 11 ${new_replica_id}
+upsert true 18 18 ${old_replica_id}
 upsert true 11 11 ${new_replica_id}
-upsert_tbl false 9 9 ${old_replica_id}
-upsert_tbl false 0 0 ${new_replica_id}
+upsert_tbl true 9 9 ${old_replica_id}
+upsert_tbl true 0 0 ${new_replica_id}
 
 > DROP SOURCE upsert CASCADE;

--- a/test/testdrive/source-statistics-view.td
+++ b/test/testdrive/source-statistics-view.td
@@ -35,7 +35,7 @@ ALTER SYSTEM SET storage_statistics_interval = 2000
     u.offset_known > 0,
     u.offset_committed > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('counter')
 counter true true true true true true true true true true true true
 

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -71,13 +71,6 @@ goofus,gallant
 jack   jill    0
 goofus gallant 1
 
-# The `CREATE TABLE ... FROM SOURCE` command caused a recreation of the source
-# dataflow, during which we might have lost the statistics about committed
-# updates from the snapshot. Ingest some more data to ensure we see some
-# `updates_committed`.
-$ kafka-ingest topic=metrics-test format=bytes
-calvin,hobbes
-
 > SELECT
       s.name,
       bool_and(u.snapshot_committed),
@@ -87,7 +80,7 @@ calvin,hobbes
       SUM(u.bytes_received) > 0,
       bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
@@ -133,9 +126,6 @@ mammalmore    moosemoose   2
 > CREATE TABLE users FROM SOURCE auction_house_in_source_statistics_td (REFERENCE users);
 > COMMIT
 
-# Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
-# Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
-# jitter on when metrics are produced for each sub-source.
 > SELECT
       s.name,
       bool_and(u.snapshot_committed),
@@ -145,11 +135,11 @@ mammalmore    moosemoose   2
       SUM(u.bytes_received) > 0,
       bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house_in_source_statistics_td', 'auctions', 'bids', 'organizations', 'users')
   GROUP BY s.name
   ORDER BY s.name
-auction_house_in_source_statistics_td true true false false true true
+auction_house_in_source_statistics_td true true true true true true
 
 
 # Assert that the codepath that ensures a 0-value as the first value in `mz_source_statistics` occurs, using a `SUBSCRIBE`.
@@ -183,7 +173,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
     SUM(u.messages_received) >= 18,
     SUM(u.bytes_received) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -199,7 +189,7 @@ upsert true true
     SUM(u.records_indexed),
     bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -213,7 +203,7 @@ $ set-from-sql var=updates-committed
 SELECT
     (SUM(u.updates_committed) + 1)::text
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
 
 $ set-from-sql var=state-bytes
@@ -230,7 +220,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
     SUM(u.messages_received) >= 20,
     SUM(u.bytes_received) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -243,7 +233,7 @@ upsert true true
     SUM(u.bytes_indexed) < ${state-bytes},
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -114,13 +114,13 @@ sink_cluster 1 1 true true
 > SELECT s.name,
   SUM(u.updates_committed) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert_size', 'upsert_cluster', 's', 'bids')
   GROUP BY s.id, s.name
 upsert_size true
 upsert_cluster true
-s false
-s false
+s true
+s true
 
 # We have to obtain these before we delete the sink.
 $ set-from-sql var=sink-size-id

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -69,7 +69,7 @@ sink1 1 1 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true true
@@ -89,7 +89,7 @@ sink1 1 1 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 2
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true true
@@ -113,7 +113,7 @@ sink1 2 2 true true
   SUM(u.updates_committed) > 0,
   SUM(u.messages_received) >= 4
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
 upsert1 true true

--- a/test/testdrive/steady-state-source-statistics.td
+++ b/test/testdrive/steady-state-source-statistics.td
@@ -83,10 +83,10 @@ mammalmore    moose   2
 
 > SELECT
     s.name,
-    SUM(u.offset_known) > 0,
-    SUM(u.offset_known) = SUM(u.offset_committed)
+    MAX(u.offset_known) > 0,
+    MAX(u.offset_known) = MAX(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
@@ -94,10 +94,10 @@ upsert true true
 
 > SELECT
     s.name,
-    SUM(u.offset_known) > 0,
-    SUM(u.offset_committed) > 0
+    MAX(u.offset_known) > 0,
+    MAX(u.offset_committed) > 0
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('counter')
   GROUP BY s.name
   ORDER BY s.name
@@ -105,9 +105,9 @@ counter true true
 
 $ set-from-sql var=previous-offset-known
 SELECT
-    (SUM(u.offset_known))::text
+    (MAX(u.offset_known))::text
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
 
 
@@ -122,10 +122,10 @@ birdmore      geese   56
 
 > SELECT
     s.name,
-    SUM(u.offset_known) > ${previous-offset-known},
-    SUM(u.offset_known) = SUM(u.offset_committed)
+    MAX(u.offset_known) > ${previous-offset-known},
+    MAX(u.offset_known) = MAX(u.offset_committed)
   FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -600,13 +600,13 @@ def workflow_load_test(c: Composition, parser: WorkflowArgumentParser) -> None:
                     dedent(
                         f"""
                 > select sum(records_indexed)
-                  from mz_internal.mz_source_statistics_raw st
+                  from mz_internal.mz_source_statistics st
                   join mz_sources s on s.id = st.id
                   where name = 's1';
                 {repeat + 2}
 
                 > select bool_and(rehydration_latency IS NOT NULL)
-                  from mz_internal.mz_source_statistics_raw st
+                  from mz_internal.mz_source_statistics st
                   join mz_sources s on s.id = st.id
                   where name = 's1';
                 true
@@ -618,7 +618,7 @@ def workflow_load_test(c: Composition, parser: WorkflowArgumentParser) -> None:
                 while rehydration_latency == last_latency:
                     rehydration_latency = c.sql_query(
                         """select max(rehydration_latency)
-                        from mz_internal.mz_source_statistics_raw st
+                        from mz_internal.mz_source_statistics st
                         join mz_sources s on s.id = st.id
                         where name = 's1';"""
                     )[0]

--- a/test/upsert/rehydration/02-source-setup.td
+++ b/test/upsert/rehydration/02-source-setup.td
@@ -71,7 +71,7 @@ mammalmore    moose    2
     SUM(u.records_indexed),
     bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name

--- a/test/upsert/rehydration/03-after-rehydration.td
+++ b/test/upsert/rehydration/03-after-rehydration.td
@@ -40,7 +40,7 @@ mammalmore    moose    2
     SUM(u.records_indexed),
     bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -51,7 +51,7 @@ $ set-from-sql var=rehydrated-state-bytes
 SELECT
     (SUM(u.bytes_indexed))::text
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
 
 # Ensure we process updates correctly.
@@ -76,7 +76,7 @@ mammalmore    moose               2
     SUM(u.bytes_indexed) != ${rehydrated-state-bytes},
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -86,7 +86,7 @@ $ set-from-sql var=state-bytes
 SELECT
     (SUM(u.bytes_indexed))::text
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
 
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
@@ -96,7 +96,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
     SUM(u.bytes_indexed) > ${state-bytes},
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name
@@ -116,7 +116,7 @@ mammalmore    moose               2
 > SELECT
     SUM(u.records_indexed)
   FROM mz_tables t
-  JOIN mz_internal.mz_source_statistics_raw u ON t.id = u.id
+  JOIN mz_internal.mz_source_statistics u ON t.id = u.id
   WHERE t.name IN ('upsert_tbl')
   GROUP BY t.name
   ORDER BY t.name


### PR DESCRIPTION
Makes it so `mz_source_statistics_raw` only records information for actual source exports. Then, `mz_source_statistics` includes everything in the raw table and an aggregated view over the entire source. The aggregation is defined as a simple SQL query instead of each source managing it in its Rust implementation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
