### PR TITLE
DNM  Debugging: Assert various read hold stuff

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -196,7 +196,7 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_frontend_peek_sequencing",
-            "false",
+            "true",
             ["true", "false"],
         ),
         VariableSystemParameter(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1343,9 +1343,9 @@ impl Drop for ExecuteContextExtra {
             // Note: the impact when this error hits
             // is that the statement will never be marked
             // as finished in the statement log.
-            soft_panic_or_log!(
-                "execute context for statement {statement_uuid:?} dropped without being properly retired."
-            );
+            // soft_panic_or_log!(
+            //     "execute context for statement {statement_uuid:?} dropped without being properly retired."
+            // );
         }
     }
 }

--- a/src/storage-types/src/read_holds.rs
+++ b/src/storage-types/src/read_holds.rs
@@ -31,10 +31,10 @@ pub type ChangeTx<T> = Arc<
 /// the issuer behind the scenes.
 pub struct ReadHold<T: TimelyTimestamp> {
     /// Identifies that collection that we have a hold on.
-    id: GlobalId,
+    pub id: GlobalId,
 
     /// The times at which we hold.
-    since: Antichain<T>,
+    pub since: Antichain<T>,
 
     /// For communicating changes to this read hold back to whoever issued it.
     change_tx: ChangeTx<T>,


### PR DESCRIPTION
This is just debugging the `SinceViolation` and the `dataflow has an as_of not beyond the since of collection` in https://github.com/MaterializeInc/database-issues/issues/9593, adding a lot of DNM asserts.