### PR TITLE
[poc] evolving catalog item IDs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2362,7 +2362,8 @@ impl Coordinator {
                                 CatalogItemId::System(id) => *id >= next_system_item_id,
                                 CatalogItemId::User(id) => *id >= next_user_item_id,
                                 CatalogItemId::IntrospectionSourceIndex(_)
-                                | CatalogItemId::Transient(_) => false,
+                                | CatalogItemId::Transient(_)
+                                | CatalogItemId::Explain => false,
                             };
                             if id_too_large {
                                 info!(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5143,7 +5143,7 @@ impl Coordinator {
 
         self.catalog_transact_with_side_effects(Some(ctx), ops, move |coord, _ctx| {
             Box::pin(async move {
-                let entry = coord.catalog().get_entry(&relation_id);
+                let entry = coord.catalog().get_entry(&new_global_id);
                 let CatalogItem::Table(table) = &entry.item else {
                     panic!("programming error, expected table found {:?}", entry.item);
                 };

--- a/src/catalog-protos/protos/hashes.json
+++ b/src/catalog-protos/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "3e9f4c62f87441ac7897d96462f3c0c9"
+    "md5": "d10b5b1e3f1b2fd6e717d77b1bf5b7d8"
   },
   {
     "name": "objects_v67.proto",

--- a/src/catalog-protos/protos/objects.proto
+++ b/src/catalog-protos/protos/objects.proto
@@ -317,6 +317,7 @@ message CatalogItemId {
     uint64 user = 2;
     uint64 transient = 3;
     uint64 introspection_source_index = 4;
+    Empty explain = 5;
   }
 }
 

--- a/src/catalog-protos/src/serialization.rs
+++ b/src/catalog-protos/src/serialization.rs
@@ -590,6 +590,9 @@ impl RustType<crate::objects::CatalogItemId> for CatalogItemId {
                 CatalogItemId::Transient(x) => {
                     crate::objects::catalog_item_id::Value::Transient(*x)
                 }
+                CatalogItemId::Explain => {
+                    crate::objects::catalog_item_id::Value::Explain(crate::objects::Empty {})
+                }
             }),
         }
     }
@@ -604,6 +607,7 @@ impl RustType<crate::objects::CatalogItemId> for CatalogItemId {
             Some(crate::objects::catalog_item_id::Value::Transient(x)) => {
                 Ok(CatalogItemId::Transient(x))
             }
+            Some(crate::objects::catalog_item_id::Value::Explain(_)) => Ok(CatalogItemId::Explain),
             None => Err(TryFromProtoError::missing_field("CatalogItemId::kind")),
         }
     }

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -637,6 +637,7 @@ impl TryFrom<CatalogItemId> for SystemCatalogItemId {
             CatalogItemId::IntrospectionSourceIndex(_) => Err("introspection_source_index"),
             CatalogItemId::User(_) => Err("user"),
             CatalogItemId::Transient(_) => Err("transient"),
+            CatalogItemId::Explain => Err("explain"),
         }
     }
 }
@@ -662,6 +663,7 @@ impl TryFrom<CatalogItemId> for IntrospectionSourceIndexCatalogItemId {
             }
             CatalogItemId::User(_) => Err("user"),
             CatalogItemId::Transient(_) => Err("transient"),
+            CatalogItemId::Explain => Err("explain"),
         }
     }
 }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2009,6 +2009,72 @@ impl CatalogItem {
         }
     }
 
