### PR TITLE
Revert recent changes to the caught-up checks

### DIFF
--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -260,7 +260,7 @@ impl Coordinator {
         let storage_frontiers = self
             .controller
             .storage
-            .active_ingestion_exports(cluster.id)
+            .active_ingestions(cluster.id)
             .copied()
             .filter(|id| !id.is_transient() && !exclude_collections.contains(id))
             .map(|id| {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -359,10 +359,8 @@ pub trait StorageController: Debug {
     /// capabilties.
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
-    /// Returns the IDs of ingestion exports running on the given instance. This
-    /// includes the ingestion itself, if any, and running source tables (aka.
-    /// subsources).
-    fn active_ingestion_exports(
+    /// Returns the IDs of all active ingestions for the given storage instance.
+    fn active_ingestions(
         &self,
         instance_id: StorageInstanceId,
     ) -> Box<dyn Iterator<Item = &GlobalId> + '_>;

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -259,11 +259,6 @@ where
 
     /// Returns ingestion exports running on this instance. This includes the
     /// ingestion itself, if any, and running source tables (aka. subsources).
-    ///
-    /// This does _not_ filter out exports whose write frontier is the empty
-    /// frontier, which some might consider not active anymore. But for the
-    /// purposes of the instance controller, these are still considered active
-    /// because we don't know about frontiers.
     pub fn active_ingestion_exports(&self) -> impl Iterator<Item = &GlobalId> {
         let ingestion_exports = self.ingestion_exports.keys();
         self.active_ingestions.keys().chain(ingestion_exports)

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -251,17 +251,9 @@ where
         }
     }
 
-    /// Returns ingestions running on this instance. This _only_ includes the
-    /// "toplevel" ingestions, not any of their source tables (aka. subsources).
+    /// Returns the ingestions running on this instance.
     pub fn active_ingestions(&self) -> impl Iterator<Item = &GlobalId> {
         self.active_ingestions.keys()
-    }
-
-    /// Returns ingestion exports running on this instance. This includes the
-    /// ingestion itself, if any, and running source tables (aka. subsources).
-    pub fn active_ingestion_exports(&self) -> impl Iterator<Item = &GlobalId> {
-        let ingestion_exports = self.ingestion_exports.keys();
-        self.active_ingestions.keys().chain(ingestion_exports)
     }
 
     /// Returns the exports running on this instance.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -498,11 +498,11 @@ where
         self.storage_collections.active_collection_metadatas()
     }
 
-    fn active_ingestion_exports(
+    fn active_ingestions(
         &self,
         instance_id: StorageInstanceId,
     ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
-        Box::new(self.instances[&instance_id].active_ingestion_exports())
+        Box::new(self.instances[&instance_id].active_ingestions())
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -502,27 +502,7 @@ where
         &self,
         instance_id: StorageInstanceId,
     ) -> Box<dyn Iterator<Item = &GlobalId> + '_> {
-        let active_storage_collections: BTreeMap<_, _> = self
-            .storage_collections
-            .active_collection_frontiers()
-            .into_iter()
-            .map(|c| (c.id, c))
-            .collect();
-
-        let active_exports = self.instances[&instance_id]
-            .active_ingestion_exports()
-            .filter(move |id| {
-                let frontiers = active_storage_collections.get(id);
-                match frontiers {
-                    Some(frontiers) => !frontiers.write_frontier.is_empty(),
-                    None => {
-                        // Not "active", so we don't care here.
-                        false
-                    }
-                }
-            });
-
-        Box::new(active_exports)
+        Box::new(self.instances[&instance_id].active_ingestion_exports())
     }
 
     fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {


### PR DESCRIPTION
This reverts two recent changes made to the caught-up checks. Because subsources don't emit status updates when no data flows through them, these changes could cause 0dt deployments to get stuck in the face of low-traffic sources.

Reverted changes:
* https://github.com/MaterializeInc/materialize/pull/33589
* https://github.com/MaterializeInc/materialize/pull/33672

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9721

### Tips for reviewer

See [Slack thread](https://materializeinc.slack.com/archives/CTESPM7FU/p1758701682084949).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
