### PR TITLE
Revert "Merge pull request #33686 from teskje/heap-metrics"

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -162,15 +162,13 @@ for all processes of all extant cluster replicas.
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_metrics -->
-| Field               | Type         | Meaning
-| ------------------- | ------------ | --------
-| `replica_id`        | [`text`]     | The ID of a cluster replica.
-| `process_id`        | [`uint8`]    | The ID of a process within the replica.
-| `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.
-| `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.
-| `disk_bytes`        | [`uint8`]    | Approximate disk usage, in bytes.
-| `heap_bytes`        | [`uint8`]    | Approximate heap (RAM + swap) usage, in bytes.
-| `heap_limit`        | [`uint8`]    | Available heap (RAM + swap) space, in bytes.
+| Field               | Type         | Meaning                                                                                                                                                      |
+| ------------------- | ------------ | --------                                                                                                                                                     |
+| `replica_id`        | [`text`]     | The ID of a cluster replica.                                                                                                                                 |
+| `process_id`        | [`uint8`]    | The ID of a process within the replica.                                                                                                         |
+| `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.                                                                                                         |
+| `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.                                                                                                                             |
+| `disk_bytes`        | [`uint8`]    | Approximate disk usage in bytes.                                                                                                                             |
 
 ## `mz_cluster_replica_metrics_history`
 
@@ -185,12 +183,10 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | ---------------- | --------- | --------
 | `replica_id`     | [`text`]  | The ID of a cluster replica.
 | `process_id`     | [`uint8`] | The ID of a process within the replica.
-| `cpu_nano_cores` | [`uint8`] | Approximate CPU usage, in billionths of a vCPU core.
-| `memory_bytes`   | [`uint8`] | Approximate memory usage, in bytes.
-| `disk_bytes`     | [`uint8`] | Approximate disk usage, in bytes.
+| `cpu_nano_cores` | [`uint8`] | Approximate CPU usage in billionths of a vCPU core.
+| `memory_bytes`   | [`uint8`] | Approximate memory usage in bytes.
+| `disk_bytes`     | [`uint8`] | Approximate disk usage in bytes.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
-| `heap_bytes`     | [`uint8`] | Approximate heap (RAM + swap) usage, in bytes.
-| `heap_limit`     | [`uint8`] | Available heap (RAM + swap) space, in bytes.
 
 ## `mz_cluster_replica_statuses`
 
@@ -229,14 +225,13 @@ for all processes of all extant cluster replicas, as a percentage of the total r
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_utilization -->
-| Field            | Type                 | Meaning
-|------------------|----------------------|---------
-| `replica_id`     | [`text`]             | The ID of a cluster replica.
-| `process_id`     | [`uint8`]            | The ID of a process within the replica.
-| `cpu_percent`    | [`double precision`] | Approximate CPU usage, in percent of the total allocation.
-| `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
-| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
-| `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
+| Field            | Type                 | Meaning                                                                                                                                                                                |
+|------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `replica_id`     | [`text`]             | The ID of a cluster replica.                                                                                                                                                           |
+| `process_id`     | [`uint8`]            | The ID of a process within the replica.                                                                                                                                   |
+| `cpu_percent`    | [`double precision`] | Approximate CPU usage in percent of the total allocation.                                                                                                                              |
+| `memory_percent` | [`double precision`] | Approximate RAM usage in percent of the total allocation.                                                                                                                              |
+| `disk_percent`   | [`double precision`] | Approximate disk usage in percent of the total allocation.                                                                                                                             |
 
 ## `mz_cluster_replica_utilization_history`
 
@@ -251,10 +246,9 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 |------------------|----------------------|--------
 | `replica_id`     | [`text`]             | The ID of a cluster replica.
 | `process_id`     | [`uint8`]            | The ID of a process within the replica.
