### PR TITLE
Adds global and per ip connection rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7139,6 +7139,7 @@ dependencies = [
  "bytesize",
  "enum-kinds",
  "futures",
+ "governor",
  "itertools 0.14.0",
  "mz-adapter",
  "mz-adapter-types",

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.10.1"
 bytesize = "2.1.0"
 enum-kinds = "0.5.1"
 futures = "0.3.31"
+governor = "0.10.1"
 itertools = "0.14.0"
 mz-adapter = { path = "../adapter" }
 mz-adapter-types = { path = "../adapter-types" }

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -30,4 +30,4 @@ mod server;
 
 pub use metrics::MetricsConfig;
 pub use protocol::match_handshake;
-pub use server::{Config, Server};
+pub use server::{Config, RateLimitConfig, Server};

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1148,6 +1148,10 @@ impl SystemVars {
             &KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT,
             &ENABLE_LAUNCHDARKLY,
             &MAX_CONNECTIONS,
+            &PGWIRE_CONNECTION_RATE_LIMIT,
+            &PGWIRE_CONNECTION_RATE_LIMIT_BURST,
+            &PGWIRE_CONNECTION_RATE_LIMIT_PER_IP,
+            &PGWIRE_CONNECTION_RATE_LIMIT_PER_IP_BURST,
             &NETWORK_POLICY,
             &SUPERUSER_RESERVED_CONNECTIONS,
             &KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES,
@@ -1949,6 +1953,30 @@ impl SystemVars {
     /// Returns the `superuser_reserved_connections` configuration parameter.
     pub fn superuser_reserved_connections(&self) -> u32 {
         *self.expect_value(&SUPERUSER_RESERVED_CONNECTIONS)
+    }
+
+    /// Returns the `pgwire_connection_rate_limit` configuration parameter.
+    /// A value of 0 means rate limiting is disabled.
+    pub fn pgwire_connection_rate_limit(&self) -> u32 {
+        *self.expect_value(&PGWIRE_CONNECTION_RATE_LIMIT)
+    }
+
+    /// Returns the `pgwire_connection_rate_limit_burst` configuration parameter.
+    /// A value of 0 means use the rate limit value as the burst size.
+    pub fn pgwire_connection_rate_limit_burst(&self) -> u32 {
+        *self.expect_value(&PGWIRE_CONNECTION_RATE_LIMIT_BURST)
+    }
+
+    /// Returns the `pgwire_connection_rate_limit_per_ip` configuration parameter.
+    /// A value of 0 means rate limiting is disabled.
+    pub fn pgwire_connection_rate_limit_per_ip(&self) -> u32 {
+        *self.expect_value(&PGWIRE_CONNECTION_RATE_LIMIT_PER_IP)
+    }
+
+    /// Returns the `pgwire_connection_rate_limit_per_ip_burst` configuration parameter.
+    /// A value of 0 means use the rate limit value as the burst size.
+    pub fn pgwire_connection_rate_limit_per_ip_burst(&self) -> u32 {
+        *self.expect_value(&PGWIRE_CONNECTION_RATE_LIMIT_PER_IP_BURST)
     }
 
     pub fn keep_n_source_status_history_entries(&self) -> usize {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1388,6 +1388,34 @@ pub static MAX_CONNECTIONS: VarDefinition = VarDefinition::new(
     true,
 );
 
+pub static PGWIRE_CONNECTION_RATE_LIMIT: VarDefinition = VarDefinition::new(
+    "pgwire_connection_rate_limit",
+    value!(u32; 0),
+    "The maximum number of new pgwire connections per second globally. 0 disables rate limiting (Materialize).",
+    false,
+);
+
+pub static PGWIRE_CONNECTION_RATE_LIMIT_BURST: VarDefinition = VarDefinition::new(
+    "pgwire_connection_rate_limit_burst",
+    value!(u32; 0),
+    "The burst size for the global pgwire connection rate limit. 0 uses the rate limit value as burst size (Materialize).",
+    false,
+);
+
+pub static PGWIRE_CONNECTION_RATE_LIMIT_PER_IP: VarDefinition = VarDefinition::new(
+    "pgwire_connection_rate_limit_per_ip",
+    value!(u32; 0),
+    "The maximum number of new pgwire connections per second per IP address. Uses MZ_FORWARDED_FOR_KEY if available. 0 disables rate limiting (Materialize).",
+    false,
+);
+
+pub static PGWIRE_CONNECTION_RATE_LIMIT_PER_IP_BURST: VarDefinition = VarDefinition::new(
+    "pgwire_connection_rate_limit_per_ip_burst",
+    value!(u32; 0),
+    "The burst size for the per-IP pgwire connection rate limit. 0 uses the rate limit value as burst size (Materialize).",
+    false,
+);
+
 pub static SUPERUSER_RESERVED_CONNECTIONS: VarDefinition = VarDefinition::new(
     "superuser_reserved_connections",
     value!(u32; 3),


### PR DESCRIPTION
Currently a large number of connections per second can overwhelm environmentd impacting work for existing connections. In order to isolate the impact of connection floods while still maintaining a reasonably high max_connections I propose that we add connection rate limiting. This will send a `too many connections` error to the client which can then retry with backoffs spreading connection requests a bit. This should reduce impact somewhat, however, large CPS floods will still be making TLS connections which may still lead to environmentd health impairment. 

Adds connection rate limiting through governor handled by burstable quotas added to the pgwire server config. Limits are checked in handle_connection, and controlled by the following system params.
- PGWIRE_CONNECTION_RATE_LIMIT
- PGWIRE_CONNECTION_RATE_LIMIT_BURST
- PGWIRE_CONNECTION_RATE_LIMIT_PER_IP
- PGWIRE_CONNECTION_RATE_LIMIT_BURST_PER_IP

Environmentd must be restarted to update params.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
