### PR TITLE
orchestratord: make more general claim to console about auth mode

### DIFF
--- a/src/orchestratord/src/controller/materialize/console.rs
+++ b/src/orchestratord/src/controller/materialize/console.rs
@@ -212,7 +212,7 @@ struct ConsoleAppConfig {
 
 #[derive(Serialize)]
 struct ConsoleAppConfigAuth {
-    mode: AuthenticatorKind,
+    self_managed_password_auth_enabled: bool,
 }
 
 fn create_console_app_configmap_object(mz: &Materialize, console_image_ref: &str) -> ConfigMap {
@@ -224,7 +224,10 @@ fn create_console_app_configmap_object(mz: &Materialize, console_image_ref: &str
     let app_config_json = serde_json::to_string(&ConsoleAppConfig {
         version,
         auth: ConsoleAppConfigAuth {
-            mode: mz.spec.authenticator_kind,
+            self_managed_password_auth_enabled: mz
+                .spec
+                .authenticator_kind
+                .password_style_self_managed_auth(),
         },
     })
     .expect("known valid");

--- a/src/orchestratord/src/controller/materialize/environmentd.rs
+++ b/src/orchestratord/src/controller/materialize/environmentd.rs
@@ -1394,10 +1394,7 @@ fn create_environmentd_statefulset_object(
             ..Default::default()
         });
         args.push("--listeners-config-path=/listeners/listeners.json".to_owned());
-        if matches!(
-            mz.spec.authenticator_kind,
-            AuthenticatorKind::Password | AuthenticatorKind::Sasl
-        ) {
+        if mz.spec.authenticator_kind.password_style_self_managed_auth() {
             args.push("--system-parameter-default=enable_password_auth=true".into());
             env.push(EnvVar {
                 name: "MZ_EXTERNAL_LOGIN_PASSWORD_MZ_SYSTEM".to_string(),
@@ -1691,10 +1688,7 @@ fn create_connection_info(
         },
     };
 
-    if matches!(
-        authenticator_kind,
-        AuthenticatorKind::Password | AuthenticatorKind::Sasl
-    ) {
+    if mz.spec.authenticator_kind.password_style_self_managed_auth() {
         listeners_config.sql.remove("internal");
         listeners_config.http.remove("internal");
 
@@ -1747,17 +1741,18 @@ fn create_connection_info(
         },
     };
 
-    let (scheme, leader_api_port, mz_system_secret_name) = match authenticator_kind {
-        AuthenticatorKind::Password | AuthenticatorKind::Sasl => {
+    let (scheme, leader_api_port, mz_system_secret_name) =
+        if mz.spec.authenticator_kind.password_style_self_managed_auth() {
             let scheme = if external_enable_tls { "https" } else { "http" };
             (
                 scheme,
                 config.environmentd_http_port,
                 Some(mz.spec.backend_secret_name.clone()),
             )
-        }
-        _ => ("http", config.environmentd_internal_http_port, None),
-    };
+        } else {
+            ("http", config.environmentd_internal_http_port, None)
+        };
+
     let environmentd_url = format!(
         "{}://{}.{}.svc.cluster.local:{}",
         scheme,

--- a/src/server-core/src/listeners.rs
+++ b/src/server-core/src/listeners.rs
@@ -26,6 +26,13 @@ pub enum AuthenticatorKind {
     None,
 }
 
+impl AuthenticatorKind {
+    /// Whether this authenticator kind supports password-style self-managed authentication.
+    pub fn password_style_self_managed_auth(&self) -> bool {
+        matches!(self, AuthenticatorKind::Password | AuthenticatorKind::Sasl)
+    }
+}
+
 /// Whether to allow internal users (ie: mz_system) and/or normal users.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
 pub enum AllowedRoles {


### PR DESCRIPTION
This will rely on a tandem console PR, but the idea is that instead of revealing the exact mode of password auth, we just reveal to the console if it needs to care about passwords at all.
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
