### PR TITLE
parallel-workload: More complex UNION/Record/List

### DIFF
--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -579,7 +579,7 @@ class VarChar(DataType):
             return "varchar(1024)"
 
 
-class Bytea(Text):
+class Bytea(DataType):
     @staticmethod
     def name(backend: Backend = Backend.MATERIALIZE) -> str:
         if backend == Backend.AVRO:
@@ -588,6 +588,44 @@ class Bytea(Text):
             return "string"
         else:
             return "bytea"
+
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if rng.randrange(10) == 0:
+            result = rng.choice(
+                [
+                    "NULL",
+                    "0.0",
+                    "True",
+                    # "",
+                    "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀",
+                    rng.randint(-100, 100),
+                ]
+            )
+        # Fails: unterminated dollar-quoted string
+        # chars = string.printable
+        chars = string.ascii_letters + string.digits
+        if record_size == RecordSize.TINY:
+            result = rng.choice(("foo", "bar", "baz"))
+        elif record_size == RecordSize.SMALL:
+            result = "".join(rng.choice(chars) for _ in range(3))
+        elif record_size == RecordSize.MEDIUM:
+            result = "".join(rng.choice(chars) for _ in range(10))
+        elif record_size == RecordSize.LARGE:
+            result = "".join(rng.choice(chars) for _ in range(100))
+        else:
+            raise ValueError(f"Unexpected record size {record_size}")
+
+        return f"{literal(str(result))}::bytea" if in_query else str(result)
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        result = f"key{num}"
+        return f"'{result}'::bytea" if in_query else str(result)
 
 
 class UUID(DataType):
@@ -768,6 +806,66 @@ class IntList(DataType):
         values = [str(num) for i in range(0, num)]
         values_str = f"{{{', '.join(values)}}}"
         return f"'{values_str}'::int list" if in_query else values_str
+
+
+class RecordList(DataType):
+    @staticmethod
+    def name(backend: Backend = Backend.MATERIALIZE) -> str:
+        if backend == Backend.AVRO:
+            raise ValueError("Unsupported")
+        elif backend == Backend.JSON:
+            raise ValueError("Unsupported")
+        else:
+            return "record list"
+
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        if record_size == RecordSize.TINY:
+            key_range = 1
+        elif record_size == RecordSize.SMALL:
+            key_range = 5
+        elif record_size == RecordSize.MEDIUM:
+            key_range = 10
+        elif record_size == RecordSize.LARGE:
+            key_range = 20
+        else:
+            raise ValueError(f"Unexpected record size {record_size}")
+        values = [f"row({rng.randint(-100, 100)})" for i in range(0, key_range)]
+        return f"list[{', '.join(values)}]"
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        values = [f"row({i})" for i in range(0, num)]
+        return f"list[{', '.join(values)}]"
+
+
+class Record(DataType):
+    @staticmethod
+    def name(backend: Backend = Backend.MATERIALIZE) -> str:
+        if backend == Backend.AVRO:
+            raise ValueError("Unsupported")
+        elif backend == Backend.JSON:
+            raise ValueError("Unsupported")
+        else:
+            return "record"
+
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        value = str(rng.choice(["null::integer", "1"]))
+        return f"row({value})"
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        value = str(num)
+        return f"row({value})"
 
 
 class Timestamp(DataType):
@@ -1190,6 +1288,10 @@ RANGE_TYPES = [Int4Range, Int8Range, NumRange, DateRange, TsRange, TsTzRange]
 
 # Sort to keep determinism for reproducible runs with specific seed
 DATA_TYPES = sorted(list(all_subclasses(DataType)), key=repr)
