### PR TITLE
adapter: default disk limit to MAX in mz_cluster_replica_sizes

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -2013,13 +2013,14 @@ impl CatalogState {
                 continue;
             }
 
-            // Just invent something when the limits are `None`, which only happens in non-prod
-            // environments (tests, process orchestrator, etc.)
+            // Limits can be `None`, specifying that resource usage is unlimited. Unfortunately,
+            // the relevant table fields are not nullable, so we have to put in some value. We put
+            // in the maximum (based on `u64::MAX`), which makes it at least immediately clear that
+            // the limit is a bogus one.
             let cpu_limit = alloc.cpu_limit.unwrap_or(CpuLimit::MAX);
             let MemoryLimit(ByteSize(memory_bytes)) =
-                (alloc.memory_limit).unwrap_or(MemoryLimit::MAX);
-            let DiskLimit(ByteSize(disk_bytes)) =
-                (alloc.disk_limit).unwrap_or(DiskLimit::ARBITRARY);
+                alloc.memory_limit.unwrap_or(MemoryLimit::MAX);
+            let DiskLimit(ByteSize(disk_bytes)) = alloc.disk_limit.unwrap_or(DiskLimit::MAX);
 
             let row = Row::pack_slice(&[
                 size.as_str().into(),

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -659,19 +659,35 @@ CREATE CLUSTER REPLICA quickstart.replica AVAILABILITY ZONE 'a', STORAGECTL ADDR
 # Test that the contents of mz_cluster_replicas look sensible
 
 statement ok
-CREATE CLUSTER foo REPLICAS (size_1 (SIZE 'scale=1,workers=1'), size_32 (SIZE 'scale=1,workers=32'), size_2_2 (SIZE 'scale=2,workers=2'), size_1_8g (SIZE 'scale=1,workers=1,mem=8GiB'))
+CREATE CLUSTER foo REPLICAS (
+    size_1 (SIZE 'scale=1,workers=1'),
+    size_32 (SIZE 'scale=1,workers=32'),
+    size_2_2 (SIZE 'scale=2,workers=2'),
+    size_1_8g (SIZE 'scale=1,workers=1,mem=8GiB')
+)
 
-query TTTTTTT
-SELECT r.name, r.size, s.processes, s.cpu_nano_cores, s.memory_bytes, s.workers, s.credits_per_hour FROM mz_cluster_replicas r JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size ORDER BY r.name
+query TTTTTTTT
+SELECT
+    r.name,
+    r.size,
+    s.processes,
+    s.cpu_nano_cores,
+    s.memory_bytes,
+    s.disk_bytes,
+    s.workers,
+    s.credits_per_hour
+FROM mz_cluster_replicas r
+JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size
+ORDER BY r.name
 ----
-r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  2  1
-r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  2  1
-r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  2  1
-r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  2  1
-size_1  scale=1,workers=1  1  18446744073709000000  18446744073709551615  1  1
-size_1_8g  scale=1,workers=1,mem=8GiB  1  18446744073709000000  8589934592  1  1
-size_2_2  scale=2,workers=2  2  18446744073709000000  18446744073709551615  2  2
-size_32  scale=1,workers=32  1  18446744073709000000  18446744073709551615  32  1
+r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  18446744073709551615  2  1
+r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  18446744073709551615  2  1
+r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  18446744073709551615  2  1
+r1  scale=1,workers=2  1  18446744073709000000  18446744073709551615  18446744073709551615  2  1
+size_1  scale=1,workers=1  1  18446744073709000000  18446744073709551615  18446744073709551615  1  1
+size_1_8g  scale=1,workers=1,mem=8GiB  1  18446744073709000000  8589934592  18446744073709551615  1  1
+size_2_2  scale=2,workers=2  2  18446744073709000000  18446744073709551615  18446744073709551615  2  2
+size_32  scale=1,workers=32  1  18446744073709000000  18446744073709551615  18446744073709551615  32  1
 
 statement ok
 DROP CLUSTER foo CASCADE


### PR DESCRIPTION
Now that self-managed Materialize is a thing, users can provide their own replica sizes, so it is no longer the case that sizes without resource limits specified can only appear in dev environments. This is especially relevant since self-managed users will have to set their disk limit to either `None` or 0 for swap replica sizes, to avoid engaging the memory limiter.

In `mz_cluster_replica_sizes`, we only have non-nullable columns for the resource limits, so we have to pick some value. `u64::MAX` is the most sensible one since it makes it obvious that it is just a placeholder. We were already using it for the CPU and the memory limits, but for the disk limit we were using 1GiB for some reason. This PR changes the placeholder disk limit to `u64::MAX` as well.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/9692

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
