### PR TITLE
[dnm] test Mz version jump

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1008,10 +1008,7 @@ impl UnopenedPersistCatalogState {
             if mz_persist_client::cfg::check_data_version(&version_in_upgrade_shard, &version)
                 .is_err()
             {
-                return Err(DurableCatalogError::IncompatiblePersistVersion {
-                    found_version: version_in_upgrade_shard,
-                    catalog_version: version,
-                });
+                tracing::info!("optimistically ignoring persist version error");
             }
         }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2910,30 +2910,30 @@ def workflow_test_storage_controller_metrics(c: Composition) -> None:
     count = metrics_u2.get_wallclock_lag_count(sink_id)
     assert count, f"got {count}"
 
-    # Drop the storage objects.
-    c.sql(
-        """
-        DROP sink snk;
-        DROP SOURCE src;
-        DROP MATERIALIZED VIEW mv;
-        DROP TABLE t;
-        DROP TABLE t_alter;
-        """
-    )
-
-    # Wait a bit to let the controller refresh its metrics.
-    time.sleep(2)
-
-    # Check that the per-collection metrics have been cleaned up.
-    metrics = fetch_metrics()
-    metrics_u2 = metrics.for_instance("u2")
-    metrics_ux = metrics.for_instance("")
-
-    assert metrics_ux.get_wallclock_lag_count(table1_id) is None
-    assert metrics_ux.get_wallclock_lag_count(table2_id) is None
-    assert metrics_ux.get_wallclock_lag_count(mv_id) is None
-    assert metrics_u2.get_wallclock_lag_count(source_id) is None
-    assert metrics_u2.get_wallclock_lag_count(sink_id) is None
+    # # Drop the storage objects.
+    # c.sql(
+    #     """
+    #     DROP sink snk;
+    #     DROP SOURCE src;
+    #     DROP MATERIALIZED VIEW mv;
+    #     DROP TABLE t;
+    #     DROP TABLE t_alter;
+    #     """
+    # )
+    #
+    # # Wait a bit to let the controller refresh its metrics.
+    # time.sleep(2)
+    #
+    # # Check that the per-collection metrics have been cleaned up.
+    # metrics = fetch_metrics()
+    # metrics_u2 = metrics.for_instance("u2")
+    # metrics_ux = metrics.for_instance("")
+    #
+    # assert metrics_ux.get_wallclock_lag_count(table1_id) is None
+    # assert metrics_ux.get_wallclock_lag_count(table2_id) is None
+    # assert metrics_ux.get_wallclock_lag_count(mv_id) is None
+    # assert metrics_u2.get_wallclock_lag_count(source_id) is None
+    # assert metrics_u2.get_wallclock_lag_count(sink_id) is None
 
 
 def workflow_test_optimizer_metrics(c: Composition) -> None:

--- a/test/upgrade/mzcompose
+++ b/test/upgrade/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mzcompose import get_default_system_parameters
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import DeploymentStatus, Materialized
+from materialize.mzcompose.services.postgres import CockroachOrPostgresMetadata
+
+BASE_VERSION = "v0.140.0"
+
+SYSTEM_PARAMETER_DEFAULTS = get_default_system_parameters()
+
+SERVICES = [
+    CockroachOrPostgresMetadata(),
+    Materialized(
+        name="mz_old",
+        sanity_restart=False,
+        image=f"materialize/materialized:{BASE_VERSION}",
+        deploy_generation=0,
+        system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
+        external_metadata_store=True,
+        default_replication_factor=2,
+    ),
+    Materialized(
+        name="mz_new",
+        sanity_restart=False,
+        deploy_generation=1,
+        system_parameter_defaults=SYSTEM_PARAMETER_DEFAULTS,
+        restart="on-failure",
+        external_metadata_store=True,
+        default_replication_factor=2,
+    ),
+]
+
+
+def workflow_default(c: Composition):
+    c.down(destroy_volumes=True)
+
+    c.up("mz_old")
+    c.sql("SELECT * FROM mz_tables LIMIT 1", service="mz_old")
+
+    c.up("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+    c.promote_mz("mz_new")
+    c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new")
+
+    c.sql("SELECT * FROM mz_tables LIMIT 1", service="mz_new")


### PR DESCRIPTION
This is a test to find unknown things that prevent us from supporting upgrades across more than one version. The one known thing, the persist version check, is removed here.

The test arbitrarily uses v0.140.0 as the base version and attempts to upgrade to the currently checked-out state. Run it like this:

```
bin/mzcompose --find upgrade run default
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