-| `cpu_percent`    | [`double precision`] | Approximate CPU usage, in percent of the total allocation.
-| `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
-| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
-| `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
+| `cpu_percent`    | [`double precision`] | Approximate CPU usage in percent of the total allocation.
+| `memory_percent` | [`double precision`] | Approximate RAM usage in percent of the total allocation.
+| `disk_percent`   | [`double precision`] | Approximate disk usage in percent of the total allocation.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 
 ## `mz_cluster_replica_history`

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -4893,19 +4893,14 @@ pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
             ("process_id", "The ID of a process within the replica."),
             (
                 "cpu_nano_cores",
-                "Approximate CPU usage, in billionths of a vCPU core.",
+                "Approximate CPU usage in billionths of a vCPU core.",
             ),
-            ("memory_bytes", "Approximate memory usage, in bytes."),
-            ("disk_bytes", "Approximate disk usage, in bytes."),
+            ("memory_bytes", "Approximate memory usage in bytes."),
+            ("disk_bytes", "Approximate disk usage in bytes."),
             (
                 "occurred_at",
                 "Wall-clock timestamp at which the event occurred.",
             ),
-            (
-                "heap_bytes",
-                "Approximate heap (RAM + swap) usage, in bytes.",
-            ),
-            ("heap_limit", "Available heap (RAM + swap) space, in bytes."),
         ]),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
@@ -4939,8 +4934,6 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| 
         .with_column("cpu_nano_cores", SqlScalarType::UInt64.nullable(true))
         .with_column("memory_bytes", SqlScalarType::UInt64.nullable(true))
         .with_column("disk_bytes", SqlScalarType::UInt64.nullable(true))
-        .with_column("heap_bytes", SqlScalarType::UInt64.nullable(true))
-        .with_column("heap_limit", SqlScalarType::UInt64.nullable(true))
         .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -4951,12 +4944,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| 
             "Approximate CPU usage, in billionths of a vCPU core.",
         ),
         ("memory_bytes", "Approximate RAM usage, in bytes."),
-        ("disk_bytes", "Approximate disk usage, in bytes."),
-        (
-            "heap_bytes",
-            "Approximate heap (RAM + swap) usage, in bytes.",
-        ),
-        ("heap_limit", "Available heap (RAM + swap) space, in bytes."),
+        ("disk_bytes", "Approximate disk usage in bytes."),
     ]),
     sql: "
 SELECT
@@ -4965,9 +4953,7 @@ SELECT
     process_id,
     cpu_nano_cores,
     memory_bytes,
-    disk_bytes,
-    heap_bytes,
-    heap_limit
+    disk_bytes
 FROM mz_internal.mz_cluster_replica_metrics_history
 JOIN mz_cluster_replicas r ON r.id = replica_id
 ORDER BY replica_id, process_id, occurred_at DESC",
@@ -8866,26 +8852,21 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION: LazyLock<BuiltinView> = LazyLock::new
         .with_column("cpu_percent", SqlScalarType::Float64.nullable(true))
         .with_column("memory_percent", SqlScalarType::Float64.nullable(true))
         .with_column("disk_percent", SqlScalarType::Float64.nullable(true))
-        .with_column("heap_percent", SqlScalarType::Float64.nullable(true))
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("replica_id", "The ID of a cluster replica."),
         ("process_id", "The ID of a process within the replica."),
         (
             "cpu_percent",
-            "Approximate CPU usage, in percent of the total allocation.",
+            "Approximate CPU usage in percent of the total allocation.",
         ),
         (
             "memory_percent",
-            "Approximate RAM usage, in percent of the total allocation.",
+            "Approximate RAM usage in percent of the total allocation.",
         ),
         (
             "disk_percent",
-            "Approximate disk usage, in percent of the total allocation.",
-        ),
-        (
-            "heap_percent",
-            "Approximate heap (RAM + swap) usage, in percent of the total allocation.",
+            "Approximate disk usage in percent of the total allocation.",
         ),
     ]),
     sql: "
