### PR TITLE
Increase default session timeout from 1 hour to 8 hours

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -100,7 +100,7 @@ pub use sql::{SqlResponse, WebSocketAuth, WebSocketResponse};
 /// Maximum allowed size for a request.
 pub const MAX_REQUEST_SIZE: usize = u64_to_usize(5 * bytesize::MIB);
 
-const SESSION_DURATION: Duration = Duration::from_secs(3600); // 1 hour
+const SESSION_DURATION: Duration = Duration::from_secs(8 * 3600); // 8 hours
 
 const PROFILING_API_ENDPOINTS: &[&str] = &["/memory", "/hierarchical-memory", "/prof/"];
 


### PR DESCRIPTION
This is supposed to get automatically renewed upon health check anyway, but some browsers might not allow the health check to run if the tab is backgrounded. 8 hours (one workday) should be ok.

See discussion [here](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1759513058586999?thread_ts=1759510882.253709&cid=CU7ELJ6E9) for more context.
