### PR TITLE
ci: Also build Rust nightly in Release mode

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -72,7 +72,16 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: hetzner-aarch64-16cpu-32gb
-        branches: "main"
+        branches: "main *build*"
+
+      - id: build-rust-latest-beta-release
+        label: "Build with Latest Rust Beta (Release)"
+        command: bin/ci-builder run stable ci/test/rust-beta-build.sh --release
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: hetzner-x86-64-dedi-48cpu-192gb
+        branches: "main *build*"
 
       - id: devel-docker-tags
         label: Tag development docker images

--- a/ci/test/rust-beta-build.sh
+++ b/ci/test/rust-beta-build.sh
@@ -16,4 +16,4 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 source /cargo/env
 trap "rustup self uninstall -y || true" SIGTERM SIGINT EXIT
 rustup install beta
-rustup run beta cargo build --all-targets
+rustup run beta cargo build --all-targets "$@"


### PR DESCRIPTION
Would have caught https://materializeinc.slack.com/archives/C08ACQNGSQK/p1759754676092499

Let's see if it's fixed in Nightly already: https://buildkite.com/materialize/nightly/builds/13849

Edit: Blocked on https://github.com/rust-lang/rust/issues/146998
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
