### PR TITLE
sql server: Try 5 min start_period

### DIFF
--- a/misc/python/materialize/mzcompose/services/sql_server.py
+++ b/misc/python/materialize/mzcompose/services/sql_server.py
@@ -42,7 +42,8 @@ class SqlServer(Service):
                 "healthcheck": {
                     "test": f"/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P '{sa_password}' -Q 'SELECT 1'",
                     "interval": "1s",
-                    "start_period": "60s",
+                    # Recovering can take a while
+                    "start_period": "300s",
                 },
             },
         )

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -36,6 +36,7 @@ from materialize.zippy.mysql_cdc_actions import CreateMySqlCdcTable
 from materialize.zippy.sql_server_actions import (
     CreateSqlServerTable,
     SqlServerDML,
+    SqlServerRestart,
     SqlServerStart,
 )
 from materialize.zippy.sql_server_cdc_actions import CreateSqlServerCdcTable
@@ -252,8 +253,7 @@ class SqlServerCdc(Scenario):
             KillClusterd: 5,
             StoragedKill: 5,
             StoragedStart: 5,
-            # TODO: Reenable when database-issues#9624 is fixed
-            # SqlServerRestart: 10,
+            SqlServerRestart: 10,
             CreateViewParameterized(): 10,
             ValidateView: 20,
             SqlServerDML: 100,


### PR DESCRIPTION
My only explanation so far is that CI is just slower than local runs. I haven't managed to reproduce the failure yet with this, did 10 runs.

Fixes: https://github.com/MaterializeInc/database-issues/issues/9624
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
