### PR TITLE
sql server: fix handling of float data type

### DIFF
--- a/doc/user/shared-content/sql-server-supported-types.md
+++ b/doc/user/shared-content/sql-server-supported-types.md
@@ -6,7 +6,8 @@ Materialize natively supports the following SQL Server types:
 <li><code>int</code></li>
 <li><code>bigint</code></li>
 <li><code>real</code></li>
-<li><code>double</code></li>
+<li><code>double precision</code></li>
+<li><code>float</code></li>
 <li><code>bit</code></li>
 <li><code>decimal</code></li>
 <li><code>numeric</code></li>

--- a/test/sql-server-cdc/40-data-types.td
+++ b/test/sql-server-cdc/40-data-types.td
@@ -90,6 +90,11 @@ CREATE TABLE table_nvarchar(val nvarchar(999));
 INSERT INTO table_nvarchar VALUES (N'🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀'), (N'💯💯💯💯💯💯💯💯💯'), (NULL);
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_nvarchar', @role_name = 'SA', @supports_net_changes = 0;
 
+CREATE TABLE table_floats(a real, b float, c float(24), d float(25), e float(53), f double precision);
+INSERT INTO table_floats VALUES (0.01, 0.002, 16777217, 16777217, 16777217, 16777217);
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table_floats', @role_name = 'SA', @supports_net_changes = 0;
+
+
 # Exercise Materialize.
 
 > CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
@@ -264,5 +269,8 @@ true
 "🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀🦀🚀"
 "💯💯💯💯💯💯💯💯💯"
 <null>
+
+> SELECT * FROM table_floats;
+0.01 0.002 16777216 16777217 16777217 16777217
 
 > DROP SOURCE test_40_data_types CASCADE;


### PR DESCRIPTION
Corrects how MZ handles SQL Server `float` data type. 

### Motivation

fixes https://github.com/MaterializeInc/database-issues/issues/9742

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
