### PR TITLE
ci: Clean up Rust after beta run

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -78,7 +78,7 @@ steps:
 
       - id: build-rust-latest-beta
         label: "Build with Latest Rust Beta"
-        command: bin/ci-builder run stable bash -c "curl https://sh.rustup.rs -sSf | sh -s -- -y && source /cargo/env && rustup install beta && rustup run beta cargo build --all-targets"
+        command: bin/ci-builder run stable ci/test/rust-beta-build.sh
         depends_on: []
         timeout_in_minutes: 60
         agents:

--- a/ci/test/rust-beta-build.sh
+++ b/ci/test/rust-beta-build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -euo pipefail
+
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+# shellcheck source=/dev/null
+source /cargo/env
+trap "rustup self uninstall -y" SIGTERM SIGINT EXIT
+rustup install beta
+rustup run beta cargo build --all-targets


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/13629#01999cf6-b084-4764-94c9-05ef8c9487e7

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
