### PR TITLE
storage: fix running status for source exports

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -4531,17 +4531,6 @@ pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
                     self_events.status <> 'ceased' AND
                     parent_events.status = 'stalled'
                 THEN parent_events.source_id
-                -- TODO: Remove this once subsources eagerly propogate their status
-                -- Subsources move from starting to running lazily once they see
-                -- a record flow through, even though they are online and healthy.
-                -- This has been repeatedly brought up as confusing by users.
-                -- So now, if the parent source is running, and the subsource is
-                -- starting, we override its status to running to relfect its healthy
-                -- status.
-                WHEN
-                    self_events.status = 'starting' AND
-                    parent_events.status = 'running'
-                THEN parent_events.source_id
                 ELSE self_events.source_id
             END AS id_to_use
         FROM

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -196,12 +196,17 @@ impl SourceRender for MySqlSourceConnection {
             data_collections.insert(*id, data_stream.as_collection());
         }
 
-        let health_init = std::iter::once(HealthStatusMessage {
-            id: None,
-            namespace: Self::STATUS_NAMESPACE,
-            update: HealthStatusUpdate::Running,
-        })
-        .to_stream(scope);
+        let export_ids = config.source_exports.keys().copied();
+        let health_init = export_ids
+            .map(Some)
+            .chain(None)
+            .map(|id| HealthStatusMessage {
+                id,
+                namespace: Self::STATUS_NAMESPACE,
+                update: HealthStatusUpdate::Running,
+            })
+            .collect::<Vec<_>>()
+            .to_stream(scope);
 
         let health_errs = snapshot_err
             .concat(&repl_err)

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -9,189 +9,474 @@
 
 $ set-arg-default default-storage-size=scale=1,workers=1
 
-# Specify the behaviour of the status history tables
-$ set-regex match="\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)?" replacement="<TIMESTAMP>"
-
-> DROP CLUSTER IF EXISTS c CASCADE
-
-> CREATE CLUSTER c SIZE 'scale=1,workers=1', REPLICATION FACTOR 0
-
-> CREATE SOURCE counter in cluster c FROM LOAD GENERATOR COUNTER (UP TO 100)
-
-$ set-from-sql var=load_id
-SELECT id FROM mz_sources WHERE name = 'counter'
-
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${load_id}' ORDER BY occurred_at DESC LIMIT 1;
-"<TIMESTAMP> UTC" ${load_id} paused <null> "{\"hints\":[\"There is currently no replica running this source\"]}" <null>
-
-> ALTER CLUSTER c SET (REPLICATION FACTOR 1)
-
-$ set-from-sql var=replica_id
-SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'c'
-
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${load_id}' ORDER BY occurred_at DESC LIMIT 3;
-"<TIMESTAMP> UTC" ${load_id} running <null> <null> ${replica_id}
-"<TIMESTAMP> UTC" ${load_id} starting <null> <null> ${replica_id}
-"<TIMESTAMP> UTC" ${load_id} paused <null> "{\"hints\":[\"There is currently no replica running this source\"]}" <null>
-
-> ALTER CLUSTER c SET (REPLICATION FACTOR 0)
-
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${load_id}' ORDER BY occurred_at DESC LIMIT 4;
-"<TIMESTAMP> UTC" ${load_id} paused <null> "{\"hints\":[\"The replica running this source has been dropped\"]}"  ${replica_id}
-"<TIMESTAMP> UTC" ${load_id} running <null> <null> ${replica_id}
-"<TIMESTAMP> UTC" ${load_id} starting <null> <null> ${replica_id}
-"<TIMESTAMP> UTC" ${load_id} paused <null> "{\"hints\":[\"There is currently no replica running this source\"]}" <null>
-
-> DROP CLUSTER c CASCADE
-
-
 $ kafka-create-topic topic=status-history
 
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
-
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
   );
 
-## The basics: create a source and sink, pass in some data, and confirm that we see the status
-## entries we expect.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+CREATE TABLE pg_table (a int);
+ALTER TABLE pg_table REPLICA IDENTITY FULL;
 