+
+# Record and RecordList are only used nested within expressions, not as
+# top-level table columns.
+DATA_TYPES_FOR_COLUMNS = sorted(list(set(DATA_TYPES) - {Record, RecordList}), key=repr)
 
 # Explicit allowlists so that the actually exercised types are visible at a
 # glance. A type belongs in one of these lists only if it maps to a native

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -27,6 +27,7 @@ from psycopg.errors import OperationalError
 
 import materialize.parallel_workload.column
 from materialize.data_ingest.data_type import (
+    DATA_TYPES,
     NUMBER_TYPES,
     Boolean,
     Text,
@@ -43,7 +44,6 @@ from materialize.mzcompose.services.materialized import (
 )
 from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.parallel_workload.database import (
-    DATA_TYPES,
     DB,
     MAX_CLUSTER_REPLICAS,
     MAX_CLUSTERS,
@@ -200,6 +200,7 @@ class Action:
             # a path that wrongly accepts it instead panics the coordinator on
             # catalog apply, which surfaces as an unexpected failure.
             "non-temporary items cannot depend on temporary item",
+            "is not of expected type SqlColumnType",  # TODO: Remove when SQL-566 is fixed
         ]
         if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(
@@ -309,24 +310,27 @@ class Action:
 
         join = obj_name != obj2_name and obj not in exe.db.views and columns
 
-        if join:
-            all_columns = list(obj.columns) + list(obj2.columns)
-        else:
-            all_columns = obj.columns
+        all_columns = list(obj.columns) + list(obj2.columns) if join else obj.columns
 
+        column_types = []
         if self.rng.random() < 0.9:
+            column_types = [
+                self.rng.choice(list(DATA_TYPES))
+                for i in range(self.rng.randint(1, 10))
+            ]
             expressions = ", ".join(
                 [
                     expression(
-                        self.rng.choice(list(DATA_TYPES)),
+                        column_type,
                         all_columns,
                         self.rng,
                         expr_kind,
                     )
-                    for i in range(self.rng.randint(1, 10))
+                    for column_type in column_types
                 ]
             )
             if self.rng.choice([True, False]):
+                column_types = []
                 column1 = self.rng.choice(all_columns)
                 column2 = self.rng.choice(all_columns)
                 column3 = self.rng.choice(all_columns)
@@ -369,17 +373,42 @@ class Action:
         if self.rng.choice([True, False]):
             query += f" WHERE {expression(Boolean, all_columns, self.rng, expr_kind)}"
 
-        if self.rng.choice([True, False]):
-            query += f" UNION ALL SELECT {expressions} FROM {obj_name}"
+        if bool(column_types) and self.rng.choice([True, False]):
+            obj3 = self.rng.choice(exe.db.db_objects())
+            obj3_name = str(obj3)
+            column3 = self.rng.choice(obj3.columns)
+            obj4 = self.rng.choice(exe.db.db_objects())
+            obj4_name = str(obj4)
+            columns_union = [
+                c
+                for c in obj4.columns
+                if c.data_type == column3.data_type and c.data_type != TextTextMap
+            ]
+            join_union = (
+                obj3_name != obj4_name and obj3 not in exe.db.views and columns_union
+            )
+            all_columns_union = (
+                list(obj3.columns) + list(obj4.columns) if join_union else obj3.columns
+            )
+            expressions3 = ", ".join(
+                [
+                    expression(
+                        column_type,
+                        all_columns_union,
+                        self.rng,
+                        expr_kind,
+                    )
+                    for column_type in column_types
+                ]
+            )
+            query += f" UNION ALL SELECT {expressions3} FROM {obj3_name}"
 
-            if join:
-                column2 = self.rng.choice(columns)
-                query += f" JOIN {obj2_name} ON {column} = {column2}"
+            if join_union:
+                column4 = self.rng.choice(columns_union)
+                query += f" JOIN {obj4_name} ON {column3} = {column4}"
 
             if self.rng.choice([True, False]):
-                query += (
-                    f" WHERE {expression(Boolean, all_columns, self.rng, expr_kind)}"
-                )
+                query += f" WHERE {expression(Boolean, all_columns_union, self.rng, expr_kind)}"
 
         query += f" LIMIT {self.rng.randint(0, 100)}"
         return query

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -16,8 +16,8 @@ from enum import Enum
 from pg8000.native import identifier, literal
 
 from materialize.data_ingest.data_type import (
-    DATA_TYPES,
     DATA_TYPES_FOR_AVRO,
+    DATA_TYPES_FOR_COLUMNS,
     DATA_TYPES_FOR_KEY,
     DATA_TYPES_FOR_MYSQL,
     DATA_TYPES_FOR_SQL_SERVER,
@@ -190,7 +190,7 @@ class Table(DBObject):
         self.table_id = table_id
         self.schema = schema
         self.columns = [
-            Column(rng, i, rng.choice(DATA_TYPES), self)
+            Column(rng, i, rng.choice(DATA_TYPES_FOR_COLUMNS), self)
             for i in range(rng.randint(2, MAX_COLUMNS))
         ]
         self.num_rows = 0
@@ -265,7 +265,8 @@ class View(DBObject):
             list(base_object2.columns) if base_object2 else []
         )
         self.data_types = [
-            rng.choice(list(DATA_TYPES)) for i in range(rng.randint(1, MAX_COLUMNS))
+            rng.choice(list(DATA_TYPES_FOR_COLUMNS))
+            for i in range(rng.randint(1, MAX_COLUMNS))
         ]
         self.expressions = [
             expression(data_type, all_columns, rng, kind=ExprKind.MATERIALIZABLE)

--- a/misc/python/materialize/parallel_workload/expression.py
+++ b/misc/python/materialize/parallel_workload/expression.py
@@ -29,6 +29,8 @@ from materialize.data_ingest.data_type import (
     MzTimestamp,
     Numeric,
     Numeric383,
+    Record,
+    RecordList,
     RecordSize,
     Text,
     TextTextMap,
@@ -80,6 +82,8 @@ for dt in DATA_TYPES:
 
     if dt not in (
         IntList,
+        RecordList,
+        Record,
         IntArray,
         TextTextMap,
         Bytea,
@@ -92,7 +96,16 @@ for dt in DATA_TYPES:
             FuncOp("{} || {}", [Text, dt]),
         ]
 
-    if dt not in (IntList, IntArray, TextTextMap, Bytea, Jsonb, *RANGE_TYPES):
+    if dt not in (
+        IntList,
+        RecordList,
+        Record,
+        IntArray,
+        TextTextMap,
+        Bytea,
+        Jsonb,
+        *RANGE_TYPES,
+    ):
         FUNC_OPS[Boolean] += [
             FuncOp("{} > {}", [dt, dt]),
             FuncOp("{} < {}", [dt, dt]),
@@ -194,6 +207,10 @@ FUNC_OPS[Boolean] += [
     FuncOp("mz_is_superuser()", [], unsupported=ExprKind.MATERIALIZABLE),
 ]
 
+FUNC_OPS[Record] += [FuncOp("row{}", [Int])]
+
+FUNC_OPS[RecordList] += [FuncOp("list[{}]", [Record])]
+
 FUNC_OPS[Text] += [
     FuncOp("lower{}", [Text]),
     FuncOp("upper{}", [Text]),
@@ -225,6 +242,7 @@ FUNC_OPS[Int] += [
     FuncOp("char_length{}", [Text]),
     FuncOp("map_length{}", [TextTextMap]),
     FuncOp("list_length{}", [IntList]),
+    FuncOp("list_length{}", [RecordList]),
     FuncOp("mz_version_num()", [], unsupported=ExprKind.MATERIALIZABLE),
     FuncOp("pg_backend_pid()", [], unsupported=ExprKind.MATERIALIZABLE),
     FuncOp("{} - {}", [Date, Date]),


### PR DESCRIPTION
Inspired by https://materializeinc.slack.com/archives/C08ACQNGSQK/p1764749200253109

Success: https://buildkite.com/materialize/nightly/builds/14357
```
parallel-workload-materialized-1     | thread 'tokio:work-8' panicked at src/repr/src/row/encode.rs:150:9: tried pushing Null into non-nullable column
```

Now trying with the WIP fix by @ggevay : https://github.com/MaterializeInc/materialize/pull/34341 https://buildkite.com/materialize/nightly/builds/14358 Edit: All green!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
