### PR TITLE
dev docs: Fix s3 metadata properly

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -15,15 +15,15 @@ set -euo pipefail
 
 cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
-aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
+aws s3 cp --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --recursive misc/www/ s3://materialize-dev-website/
 
 # We exclude all of these pages from search engines for SEO purposes. We don't
 # want to spend our crawl budget on these pages, nor have these pages appear
 # ahead of our marketing content.
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
-aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
-aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
+aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
+aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 
 bin/pydoc
-aws s3 sync --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python
+aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python


### PR DESCRIPTION
Didn't realize the order matters for its arg parser. Seen in https://buildkite.com/materialize/deploy/builds/19687#01997e8c-db4e-4ea2-990d-f442b22ffa6a

Follow-up to https://github.com/MaterializeInc/materialize/pull/33706