@@ -8894,8 +8875,7 @@ SELECT
     m.process_id,
     m.cpu_nano_cores::float8 / NULLIF(s.cpu_nano_cores, 0) * 100 AS cpu_percent,
     m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
-    m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent,
-    m.heap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS heap_percent
+    m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent
 FROM
     mz_catalog.mz_cluster_replicas AS r
         JOIN mz_catalog.mz_cluster_replica_sizes AS s ON r.size = s.size
@@ -8914,7 +8894,6 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
             .with_column("cpu_percent", SqlScalarType::Float64.nullable(true))
             .with_column("memory_percent", SqlScalarType::Float64.nullable(true))
             .with_column("disk_percent", SqlScalarType::Float64.nullable(true))
-            .with_column("heap_percent", SqlScalarType::Float64.nullable(true))
             .with_column(
                 "occurred_at",
                 SqlScalarType::TimestampTz { precision: None }.nullable(false),
@@ -8925,19 +8904,15 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
             ("process_id", "The ID of a process within the replica."),
             (
                 "cpu_percent",
-                "Approximate CPU usage, in percent of the total allocation.",
+                "Approximate CPU usage in percent of the total allocation.",
             ),
             (
                 "memory_percent",
-                "Approximate RAM usage, in percent of the total allocation.",
+                "Approximate RAM usage in percent of the total allocation.",
             ),
             (
                 "disk_percent",
-                "Approximate disk usage, in percent of the total allocation.",
-            ),
-            (
-                "heap_percent",
-                "Approximate heap (RAM + swap) usage, in percent of the total allocation.",
+                "Approximate disk usage in percent of the total allocation.",
             ),
             (
                 "occurred_at",
@@ -8951,7 +8926,6 @@ SELECT
     m.cpu_nano_cores::float8 / NULLIF(s.cpu_nano_cores, 0) * 100 AS cpu_percent,
     m.memory_bytes::float8 / NULLIF(s.memory_bytes, 0) * 100 AS memory_percent,
     m.disk_bytes::float8 / NULLIF(s.disk_bytes, 0) * 100 AS disk_percent,
-    m.heap_bytes::float8 / NULLIF(m.heap_limit, 0) * 100 AS heap_percent,
     m.occurred_at
 FROM
     mz_catalog.mz_cluster_replicas AS r

--- a/src/clusterd/src/usage_metrics.rs
+++ b/src/clusterd/src/usage_metrics.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 use serde::Serialize;
-use tracing::{debug, error};
+use tracing::error;
 
 /// A system usage metrics collector.
 pub(crate) struct Collector {
@@ -25,15 +25,9 @@ pub(crate) struct Collector {
 impl Collector {
     /// Collect current system usage metrics.
     pub fn collect(&self) -> Usage {
-        let disk_bytes = self.collect_disk_usage();
-        let (memory_bytes, swap_bytes) = collect_heap_usage();
-        let heap_limit = collect_heap_limit();
-
         Usage {
-            disk_bytes,
-            memory_bytes,
-            swap_bytes,
-            heap_limit,
+            disk_bytes: self.collect_disk_usage(),
+            swap_bytes: self.collect_swap_usage(),
         }
     }
 
@@ -55,9 +49,29 @@ impl Collector {
         let used_blocks = u64::from(stat.blocks() - stat.blocks_available());
         let used_bytes = used_blocks * stat.fragment_size();
 
-        debug!("disk usage: {used_bytes}");
-
         Some(used_bytes)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn collect_swap_usage(&self) -> Option<u64> {
+        use mz_compute::memory_limiter::ProcStatus;
+        use mz_ore::cast::CastInto;
+
+        match ProcStatus::from_proc() {
+            Ok(status) => {
+                let bytes = status.vm_swap.cast_into();
+                Some(bytes)
+            }
+            Err(err) => {
+                error!("error reading /proc/self/status: {err}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn collect_swap_usage(&self) -> Option<u64> {
+        None
     }
 }
 
@@ -65,166 +79,5 @@ impl Collector {
 #[derive(Serialize)]
 pub(crate) struct Usage {
     disk_bytes: Option<u64>,
-    memory_bytes: Option<u64>,
     swap_bytes: Option<u64>,
-    heap_limit: Option<u64>,
 }
-
-#[cfg(target_os = "linux")]
-mod linux {
-    use std::fs;
-    use std::path::Path;
-
-    use anyhow::{anyhow, bail};
-    use mz_compute::memory_limiter;
-    use mz_ore::cast::CastInto;
-    use tracing::{debug, error};
-
-    /// Collect memory and swap usage.
-    pub fn collect_heap_usage() -> (Option<u64>, Option<u64>) {
-        use mz_ore::cast::CastInto;
-
-        match memory_limiter::ProcStatus::from_proc() {
-            Ok(status) => {
-                let memory_bytes = status.vm_rss.cast_into();
-                let swap_bytes = status.vm_swap.cast_into();
-
-                debug!("memory usage: {memory_bytes}");
-                debug!("swap usage: {swap_bytes}");
-
-                (Some(memory_bytes), Some(swap_bytes))
-            }
-            Err(err) => {
-                error!("error reading /proc/self/status: {err}");
-                (None, None)
-            }
-        }
-    }
-
-    /// Collect the heap limit, i.e. memory + swap limit.
-    pub fn collect_heap_limit() -> Option<u64> {
-        // If we don't know the physical limits, we can't know the heap limit.
-        let (phys_mem_limit, phys_swap_limit) = get_physical_limits()?;
-
-        // Limits might be reduced by the cgroup.
-        let (cgroup_mem_limit, cgroup_swap_limit) = get_cgroup_limits();
-        let mem_limit = cgroup_mem_limit.unwrap_or(u64::MAX).min(phys_mem_limit);
-        let swap_limit = cgroup_swap_limit.unwrap_or(u64::MAX).min(phys_swap_limit);
-
-        let heap_limit = mem_limit + swap_limit;
-
-        // Heap limit might be reduced by the memory limiter.
-        let limiter_limit = memory_limiter::get_memory_limit().map(CastInto::cast_into);
-        let heap_limit = limiter_limit.unwrap_or(u64::MAX).min(heap_limit);
-
-        debug!("memory limit: {mem_limit} (phys={phys_mem_limit}, cgroup={cgroup_mem_limit:?})");
-        debug!("swap limit: {swap_limit} (phys={phys_swap_limit}, cgroup={cgroup_swap_limit:?})");
-        debug!("heap limit: {heap_limit} (limiter={limiter_limit:?})");
-
-        Some(heap_limit)
-    }
-
-    /// Helper for parsing `/proc/meminfo`.
-    struct ProcMemInfo {
-        mem_total: u64,
-        swap_total: u64,
-    }
-
-    impl ProcMemInfo {
-        fn from_proc() -> anyhow::Result<Self> {
-            let contents = fs::read_to_string("/proc/meminfo")?;
-
-            fn parse_kib_line(line: &str) -> anyhow::Result<u64> {
-                if let Some(kib) = line
-                    .split_whitespace()
-                    .nth(1)
-                    .and_then(|x| x.parse::<u64>().ok())
-                {
-                    Ok(kib * 1024)
-                } else {
-                    bail!("invalid meminfo line: {line}");
-                }
-            }
-
-            let mut memory = None;
-            let mut swap = None;
-            for line in contents.lines() {
-                if line.starts_with("MemTotal:") {
-                    memory = Some(parse_kib_line(line)?);
-                } else if line.starts_with("SwapTotal:") {
-                    swap = Some(parse_kib_line(line)?);
-                }
-            }
-
-            let mem_total = memory.ok_or_else(|| anyhow!("MemTotal not found"))?;
-            let swap_total = swap.ok_or_else(|| anyhow!("SwapTotal not found"))?;
-
-            Ok(Self {
-                mem_total,
-                swap_total,
-            })
-        }
-    }
-
-    /// Collect the physical memory and swap limits.
-    fn get_physical_limits() -> Option<(u64, u64)> {
-        let meminfo = match ProcMemInfo::from_proc() {
-            Ok(meminfo) => meminfo,
-            Err(error) => {
-                error!("reading `/proc/meminfo`: {error}");
-                return None;
-            }
-        };
-
-        Some((meminfo.mem_total, meminfo.swap_total))
-    }
-
-    /// Collect the memory and swap limits enforced by the current cgroup.
-    ///
-    /// We make the following simplifying assumptions that hold for a standard Kubernetes
-    /// environment:
-    //  * The current process is a member of exactly one cgroups v2 hierarchy.
-    //  * The cgroups hierarchy is mounted at `/sys/fs/cgroup`.
-    //  * The limits are applied to the current cgroup directly (and not one of its ancestors).
-    fn get_cgroup_limits() -> (Option<u64>, Option<u64>) {
-        let Ok(proc_cgroup) = fs::read_to_string("/proc/self/cgroup") else {
-            return (None, None);
-        };
-        let Some(cgroup_path) = proc_cgroup.split(':').nth(2) else {
-            error!("invalid `/proc/self/cgroup` format: {proc_cgroup}");
-            return (None, None);
-        };
-
-        let root = Path::new("/sys/fs/cgroup").join(cgroup_path);
-        let memory_file = root.join("memory.max");
-        let swap_file = root.join("memory.swap.max");
-
-        let memory = fs::read_to_string(memory_file)
-            .ok()
-            .and_then(|s| s.parse().ok());
-        let swap = fs::read_to_string(swap_file)
-            .ok()
-            .and_then(|s| s.parse().ok());
-
-        (memory, swap)
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-mod macos {
-    use mz_compute::memory_limiter;
-    use mz_ore::cast::CastInto;
-
-    pub fn collect_heap_usage() -> (Option<u64>, Option<u64>) {
-        (None, None)
-    }
-
-    pub fn collect_heap_limit() -> Option<u64> {
-        memory_limiter::get_memory_limit().map(CastInto::cast_into)
-    }
-}
-
-#[cfg(target_os = "linux")]
-use linux::*;
-#[cfg(not(target_os = "linux"))]
-use macos::*;

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -591,10 +591,8 @@ where
                     Datum::UInt64(u64::cast_from(process_id)),
                     m.cpu_nano_cores.into(),
                     m.memory_bytes.into(),
-                    m.disk_bytes.into(),
+                    m.disk_usage_bytes.into(),
                     Datum::TimestampTz(now_tz),
-                    m.heap_bytes.into(),
-                    m.heap_limit.into(),
                 ]);
                 (row.clone(), mz_repr::Diff::ONE)
             })

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -553,10 +553,8 @@ impl OrchestratorWorker {
             metrics.push(ServiceProcessMetrics {
                 cpu_nano_cores,
                 memory_bytes,
-                // Process orchestrator does not support the remaining fields right now.
-                disk_bytes: None,
-                heap_bytes: None,
-                heap_limit: None,
+                // Process orchestrator does not support this right now.
+                disk_usage_bytes: None,
             });
         }
         Ok(metrics)

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -145,9 +145,7 @@ pub trait Service: fmt::Debug + Send + Sync {
 pub struct ServiceProcessMetrics {
     pub cpu_nano_cores: Option<u64>,
     pub memory_bytes: Option<u64>,
-    pub disk_bytes: Option<u64>,
-    pub heap_bytes: Option<u64>,
-    pub heap_limit: Option<u64>,
+    pub disk_usage_bytes: Option<u64>,
 }
 
 /// A simple language for describing assertions about a label's existence and value.

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -158,9 +158,6 @@ pub static REPLICA_STATUS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|
         .finish()
 });
 
-/// NOTE: We want to avoid breaking schema changes, as those would cause the builtin migrations to
-/// drop all existing data. For details on what changes are compatible, see
-/// [`mz_persist_types::schema::backward_compatible`].
 pub static REPLICA_METRICS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(|| {
     RelationDesc::builder()
         .with_column("replica_id", SqlScalarType::String.nullable(false))
@@ -172,8 +169,6 @@ pub static REPLICA_METRICS_HISTORY_DESC: LazyLock<RelationDesc> = LazyLock::new(
             "occurred_at",
             SqlScalarType::TimestampTz { precision: None }.nullable(false),
         )
-        .with_column("heap_bytes", SqlScalarType::UInt64.nullable(true))
-        .with_column("heap_limit", SqlScalarType::UInt64.nullable(true))
         .finish()
 });
 

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -118,8 +118,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  cpu_nano_cores  uint8
 4  memory_bytes  uint8
 5  disk_bytes  uint8
-6  heap_bytes  uint8
-7  heap_limit  uint8
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_metrics_history' ORDER BY position
@@ -130,8 +128,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 4  memory_bytes  uint8
 5  disk_bytes  uint8
 6  occurred_at  timestamp␠with␠time␠zone
-7  heap_bytes  uint8
-8  heap_limit  uint8
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_statuses' ORDER BY position
@@ -159,7 +155,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  cpu_percent  double␠precision
 4  memory_percent  double␠precision
 5  disk_percent  double␠precision
-6  heap_percent  double␠precision
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_utilization_history' ORDER BY position
@@ -169,8 +164,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  cpu_percent  double␠precision
 4  memory_percent  double␠precision
 5  disk_percent  double␠precision
-6  heap_percent  double␠precision
-7  occurred_at  timestamp␠with␠time␠zone
+6  occurred_at  timestamp␠with␠time␠zone
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_history' ORDER BY position

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -224,15 +224,11 @@ mz_cluster_replica_history  replica_name
 mz_cluster_replica_history  size
 mz_cluster_replica_metrics  cpu_nano_cores
 mz_cluster_replica_metrics  disk_bytes
-mz_cluster_replica_metrics  heap_bytes
-mz_cluster_replica_metrics  heap_limit
 mz_cluster_replica_metrics  memory_bytes
 mz_cluster_replica_metrics  process_id
 mz_cluster_replica_metrics  replica_id
 mz_cluster_replica_metrics_history  cpu_nano_cores
 mz_cluster_replica_metrics_history  disk_bytes
-mz_cluster_replica_metrics_history  heap_bytes
-mz_cluster_replica_metrics_history  heap_limit
 mz_cluster_replica_metrics_history  memory_bytes
 mz_cluster_replica_metrics_history  occurred_at
 mz_cluster_replica_metrics_history  process_id

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -410,7 +410,7 @@ ORDER BY r.id;
 ----
 Explained Query:
   Finish order_by=[#0{id} asc nulls_last] output=[#0..=#5]
-    Project (#0{id}..=#3{size}, #5{name}, #31)
+    Project (#0{id}..=#3{size}, #5{name}, #29)
       Map (((uint8_to_double(#27{memory_bytes}) / uint8_to_double(case when (0 = uint8_to_numeric(#21{memory_bytes})) then null else #21{memory_bytes} end)) * 100))
         Join on=(#0{id} = #15{id} = #24{replica_id} AND #2{cluster_id} = #4{id} AND #16{size} = #17{size}) type=delta
           ArrangeBy keys=[[#0{id}], [#2{cluster_id}]]


### PR DESCRIPTION
This reverts the changes made in https://github.com/MaterializeInc/materialize/pull/33686. They rely on schema evolution support for builtin item migrations, which currently breaks the upgrade checks. Thus, reverting unblocks the release.

See [Slack thread](https://materializeinc.slack.com/archives/CTESPM7FU/p1759517500626729).

### Motivation

  * This PR reverts a known-desirable feature.

### Tips for reviewer

As an alternative, we can also merge the forward fix, https://github.com/MaterializeInc/materialize/pull/33771, if we feel comfortable.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
