### PR TITLE
Allow null values in multi-dimensional arrays

### DIFF
--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -54,6 +54,12 @@ pub struct ArrayDimensions<'a> {
     pub(crate) data: &'a [u8],
 }
 
+impl Default for ArrayDimensions<'static> {
+    fn default() -> Self {
+        Self { data: &[] }
+    }
+}
+
 impl ArrayDimensions<'_> {
     /// Returns the number of dimensions in the array as a [`u8`].
     pub fn ndims(&self) -> u8 {

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -1461,12 +1461,15 @@ CREATE MATERIALIZED VIEW json_mv AS (
     SELECT * FROM jsons WHERE random_id = CAST(payload->>'my_field' AS uuid[])[random_index]
 )
 
-# Regression test for issue #9757
+# Regression test for issue MaterializeInc/database-issues#9757
 
-query error db error: ERROR: number of array elements \(0\) does not match declared cardinality \(1\)
+query error db error: ERROR: number of array elements \(1\) does not match declared cardinality \(0\)
 SELECT ARRAY[NULL::BIGINT[], ARRAY[1::BIGINT, 2::BIGINT]];
 
 query T
 SELECT ARRAY[NULL::BIGINT[], ARRAY[]::BIGINT[], NULL::BIGINT[]];
 ----
 {}
+
+query error db error: ERROR: number of array elements \(3\) does not match declared cardinality \(2\)
+SELECT ARRAY[ARRAY[1, 2], ARRAY[3, 4, 5], ARRAY[6]];


### PR DESCRIPTION
Allow constructing multi-dimensional arrays with null values instead of panicking. Similarly to PostgreSQL, treat null elements as zero-dimensional arrays.

Fixes MaterializeInc/database-issues#9757
