### PR TITLE
platform-checks: Add prefix for output when running in parallel mode

### DIFF
--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -90,6 +90,11 @@ class MzcomposeExecutorParallel(MzcomposeExecutor):
                     f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
                     f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",
                 ],
+                print_prefix=(
+                    f"{caller.filename.split('/')[-1]}:{caller.lineno} "
+                    if caller
+                    else None
+                ),
             )
         except BaseException as e:
             self.exception = e


### PR DESCRIPTION
To make it easier to tell where a query is hanging, for example in https://buildkite.com/materialize/test/builds/109778#019973b2-dcda-487f-b193-6672db5d9722/106-809
Before:
<img width="1202" height="1242" alt="Screenshot 2025-09-23 at 15 06 53" src="https://github.com/user-attachments/assets/c71d683e-3741-4168-bb78-e74e5585896b" />
After:
<img width="1397" height="1076" alt="Screenshot 2025-09-23 at 15 06 00" src="https://github.com/user-attachments/assets/6023e462-27af-4318-bdd8-a7d5b3a15c4b" />

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
