### PR TITLE
emulator docs: Mention `docker pull --no-cache`

### DIFF
--- a/doc/developer/emulator.md
+++ b/doc/developer/emulator.md
@@ -34,6 +34,12 @@ Run the emulator using the following command to allow for local access to the he
 
 Navigate to `http://localhost:6878` to view debug information for environtmentd.
 
+Note that when using the `latest` tag, you might have to pull the latest version manually if you had already used it previously:
+
+```bash
+docker pull --no-cache materialize/materialized:latest
+```
+
 **Linux Only**
 
 To profile using the [parka agent](https://github.com/parca-dev/parca-agent) you must be running on Linux as it requires sharing a variety of directories with the emulator container.

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -119,6 +119,7 @@ Time: 10.459 ms
 
 Or in mzcompose:
 ```bash
+docker pull --no-cache materialize/materialized:latest
 docker run --env MZ_EAT_MY_DATA=1 -p 127.0.0.1:6875:6875 materialize/materialized:latest
 ```
 

--- a/src/materialized/ci/README.md
+++ b/src/materialized/ci/README.md
@@ -19,7 +19,7 @@ The Materialize Emulator is an all-in-one Docker image available on Docker Hub, 
 To launch the Docker container:
 
 ```
-docker pull materialize/materialized:latest
+docker pull --no-cache materialize/materialized:latest
 docker run -d -p 127.0.0.1:6874:6874 -p 127.0.0.1:6875:6875 -p 127.0.0.1:6876:6876 materialize/materialized:latest
 ```
 


### PR DESCRIPTION
Otherwise you can end up any old version you previously pulled on your system.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
