### PR TITLE
support configuring replicas for balancerd and console in MZ CR

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -99,6 +99,10 @@ pub mod v1alpha1 {
         pub balancerd_resource_requirements: Option<ResourceRequirements>,
         // Resource requirements for the console pod
         pub console_resource_requirements: Option<ResourceRequirements>,
+        // Number of balancerd pods to create
+        pub balancerd_replicas: Option<i32>,
+        // Number of console pods to create
+        pub console_replicas: Option<i32>,
 
         // Name of the kubernetes service account to use.
         // If not set, we will create one with the same name as this Materialize object.
@@ -266,6 +270,14 @@ pub mod v1alpha1 {
 
         pub fn balancerd_external_certificate_secret_name(&self) -> String {
             self.name_prefixed("balancerd-external-tls")
+        }
+
+        pub fn balancerd_replicas(&self) -> i32 {
+            self.spec.balancerd_replicas.unwrap_or(2)
+        }
+
+        pub fn console_replicas(&self) -> i32 {
+            self.spec.console_replicas.unwrap_or(2)
         }
 
         pub fn console_configmap_name(&self) -> String {

--- a/src/orchestratord/src/controller/materialize/balancer.rs
+++ b/src/orchestratord/src/controller/materialize/balancer.rs
@@ -320,7 +320,7 @@ fn create_balancerd_deployment_object(
     };
 
     let deployment_spec = DeploymentSpec {
-        replicas: Some(1),
+        replicas: Some(mz.balancerd_replicas()),
         selector: LabelSelector {
             match_labels: Some(pod_template_labels.clone()),
             ..Default::default()

--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -395,7 +395,7 @@ ssl_certificate_key /nginx/tls/tls.key;",
     };
 
     let deployment_spec = DeploymentSpec {
-        replicas: Some(2),
+        replicas: Some(mz.console_replicas()),
         selector: LabelSelector {
             match_labels: Some(pod_template_labels.clone()),
             ..Default::default()


### PR DESCRIPTION
Support configuring replicas for balancerd and console in the Materialize CR, and default to two pods each.

### Motivation

  * This PR adds a known-desirable feature.
Resolves https://github.com/MaterializeInc/cloud/issues/11619

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
