### PR TITLE
Design doc for prometheus metrics from queries

### DIFF
--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -11,13 +11,21 @@ This also applies to Materialize Cloud, as we run our own external SQL exporter 
 
 - Users can define SQL queries that get turned into prometheus metrics.
 - Users can group these metrics into HTTP endpoints, so they may have separate scrape configs (for different auth requirements and/or scrape frequency).
-- Materialize Cloud can remove the promsql exporter.
 
 ## Out of Scope
 
 - Generic HTTP endpoint creation for formats other than Prometheus.
 
     While the proposed solution could easily be extended for other API types, that is not required for this to work for prometheus.
+
+- Removal of the Materialize Cloud promsql exporter.
+
+    The promsql exporter relies on internal tables which cannot have views made from them, which would complicate this proposal.
+    We should just move all those queries into normal metrics endpoints instead. That way, customers can also get access to these metrics.
+
+    There are two open tickets related to this:
+    - https://github.com/MaterializeInc/database-issues/issues/10028
+    - https://github.com/MaterializeInc/database-issues/issues/10030
 
 ## Solution Proposal
 
@@ -26,20 +34,32 @@ Allow users to create HTTP endpoints in SQL with custom prometheus metrics.
 ```sql
 CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS ON CLUSTER "mycluster" ON LISTENER "external";
 ```
-This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on the "external" HTTP listener (as named in the listeners configmap), and a (currently empty) table with the following schema:
+This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on the "external" HTTP listener (as named in the listeners configmap).
+
+This new api object would be added to a system table `mz_apis` for later reference.
+
+Users can then add metrics to that endpoint using SQL commands:
+```sql
+CREATE METRIC <name>
+IN API <api>
+AS (TYPE <prometheus_type>,
+    HELP <help_text>,
+    VALUES_FROM <reference_to_view>,
+    VALUE_COLUMN <name_of_value_column>);
+```
+
+This will add a new metric object to a system table `mz_metrics` for later reference:
 ```
 metric_name TEXT,
 metric_type TEXT,
 help TEXT,
-database TEXT,
-schema TEXT,
-view TEXT,
+values_from TEXT,
 value_column_name TEXT
 ```
 
 The `metric_name`, `metric_type`, and `help` fields describe the prometheus metric itself.
 
-The `database`, `schema`, and `view` fields are a reference to a view containing the metric data. The `value_column_name` is the name of a column in that view which contains the value of the metric. All other columns in the view will be used as labels.
+The `values_from` field is a reference to a view containing the metric data. The `value_column_name` is the name of a column in that view which contains the value of the metric. All other columns in the view will be used as labels.
 
 An example metric view:
 ```sql
@@ -64,14 +84,20 @@ This might look like:
 
 The user can then add this metric to their registry:
 ```sql
-INSERT INTO mydatabase.myschema.myprometheus
-VALUES      ('leads',
-             'gauge',
-             'Count of leads and whether they have been converted',
-             'mydatabase',
-             'myschema',
-             'converted_leads',
-             'count')
+CREATE METRIC leads
+IN API mydatabase.myschema.myprometheus
+AS (TYPE 'gauge',
+    HELP 'Count of leads and whether they have been converted',
+    VALUES_FROM mydatabase.myschema.converted_leads,
+    VALUE_COLUMN 'count');
+```
+
+When querying the HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus`, they would then get a response like:
+```
+# HELP leads Count of leads and whether they have been converted
+# TYPE leads gauge
+leads{converted="TRUE"} 22
+leads{converted="FALSE"} 67
 ```
 
 ## Minimal Viable Prototype
@@ -92,3 +118,4 @@ We currently use one of our own in Materialize Cloud, which we wrote after we hi
 
 - Exact syntax and SQL object types. We might want to have dedicated SQL syntax for creating metrics, or have some dedicated reference to the views rather than text fields, for example.
 - How to specify which listener a metrics endpoint is on. Users don't define the listeners configmap, so referencing the names we define there seems a bit weird.
+- Should we require indexed or materialized views?

