### PR TITLE
COPY TO: set content-length header to 0 when creating MPU

### DIFF
--- a/src/aws-util/src/s3_uploader.rs
+++ b/src/aws-util/src/s3_uploader.rs
@@ -164,6 +164,12 @@ impl S3MultiPartUploader {
             .create_multipart_upload()
             .bucket(&bucket)
             .key(&key)
+            .customize()
+            .mutate_request(|req| {
+                // For GCS, Content-Length must be 0 when initiating MPU
+                // https://cloud.google.com/storage/docs/xml-api/post-object-multipart
+                req.headers_mut().insert("Content-Length", "0");
+            })
             .send()
             .await?;
         let upload_id = res


### PR DESCRIPTION
Set Content-Length header to 0 when initiating the multi-part upload for `COPY TO .. s3://...`.  This is required when writing to GCS.

### Motivation

Fixes a compatibility issue with GCS.

I tested this locally with some AWS overrides and GCS xml-api.  I don't immediately see how to add tests to CI for GCS, but will check with @def-.

```
AWS_ENDPOINT_URL=https://storage.googleapis.com
AWS_REGION=us
```

parquet
```
2025-09-25T20:15:51.074537Z  INFO mz_storage_operators::s3_oneshot_sink::parquet: finished upload: bucket .... , key marty/mz-t35-batch-0000-0000.parquet, bytes_uploaded 16561647, parts_uploaded 2
```

csv
```
mz_storage_operators::s3_oneshot_sink::pgcopy: finished upload: bucket .... , key marty-foo/mz-t36-batch-0000-0001.csv, bytes_uploaded 16989075, parts_uploaded 3
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
