### PR TITLE
test: fix read-frontiers-not-stuck check

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4010,9 +4010,9 @@ def check_read_frontiers_not_stuck(c: Composition, object_names: list[str]):
         """
 
     # Because `mz_frontiers` isn't a linearizable relation it's possible that
-    # we need to wait a bit for the object's frontier to show up.
+    # we need to wait a bit for the objects' frontiers to show up.
     result = c.sql_query(query)
-    if not result:
+    if len(result) < len(object_names):
         time.sleep(2)
         result = c.sql_query(query)
 


### PR DESCRIPTION
The check was already waiting for _any_ results to appear, to work around the fact that `mz_frontiers` is not linearizable. However, it didn't consider the situation where only some of the requested frontiers were missing.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9743

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
