### PR TITLE
testdrive: bump kafka timeouts to 60s

### DIFF
--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -166,11 +166,11 @@ pub async fn run_verify_data(
         .context("subscribing to kafka topic")?;
 
     let (mut stream_messages_remaining, stream_timeout) = match partial_search {
-        Some(size) => (size, state.default_timeout),
+        Some(size) => (size, state.timeout),
         None => (expected_messages.len(), Duration::from_secs(15)),
     };
 
-    let timeout = cmp::max(state.default_timeout, stream_timeout);
+    let timeout = cmp::max(state.timeout, stream_timeout);
 
     let message_stream = consumer.stream().timeout(timeout);
     pin!(message_stream);

--- a/test/testdrive/kafka-alter-source.td
+++ b/test/testdrive/kafka-alter-source.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # Verify commands do not work on kafka.

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/test/testdrive/kafka-avro-sinks-defaults.td
+++ b/test/testdrive/kafka-avro-sinks-defaults.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-commit.td
+++ b/test/testdrive/kafka-commit.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 # Test that the source ingestion pipeline commits offsets back to Kafka with

--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-correctness.td
+++ b/test/testdrive/kafka-correctness.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 $ set keyschema={

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 $ kafka-create-topic topic=input_csv partitions=1

--- a/test/testdrive/kafka-debezium-sources-compound-key.td
+++ b/test/testdrive/kafka-debezium-sources-compound-key.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 # Must be a subset of the keys in the rows AND
 # in a different order than the value.
 $ set keyschema={

--- a/test/testdrive/kafka-debezium-sources-no-before.td
+++ b/test/testdrive/kafka-debezium-sources-no-before.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 # Verify that we can (and continue to do so) ingest debezium topics that don't

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 $ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }

--- a/test/testdrive/kafka-envelope-none.td
+++ b/test/testdrive/kafka-envelope-none.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 $ kafka-create-topic topic=missing_keys_or_values partitions=1

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -6,6 +6,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -6,6 +6,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart
 

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 > CREATE MATERIALIZED VIEW simple_view AS SELECT 1 AS a, 2 AS b, 3 AS c;

--- a/test/testdrive/kafka-progress.td
+++ b/test/testdrive/kafka-progress.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # Create sources and verify they can ingest data while `environmentd` is online.

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 

--- a/test/testdrive/kafka-sink-empty-progress-topic.td
+++ b/test/testdrive/kafka-sink-empty-progress-topic.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 # Test creating a sink when the progress topic is empty but has a non-zero low
 # water mark.
 #

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 #

--- a/test/testdrive/kafka-sink-headers.td
+++ b/test/testdrive/kafka-sink-headers.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # Test the HEADER option for Kafka sinks, which allows attaching user-specified

--- a/test/testdrive/kafka-sink-multi-partition.td
+++ b/test/testdrive/kafka-sink-multi-partition.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 # We will create topics with 100 partitions and we create two sinks that
 # publishes a single record twice, each time with a different Avro schema ID due
 # to changed comments.

--- a/test/testdrive/kafka-sink-partition-by.td
+++ b/test/testdrive/kafka-sink-partition-by.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # Test the PARTITION BY option for Kafka sinks

--- a/test/testdrive/kafka-sink-topic-config.td
+++ b/test/testdrive/kafka-sink-topic-config.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 #

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 $ set-arg-default default-replica-size=scale=1,workers=1
 $ set-arg-default single-replica-cluster=quickstart

--- a/test/testdrive/kafka-start-offset.td
+++ b/test/testdrive/kafka-start-offset.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 $ kafka-create-topic topic=t0 partitions=1

--- a/test/testdrive/kafka-upsert-debezium-sources-unordered.td
+++ b/test/testdrive/kafka-upsert-debezium-sources-unordered.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # must be a subset of the keys in the rows

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # must be a subset of the keys in the rows

--- a/test/testdrive/kafka-upsert-sources-key-decode-error.td
+++ b/test/testdrive/kafka-upsert-sources-key-decode-error.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 $ set keyschema-1-int-key={

--- a/test/testdrive/kafka-upsert-sources-named.td
+++ b/test/testdrive/kafka-upsert-sources-named.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default single-replica-cluster=quickstart
 
 # This testdrive file uses the deprecated syntax, but is otherwise identical to upsert-kafka-new.td

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=60s
+
 $ set-arg-default default-storage-size=scale=1,workers=1
 
 # This testdrive file is exactly the same as upsert-kafka.td, but using the new syntax.

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -92,7 +92,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "--default-timeout",
         type=str,
-        default="40s",
         help="set the default timeout for Testdrive",
     )
 


### PR DESCRIPTION
The default timeout used to be on the order of minutes, but was moved down to 20s as part of improving the speed of testing. For kafka in the testdrive tests, it might be too low as we're seeing a lot of deadline expired failures leading to missing results.

Alternatively, I could modify the min timeout set in `kafka-verify-data` (which is 15s).  Much broader scope and I'm not sure if we want to necessarily make the minimum timeout a high value.

### Motivation

address test failures due to kafka-verify-timeout https://github.com/MaterializeInc/database-issues/issues/9688

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
