### PR TITLE
adapter: set `mz_cluster{_replica}s.disk` to false with swap

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2339,12 +2339,17 @@ impl CatalogState {
 
     /// Return whether the given replica size requests a disk.
     ///
+    /// Note that here we treat replica sizes that enable swap as _not_ requesting disk. For swap
+    /// replicas, the provided disk limit is informational and mostly ignored. Whether an instance
+    /// has access to swap depends on the configuration of the node it gets scheduled on, and is
+    /// not something we can know at this point.
+    ///
     /// # Panics
     ///
     /// Panics if the given size doesn't exist in `cluster_replica_sizes`.
     pub(crate) fn cluster_replica_size_has_disk(&self, size: &str) -> bool {
         let alloc = &self.cluster_replica_sizes.0[size];
-        alloc.disk_limit != Some(DiskLimit::ZERO)
+        !alloc.swap_enabled && alloc.disk_limit != Some(DiskLimit::ZERO)
     }
 
     pub(crate) fn ensure_valid_replica_size(


### PR DESCRIPTION
This PR changes the meaning of the existing `disk` field in `mz_clusters` and `mz_cluster_replicas` from "whether this cluster/replica has a disk or swap" to "whether this cluster/replica has a disk". I.e. the change is that the field shows `false` for swap-enabled clusters/replicas.

The motivation is two-fold:
* Whether a replica gets swap or not depends on the node it gets scheduled on. Pretending that swap-enabled replicas always get swap would be lying.
* More importantly, the console needs a way to know which clusters still use the old way of spilling to disk, to adjust its metrics UI accordingly. This change provides that way.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/database-issues/issues/9692

See [Slack thread](https://materializeinc.slack.com/archives/C06GZ7GBKB5/p1758719170479669).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