--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -1,0 +1,94 @@
+# Prometheus Metrics From Queries
+
+## The Problem
+
+Users want to be able to monitor their Materialize workloads and data products.
+Setting up external tools to convert SQL queries into prometheus metrics is labor intensive, error prone, and often buggy.
+
+This also applies to Materialize Cloud, as we run our own external SQL exporter which could be removed if this could be hosted by environmentd.
+
+## Success Criteria
+
+- Users can define SQL queries that get turned into prometheus metrics.
+- Users can group these metrics into HTTP endpoints, so they may have separate scrape configs (for different auth requirements and/or scrape frequency).
+- Materialize Cloud can remove the promsql exporter.
+
+## Out of Scope
+
+- Generic HTTP endpoint creation for formats other than Prometheus.
+
+    While the proposed solution could easily be extended for other API types, that is not required for this to work for prometheus.
+
+## Solution Proposal
+
+Allow users to create HTTP endpoints in SQL with custom prometheus metrics.
+
+```sql
+CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS ON CLUSTER "mycluster" ON LISTENER "external";
+```
+This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on the "external" HTTP listener (as named in the listeners configmap), and a (currently empty) table with the following schema:
+```
+metric_name TEXT,
+metric_type TEXT,
+help TEXT,
+database TEXT,
+schema TEXT,
+view TEXT,
+value_column_name TEXT
+```
+
+The `metric_name`, `metric_type`, and `help` fields describe the prometheus metric itself.
+
+The `database`, `schema`, and `view` fields are a reference to a view containing the metric data. The `value_column_name` is the name of a column in that view which contains the value of the metric. All other columns in the view will be used as labels.
+
+An example metric view:
+```sql
+ CREATE VIEW converted_leads
+AS
+  (SELECT Count(*),
+          converted
+   FROM   (SELECT id,
+                  CASE
+                    WHEN converted_at IS NULL THEN 'FALSE'
+                    ELSE 'TRUE'
+                  END AS converted
+           FROM   leads)
+   GROUP  BY converted);
+```
+
+This might look like:
+| count | converted |
+|-------|-----------|
+|22|TRUE|
+|67|FALSE|
+
+The user can then add this metric to their registry:
+```sql
+INSERT INTO mydatabase.myschema.myprometheus
+VALUES      ('leads',
+             'gauge',
+             'Count of leads and whether they have been converted',
+             'mydatabase',
+             'myschema',
+             'converted_leads',
+             'count')
+```
+
+## Minimal Viable Prototype
+
+- [Hackathon presentation from May 2025](https://docs.google.com/presentation/d/1ek0tOlECHfpoBp_-vtcDWhN4YHpaWBfRuQyENGFbWLw/edit?slide=id.g35c518b4039_14_3503#slide=id.g35c518b4039_14_3503)
+- [Hackathon code from May 2025](https://github.com/MaterializeInc/materialize/compare/main...alex-hunt-materialize:materialize:external_api)
+- [Hackathon brainstorming from May 2025](https://www.notion.so/materialize/Hackathon-Alex-Justin-1f913f48d37b805e88b0e25a8ad1a763)
+
+While not the exact same interface, it captures the idea proposed here.
+
+## Alternatives
+
+External SQL exporters.
+
+We currently use one of our own in Materialize Cloud, which we wrote after we hit numerous problems with third-party ones. We currently still recommend third-party solutions to our customers, which is not ideal.
+
+## Open questions
+
+- Exact syntax and SQL object types. We might want to have dedicated SQL syntax for creating metrics, or have some dedicated reference to the views rather than text fields, for example.
+- How to specify which listener a metrics endpoint is on. Users don't define the listeners configmap, so referencing the names we define there seems a bit weird.

--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -30,11 +30,22 @@ Setting up external tools to convert SQL queries into prometheus metrics is labo
 Allow users to create HTTP endpoints in SQL with custom prometheus metrics.
 
 ```sql
-CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS ON CLUSTER "mycluster";
+CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS IN CLUSTER "mycluster";
 ```
 This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on all HTTP listeners with the `endpoint_api` enabled in the listeners configmap.
 
-This new api object would be added to a system table `mz_apis` for later reference.
+This new api object would be added to a system table `mz_apis` for later reference:
+```
+id TEXT,
+oid OID,
+schema_id TEXT,
+name TEXT,
+cluster_id TEXT,
+owner_id TEXT,
+privileges mz_aclitem[]
+```
+
+The `cluster_id` references the cluster used to peek the metric source relations (corresponds to `mz_clusters.id`).
 
 Users can then add metrics to that endpoint using SQL commands:
 ```sql
@@ -42,22 +53,27 @@ CREATE METRIC <name>
 IN API <api>
 AS (TYPE <prometheus_type>,
     HELP <help_text>,
-    VALUES_FROM <reference_to_view>,
-    VALUE_COLUMN <name_of_value_column>);
+    VALUES FROM <reference_to_view>,
+    VALUE COLUMN <name_of_value_column>);
 ```
 
 This will add a new metric object to a system table `mz_metrics` for later reference:
 ```
-metric_name TEXT,
-metric_type TEXT,
+id TEXT,
+oid OID,
+schema_id TEXT,
+name TEXT,
+api_id TEXT,
+type TEXT,
 help TEXT,
 values_from TEXT,
-value_column_name TEXT
+value_column TEXT,
+owner_id TEXT
 ```
 
-The `metric_name`, `metric_type`, and `help` fields describe the prometheus metric itself.
+The `name`, `type`, and `help` fields describe the prometheus metric itself. `api_id` references the `mz_apis` entry the metric is attached to.
 
-The `values_from` field is a reference to a view containing the metric data. The `value_column_name` is the name of a column in that view which contains the value of the metric. All other columns in the view will be used as labels.
+The `values_from` field is the ID of the relation containing the metric data (corresponds to `mz_catalog.mz_relations.id`). The `value_column` is the name of a column in that relation which contains the value of the metric. All other columns in the relation will be used as labels.
 
 An example metric view:
 ```sql
@@ -86,8 +102,8 @@ CREATE METRIC leads
 IN API mydatabase.myschema.myprometheus
 AS (TYPE 'gauge',
     HELP 'Count of leads and whether they have been converted',
-    VALUES_FROM mydatabase.myschema.converted_leads,
-    VALUE_COLUMN 'count');
+    VALUES FROM mydatabase.myschema.converted_leads,
+    VALUE COLUMN 'count');
 ```
 
 When querying the HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus`, they would then get a response like:

--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -32,7 +32,7 @@ Allow users to create HTTP endpoints in SQL with custom prometheus metrics.
 ```sql
 CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS IN CLUSTER "mycluster";
 ```
-This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on all HTTP listeners with the `endpoint_api` enabled in the listeners configmap.
+This will create an HTTP endpoint at `/api/metrics/custom/mydatabase/myschema/myprometheus` on all HTTP listeners with the `endpoint_api` enabled in the listeners configmap.
 
 This new api object would be added to a system table `mz_apis` for later reference:
 ```
@@ -53,7 +53,7 @@ CREATE METRIC <name>
 IN API <api>
 AS (TYPE <prometheus_type>,
     HELP <help_text>,
-    VALUES FROM <reference_to_view>,
+    SERIES FROM <reference_to_view>,
     VALUE COLUMN <name_of_value_column>);
 ```
 
@@ -66,14 +66,14 @@ name TEXT,
 api_id TEXT,
 type TEXT,
 help TEXT,
-values_from TEXT,
+series_from TEXT,
 value_column TEXT,
 owner_id TEXT
 ```
 
 The `name`, `type`, and `help` fields describe the prometheus metric itself. `api_id` references the `mz_apis` entry the metric is attached to.
 
-The `values_from` field is the ID of the relation containing the metric data (corresponds to `mz_catalog.mz_relations.id`). The `value_column` is the name of a column in that relation which contains the value of the metric. All other columns in the relation will be used as labels.
+The `series_from` field is the ID of the relation containing the metric data (corresponds to `mz_catalog.mz_relations.id`). The `value_column` is the name of a column in that relation which contains the value of the metric. All other columns in the relation will be used as labels.
 
 An example metric view:
 ```sql
@@ -102,11 +102,11 @@ CREATE METRIC leads
 IN API mydatabase.myschema.myprometheus
 AS (TYPE 'gauge',
     HELP 'Count of leads and whether they have been converted',
-    VALUES FROM mydatabase.myschema.converted_leads,
+    SERIES FROM mydatabase.myschema.converted_leads,
     VALUE COLUMN 'count');
 ```
 
-When querying the HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus`, they would then get a response like:
+When querying the HTTP endpoint at `/api/metrics/custom/mydatabase/myschema/myprometheus`, they would then get a response like:
 ```
 # HELP mz_custom_leads Count of leads and whether they have been converted
 # TYPE mz_custom_leads gauge
@@ -115,6 +115,23 @@ mz_custom_leads{converted="FALSE"} 67
 ```
 
 All exposed metric names are prefixed with `mz_custom_` to namespace user-defined metrics and avoid collisions with Materialize's built-in metrics. The prefix is injected at exposition time; the user-supplied metric name (e.g. `leads`) is what appears in `CREATE METRIC` and the `mz_metrics` catalog.
+
+## RBAC
+
+Scrapes do **not** run as the API owner. Each request to `/api/metrics/custom/...` runs as the role that authenticated the HTTP request, exactly as if that role had issued the underlying `SELECT`s itself. On listeners with `authenticator_kind = "None"`, the role is taken from the basic-auth userinfo (the password is not checked); if no username is supplied, the request falls back to the built-in `anonymous_http_user` role.
+
+For a scrape to succeed, the scraping role must hold:
+
+- `USAGE` on the API object,
+- `USAGE` on the API's cluster (the cluster used to peek the metric relations), and
+- `SELECT` on every relation referenced by a metric's `SERIES FROM` (and the `USAGE` on the containing database/schema that `SELECT` already requires).
+
+When a permission is missing, the endpoint fails the whole scrape rather than silently omitting metrics (a partial exposition would otherwise look like a healthy target reporting zero):
+
+- Missing `USAGE` on the API → `404 Not Found`. The API is resolved from the catalog and gated before any query runs; returning `404` rather than `403` means the role cannot distinguish "API exists but you can't see it" from "no such API", matching how Materialize hides objects a role has no access to.
+- Missing `USAGE` on the cluster, or missing `SELECT` on any metric's `SERIES FROM` relation → `403 Forbidden`. Both surface from executing the scrape query as the scraping role (SQLSTATE `42501`, insufficient privilege), so they are not distinguished from each other.
+
+The API-`USAGE` check reuses the same RBAC gating predicate as `CREATE`-time validation (`is_rbac_enforced_for_session`), so scrape-time checks cannot drift from the rules applied when the object was defined, and the cluster/relation checks fall out of running the query itself. This also means the usual escape hatches apply: superusers, system roles, and environments with RBAC disabled bypass these checks.
 
 ## Minimal Viable Prototype
 

--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -108,11 +108,13 @@ AS (TYPE 'gauge',
 
 When querying the HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus`, they would then get a response like:
 ```
-# HELP leads Count of leads and whether they have been converted
-# TYPE leads gauge
-leads{converted="TRUE"} 22
-leads{converted="FALSE"} 67
+# HELP mz_custom_leads Count of leads and whether they have been converted
+# TYPE mz_custom_leads gauge
+mz_custom_leads{converted="TRUE"} 22
+mz_custom_leads{converted="FALSE"} 67
 ```
+
+All exposed metric names are prefixed with `mz_custom_` to namespace user-defined metrics and avoid collisions with Materialize's built-in metrics. The prefix is injected at exposition time; the user-supplied metric name (e.g. `leads`) is what appears in `CREATE METRIC` and the `mz_metrics` catalog.
 
 ## Minimal Viable Prototype
 

--- a/doc/developer/design/20251217_prometheus_metrics_from_queries.md
+++ b/doc/developer/design/20251217_prometheus_metrics_from_queries.md
@@ -5,8 +5,6 @@
 Users want to be able to monitor their Materialize workloads and data products.
 Setting up external tools to convert SQL queries into prometheus metrics is labor intensive, error prone, and often buggy.
 
-This also applies to Materialize Cloud, as we run our own external SQL exporter which could be removed if this could be hosted by environmentd.
-
 ## Success Criteria
 
 - Users can define SQL queries that get turned into prometheus metrics.
@@ -32,9 +30,9 @@ This also applies to Materialize Cloud, as we run our own external SQL exporter 
 Allow users to create HTTP endpoints in SQL with custom prometheus metrics.
 
 ```sql
-CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS ON CLUSTER "mycluster" ON LISTENER "external";
+CREATE API mydatabase.myschema.myprometheus FORMAT PROMETHEUS ON CLUSTER "mycluster";
 ```
-This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on the "external" HTTP listener (as named in the listeners configmap).
+This will create an HTTP endpoint at `/metrics/custom/mydatabase/myschema/myprometheus` on all HTTP listeners with the `endpoint_api` enabled in the listeners configmap.
 
 This new api object would be added to a system table `mz_apis` for later reference.
 
@@ -117,5 +115,4 @@ We currently use one of our own in Materialize Cloud, which we wrote after we hi
 ## Open questions
 
 - Exact syntax and SQL object types. We might want to have dedicated SQL syntax for creating metrics, or have some dedicated reference to the views rather than text fields, for example.
-- How to specify which listener a metrics endpoint is on. Users don't define the listeners configmap, so referencing the names we define there seems a bit weird.
 - Should we require indexed or materialized views?


### PR DESCRIPTION
Design doc for prometheus metrics from queries

### Motivation

Design doc.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
