### PR TITLE
self-managed docs: Mention swap labels

### DIFF
--- a/doc/user/content/installation/install-on-local-kind/_index.md
+++ b/doc/user/content/installation/install-on-local-kind/_index.md
@@ -80,12 +80,14 @@ reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
    kind create cluster
    ```
 
-1. Add labels `materialize.cloud/disk=true` and `workload=materialize-instance`
-   to the `kind` node (in this example, the `kind-control-plane` node).
+1. Add labels `materialize.cloud/disk=true`, `materialize.cloud/swap=true` and
+   `workload=materialize-instance` to the `kind` node (in this example, the
+   `kind-control-plane` node).
 
    ```shell
    MYNODE=$(kubectl get nodes --no-headers | awk '{print $1}')
    kubectl label node  $MYNODE materialize.cloud/disk=true
+   kubectl label node  $MYNODE materialize.cloud/swap=true
    kubectl label node  $MYNODE workload=materialize-instance
    ```
 

--- a/doc/user/content/installation/install-on-local-minikube/_index.md
+++ b/doc/user/content/installation/install-on-local-minikube/_index.md
@@ -84,12 +84,14 @@ reference](https://kubernetes.io/docs/reference/kubectl/quick-reference/).
    minikube start
    ```
 
-1. Add labels `materialize.cloud/disk=true` and `workload=materialize-instance`
-   to the `minikube` node (in this example, named `minikube`).
+1. Add labels `materialize.cloud/disk=true`, `materialize.cloud/swap=true` and
+   `workload=materialize-instance` to the `minikube` node (in this example,
+   named `minikube`).
 
    ```shell
    MYNODE=$(kubectl get nodes --no-headers | awk '{print $1}')
    kubectl label node  $MYNODE materialize.cloud/disk=true
+   kubectl label node  $MYNODE materialize.cloud/swap=true
    kubectl label node  $MYNODE workload=materialize-instance
    ```
 


### PR DESCRIPTION
Based on https://materializeinc.slack.com/archives/CPNFV9CVB/p1758573482775129
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
