### PR TITLE
Enable license key checks by default

### DIFF
--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -134,6 +134,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.additionalMaterializeCRDColumns` | Additional columns to display when printing the Materialize CRD in table format. | ``nil`` |
 | `operator.affinity` | Affinity to use for the operator pod | ``nil`` |
 | `operator.args.enableInternalStatementLogging` |  | ``true`` |
+| `operator.args.enableLicenseKeyChecks` |  | ``true`` |
 | `operator.args.startupLogFilter` | Log filtering settings for startup logs | ``"INFO,mz_orchestratord=TRACE"`` |
 | `operator.cloudProvider.providers.aws.accountID` | When using AWS, accountID is required | ``""`` |
 | `operator.cloudProvider.providers.aws.enabled` |  | ``false`` |

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -64,10 +64,10 @@ tests:
     storage.storageClass.name: ""
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]      # Index of the environmentd-cluster-replica-sizes argument
+      path: spec.template.spec.containers[0].args[12]      # Index of the environmentd-cluster-replica-sizes argument
       pattern: disk_limit":"0"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: is_cc":true
 
 - it: should have a cluster with disk limit to 1552MiB when storage class is configured and swap disabled
@@ -76,25 +76,25 @@ tests:
     operator.clusters.swap_enabled: false
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: disk_limit":"1552MiB"
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: is_cc":true
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: materialize.cloud/scratch-fs":"true"
 
 - it: should have a cluster with swap_enabled
   asserts:
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: is_cc":true
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: swap_enabled":true
   - matchRegex:
-      path: spec.template.spec.containers[0].args[13]
+      path: spec.template.spec.containers[0].args[12]
       pattern: materialize.cloud/swap":"true"
 
 - it: should configure for AWS provider correctly
@@ -208,3 +208,17 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: "--scheduler-name=my-scheduler"
+
+- it: should have license key checks enabled by default
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].args
+      content: "--disable-license-key-checks"
+
+- it: should support disabling license key checks
+  set:
+    operator.args.enableLicenseKeyChecks: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--disable-license-key-checks"

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -22,6 +22,7 @@ operator:
     # -- Log filtering settings for startup logs
     startupLogFilter: "INFO,mz_orchestratord=TRACE"
     enableInternalStatementLogging: true
+    enableLicenseKeyChecks: true
 
   # -- Additional columns to display when printing the Materialize CRD in table format.
   additionalMaterializeCRDColumns:

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -201,7 +201,7 @@ class LicenseKey(Modification):
     def validate(self, mods: dict[type[Modification], Any]) -> None:
         environmentd = get_environmentd_data()
         envs = environmentd["items"][0]["spec"]["containers"][0]["env"]
-        if self.value == "del" or not mods[LicenseKeyCheck]:
+        if self.value == "del" or (mods[LicenseKeyCheck] == False):
             for env in envs:
                 assert (
                     env["name"] != "MZ_LICENSE_KEY"
@@ -230,7 +230,7 @@ class LicenseKeyCheck(Modification):
     @classmethod
     def values(cls) -> list[Any]:
         # TODO: Reenable False when fixed
-        return [True]
+        return [None, True]
 
     # @classmethod
     # def bad_values(cls) -> list[Any]:
@@ -238,19 +238,19 @@ class LicenseKeyCheck(Modification):
 
     @classmethod
     def default(cls) -> Any:
-        # TODO: Revert to False when fixed: error: unexpected argument '--disable-license-key-checks' found
-        return True
+        return None
 
     def modify(self, definition: dict[str, Any]) -> None:
-        definition["operator"]["operator"]["args"]["enableLicenseKeyChecks"] = bool(
-            self.value
-        )
+        if self.value is not None:
+            definition["operator"]["operator"]["args"]["enableLicenseKeyChecks"] = bool(
+                self.value
+            )
 
     def validate(self, mods: dict[type[Modification], Any]) -> None:
         environmentd = get_environmentd_data()
         args = environmentd["items"][0]["spec"]["containers"][0]["args"]
         expected = "--disable-license-key-checks"
-        if self.value:
+        if self.value is None or self.value:
             assert (
                 expected not in args
             ), f"Expected no {expected} in environmentd args, but found it: {args}"


### PR DESCRIPTION
Enable license key checks by default in the helm chart values.

### Motivation

Newer releases require it, so lets default to enabling them by default.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
