### PR TITLE
cluster spec sheet: Store results in test analytics db

### DIFF
--- a/misc/python/materialize/test_analytics/data/cluster_spec_sheet/cluster_spec_sheet_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/cluster_spec_sheet/cluster_spec_sheet_result_storage.py
@@ -24,8 +24,8 @@ class ClusterSpecSheetResultEntry:
     test_name: str
     cluster_size: str
     repetition: int
-    size_bytes: int
-    time_ms: int
+    size_bytes: int | None
+    time_ms: int | None
 
 
 class ClusterSpecSheetResultStorage(BaseDataStorage):
@@ -69,8 +69,8 @@ class ClusterSpecSheetResultStorage(BaseDataStorage):
                     {as_sanitized_literal(result_entry.test_name)},
                     {as_sanitized_literal(result_entry.cluster_size)},
                     {result_entry.repetition},
-                    {result_entry.size_bytes},
-                    {result_entry.time_ms}
+                    {result_entry.size_bytes or 'NULL::BIGINT'},
+                    {result_entry.time_ms or 'NULL::BIGINT'}
                 ;
                 """
             )

--- a/misc/python/materialize/test_analytics/data/cluster_spec_sheet/cluster_spec_sheet_result_storage.py
+++ b/misc/python/materialize/test_analytics/data/cluster_spec_sheet/cluster_spec_sheet_result_storage.py
@@ -1,0 +1,78 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from dataclasses import dataclass
+
+from materialize import buildkite
+from materialize.buildkite import BuildkiteEnvVar
+from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util.mz_sql_util import as_sanitized_literal
+
+
+@dataclass
+class ClusterSpecSheetResultEntry:
+    scenario: str
+    scenario_version: str
+    scale: int
+    mode: str
+    category: str
+    test_name: str
+    cluster_size: str
+    repetition: int
+    size_bytes: int
+    time_ms: int
+
+
+class ClusterSpecSheetResultStorage(BaseDataStorage):
+
+    def add_result(
+        self,
+        framework_version: str,
+        results: list[ClusterSpecSheetResultEntry],
+    ) -> None:
+        job_id = buildkite.get_var(BuildkiteEnvVar.BUILDKITE_JOB_ID)
+
+        sql_statements = []
+
+        for result_entry in results:
+            # TODO: remove NULL castings when database-issues#8100 is resolved
+            sql_statements.append(
+                f"""
+                INSERT INTO cluster_spec_sheet_result
+                (
+                    build_job_id,
+                    framework_version,
+                    scenario,
+                    scenario_version,
+                    scale,
+                    mode,
+                    category,
+                    test_name,
+                    cluster_size,
+                    repetition,
+                    size_bytes,
+                    time_ms
+                )
+                SELECT
+                    {as_sanitized_literal(job_id)},
+                    {as_sanitized_literal(framework_version)},
+                    {as_sanitized_literal(result_entry.scenario)},
+                    {as_sanitized_literal(result_entry.scenario_version)},
+                    {result_entry.scale},
+                    {as_sanitized_literal(result_entry.mode)},
+                    {as_sanitized_literal(result_entry.category)},
+                    {as_sanitized_literal(result_entry.test_name)},
+                    {as_sanitized_literal(result_entry.cluster_size)},
+                    {result_entry.repetition},
+                    {result_entry.size_bytes},
+                    {result_entry.time_ms}
+                ;
+                """
+            )
+
+        self.database_connector.add_update_statements(sql_statements)

--- a/misc/python/materialize/test_analytics/setup/cleanup/remove-build.sql
+++ b/misc/python/materialize/test_analytics/setup/cleanup/remove-build.sql
@@ -13,6 +13,7 @@ DELETE FROM feature_benchmark_result WHERE build_job_id IN (SELECT build_id FROM
 DELETE FROM scalability_framework_result WHERE build_job_id IN (SELECT build_id FROM build_job WHERE build_id IN (%build-ids%));
 DELETE FROM parallel_benchmark_result WHERE build_job_id IN (SELECT build_id FROM build_job WHERE build_id IN (%build-ids%));
 DELETE FROM product_limits_result WHERE build_job_id IN (SELECT build_id FROM build_job WHERE build_id IN (%build-ids%));
+DELETE FROM cluster_spec_sheet_result WHERE build_job_id IN (SELECT build_id FROM build_job WHERE build_id IN (%build-ids%));
 DELETE FROM build_annotation_error WHERE build_job_id IN (SELECT build_job_id FROM build_annotation WHERE build_id IN (%build-ids%));
 DELETE FROM build_annotation WHERE build_id IN (%build-ids%);
 DELETE FROM build_job WHERE build_id IN (%build-ids%);

--- a/misc/python/materialize/test_analytics/setup/tables/15-cluster-spec-sheet.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/15-cluster-spec-sheet.sql
@@ -1,0 +1,28 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+
+-- result of individual product limits scenarios
+CREATE TABLE cluster_spec_sheet_result (
+   build_job_id TEXT NOT NULL,
+   framework_version TEXT NOT NULL,
+   scenario TEXT NOT NULL,
+   scenario_version TEXT NOT NULL,
+   scale INT NOT NULL,
+   mode TEXT NOT NULL,
+   category TEXT NOT NULL,
+   test_name TEXT NOT NULL,
+   cluster_size TEXT NOT NULL,
+   repetition INT NOT NULL,
+   size_bytes BIGINT NOT NULL,
+   time_ms BIGINT NOT NULL
+);
+
+ALTER TABLE cluster_spec_sheet_result OWNER TO qa;
+GRANT SELECT, INSERT, UPDATE ON TABLE cluster_spec_sheet_result TO "hetzner-ci";

--- a/misc/python/materialize/test_analytics/setup/tables/15-cluster-spec-sheet.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/15-cluster-spec-sheet.sql
@@ -20,8 +20,8 @@ CREATE TABLE cluster_spec_sheet_result (
    test_name TEXT NOT NULL,
    cluster_size TEXT NOT NULL,
    repetition INT NOT NULL,
-   size_bytes BIGINT NOT NULL,
-   time_ms BIGINT NOT NULL
+   size_bytes BIGINT,
+   time_ms BIGINT
 );
 
 ALTER TABLE cluster_spec_sheet_result OWNER TO qa;

--- a/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
+++ b/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
@@ -29,6 +29,10 @@ CREATE OR REPLACE VIEW v_data_integrity (table_name, own_item_key, referenced_it
     FROM product_limits_result
     WHERE build_job_id NOT IN (SELECT build_job_id FROM build_job)
     UNION
+    SELECT 'cluster_spec_sheet_result', build_job_id, build_job_id, 'cluster spec sheet result references missing build job'
+    FROM cluster_spec_sheet_result
+    WHERE build_job_id NOT IN (SELECT build_job_id FROM build_job)
+    UNION
     SELECT 'build_annotation', build_job_id, build_job_id, 'build annotation references missing build job'
     FROM build_annotation
     WHERE build_job_id NOT IN (SELECT build_job_id FROM build_job)

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -25,6 +25,9 @@ from materialize.test_analytics.data.build.build_history_analysis import (
 from materialize.test_analytics.data.build_annotation.build_annotation_storage import (
     BuildAnnotationStorage,
 )
+from materialize.test_analytics.data.cluster_spec_sheet.cluster_spec_sheet_result_storage import (
+    ClusterSpecSheetResultStorage,
+)
 from materialize.test_analytics.data.feature_benchmark.feature_benchmark_result_storage import (
     FeatureBenchmarkResultStorage,
 )
@@ -71,6 +74,9 @@ class TestAnalyticsDb:
             self.database_connector
         )
         self.product_limits_results = ProductLimitsResultStorage(
+            self.database_connector
+        )
+        self.cluster_spec_sheet_results = ClusterSpecSheetResultStorage(
             self.database_connector
         )
 

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -1499,8 +1499,8 @@ def upload_results_to_test_analytics(
                     test_name=row["test_name"],
                     cluster_size=row["cluster_size"],
                     repetition=int(row["repetition"]),
-                    size_bytes=int(row["size_bytes"]),
-                    time_ms=int(row["time_ms"]),
+                    size_bytes=int(row["size_bytes"]) if row["size_bytes"] else None,
+                    time_ms=int(row["time_ms"]) if row["time_ms"] else None,
                 )
             )
 


### PR DESCRIPTION
Test run: https://buildkite.com/materialize/release-qualification/builds/959
<img width="3162" height="861" alt="Screenshot 2025-09-25 at 11 22 11" src="https://github.com/user-attachments/assets/1c6769cb-a474-413b-814e-7192dc43a1d5" />

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