-> CREATE CLUSTER kafka_source_cluster SIZE '${arg.default-storage-size}';
-> BEGIN
-> CREATE SOURCE kafka_source
-  IN CLUSTER kafka_source_cluster
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg_conn
+  TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE mysql_table (a int);
+
+> CREATE SECRET mysqlpass AS 'p@ssw0rd';
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+# Test the contents of `mz_source_status_history` with various types of sources.
+
+> CREATE CLUSTER sources SIZE '${arg.default-storage-size}', REPLICATION FACTOR 0
+
+> CREATE SOURCE auction
+  IN CLUSTER sources
+  FROM LOAD GENERATOR AUCTION FOR ALL TABLES
+
+> CREATE SOURCE kafka
+  IN CLUSTER sources
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
-
-> CREATE TABLE kafka_source_tbl FROM SOURCE kafka_source (REFERENCE "testdrive-status-history-${testdrive.seed}")
+> CREATE TABLE kafka_tbl
+  FROM SOURCE kafka (REFERENCE "testdrive-status-history-${testdrive.seed}")
   FORMAT TEXT
-> COMMIT
 
-> CREATE CLUSTER kafka_sink_cluster SIZE '${arg.default-storage-size}';
-> CREATE SINK kafka_sink
-  IN CLUSTER kafka_sink_cluster
-  FROM kafka_source_tbl
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
+> CREATE SOURCE pg
+  IN CLUSTER sources
+  FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'mz_source')
+> CREATE TABLE pg_tbl
+  FROM SOURCE pg (REFERENCE "pg_table")
+
+> CREATE SOURCE mysql
+  IN CLUSTER sources
+  FROM MYSQL CONNECTION mysql_conn
+> CREATE TABLE mysql_tbl
+  FROM SOURCE mysql (REFERENCE "public"."mysql_table")
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_source_status_history s
+  JOIN mz_objects o ON o.id = s.source_id
+accounts       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auction        paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auctions       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+bids           paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+organizations  paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+users          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg             paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg_tbl         paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+
+> SELECT o.name, s.status FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
+accounts       paused
+auction        paused
+auctions       paused
+bids           paused
+organizations  paused
+users          paused
+kafka          paused
+kafka_tbl      paused
+pg             paused
+pg_tbl         paused
+mysql          paused
+mysql_tbl      paused
+auction_progress  running
+kafka_progress    running
+pg_progress       running
+mysql_progress    running
+
+> ALTER CLUSTER sources SET (REPLICATION FACTOR 1)
+
+$ set-from-sql var=replica_id_1
+SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'sources'
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_source_status_history s
+  JOIN mz_objects o ON o.id = s.source_id
+accounts       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auction        paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auctions       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+bids           paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+organizations  paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+users          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg             paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg_tbl         paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+accounts       starting  <null>                                                                 ${replica_id_1}
+auction        starting  <null>                                                                 ${replica_id_1}
+auctions       starting  <null>                                                                 ${replica_id_1}
+bids           starting  <null>                                                                 ${replica_id_1}
+organizations  starting  <null>                                                                 ${replica_id_1}
+users          starting  <null>                                                                 ${replica_id_1}
+kafka          starting  <null>                                                                 ${replica_id_1}
+kafka_tbl      starting  <null>                                                                 ${replica_id_1}
+pg             starting  <null>                                                                 ${replica_id_1}
+pg_tbl         starting  <null>                                                                 ${replica_id_1}
+mysql          starting  <null>                                                                 ${replica_id_1}
+mysql_tbl      starting  <null>                                                                 ${replica_id_1}
+accounts       running   <null>                                                                 ${replica_id_1}
+auction        running   <null>                                                                 ${replica_id_1}
+auctions       running   <null>                                                                 ${replica_id_1}
+bids           running   <null>                                                                 ${replica_id_1}
+organizations  running   <null>                                                                 ${replica_id_1}
+users          running   <null>                                                                 ${replica_id_1}
+kafka          running   <null>                                                                 ${replica_id_1}
+kafka_tbl      running   <null>                                                                 ${replica_id_1}
+pg             running   <null>                                                                 ${replica_id_1}
+pg_tbl         running   <null>                                                                 ${replica_id_1}
+mysql          running   <null>                                                                 ${replica_id_1}
+mysql_tbl      running   <null>                                                                 ${replica_id_1}
+
+> SELECT o.name, s.status FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
+accounts       running
+auction        running
+auctions       running
+bids           running
+organizations  running
+users          running
+kafka          running
+kafka_tbl      running
+pg             running
+pg_tbl         running
+mysql          running
+mysql_tbl      running
+auction_progress  running
+kafka_progress    running
+pg_progress       running
+mysql_progress    running
+
+> ALTER CLUSTER sources SET (REPLICATION FACTOR 0)
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_source_status_history s
+  JOIN mz_objects o ON o.id = s.source_id
+accounts       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auction        paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auctions       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+bids           paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+organizations  paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+users          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg             paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg_tbl         paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+accounts       starting  <null>                                                                 ${replica_id_1}
+auction        starting  <null>                                                                 ${replica_id_1}
+auctions       starting  <null>                                                                 ${replica_id_1}
+bids           starting  <null>                                                                 ${replica_id_1}
+organizations  starting  <null>                                                                 ${replica_id_1}
+users          starting  <null>                                                                 ${replica_id_1}
+kafka          starting  <null>                                                                 ${replica_id_1}
+kafka_tbl      starting  <null>                                                                 ${replica_id_1}
+pg             starting  <null>                                                                 ${replica_id_1}
+pg_tbl         starting  <null>                                                                 ${replica_id_1}
+mysql          starting  <null>                                                                 ${replica_id_1}
+mysql_tbl      starting  <null>                                                                 ${replica_id_1}
+accounts       running   <null>                                                                 ${replica_id_1}
+auction        running   <null>                                                                 ${replica_id_1}
+auctions       running   <null>                                                                 ${replica_id_1}
+bids           running   <null>                                                                 ${replica_id_1}
+organizations  running   <null>                                                                 ${replica_id_1}
+users          running   <null>                                                                 ${replica_id_1}
+kafka          running   <null>                                                                 ${replica_id_1}
+kafka_tbl      running   <null>                                                                 ${replica_id_1}
+pg             running   <null>                                                                 ${replica_id_1}
+pg_tbl         running   <null>                                                                 ${replica_id_1}
+mysql          running   <null>                                                                 ${replica_id_1}
+mysql_tbl      running   <null>                                                                 ${replica_id_1}
+accounts       paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+auction        paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+auctions       paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+bids           paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+organizations  paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+users          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+kafka          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+kafka_tbl      paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+pg             paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+pg_tbl         paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+mysql          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+mysql_tbl      paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+
+> SELECT o.name, s.status FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
+accounts       paused
+auction        paused
+auctions       paused
+bids           paused
+organizations  paused
+users          paused
+kafka          paused
+kafka_tbl      paused
+pg             paused
+pg_tbl         paused
+mysql          paused
+mysql_tbl      paused
+auction_progress  running
+kafka_progress    running
+pg_progress       running
+mysql_progress    running
+
+> ALTER CLUSTER sources SET (REPLICATION FACTOR 1)
+
+$ set-from-sql var=replica_id_2
+SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'sources'
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_source_status_history s
+  JOIN mz_objects o ON o.id = s.source_id
+accounts       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auction        paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+auctions       paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+bids           paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+organizations  paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+users          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+kafka_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg             paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+pg_tbl         paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql          paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+mysql_tbl      paused    "{\"hints\":[\"There is currently no replica running this source\"]}"  <null>
+accounts       starting  <null>                                                                 ${replica_id_1}
+auction        starting  <null>                                                                 ${replica_id_1}
+auctions       starting  <null>                                                                 ${replica_id_1}
+bids           starting  <null>                                                                 ${replica_id_1}
+organizations  starting  <null>                                                                 ${replica_id_1}
+users          starting  <null>                                                                 ${replica_id_1}
+kafka          starting  <null>                                                                 ${replica_id_1}
+kafka_tbl      starting  <null>                                                                 ${replica_id_1}
+pg             starting  <null>                                                                 ${replica_id_1}
+pg_tbl         starting  <null>                                                                 ${replica_id_1}
+mysql          starting  <null>                                                                 ${replica_id_1}
+mysql_tbl      starting  <null>                                                                 ${replica_id_1}
+accounts       running   <null>                                                                 ${replica_id_1}
+auction        running   <null>                                                                 ${replica_id_1}
+auctions       running   <null>                                                                 ${replica_id_1}
+bids           running   <null>                                                                 ${replica_id_1}
+organizations  running   <null>                                                                 ${replica_id_1}
+users          running   <null>                                                                 ${replica_id_1}
+kafka          running   <null>                                                                 ${replica_id_1}
+kafka_tbl      running   <null>                                                                 ${replica_id_1}
+pg             running   <null>                                                                 ${replica_id_1}
+pg_tbl         running   <null>                                                                 ${replica_id_1}
+mysql          running   <null>                                                                 ${replica_id_1}
+mysql_tbl      running   <null>                                                                 ${replica_id_1}
+accounts       paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+auction        paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+auctions       paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+bids           paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+organizations  paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+users          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+kafka          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+kafka_tbl      paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+pg             paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+pg_tbl         paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+mysql          paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+mysql_tbl      paused    "{\"hints\":[\"The replica running this source has been dropped\"]}"   ${replica_id_1}
+accounts       starting  <null>                                                                 ${replica_id_2}
+auction        starting  <null>                                                                 ${replica_id_2}
+auctions       starting  <null>                                                                 ${replica_id_2}
+bids           starting  <null>                                                                 ${replica_id_2}
+organizations  starting  <null>                                                                 ${replica_id_2}
+users          starting  <null>                                                                 ${replica_id_2}
+kafka          starting  <null>                                                                 ${replica_id_2}
+kafka_tbl      starting  <null>                                                                 ${replica_id_2}
+pg             starting  <null>                                                                 ${replica_id_2}
+pg_tbl         starting  <null>                                                                 ${replica_id_2}
+mysql          starting  <null>                                                                 ${replica_id_2}
+mysql_tbl      starting  <null>                                                                 ${replica_id_2}
+accounts       running   <null>                                                                 ${replica_id_2}
+auction        running   <null>                                                                 ${replica_id_2}
+auctions       running   <null>                                                                 ${replica_id_2}
+bids           running   <null>                                                                 ${replica_id_2}
+organizations  running   <null>                                                                 ${replica_id_2}
+users          running   <null>                                                                 ${replica_id_2}
+kafka          running   <null>                                                                 ${replica_id_2}
+kafka_tbl      running   <null>                                                                 ${replica_id_2}
+pg             running   <null>                                                                 ${replica_id_2}
+pg_tbl         running   <null>                                                                 ${replica_id_2}
+mysql          running   <null>                                                                 ${replica_id_2}
+mysql_tbl      running   <null>                                                                 ${replica_id_2}
+
+> SELECT o.name, s.status FROM mz_internal.mz_source_statuses s JOIN mz_objects o USING (id)
+accounts       running
+auction        running
+auctions       running
+bids           running
+organizations  running
+users          running
+kafka          running
+kafka_tbl      running
+pg             running
+pg_tbl         running
+mysql          running
+mysql_tbl      running
+auction_progress  running
+kafka_progress    running
+pg_progress       running
+mysql_progress    running
+
+# Ensure `dropped` status also shows up.
 
 $ set-from-sql var=source_id
