### PR TITLE
dev docs: Restore previous state

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -15,15 +15,15 @@ set -euo pipefail
 
 cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
-aws s3 cp --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --recursive misc/www/ s3://materialize-dev-website/
+aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
 
 # We exclude all of these pages from search engines for SEO purposes. We don't
 # want to spend our crawl budget on these pages, nor have these pages appear
 # ahead of our marketing content.
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
-aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
-aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
+aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
+aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 
 bin/pydoc
-aws s3 sync --metadata-directive REPLACE --metadata "X-Robots-Tag=noindex,nofollow" --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python
+aws s3 sync --size-only --delete target/pydoc/ s3://materialize-dev-website/api/python


### PR DESCRIPTION
Still failing unfortunately: https://buildkite.com/materialize/deploy/builds/19691#01998083-b58a-4617-a671-3fd35f46d8e1

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