+    pub fn replace_item_refs(&self, old_id: GlobalId, new_id: GlobalId) -> CatalogItem {
+        let do_rewrite = |create_sql: String| -> String {
+            let mut create_stmt = mz_sql::parse::parse(&create_sql)
+                .expect("invalid create sql persisted to catalog")
+                .into_element()
+                .ast;
+            mz_sql::ast::transform::create_stmt_replace_ids(
+                &mut create_stmt,
+                &[(old_id, new_id)].into(),
+            );
+            create_stmt.to_ast_string_stable()
+        };
+
+        match self {
+            CatalogItem::Table(i) => {
+                let mut i = i.clone();
+                i.create_sql = i.create_sql.map(do_rewrite);
+                CatalogItem::Table(i)
+            }
+            CatalogItem::Log(i) => CatalogItem::Log(i.clone()),
+            CatalogItem::Source(i) => {
+                let mut i = i.clone();
+                i.create_sql = i.create_sql.map(do_rewrite);
+                CatalogItem::Source(i)
+            }
+            CatalogItem::Sink(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::Sink(i)
+            }
+            CatalogItem::View(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::View(i)
+            }
+            CatalogItem::MaterializedView(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::MaterializedView(i)
+            }
+            CatalogItem::Index(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::Index(i)
+            }
+            CatalogItem::Secret(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::Secret(i)
+            }
+            CatalogItem::Func(_) | CatalogItem::Type(_) => {
+                unimplemented!()
+            }
+            CatalogItem::Connection(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::Connection(i)
+            }
+            CatalogItem::ContinualTask(i) => {
+                let mut i = i.clone();
+                i.create_sql = do_rewrite(i.create_sql);
+                CatalogItem::ContinualTask(i)
+            }
+        }
+    }
+
     /// Updates the retain history for an item. Returns the previous retain history value. Returns
     /// an error if this item does not support retain history.
     pub fn update_retain_history(

--- a/src/repr/src/catalog_item_id.proto
+++ b/src/repr/src/catalog_item_id.proto
@@ -19,5 +19,6 @@ message ProtoCatalogItemId {
     uint64 user = 2;
     uint64 transient = 3;
     uint64 introspection_source_index = 4;
+    google.protobuf.Empty explain = 5;
   }
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -48,7 +48,7 @@ pub use crate::relation_and_scalar::ProtoScalarType;
 pub use crate::relation_and_scalar::proto_scalar_type::ProtoRecordField;
 use crate::role_id::RoleId;
 use crate::row::DatumNested;
-use crate::{CatalogItemId, ColumnName, DatumList, DatumMap, Row, RowArena, SqlColumnType};
+use crate::{ColumnName, DatumList, DatumMap, GlobalId, Row, RowArena, SqlColumnType};
 
 /// A single value.
 ///
@@ -1691,7 +1691,7 @@ pub enum SqlScalarType {
     /// always be [`Datum::Null`].
     List {
         element_type: Box<SqlScalarType>,
-        custom_id: Option<CatalogItemId>,
+        custom_id: Option<GlobalId>,
     },
     /// An ordered and named sequence of datums.
     Record {
@@ -1700,7 +1700,7 @@ pub enum SqlScalarType {
         ///
         /// Boxed slice to reduce the size of the enum variant.
         fields: Box<[(ColumnName, SqlColumnType)]>,
-        custom_id: Option<CatalogItemId>,
+        custom_id: Option<GlobalId>,
     },
     /// A PostgreSQL object identifier.
     Oid,
@@ -1711,7 +1711,7 @@ pub enum SqlScalarType {
     /// be [`Datum::Null`].
     Map {
         value_type: Box<SqlScalarType>,
-        custom_id: Option<CatalogItemId>,
+        custom_id: Option<GlobalId>,
     },
     /// A PostgreSQL function name.
     RegProc,
@@ -3906,14 +3906,14 @@ impl Arbitrary for SqlScalarType {
         leaf.prop_recursive(2, 3, 5, |inner| {
             Union::new(vec![
                 // List
-                (inner.clone(), any::<Option<CatalogItemId>>())
+                (inner.clone(), any::<Option<GlobalId>>())
                     .prop_map(|(x, id)| SqlScalarType::List {
                         element_type: Box::new(x),
                         custom_id: id,
                     })
                     .boxed(),
                 // Map
-                (inner.clone(), any::<Option<CatalogItemId>>())
+                (inner.clone(), any::<Option<GlobalId>>())
                     .prop_map(|(x, id)| SqlScalarType::Map {
                         value_type: Box::new(x),
                         custom_id: id,
@@ -3935,7 +3935,7 @@ impl Arbitrary for SqlScalarType {
                         prop::collection::vec((any::<ColumnName>(), column_type_strat), 0..10);
 
                     // Now we combine it with the default strategies to get Records.
-                    (fields_strat, any::<Option<CatalogItemId>>())
+                    (fields_strat, any::<Option<GlobalId>>())
                         .prop_map(|(fields, custom_id)| SqlScalarType::Record {
                             fields: fields.into(),
                             custom_id,

--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -105,6 +105,13 @@ impl RawItemName {
             RawItemName::Id(_, name, _) => name,
         }
     }
+
+    pub fn id_mut(&mut self) -> Option<&mut String> {
+        match self {
+            RawItemName::Name(_) => None,
+            RawItemName::Id(id, _, _) => Some(id),
+        }
+    }
 }
 
 impl AstDisplay for RawItemName {

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -48,7 +48,6 @@ pub trait AlterCompatible: std::fmt::Debug + PartialEq {
 }
 
 impl AlterCompatible for mz_repr::GlobalId {}
-impl AlterCompatible for mz_repr::CatalogItemId {}
 
 /// The diff type used by storage.
 pub type StorageDiff = i64;

--- a/test/sqllogictest/alter-table.slt
+++ b/test/sqllogictest/alter-table.slt
@@ -413,15 +413,15 @@ DROP TABLE t1 CASCADE;
 query TT
 SELECT id, name FROM mz_tables WHERE id LIKE 'u%';
 ----
-u1 t2
+u16 t2
 
 statement ok
 COMMENT ON COLUMN t2.a IS 'this column existed originally';
 
 query TTIT
-SELECT * FROM mz_internal.mz_comments WHERE id = 'u1';
+SELECT * FROM mz_internal.mz_comments WHERE id = 'u16';
 ----
-u1  table  1  this␠column␠existed␠originally
+u16  table  1  this␠column␠existed␠originally
 
 statement ok
 ALTER TABLE t2 ADD COLUMN c timestamp;
@@ -430,14 +430,14 @@ statement ok
 COMMENT ON COLUMN t2.c IS 'added later';
 
 query TTIT rowsort
-SELECT * FROM mz_internal.mz_comments WHERE id = 'u1';
+SELECT * FROM mz_internal.mz_comments WHERE id = 'u17';
 ----
-u1  table  3  added␠later
-u1  table  1  this␠column␠existed␠originally
+u17  table  3  added␠later
+u17  table  1  this␠column␠existed␠originally
 
 statement ok
 DROP TABLE t2 CASCADE;
 
 query TTIT
-SELECT * FROM mz_internal.mz_comments WHERE id = 'u1';
+SELECT * FROM mz_internal.mz_comments WHERE id = 'u17';
 ----


### PR DESCRIPTION
This is a poc implementing an idea for resolving the current `CatalogItemId`/`GlobalId` mess.

Roughly, the mess is twofold:
* Implementation complexity: Everywhere in adapter we have to deal with both ID types. Sometimes we need to translate them into one another, sometimes we have to pass around two IDs instead of one. Also, sometimes we use the logically wrong ID type (`GlobalId` instead of `CatalogItemId`) for backwards compat reasons. What's more, the `CatalogItemId` type is supposed to be a SQL-level concept, but it leaks into the storage and compute crates as well.
* Interface complexity: If we keep both ID types, users will have to learn about the various layers of our implementation. Or, we attempt to paper over the split by providing views translating everything to the same ID type, at the cost of more noise in the system catalog, and some runtime cost for joins (and more implementation complexity).

What this poc tries is to remove `CatalogItemId` again. Here we simply make it an alias of `GlobalId`, to avoid a huge amount of typing, which is why all of the implementation complexity remains (though it could be removed by a huge amount of typing). Instead of treating item IDs as a namespace separate from the `GlobalId` namespace, we declare the ID of a catalog item to be the `GlobalId` of its most recent underlying collection. A necessary assumption for this is that each catalog item only has a single underlying collection (with some handwaving for MVs that have two collections that share a `GlobalId`) at any point in time.

Fixing the item ID to the latest `GlobalId` means that the item ID can change over time. This is a major departure from how things worked previously. The thinking is that nothing relies on item IDs being stable, but the point of this poc is to figure out if this is actually true.

If it is true, the approach has the benefit that it brings us mostly back into a world where we only have to worry about a single ID for each object. We don't quite get there for two reasons:
* Collections depending on previous versions of an evolved object still need a way to reference that object. For this purpose, every evolvable object keeps a `versions` list with its previous `GlobalId`s, and the catalog provides mechanisms to resolve `GlobalId`s for older versions through these lists. (This exists already but can be cleaned up.)
* Users might want to connect metrics collected for previous versions of a catalog item back to the item. For this purpose, we can provide an `mz_object_versions` system relations, that's mostly equivalent to the current `mz_object_global_ids` but models the versioning explicitly and is presumably easier to explain to users.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
