### PR TITLE
fix durable subscribe documentation

### DIFF
--- a/doc/user/content/transform-data/patterns/durable-subscriptions.md
+++ b/doc/user/content/transform-data/patterns/durable-subscriptions.md
@@ -239,7 +239,7 @@ continuous query against Materialize in your application code:
    updates with timestamp greater than the `AS OF` timestamp. To include updates
    that occurred at the last progress timestamp, subtract `1` from the last
    progress timestamp.
-      
+
    In a similar way, as results come in continuously, buffer the latest results
    in memory until you receive a [progress](/sql/subscribe#progress) message. At that point,
    the data up until the progress message is complete, so you can:

--- a/doc/user/content/transform-data/patterns/durable-subscriptions.md
+++ b/doc/user/content/transform-data/patterns/durable-subscriptions.md
@@ -231,11 +231,14 @@ continuous query against Materialize in your application code:
    SUBSCRIBE (<your query>) WITH (PROGRESS, SNAPSHOT false) AS OF <last_progress_mz_timestamp - 1>;
    ```
 
-   Note the subtraction of one from the last received progress timestamp. The
-   `AS OF` timestamp specifies the time of the snapshot, but since we've set
-   `SNAPSHOT false` we'll only get updates for times stricly greater than the
-   `AS OF` timestamp. By subtracting one we ensure we see the events that happened
-   at exactly the last progress timestamp.
+   Note the subtraction of `1` from the last received progress timestamp. By
+   default (i.e., `SNAPSHOT true`), `SUBSCRIBE` begins by emitting a snapshot at
+   the `AS OF` timestamp (if specified) and then emits subsequent updates as
+   they occur. However, when `SNAPSHOT false` is set, the snapshot is not
+   emitted, and `SUBSCRIBE` emits only updates subsequent to the snapshot; i.e.,
+   updates with timestamp greater than the `AS OF` timestamp. To include updates
+   that occurred at the last progress timestamp, subtract `1` from the last
+   progress timestamp.
       
    In a similar way, as results come in continuously, buffer the latest results
    in memory until you receive a [progress](/sql/subscribe#progress) message. At that point,

--- a/doc/user/content/transform-data/patterns/durable-subscriptions.md
+++ b/doc/user/content/transform-data/patterns/durable-subscriptions.md
@@ -228,9 +228,15 @@ data up until the progress message is complete, so you can:
 continuous query against Materialize in your application code:
 
    ```mzsql
-   SUBSCRIBE (<your query>) WITH (PROGRESS, SNAPSHOT false) AS OF <last_progress_mz_timestamp>;
+   SUBSCRIBE (<your query>) WITH (PROGRESS, SNAPSHOT false) AS OF <last_progress_mz_timestamp - 1>;
    ```
 
+   Note the subtraction of one from the last received progress timestamp. The
+   `AS OF` timestamp specifies the time of the snapshot, but since we've set
+   `SNAPSHOT false` we'll only get updates for times stricly greater than the
+   `AS OF` timestamp. By subtracting one we ensure we see the events that happened
+   at exactly the last progress timestamp.
+      
    In a similar way, as results come in continuously, buffer the latest results
    in memory until you receive a [progress](/sql/subscribe#progress) message. At that point,
    the data up until the progress message is complete, so you can:


### PR DESCRIPTION
Observed by @bkirwi, the current docs instruct users to resume subscriptions in a way that misses any events that happened at exactly the progress message they received.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
