### PR TITLE
Fix lint warnings new in Rust 1.90.0

### DIFF
--- a/src/avro/src/writer.rs
+++ b/src/avro/src/writer.rs
@@ -369,8 +369,6 @@ mod tests {
     use std::io::Cursor;
     use std::str::FromStr;
 
-    use serde::{Deserialize, Serialize};
-
     use crate::Reader;
     use crate::types::Record;
     use crate::util::zig_i64;
@@ -524,12 +522,6 @@ mod tests {
                 .collect::<Vec<u8>>(),
             data
         );
-    }
-
-    #[derive(Debug, Clone, Deserialize, Serialize)]
-    struct TestSerdeSerialize {
-        a: i64,
-        b: String,
     }
 
     #[mz_ore::test]

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -3620,11 +3620,6 @@ async fn webhook_concurrent_swap() {
     let server = test_util::TestHarness::default().start().await;
     let mut client = server.connect().await.unwrap();
 
-    #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-    struct WebhookEvent {
-        name: String,
-    }
-
     // Create our webhook sources.
     let webhook_cluster = "webhook_cluster_concurrent_swap";
     client

--- a/src/mz/src/command/profile.rs
+++ b/src/mz/src/command/profile.rs
@@ -162,7 +162,7 @@ pub async fn init(
     let config_file = scx.config_file();
     let profile = scx
         .get_global_profile()
-        .map_or(config_file.profile().to_string(), |n| n);
+        .unwrap_or_else(|| config_file.profile().to_string());
 
     if let Some(profiles) = scx.config_file().profiles() {
         if profiles.contains_key(&profile) && !force {

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -700,8 +700,6 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
 pub(crate) struct K;
 #[derive(Default, Debug, PartialEq, Eq)]
 pub(crate) struct V;
-#[derive(Default, Debug, PartialEq, Eq)]
-struct T;
 
 pub(crate) static KVTD_CODECS: Mutex<(String, String, String, String, Option<CodecConcreteType>)> =
     Mutex::new((
@@ -755,34 +753,6 @@ impl Codec for V {
     }
 
     fn decode(_buf: &[u8], _schema: &TodoSchema<V>) -> Result<Self, String> {
-        Ok(Self)
-    }
-
-    fn encode_schema(_schema: &Self::Schema) -> Bytes {
-        Bytes::new()
-    }
-
-    fn decode_schema(buf: &Bytes) -> Self::Schema {
-        assert_eq!(*buf, Bytes::new());
-        TodoSchema::default()
-    }
-}
-
-impl Codec for T {
-    type Storage = ();
-    type Schema = TodoSchema<T>;
-
-    fn codec_name() -> String {
-        KVTD_CODECS.lock().expect("lockable").2.clone()
-    }
-
-    fn encode<B>(&self, _buf: &mut B)
-    where
-        B: BufMut,
-    {
-    }
-
-    fn decode(_buf: &[u8], _schema: &TodoSchema<T>) -> Result<Self, String> {
         Ok(Self)
     }
 

--- a/src/testdrive/src/action/fivetran.rs
+++ b/src/testdrive/src/action/fivetran.rs
@@ -16,7 +16,7 @@ use crate::parser::BuiltinCommand;
 
 // Note(parkmycar): We wrap this in a `mod` block soley for the purpose of allowing lints for the
 // generated protobuf code.
-#[allow(clippy::as_conversions, clippy::clone_on_ref_ptr)]
+#[allow(dead_code, clippy::as_conversions, clippy::clone_on_ref_ptr)]
 mod proto {
     pub mod fivetran {
         include!(concat!(env!("OUT_DIR"), "/fivetran_sdk.v2.rs"));


### PR DESCRIPTION
We had to revert the upgrade to Rust 1.90.0 due to https://github.com/rust-lang/rust/issues/146998, but we can still merge the lint fixes.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