-SELECT id FROM mz_sources WHERE name = 'kafka_source'
+SELECT id FROM mz_sources WHERE name = 'kafka'
 
-$ set-from-sql var=source_replica_id
-SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'kafka_source_cluster'
+> DROP SOURCE kafka CASCADE
+> SELECT true
+  FROM mz_internal.mz_source_status_history
+  WHERE source_id = '${source_id}' and status = 'dropped'
+true
 
-$ set-from-sql var=sink_replica_id
-SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'kafka_sink_cluster'
+> DROP CLUSTER sources CASCADE
 
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${source_id}' ORDER BY occurred_at DESC LIMIT 2;
-"<TIMESTAMP> UTC" ${source_id} running <null> <null> ${source_replica_id}
-"<TIMESTAMP> UTC" ${source_id} starting <null> <null> ${source_replica_id}
 
-> SELECT * FROM mz_internal.mz_source_statuses WHERE id = '${source_id}';
-"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
+# Test the contents of `mz_sink_status_history`.
+#
+# Note that a sink sometimes enters a "stalled" state after creation because
+# there is a race between creating the progress collection and reading from it.
+# The sink then restarts and comes back up healthy. We have to account for that
+# sequence in events in the history queries below.
 
-$ set-from-sql var=sink_id
-SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
+> CREATE CLUSTER sinks SIZE '${arg.default-storage-size}', REPLICATION FACTOR 0
 
