### PR TITLE
platform-checks: Enable python-based actions

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -9,6 +9,7 @@
 
 import textwrap
 import time
+from collections.abc import Callable
 from inspect import getframeinfo, stack
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +46,19 @@ class Testdrive(Action):
     def execute(self, e: Executor, mz_service: str | None = None) -> None:
         """Pass testdrive actions to be run by an Executor-specific implementation."""
         self.handle = e.testdrive(self.input, self.caller, mz_service)
+
+    def join(self, e: Executor) -> None:
+        e.join(self.handle)
+
+
+class PyAction(Action):
+    def __init__(self, method: Callable) -> None:
+        self.method: Any = method
+        self.handle: Any | None = None
+
+    def execute(self, e: Executor, mz_service: str | None = None) -> None:
+        """Pass Python-based actions to be run by an Executor-specific implementation."""
+        self.handle = e.run_pyaction(self.method, mz_service)
 
     def join(self, e: Executor) -> None:
         e.join(self.handle)

--- a/misc/python/materialize/checks/all_checks/table_data.py
+++ b/misc/python/materialize/checks/all_checks/table_data.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+import random
+from typing import Any
+
+from materialize.checks.actions import PyAction
+from materialize.checks.checks import Check, externally_idempotent
+
+
+@externally_idempotent(False)
+class TableData(Check):
+    data: list[int]
+
+    def initialize(self) -> PyAction:
+        self.data = []
+
+        def run(conn: Any) -> None:
+            with conn.cursor() as cur:
+                cur.execute("CREATE TABLE table_data (f1 INTEGER)")
+
+        return PyAction(run)
+
+    def manipulate(self) -> list[PyAction]:
+        def run(conn: Any) -> None:
+            with conn.cursor() as cur:
+                for _ in range(100):
+                    value = random.randint(1, 1000000)
+                    self.data.append(value)
+                    cur.execute(f"INSERT INTO table_data VALUES ({value})")
+
+        return [PyAction(run) for _ in range(2)]
+
+    def validate(self) -> PyAction:
+        def run(conn: Any) -> None:
+            with conn.cursor() as cur:
+                self.data.sort()
+                cur.execute("SELECT f1 FROM table_data ORDER BY f1")
+                for i, row in enumerate(cur.fetchall()):
+                    assert row[0] == self.data[i]
+
+        return PyAction(run)

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from materialize import buildkite
 from materialize.buildkite import BuildkiteEnvVar
-from materialize.checks.actions import Testdrive
+from materialize.checks.actions import PyAction, Testdrive
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
 
@@ -50,13 +50,13 @@ class Check:
         """
         return "quickstart"
 
-    def initialize(self) -> Testdrive:
+    def initialize(self) -> Testdrive | PyAction:
         return Testdrive(TESTDRIVE_NOP)
 
-    def manipulate(self) -> list[Testdrive]:
+    def manipulate(self) -> list[Testdrive] | list[PyAction]:
         raise NotImplementedError
 
-    def validate(self) -> Testdrive:
+    def validate(self) -> Testdrive | PyAction:
         """Note that the validation method may be invoked multiple times (depending on the scenario)."""
         raise NotImplementedError
 


### PR DESCRIPTION
Based on https://materializeinc.slack.com/archives/C01LKF361MZ/p1758875954008029

This allows us to keep state around in checks.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
