### PR TITLE
rust beta build: Ignore uninstall not completing

### DIFF
--- a/ci/test/rust-beta-build.sh
+++ b/ci/test/rust-beta-build.sh
@@ -14,6 +14,6 @@ set -euo pipefail
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 # shellcheck source=/dev/null
 source /cargo/env
-trap "rustup self uninstall -y" SIGTERM SIGINT EXIT
+trap "rustup self uninstall -y || true" SIGTERM SIGINT EXIT
 rustup install beta
 rustup run beta cargo build --all-targets


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/13642#0199a743-6cec-4b7c-bb15-38c5d806da6d

I think we try to uninstall twice, but the error during cleanup shouldn't cause a test failure anyway.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
