### PR TITLE
dev docs: Don't index, don't follow

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -13,17 +13,21 @@
 
 set -euo pipefail
 
+aws_s3_noindex_nofollow() {
+    aws s3 --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" "$@"
+}
+
 cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
-aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
+aws_s3_noindex_nofollow cp --recursive misc/www/ s3://materialize-dev-website/
 
 # We exclude all of these pages from search engines for SEO purposes. We don't
 # want to spend our crawl budget on these pages, nor have these pages appear
 # ahead of our marketing content.
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
-aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
-aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
+aws_s3_noindex_nofollow sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
+aws_s3_noindex_nofollow sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 
 bin/pydoc
-aws s3 sync --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python
+aws_s3_noindex_nofollow sync --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