-# Verify we get a starting -- it's possible we move to running by the time this query runs.
-# Additionally it can happen that both 'starting' and 'running' are reported on the same millisecond
-# so we filter out any other statuses.
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' AND status = 'starting' ORDER BY occurred_at ASC LIMIT 1;
-"<TIMESTAMP> UTC" ${sink_id} starting <null> <null> ${sink_replica_id}
-
-$ kafka-ingest format=bytes topic=status-history
-a
-b
-c
-d
-
-> SELECT * FROM kafka_source_tbl ORDER BY 1;
-a
-b
-c
-d
-
-$ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages=true
-{"before": null, "after": {"row":{"text": "a"}}}
-{"before": null, "after": {"row":{"text": "b"}}}
-{"before": null, "after": {"row":{"text": "c"}}}
-{"before": null, "after": {"row":{"text": "d"}}}
-
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at DESC LIMIT 2;
-"<TIMESTAMP> UTC" ${sink_id} running <null> <null> ${sink_replica_id}
-"<TIMESTAMP> UTC" ${sink_id} starting <null> <null> ${sink_replica_id}
-
-> SELECT * FROM mz_internal.mz_sink_statuses WHERE id = '${sink_id}';
-"${sink_id}" kafka_sink kafka "<TIMESTAMP> UTC" running <null> <null>
-
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${source_id}' ORDER BY occurred_at DESC LIMIT 2;
-"<TIMESTAMP> UTC" ${source_id} starting <null> <null> ${source_replica_id}
-"<TIMESTAMP> UTC" ${source_id} running <null> <null> ${source_replica_id}
-
-> SELECT * FROM mz_internal.mz_source_statuses WHERE id = '${source_id}';
-"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
-
-## Confirm that the tables report statuses for multiple sources and sinks.
-
-> CREATE CLUSTER kafka_source_2_cluster SIZE '${arg.default-storage-size}';
-> BEGIN
-> CREATE SOURCE kafka_source_2
-  IN CLUSTER kafka_source_2_cluster
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
-
-> CREATE TABLE kafka_source_2_tbl FROM SOURCE kafka_source_2 (REFERENCE "testdrive-status-history-${testdrive.seed}")
-  FORMAT TEXT
-> COMMIT
-
-> CREATE CLUSTER kafka_sink_2_cluster SIZE '${arg.default-storage-size}';
-> CREATE SINK kafka_sink_2
-  IN CLUSTER kafka_sink_2_cluster
-  FROM kafka_source_2_tbl
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-2-${testdrive.seed}')
+> CREATE TABLE t (a int)
+> CREATE SINK kafka1
+  IN CLUSTER sinks
+  FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka1-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+> CREATE SINK kafka2
+  IN CLUSTER sinks
+  FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka2-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
-$ set-from-sql var=source_id_2
-SELECT id FROM mz_sources WHERE name = 'kafka_source_2'
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_objects o ON o.id = s.sink_id
+kafka1  paused  "{\"hints\":[\"There is currently no replica running this sink\"]}"  <null>
+kafka2  paused  "{\"hints\":[\"There is currently no replica running this sink\"]}"  <null>
 
