### PR TITLE
terraform test: bump azure module to latest

### DIFF
--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_resource_group" "materialize" {
 }
 
 module "materialize" {
-  source              = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=v0.5.2"
+  source              = "git::https://github.com/MaterializeInc/terraform-azurerm-materialize.git?ref=v0.5.3"
   resource_group_name = azurerm_resource_group.materialize.name
   location            = "eastus2"
   prefix              = "mz-tf-test"
@@ -78,35 +78,6 @@ module "materialize" {
     operator = {
       args = {
         enableLicenseKeyChecks = true
-      }
-      clusters = {
-        # Overriding here because merging values doesn't work.
-        # Remove this when that is fixed.
-        swap_enabled = false
-      }
-      image = {
-        tag = var.orchestratord_version
-      }
-      cloudProvider = {
-        type   = "azure"
-        region = "eastus2"
-      }
-    }
-    observability = {
-      podMetrics = {
-        enabled = true
-      }
-    }
-    storage = {
-      storageClass = {
-        create      = true
-        name        = "openebs-lvm-instance-store-ext4"
-        provisioner = "local.csi.openebs.io"
-        parameters = {
-          storage  = "lvm"
-          fsType   = "ext4"
-          volgroup = "instance-store-vg"
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Bumping the Azure TF module to v0.5.3 where we have a fix for the shallow yaml merge, hence no longer requiring to explicitly override all helm values.

Testing this here: https://buildkite.com/materialize/nightly/builds/13685

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
