### PR TITLE
Don't default to initial role attributes

### DIFF
--- a/src/catalog/src/durable/upgrade/v76_to_v77.rs
+++ b/src/catalog/src/durable/upgrade/v76_to_v77.rs
@@ -9,33 +9,22 @@
 
 use crate::durable::traits::UpgradeFrom;
 use crate::durable::upgrade::MigrationAction;
-use crate::durable::upgrade::{objects_v76 as v76, objects_v77 as v77};
-use crate::wire_compatible;
-
-wire_compatible!(v76::RoleKey with v77::RoleKey);
-wire_compatible!(v76::RoleValue with v77::RoleValue);
-wire_compatible!(v76::RoleVars with v77::RoleVars);
-wire_compatible!(v76::RoleMembership with v77::RoleMembership);
-wire_compatible!(v76::role_membership::Entry with v77::role_membership::Entry);
-wire_compatible!(v76::role_vars::Entry with v77::role_vars::Entry);
-wire_compatible!(v76::role_vars::SqlSet with v77::role_vars::SqlSet);
-wire_compatible!(v76::RoleAttributes with v77::RoleAttributes);
-wire_compatible!(v76::RoleId with v77::RoleId);
+use crate::durable::upgrade::objects_v76 as v76;
 
 /// This upgrade doesn't change any protos, simply retroactively marks mz_system as login
 pub fn upgrade(
     snapshot: Vec<v76::StateUpdateKind>,
-) -> Vec<MigrationAction<v76::StateUpdateKind, v77::StateUpdateKind>> {
+) -> Vec<MigrationAction<v76::StateUpdateKind, v76::StateUpdateKind>> {
     let mut migrations = Vec::new();
     for update in snapshot {
         match update.kind {
             Some(v76::state_update_kind::Kind::Role(old_role)) => {
-                let new_role = v77::state_update_kind::Role::upgrade_from(old_role.clone());
+                let new_role = v76::state_update_kind::Role::upgrade_from(old_role.clone());
                 let old_role = v76::StateUpdateKind {
                     kind: Some(v76::state_update_kind::Kind::Role(old_role)),
                 };
-                let new_role = v77::StateUpdateKind {
-                    kind: Some(v77::state_update_kind::Kind::Role(new_role)),
+                let new_role = v76::StateUpdateKind {
+                    kind: Some(v76::state_update_kind::Kind::Role(new_role)),
                 };
                 let migration = MigrationAction::Update(old_role, new_role);
                 migrations.push(migration);
@@ -46,23 +35,21 @@ pub fn upgrade(
     migrations
 }
 
-impl UpgradeFrom<v76::state_update_kind::Role> for v77::state_update_kind::Role {
+impl UpgradeFrom<v76::state_update_kind::Role> for v76::state_update_kind::Role {
     fn upgrade_from(value: v76::state_update_kind::Role) -> Self {
-        let new_key = value.key.map(|key| v77::RoleKey {
-            id: key.id.map(v77::RoleId::upgrade_from),
-        });
+        let new_key = value.key;
 
         let is_mz_system = value
             .value
             .as_ref()
             .map_or(false, |v| v.name == "mz_system");
 
-        let mut new_value = value.value.map(|value| v77::RoleValue {
+        let mut new_value = value.value.map(|value| v76::RoleValue {
             name: value.name,
             oid: value.oid,
-            attributes: value.attributes.map(v77::RoleAttributes::upgrade_from),
-            membership: value.membership.map(v77::RoleMembership::upgrade_from),
-            vars: value.vars.map(v77::RoleVars::upgrade_from),
+            attributes: value.attributes,
+            membership: value.membership,
+            vars: value.vars,
         });
 
         if is_mz_system {
@@ -73,102 +60,9 @@ impl UpgradeFrom<v76::state_update_kind::Role> for v77::state_update_kind::Role 
             }
         }
 
-        v77::state_update_kind::Role {
+        v76::state_update_kind::Role {
             key: new_key,
             value: new_value,
-        }
-    }
-}
-
-impl UpgradeFrom<v76::RoleVars> for v77::RoleVars {
-    fn upgrade_from(value: v76::RoleVars) -> Self {
-        v77::RoleVars {
-            entries: value
-                .entries
-                .iter()
-                .map(|val| v77::role_vars::Entry::upgrade_from(val.clone()))
-                .collect(),
-        }
-    }
-}
-
-impl UpgradeFrom<v76::RoleMembership> for v77::RoleMembership {
-    fn upgrade_from(value: v76::RoleMembership) -> Self {
-        v77::RoleMembership {
-            map: value
-                .map
-                .iter()
-                .map(|val| v77::role_membership::Entry::upgrade_from(*val))
-                .collect(),
-        }
-    }
-}
-
-impl UpgradeFrom<v76::role_membership::Entry> for v77::role_membership::Entry {
-    fn upgrade_from(value: v76::role_membership::Entry) -> Self {
-        v77::role_membership::Entry {
-            key: value.key.map(v77::RoleId::upgrade_from),
-            value: value.value.map(v77::RoleId::upgrade_from),
-        }
-    }
-}
-
-impl UpgradeFrom<v76::role_vars::Entry> for v77::role_vars::Entry {
-    fn upgrade_from(value: v76::role_vars::Entry) -> Self {
-        v77::role_vars::Entry {
-            key: value.key,
-            val: value.val.map(v77::role_vars::entry::Val::upgrade_from),
-        }
-    }
-}
-
-impl UpgradeFrom<v76::role_vars::entry::Val> for v77::role_vars::entry::Val {
-    fn upgrade_from(value: v76::role_vars::entry::Val) -> Self {
-        match value {
-            v76::role_vars::entry::Val::Flat(x) => v77::role_vars::entry::Val::Flat(x),
-            v76::role_vars::entry::Val::SqlSet(x) => {
-                v77::role_vars::entry::Val::SqlSet(v77::role_vars::SqlSet::upgrade_from(x))
-            }
-        }
-    }
-}
-
-impl UpgradeFrom<v76::role_vars::SqlSet> for v77::role_vars::SqlSet {
-    fn upgrade_from(value: v76::role_vars::SqlSet) -> Self {
-        v77::role_vars::SqlSet {
-            entries: value.entries,
-        }
-    }
-}
-
-impl UpgradeFrom<v76::RoleAttributes> for v77::RoleAttributes {
-    fn upgrade_from(value: v76::RoleAttributes) -> Self {
-        v77::RoleAttributes {
-            inherit: value.inherit,
-            ..Default::default()
-        }
-    }
-}
-
-impl UpgradeFrom<v76::RoleId> for v77::RoleId {
-    fn upgrade_from(value: v76::RoleId) -> Self {
-        let value = match value.value {
-            Some(v76::role_id::Value::System(x)) => Some(v77::role_id::Value::System(x)),
-            Some(v76::role_id::Value::User(x)) => Some(v77::role_id::Value::User(x)),
-            Some(v76::role_id::Value::Public(_)) => {
-                Some(v77::role_id::Value::Public(v77::Empty {}))
-            }
-            Some(v76::role_id::Value::Predefined(x)) => Some(v77::role_id::Value::Predefined(x)),
-            None => None,
-        };
-        v77::RoleId { value }
-    }
-}
-
-impl UpgradeFrom<v76::RoleKey> for v77::RoleKey {
-    fn upgrade_from(value: v76::RoleKey) -> Self {
-        Self {
-            id: value.id.map(v77::RoleId::upgrade_from),
         }
     }
 }


### PR DESCRIPTION
Because the initial role attribute has login set to false, we were deactivating login for all roles on migration.

Equivalent backport commit https://github.com/MaterializeInc/materialize/pull/33655/commits/e3954561cc1426df937d481d187076ee3dd4bc94 (only difference is v74 instead of v76)

For the test, I plan on making a platform test that asserts against an upgrade of v147.1 to v147.15 (the upcoming patch release). However for that test to even pass, the backport needs to be merged.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
