### PR TITLE
Unflake REFRESH scheduling test

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -1276,7 +1276,7 @@ impl Coordinator {
             }
             _ => {}
         }
-        self.catalog_transact(session, ops.clone()).await?;
+        self.catalog_transact(session, ops).await?;
         for (cluster_id, replica_name) in create_cluster_replicas {
             let replica_id = self
                 .catalog()

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1582,11 +1582,11 @@ FROM mz_audit_events
 WHERE
   event_type IN ('create', 'drop') AND
   object_type = 'cluster-replica' AND
-  ((details->'cluster_name')::text LIKE '"c_schedule_%"' OR (details->'cluster_name')::text = '"other"');
+  ((details->'cluster_name')::text LIKE '"c_schedule_%"' OR (details->'cluster_name')::text = '"other"') AND
+  (details->'cluster_name')::text != '"c_schedule_4"';
 ----
 drop  cluster-replica  "other"  "manual"  true  NULL
 create  cluster-replica  "other"  "manual"  true  NULL
-drop  cluster-replica  "c_schedule_4"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_1"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_2"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_5"  "manual"  true  NULL
@@ -1594,7 +1594,6 @@ drop  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"off","hyd
 drop  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"off","hydration_time_estimate":"00:00:00","objects_needing_compaction":[],"objects_needing_refresh":[]}
 create  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_compaction":[],"objects_needing_refresh":["uXXX"]}
 create  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_compaction":[],"objects_needing_refresh":["uXXX"]}
-create  cluster-replica  "c_schedule_4"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_compaction":[],"objects_needing_refresh":["uXXX"]}
 create  cluster-replica  "c_schedule_hydration_time_estimate"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:16:35","objects_needing_compaction":[],"objects_needing_refresh":["uXXX"]}
 
 ## Now test `cluster_refresh_mv_compaction_estimate`.


### PR DESCRIPTION
This solves a rare test flake discussed [here](https://materializeinc.slack.com/archives/CTESPM7FU/p1759854423058209?thread_ts=1759771998.026359&cid=CTESPM7FU) by simply removing the check of the problematic cluster. The test still tests plenty of other clusters.

(Plus removed an unneeded `.clone()`.)