### PR TITLE
Cluster Spec Sheet: Move to another region so we don't conflict with other tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1374,7 +1374,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 1200
       concurrency: 1
-      concurrency_group: 'cloud-canary'
+      concurrency_group: 'mz-e2e-test'
       agents:
         # Requires real Mz access, CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME, etc.
         queue: linux-aarch64-small

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -537,19 +537,16 @@ steps:
         agents:
           queue: hetzner-x86-64-dedi-48cpu-192gb # 1 TB disk
 
-  - group: Cluster spec sheet
-    key: cluster-spec-sheet-group
-    steps:
-      - id: cluster-spec-sheet
-        label: Cluster spec sheet
-        depends_on: build-aarch64
-        timeout_in_minutes: 3600
-        concurrency: 1
-        concurrency_group: 'cloud-canary'
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: cluster-spec-sheet
-              run: default
-              args: [--cleanup]
-        agents:
-          queue: linux-aarch64-small
+  - id: cluster-spec-sheet
+    label: Cluster spec sheet
+    depends_on: build-aarch64
+    timeout_in_minutes: 3600
+    concurrency: 1
+    concurrency_group: 'cluster-spec-sheet'
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: cluster-spec-sheet
+          run: default
+          args: [--cleanup]
+    agents:
+      queue: linux-aarch64-small

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -38,7 +38,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
 from materialize.ui import UIError
 
-REGION = os.getenv("REGION", "aws/us-west-2")
+REGION = os.getenv("REGION", "aws/us-east-1")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
 USERNAME = os.getenv("NIGHTLY_MZ_USERNAME", "infra+bot@materialize.com")
 APP_PASSWORD = os.getenv("MZ_CLI_APP_PASSWORD")


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/9654

Test run: https://buildkite.com/materialize/release-qualification/builds/954
Triggered the other e2e tests in the middle of it: https://buildkite.com/materialize/nightly/builds/13579 & https://buildkite.com/materialize/nightly/builds/13554#01997d8d-fede-4bb0-a1c3-4463b27b989c

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
