### PR TITLE
Use superuser attribute for Cloud

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -270,12 +270,10 @@ impl CatalogState {
                     builtin_supers.contains(&role.id) || matches
                 };
 
-                let rolsuper = if self_managed_auth_enabled {
-                    Datum::from(role.attributes.superuser.unwrap_or(false))
-                } else if builtin_supers.contains(&role.id) {
+                let rolsuper = if builtin_supers.contains(&role.id) {
                     Datum::from(true)
                 } else {
-                    Datum::Null
+                    Datum::from(role.attributes.superuser.unwrap_or(false))
                 };
 
                 let role_update = BuiltinTableUpdate::row(

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -683,7 +683,16 @@ impl Coordinator {
             // This includes preventing any user, except a pre-defined set of system users, from
             // connecting to an internal port. Therefore it's ok to always create a new role for the
             // user.
-            let attributes = RoleAttributesRaw::new();
+
+            let attributes = if user
+                .external_metadata
+                .as_ref()
+                .map_or(false, |meta| meta.admin)
+            {
+                RoleAttributesRaw::new().with_superuser()
+            } else {
+                RoleAttributesRaw::new()
+            };
             let plan = CreateRolePlan {
                 name: user.name.to_string(),
                 attributes,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -15,6 +15,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_adapter_types::dyncfgs::ALLOW_USER_SESSIONS;
 use mz_auth::password::Password;
 use mz_repr::namespaces::MZ_INTERNAL_SCHEMA;
+use mz_repr::user::ExternalUserMetadataDiff;
 use mz_sql::session::metadata::SessionMetadata;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
@@ -35,7 +36,7 @@ use mz_sql::ast::{
     ConstantVisitor, CopyRelation, CopyStatement, CreateSourceOptionName, Raw, Statement,
     SubscribeStatement,
 };
-use mz_sql::catalog::RoleAttributesRaw;
+use mz_sql::catalog::{CatalogRole, RoleAttributesRaw};
 use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
 use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, Params, Plan,
@@ -88,7 +89,38 @@ impl Coordinator {
     pub(crate) fn handle_command(&mut self, mut cmd: Command) -> LocalBoxFuture<'_, ()> {
         async move {
             if let Some(session) = cmd.session_mut() {
-                session.apply_external_metadata_updates();
+                if let Some(updates) = session.get_external_metadata_updates() {
+                    let diff = ExternalUserMetadataDiff::new(
+                        session.user().external_metadata.as_ref(),
+                        &updates,
+                    );
+
+                    // If we notice a change to the admin flag, we need to update the catalog.
+                    if let Some(admin) = diff.admin {
+                        let conn_id = session.conn_id();
+                        let conn = &self.active_conns[conn_id];
+
+                        let role = self.catalog().try_get_role(conn.authenticated_role_id());
+
+                        if let Some(role) = role {
+                            let mut attributes = role.attributes().clone();
+                            attributes.superuser = Some(admin);
+
+                            let op = catalog::Op::AlterRole {
+                                id: role.id(),
+                                name: role.name.clone(),
+                                attributes: RoleAttributesRaw::from(attributes),
+                                nopassword: false,
+                                vars: role.vars.clone(),
+                            };
+                            if let Err(e) = self.catalog_transact_with_context(Some(&conn_id), None, vec![op]).await {
+                                tracing::warn!("failed to sync superuser attribute from external metadata: {:?}", e);
+                            }
+                        }
+                    }
+
+                    session.apply_external_metadata_updates(updates);
+                }
             }
             match cmd {
                 Command::Startup {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -20,7 +20,7 @@ use futures::{Future, StreamExt, future};
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
-use mz_adapter_types::dyncfgs::{ENABLE_MULTI_REPLICA_SOURCES, ENABLE_PASSWORD_AUTH};
+use mz_adapter_types::dyncfgs::ENABLE_MULTI_REPLICA_SOURCES;
 use mz_catalog::memory::objects::{
     CatalogItem, Connection, DataSourceDesc, Sink, Source, Table, TableDataSource, Type,
 };

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -890,7 +890,12 @@ impl Coordinator {
         conn_id: Option<&ConnectionId>,
         plan::CreateRolePlan { name, attributes }: plan::CreateRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        println!(
+            "creating role {:?} with attributes {:?}",
+            &name, &attributes
+        );
         let op = catalog::Op::CreateRole { name, attributes };
+
         self.catalog_transact_with_context(conn_id, None, vec![op])
             .await
             .map(|_| ExecuteResponse::CreatedRole)

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -187,13 +187,6 @@ pub enum AdapterError {
     Unstructured(anyhow::Error),
     /// The named feature is not supported and will (probably) not be.
     Unsupported(&'static str),
-    /// Some feature isn't available for a (potentially opaque) reason.
-    /// For example, in cloud Self-Managed auth features aren't available,
-    /// but we don't want to mention self managed auth.
-    UnavailableFeature {
-        feature: String,
-        docs: Option<String>,
-    },
     /// Attempted to read from log sources without selecting a target replica.
     UntargetedLogRead {
         log_names: Vec<String>,
@@ -577,7 +570,6 @@ impl AdapterError {
             AdapterError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnrecognizedConfigurationParam(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
-            AdapterError::UnavailableFeature { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,
             AdapterError::UntargetedLogRead { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::DDLTransactionRace => SqlState::T_R_SERIALIZATION_FAILURE,
@@ -934,16 +926,6 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::AuthenticationError(e) => {
                 write!(f, "authentication error {e}")
-            }
-            AdapterError::UnavailableFeature { feature, docs } => {
-                write!(f, "{} is not supported in this environment.", feature)?;
-                if let Some(docs) = docs {
-                    write!(
-                        f,
-                        " For more information consult the documentation at {docs}"
-                    )?;
-                }
-                Ok(())
             }
             AdapterError::AlterClusterWhilePendingReplicas => {
                 write!(f, "cannot alter clusters with pending updates")

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -1999,11 +1999,14 @@ async fn test_auth_admin_superuser_revoked() {
 
     assert_eq!(
         pg_client
-            .query_one("SHOW is_superuser", &[])
+            .query_one(
+                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                &[]
+            )
             .await
             .unwrap()
             .get::<_, String>(0),
-        "off"
+        "false"
     );
 
     frontegg_server
@@ -2014,11 +2017,14 @@ async fn test_auth_admin_superuser_revoked() {
 
     assert_eq!(
         pg_client
-            .query_one("SHOW is_superuser", &[])
+            .query_one(
+                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                &[]
+            )
             .await
             .unwrap()
             .get::<_, String>(0),
-        "on"
+        "true"
     );
 
     frontegg_server
@@ -2029,11 +2035,14 @@ async fn test_auth_admin_superuser_revoked() {
 
     assert_eq!(
         pg_client
-            .query_one("SHOW is_superuser", &[])
+            .query_one(
+                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                &[]
+            )
             .await
             .unwrap()
             .get::<_, String>(0),
-        "off"
+        "false"
     );
 }
 

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -2000,13 +2000,13 @@ async fn test_auth_admin_superuser_revoked() {
     assert_eq!(
         pg_client
             .query_one(
-                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                "SELECT rolsuper FROM mz_roles WHERE name = 'user@_.com'",
                 &[]
             )
             .await
             .unwrap()
-            .get::<_, String>(0),
-        "false"
+            .get::<_, Option<bool>>(0),
+        Some(false)
     );
 
     frontegg_server
@@ -2018,13 +2018,13 @@ async fn test_auth_admin_superuser_revoked() {
     assert_eq!(
         pg_client
             .query_one(
-                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                "SELECT rolsuper FROM mz_roles WHERE name = 'user@_.com'",
                 &[]
             )
             .await
             .unwrap()
-            .get::<_, String>(0),
-        "true"
+            .get::<_, Option<bool>>(0),
+        Some(true)
     );
 
     frontegg_server
@@ -2036,13 +2036,13 @@ async fn test_auth_admin_superuser_revoked() {
     assert_eq!(
         pg_client
             .query_one(
-                "SELECT rolsuperuser FROM mz_roles WHERE name = 'user@_.com'",
+                "SELECT rolsuper FROM mz_roles WHERE name = 'user@_.com'",
                 &[]
             )
             .await
             .unwrap()
-            .get::<_, String>(0),
-        "false"
+            .get::<_, Option<bool>>(0),
+        Some(false)
     );
 }
 

--- a/src/repr/src/user.rs
+++ b/src/repr/src/user.rs
@@ -19,6 +19,24 @@ pub struct ExternalUserMetadata {
     pub admin: bool,
 }
 
+/// Represents changes to external user metadata properties.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalUserMetadataDiff {
+    pub user_id: Option<Uuid>,
+    pub admin: Option<bool>,
+}
+
+impl ExternalUserMetadataDiff {
+    pub fn new(previous: Option<&ExternalUserMetadata>, new: &ExternalUserMetadata) -> Self {
+        let previous_user_id = previous.map(|m| m.user_id);
+        let previous_admin = previous.map(|m| m.admin);
+        ExternalUserMetadataDiff {
+            user_id: (previous_user_id != Some(new.user_id)).then_some(new.user_id),
+            admin: (previous_admin != Some(new.admin)).then_some(new.admin),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InternalUserMetadata {
     pub superuser: bool,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -562,8 +562,8 @@ impl RoleAttributesRaw {
     }
 
     /// Sets the superuser attribute to true.
-    pub const fn with_superuser(mut self) -> RoleAttributesRaw {
-        self.superuser = Some(true);
+    pub const fn with_superuser(mut self, superuser: bool) -> RoleAttributesRaw {
+        self.superuser = Some(superuser);
         self
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -560,6 +560,12 @@ impl RoleAttributesRaw {
         self.login = Some(true);
         self
     }
+
+    /// Sets the superuser attribute to true.
+    pub const fn with_superuser(mut self) -> RoleAttributesRaw {
+        self.superuser = Some(true);
+        self
+    }
 }
 
 impl RoleAttributes {

--- a/test/sqllogictest/pg_catalog_user.slt
+++ b/test/sqllogictest/pg_catalog_user.slt
@@ -27,7 +27,7 @@ CREATE ROLE "materialize@foocorp.io"
 query TIBBBBTTT rowsort
 SELECT usename, usesysid, usecreatedb, usesuper, userepl, usebypassrls, passwd, valuntil, useconfig FROM pg_user;
 ----
-materialize@foocorp.io  20196  false  NULL  false  false  NULL  NULL  NULL
+materialize@foocorp.io  20196  false  false  false  false  NULL  NULL  NULL
 mz_system  16661  true  true  false  false  NULL  NULL  NULL
 
 statement ok

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -60,14 +60,11 @@ COMPLETE 0
 statement error non inherit roles not yet supported
 CREATE ROLE foo NOINHERIT
 
-statement error db error: ERROR: SUPERUSER, PASSWORD, and LOGIN attributes is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+statement error db error: ERROR: LOGIN attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 CREATE ROLE foo LOGIN
 
-simple
+statement error db error: ERROR: SUPERUSER attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 CREATE ROLE foo SUPERUSER
-----
-db error: ERROR: permission denied to create superuser role
-DETAIL: You must be a superuser to create superuser role
 
 statement error conflicting or redundant options
 CREATE ROLE foo INHERIT INHERIT

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -156,7 +156,7 @@ DETAIL: You must be a superuser to alter superuser role
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb NOSUPERUSER;
 ----
-db error: ERROR: SUPERUSER, PASSWORD, and LOGIN attributes is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+db error: ERROR: NOSUPERUSER attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_createrole;
@@ -246,12 +246,12 @@ db error: ERROR: Expected end of statement, found identifier "noreplication"
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_noiseword LOGIN;
 ----
-db error: ERROR: SUPERUSER, PASSWORD, and LOGIN attributes is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+db error: ERROR: LOGIN attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_noiseword NOLOGIN;
 ----
-db error: ERROR: SUPERUSER, PASSWORD, and LOGIN attributes is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
+db error: ERROR: NOLOGIN attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_password_auth = true

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -64,8 +64,7 @@ COMPLETE 0
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_superuser SUPERUSER;
 ----
-db error: ERROR: permission denied to create superuser role
-DETAIL: You must be a superuser to create superuser role
+db error: ERROR: SUPERUSER attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_limited_admin,user=regress_role_limited_admin
 CREATE ROLE regress_nosuch_createdb CREATEDB;
@@ -150,8 +149,7 @@ DETAIL: Use system privileges instead.
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb SUPERUSER;
 ----
-db error: ERROR: permission denied to alter superuser role
-DETAIL: You must be a superuser to alter superuser role
+db error: ERROR: SUPERUSER attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_admin,user=regress_role_admin
 ALTER ROLE regress_createdb NOSUPERUSER;
@@ -181,7 +179,7 @@ db error: ERROR: Expected end of statement, found CONNECTION
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_password_null PASSWORD NULL;
 ----
-COMPLETE 0
+db error: ERROR: PASSWORD attribute is not supported in this environment. For more information consult the documentation at https://materialize.com/docs/sql/create-role/#details
 
 simple conn=regress_role_admin,user=regress_role_admin
 CREATE ROLE regress_noiseword SYSID 12345;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
See commit messages for details. Fixes https://github.com/issues/assigned?issue=MaterializeInc%7Cdatabase-issues%7C9948

Right now the behavior is the attribute / table will update when we next update the external_metadata (i.e. when we next refresh the token). We could write a catalog migration / builtin table migration for this too, but not sure how to extrapolate whether a user is a superuser from this. And practically, I believe this shouldn't make a difference given they'd need to authenticate to query mz_roles

Overall this feels kinda clunky. Talked more about it in this slack thread https://materializeinc.slack.com/archives/C08A62E0751/p1764979212773359

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
