### PR TITLE
Select in cluster

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2699,6 +2699,7 @@ impl Coordinator {
                 when: QueryWhen::FreshestTableWrite,
                 finishing,
                 copy_to: None,
+                in_cluster: None,
             },
             TargetCluster::Active,
             None,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -89,6 +89,8 @@ pub enum AdapterError {
     InvalidSetIsolationLevel,
     /// SET cluster was called in the middle of a transaction.
     InvalidSetCluster,
+    /// SELECT ... IN CLUSTER was used in an invalid context.
+    InvalidSelectInCluster,
     /// No such storage instance size has been configured.
     InvalidStorageClusterSize {
         size: String,
@@ -618,6 +620,7 @@ impl AdapterError {
                 SqlState::INVALID_PASSWORD
             }
             AdapterError::AuthenticationError(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
+            AdapterError::InvalidSelectInCluster => SqlState::FEATURE_NOT_SUPPORTED,
         }
     }
 
@@ -957,6 +960,9 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::AlterClusterWhilePendingReplicas => {
                 write!(f, "cannot alter clusters with pending updates")
+            }
+            AdapterError::InvalidSelectInCluster => {
+                write!(f, "invalid select in cluster")
             }
         }
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -286,6 +286,7 @@ pub fn statement_kind_label_value(kind: StatementKind) -> &'static str {
 pub struct SelectStatement<T: AstInfo> {
     pub query: Query<T>,
     pub as_of: Option<AsOf<T>>,
+    pub in_cluster: Option<T::ClusterName>,
 }
 
 impl<T: AstInfo> AstDisplay for SelectStatement<T> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -429,7 +429,11 @@ fn sql_impl_table_func_inner(
         .expect_element(|| "static function definition must have exactly one statement")
         .ast
     {
-        Statement::Select(SelectStatement { query, as_of: None }) => query,
+        Statement::Select(SelectStatement {
+            query,
+            as_of: None,
+            in_cluster: _,
+        }) => query,
         _ => panic!("static function definition expected SELECT statement"),
     };
     let invoke = move |qcx: &QueryContext, types: Vec<SqlScalarType>| {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -865,6 +865,8 @@ pub struct SelectPlan {
     pub finishing: RowSetFinishing,
     /// For `COPY TO STDOUT`, the format to use.
     pub copy_to: Option<CopyFormat>,
+    /// The cluster on which to run the query, if not the system default.
+    pub in_cluster: Option<ClusterId>,
 }
 
 impl SelectPlan {
@@ -876,6 +878,7 @@ impl SelectPlan {
             when: QueryWhen::Immediately,
             finishing: RowSetFinishing::trivial(arity),
             copy_to: None,
+            in_cluster: None,
         }
     }
 }

--- a/src/sql/src/plan/side_effecting_func.rs
+++ b/src/sql/src/plan/side_effecting_func.rs
@@ -135,6 +135,7 @@ fn extract_sef_call(
                 offset: None,
             },
         as_of: None,
+        in_cluster: None,
     } = select
     else {
         return Ok(None);

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -276,6 +276,8 @@ fn plan_select_inner(
             .expect("checked in offset_into_value that it is not negative")
     };
 
+    let in_cluster = select.in_cluster.as_ref().map(|cluster| cluster.id);
+
     let plan = SelectPlan {
         source: expr,
         when,
@@ -287,6 +289,7 @@ fn plan_select_inner(
         },
         copy_to,
         select: Some(Box::new(select)),
+        in_cluster,
     };
 
     Ok((plan, desc))
@@ -2147,7 +2150,11 @@ pub fn plan_copy(
                         limit: None,
                         offset: None,
                     };
-                    SelectStatement { query, as_of: None }
+                    SelectStatement {
+                        query,
+                        as_of: None,
+                        in_cluster: None,
+                    }
                 }
                 CopyRelation::Select(stmt) => {
                     if !stmt.query.order_by.is_empty() {

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -802,6 +802,7 @@ fn generate_rbac_requirements(
             when: _,
             finishing: _,
             copy_to: _,
+            in_cluster,
         }) => {
             let items = source
                 .depends_on()
@@ -810,7 +811,7 @@ fn generate_rbac_requirements(
             let mut privileges = generate_read_privileges(catalog, items, role_id);
             if let Some(privilege) = generate_cluster_usage_privileges(
                 source.as_const().is_some(),
-                target_cluster_id,
+                in_cluster.clone().or(target_cluster_id),
                 role_id,
             ) {
                 privileges.push(privilege);

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2627,6 +2627,7 @@ fn generate_view_sql(
             offset: None,
         },
         as_of: query_as_of.clone(),
+        in_cluster: None,
     })
     .to_ast_string_stable();
 


### PR DESCRIPTION
Adds support for overriding the cluster from a select query. Cannot override the cluster implied by a transaction.

Adds the `SELECT .. (IN CLUSTER cluster_name)` syntax. Note that we need to parse the suffix using parenthesis as we would otherwise interpret the `IN` as part of the query.

This needs testing and is just a quick WIP.
