### PR TITLE
compute,storage: downgrade config update logs

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -65,7 +65,7 @@ use timely::progress::frontier::Antichain;
 use timely::scheduling::Scheduler;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{oneshot, watch};
-use tracing::{Level, debug, error, info, span, warn};
+use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
@@ -414,7 +414,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     }
 
     fn handle_update_configuration(&mut self, params: ComputeParameters) {
-        info!("Applying configuration update: {params:?}");
+        debug!("Applying configuration update: {params:?}");
 
         let ComputeParameters {
             workload_class,
@@ -832,9 +832,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     let peek_persist_stash_available =
                         self.compute_state.peek_stash_persist_location.is_some();
                     if !peek_persist_stash_available && enabled {
-                        tracing::error!(
-                            "missing peek_stash_persist_location but peek stash is enabled"
-                        );
+                        error!("missing peek_stash_persist_location but peek stash is enabled");
                     }
                     enabled && peek_persist_stash_available
                 };
@@ -925,7 +923,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                         .metrics
                         .stashed_peek_seconds
                         .observe(duration.as_secs_f64());
-                    tracing::trace!(?stashing_peek.peek, ?duration, "finished stashing peek response in persist");
+                    trace!(?stashing_peek.peek, ?duration, "finished stashing peek response in persist");
 
                     Some(response)
                 } else {
@@ -1325,7 +1323,7 @@ impl PersistPeek {
                 }
 
                 let count: usize = d.try_into().map_err(|_| {
-                    tracing::error!(
+                    error!(
                         shard = %metadata.data_shard, diff = d, ?row,
                         "persist peek encountered negative multiplicities",
                     );
@@ -1471,7 +1469,7 @@ impl IndexPeek {
             });
             if copies.is_negative() {
                 let error = cursor.key(&storage);
-                tracing::error!(
+                error!(
                     target = %self.peek.target.id(), diff = %copies, %error,
                     "index peek encountered negative multiplicities in error trace",
                 );

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -111,7 +111,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::{mpsc, watch};
 use tokio::time::Instant;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::internal_control::{
@@ -737,7 +737,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 // management being a bit of a mess. we should clean this up and remove weird if
                 // statements like this.
                 if resume_uppers.values().all(|frontier| frontier.is_empty()) || as_of.is_empty() {
-                    tracing::info!(
+                    info!(
                         ?resume_uppers,
                         ?as_of,
                         "worker {}/{} skipping building ingestion dataflow \
@@ -1292,7 +1292,7 @@ impl StorageState {
             }
             StorageCommand::UpdateConfiguration(params) => {
                 // These can be done from all workers safely.
-                tracing::info!("Applying configuration update: {params:?}");
+                debug!("Applying configuration update: {params:?}");
 
                 // We serialize the dyncfg updates in StorageParameters, but configure
                 // persist separately.
@@ -1442,6 +1442,6 @@ impl StorageState {
     /// Drop the identified oneshot ingestion from the storage state.
     fn drop_oneshot_ingestion(&mut self, ingestion_id: uuid::Uuid) {
         let prev = self.oneshot_ingestions.remove(&ingestion_id);
-        tracing::info!(%ingestion_id, existed = %prev.is_some(), "dropping oneshot ingestion");
+        info!(%ingestion_id, existed = %prev.is_some(), "dropping oneshot ingestion");
     }
 }


### PR DESCRIPTION
This PR downgrades the "Applying configuration update" logs from `info` to `debug`. They have become extremely noisy over time as we have accumulated more config options, and especially with the introduction of the dyncfgs.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/database-issues/issues/9660

### Tips for reviewer

I would prefer to either (a) log only actual config changes or (b) send only actual config changes from envd to clusterd. But I didn't find a good way to implement (a) with our current `{Compute,Storage}Parameters` definition and (b) requires a refactor of adapter code I'm not very familiar with.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
