### PR TITLE
Revert "ci: Ignore unused deps warning"

### DIFF
--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -37,4 +37,4 @@ mz-build-tools = { path = "../build-tools", default-features = false, features =
 prost-build = "0.13.5"
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["workspace-hack", "tokio-postgres"]
+normal = ["workspace-hack"]


### PR DESCRIPTION
Reverts MaterializeInc/materialize#33744

@teskje had a better fix that I missed: https://github.com/MaterializeInc/materialize/pull/33740