-$ set-from-sql var=sink_id_2
-SELECT id FROM mz_sinks WHERE name = 'kafka_sink_2'
+> SELECT o.name, s.status FROM mz_internal.mz_sink_statuses s JOIN mz_objects o USING (id)
+kafka1  paused
+kafka2  paused
 
-$ set-from-sql var=source_2_replica_id
-SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'kafka_source_2_cluster'
+> ALTER CLUSTER sinks SET (REPLICATION FACTOR 1)
 
-$ set-from-sql var=sink_2_replica_id
-SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'kafka_sink_2_cluster'
+$ set-from-sql var=replica_id_1
+SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'sinks'
 
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id_2}' ORDER BY occurred_at DESC LIMIT 2;
-"<TIMESTAMP> UTC" ${sink_id_2} starting <null> <null> ${sink_2_replica_id}
-"<TIMESTAMP> UTC" ${sink_id_2} running <null> <null> ${sink_2_replica_id}
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka1'
+  ORDER BY occurred_at DESC
+  LIMIT 2
+kafka1  starting  <null>  ${replica_id_1}
+kafka1  running   <null>  ${replica_id_1}
 
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${source_id_2}' ORDER BY occurred_at DESC LIMIT 2;
-"<TIMESTAMP> UTC" ${source_id_2} running <null> <null> ${source_2_replica_id}
-"<TIMESTAMP> UTC" ${source_id_2} starting <null> <null> ${source_2_replica_id}
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka2'
+  ORDER BY occurred_at DESC
+  LIMIT 2
+kafka2  starting  <null>  ${replica_id_1}
+kafka2  running   <null>  ${replica_id_1}
 
