### PR TITLE
test: try to unflake `divergent-dataflow-cancellation.td`

### DIFF
--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -67,73 +67,33 @@ contains: canceling statement due to statement timeout
 
 > COMMIT
 
-# Confirm that all dataflows are now cancelled
+# Confirm that all dataflows are now cancelled.
+#
+# NOTE: It is important that the below queries are all fast-path queries.
+# Otherwise they'd introduce new dataflows, confusing the results.
+# For `_raw` relations, add a limit to protect against huge results.
 
-> SELECT count(*) FROM mz_introspection.mz_active_peeks_per_worker
-0
-
-> SELECT count(*) FROM mz_introspection.mz_arrangement_batches_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_arrangement_records_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_arrangement_sharing_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_compute_error_counts_raw
-0
-
-# One export for each introspection arrangement.
-> SELECT count(*)
+> SELECT * FROM mz_introspection.mz_arrangement_batches_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_arrangement_records_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_arrangement_sharing_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_compute_error_counts_raw LIMIT 10
+> SELECT *
   FROM mz_introspection.mz_compute_exports_per_worker
-  WHERE worker_id = 0
-32
-
-# One frontier for each introspection arrangement.
-> SELECT count(*)
+  WHERE export_id NOT LIKE 'si%'
+> SELECT *
   FROM mz_introspection.mz_compute_frontiers_per_worker
-  WHERE worker_id = 0
-32
-
-> SELECT count(*) FROM mz_introspection.mz_compute_import_frontiers_per_worker
-0
-
-> SELECT count(*) FROM mz_introspection.mz_compute_operator_durations_histogram_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_dataflow_addresses_per_worker
-0
-
-> SELECT count(*) FROM mz_introspection.mz_dataflow_channels_per_worker
-0
-
-> SELECT count(*) FROM mz_introspection.mz_dataflow_operator_reachability_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_dataflow_operators_per_worker
-0
-
-# This source never sees retractions.
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_shutdown_durations_histogram_raw
-true
-
-> SELECT count(*) FROM mz_introspection.mz_message_counts_received_raw
-0
-
-> SELECT count(*) FROM mz_introspection.mz_message_counts_sent_raw
-0
-
-# This source never sees retractions.
-> SELECT count(*) > 0 FROM mz_introspection.mz_peek_durations_histogram_raw
-true
-
-> SELECT count(*) FROM mz_introspection.mz_scheduling_elapsed_raw
-0
-
-# This source never sees retractions.
-> SELECT count(*) > 0 FROM mz_introspection.mz_scheduling_parks_histogram_raw
-true
+  WHERE export_id NOT LIKE 'si%'
+> SELECT *
+  FROM mz_introspection.mz_compute_import_frontiers_per_worker
+  WHERE export_id NOT LIKE 'si%'
+> SELECT * FROM mz_introspection.mz_compute_operator_durations_histogram_raw LIMIT 10
+> SELECT id, worker_id, address::text FROM mz_introspection.mz_dataflow_addresses_per_worker
+> SELECT * FROM mz_introspection.mz_dataflow_channels_per_worker
+> SELECT * FROM mz_introspection.mz_dataflow_operator_reachability_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_dataflow_operators_per_worker
+> SELECT * FROM mz_introspection.mz_message_counts_received_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_message_counts_sent_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_scheduling_elapsed_raw LIMIT 10
 
 # Cleanup.
 > DROP CLUSTER test CASCADE


### PR DESCRIPTION
This test is sometimes flaky, presumably because the queries that are supposed to ensure that all Timely dataflow state has been dropped get confused by the ad-hoc dataflows created for said queries.

Joining against other introspection sources to find and filter ad-hoc dataflows is unreliable, because the different introspection sources are not necessarily in sync. For example, it can happen that a dataflow's entries in `mz_arrangement_batches_raw` stay around for longer than its entries in `mz_dataflow_operators_per_worker`, making it impossible to identify the dataflow these arrangement batches belong to.

Instead this PR attempts to fix the flaking by making sure all introspection queries performed in the test are fast-path queries. Those don't create ad-hoc dataflows, so no confusion should occur.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9720

### Tips for reviewer

I couldn't reproduce the flake locally, so it's possible that there is another cause for it. If that's the case, the output from the changed queries should be more useful for debugging than the current output.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