-> SELECT * FROM mz_internal.mz_sink_statuses WHERE id IN ('${sink_id}', '${sink_id_2}') ORDER BY id;
-"${sink_id}" kafka_sink kafka "<TIMESTAMP> UTC" running <null> <null>
-"${sink_id_2}" kafka_sink_2 kafka "<TIMESTAMP> UTC" running <null> <null>
+> SELECT o.name, s.status FROM mz_internal.mz_sink_statuses s JOIN mz_sinks o USING (id)
+kafka1  running
+kafka2  running
 
-> SELECT * FROM mz_internal.mz_source_statuses WHERE id IN ('${source_id}', '${source_id_2}') ORDER BY id;
-"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
-"${source_id_2}" kafka_source_2 kafka "<TIMESTAMP> UTC" running <null> <null>
+> ALTER CLUSTER sinks SET (REPLICATION FACTOR 0)
 
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka1'
+  ORDER BY occurred_at DESC
+  LIMIT 1
+kafka1  paused    "{\"hints\":[\"The replica running this sink has been dropped\"]}"   ${replica_id_1}
 
-# ensure `dropped` also shows up
-> DROP SINK kafka_sink
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka2'
+  ORDER BY occurred_at DESC
+  LIMIT 1
+kafka2  paused    "{\"hints\":[\"The replica running this sink has been dropped\"]}"   ${replica_id_1}
 
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at DESC LIMIT 3;
-"<TIMESTAMP> UTC" ${sink_id} dropped <null> <null> <null>
-"<TIMESTAMP> UTC" ${sink_id} running <null> <null> ${sink_replica_id}
-"<TIMESTAMP> UTC" ${sink_id} starting <null> <null> ${sink_replica_id}
+> SELECT o.name, s.status FROM mz_internal.mz_sink_statuses s JOIN mz_objects o USING (id)
+kafka1  paused
+kafka2  paused
 
-> DROP SOURCE kafka_source CASCADE
+> ALTER CLUSTER sinks SET (REPLICATION FACTOR 1)
 
-> SELECT * FROM mz_internal.mz_source_status_history WHERE source_id = '${source_id}' ORDER BY occurred_at DESC LIMIT 3;
-"<TIMESTAMP> UTC" ${source_id} dropped <null> <null> <null>
-"<TIMESTAMP> UTC" ${source_id} running <null> <null> ${source_replica_id}
-"<TIMESTAMP> UTC" ${source_id} starting <null> <null> ${source_replica_id}
+$ set-from-sql var=replica_id_2
+SELECT r.id FROM mz_clusters c JOIN mz_cluster_replicas r ON c.id = r.cluster_id  WHERE c.name = 'sinks'
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka1'
+  ORDER BY occurred_at DESC
+  LIMIT 2
+kafka1  starting  <null>  ${replica_id_2}
+kafka1  running   <null>  ${replica_id_2}
+
+> SELECT o.name, s.status, s.details, s.replica_id
+  FROM mz_internal.mz_sink_status_history s
+  JOIN mz_sinks o ON o.id = s.sink_id
+  WHERE o.name = 'kafka2'
+  ORDER BY occurred_at DESC
+  LIMIT 2
+kafka2  starting  <null>  ${replica_id_2}
+kafka2  running   <null>  ${replica_id_2}
+
+> SELECT o.name, s.status FROM mz_internal.mz_sink_statuses s JOIN mz_objects o USING (id)
+kafka1  running
+kafka2  running
+
+# Ensure `dropped` status also shows up.
+
+$ set-from-sql var=sink_id
+SELECT id FROM mz_sinks WHERE name = 'kafka1'
+
+> DROP SINK kafka1
+> SELECT true
+  FROM mz_internal.mz_sink_status_history
+  WHERE sink_id = '${sink_id}' and status = 'dropped'
+true
+
+> DROP CLUSTER sinks CASCADE


### PR DESCRIPTION
This PR fixes a bug where source exports (aka. subsources, aka. source tables) would get stuck in "starting" status when they weren't producing any data after installation. This caused confusion, both for users and for our 0dt caught-up checks.

The fix implemented here is to make sure the various source operators always emit a "running" status for all source exports, not just the root ingestion. The approach works, but is quite verbose and adds a new peculiarity one has to keep in mind when implementing a new source. Ideally this would somehow be handled automatically by the source ingestion pipeline instead. Perhaps something to pick up as part of https://github.com/MaterializeInc/database-issues/issues/5986.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9721

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
