### PR TITLE
storage: add timely step duration metric

### DIFF
--- a/misc/python/materialize/mzcompose/helpers/metrics.py
+++ b/misc/python/materialize/mzcompose/helpers/metrics.py
@@ -1,0 +1,145 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Helpers for working with Prometheus metrics in mzcompose tests."""
+
+from copy import copy
+
+
+class Metrics:
+    """A collection of Prometheus metrics fetched from a service."""
+
+    metrics: dict[str, str]
+
+    def __init__(self, raw: str) -> None:
+        self.metrics = {}
+        for line in raw.splitlines():
+            if line.startswith("#") or not line.strip():
+                continue
+            key, value = line.split(maxsplit=1)
+            self.metrics[key] = value
+
+    def for_instance(self, id: str) -> "Metrics":
+        new = copy(self)
+        new.metrics = {
+            k: v for k, v in self.metrics.items() if f'instance_id="{id}"' in k
+        }
+        return new
+
+    def with_name(self, metric_name: str) -> dict[str, float]:
+        items = {}
+        for key, value in self.metrics.items():
+            if key.startswith(metric_name):
+                items[key] = float(value)
+        return items
+
+    def get_value(self, metric_name: str) -> float:
+        metrics = self.with_name(metric_name)
+        values = list(metrics.values())
+        assert len(values) == 1
+        return values[0]
+
+    def get_summed_value(self, metric_name: str) -> float:
+        metrics = self.with_name(metric_name)
+        return sum(metrics.values())
+
+    def get_command_count(self, metric: str, command_type: str) -> float:
+        metrics = self.with_name(metric)
+        values = [
+            v for k, v in metrics.items() if f'command_type="{command_type}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]
+
+    def get_response_count(self, metric: str, response_type: str) -> float:
+        metrics = self.with_name(metric)
+        values = [
+            v for k, v in metrics.items() if f'response_type="{response_type}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]
+
+    def get_replica_history_command_count(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_compute_replica_history_command_count", command_type
+        )
+
+    def get_compute_controller_history_command_count(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_compute_controller_history_command_count", command_type
+        )
+
+    def get_storage_controller_history_command_count(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_storage_controller_history_command_count", command_type
+        )
+
+    def get_compute_commands_total(self, command_type: str) -> float:
+        return self.get_command_count("mz_compute_commands_total", command_type)
+
+    def get_compute_responses_total(self, response_type: str) -> float:
+        return self.get_response_count("mz_compute_responses_total", response_type)
+
+    def get_storage_commands_total(self, command_type: str) -> float:
+        return self.get_command_count("mz_storage_commands_total", command_type)
+
+    def get_storage_responses_total(self, response_type: str) -> float:
+        return self.get_response_count("mz_storage_responses_total", response_type)
+
+    def get_peeks_total(self, result: str) -> float:
+        metrics = self.with_name("mz_compute_peeks_total")
+        values = [v for k, v in metrics.items() if f'result="{result}"' in k]
+        assert len(values) == 1
+        return values[0]
+
+    def get_wallclock_lag_count(self, collection_id: str) -> float | None:
+        metrics = self.with_name("mz_dataflow_wallclock_lag_seconds_count")
+        values = [
+            v for k, v in metrics.items() if f'collection_id="{collection_id}"' in k
+        ]
+        assert len(values) <= 1
+        return next(iter(values), None)
+
+    def get_e2e_optimization_time(self, object_type: str) -> float:
+        metrics = self.with_name("mz_optimizer_e2e_optimization_time_seconds_sum")
+        values = [v for k, v in metrics.items() if f'object_type="{object_type}"' in k]
+        assert len(values) == 1
+        return values[0]
+
+    def get_pgwire_message_processing_seconds(self, message_type: str) -> float:
+        metrics = self.with_name("mz_pgwire_message_processing_seconds_sum")
+        values = [
+            v for k, v in metrics.items() if f'message_type="{message_type}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]
+
+    def get_result_rows_first_to_last_byte_seconds(self, statement_type: str) -> float:
+        metrics = self.with_name("mz_result_rows_first_to_last_byte_seconds_sum")
+        values = [
+            v for k, v in metrics.items() if f'statement_type="{statement_type}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]
+
+    def get_last_command_received(self, server_name: str) -> float:
+        metrics = self.with_name("mz_grpc_server_last_command_received")
+        values = [v for k, v in metrics.items() if server_name in k]
+        assert len(values) == 1
+        return values[0]
+
+    def get_compute_collection_count(self, type_: str, hydrated: str) -> float:
+        metrics = self.with_name("mz_compute_collection_count")
+        values = [
+            v
+            for k, v in metrics.items()
+            if f'type="{type_}"' in k and f'hydrated="{hydrated}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -132,7 +132,7 @@ impl ComputeMetrics {
             )),
             timely_step_duration_seconds: registry.register(metric!(
                 name: "mz_timely_step_duration_seconds",
-                help: "The time spent in each compute step_or_park call",
+                help: "The time spent in each step_or_park call",
                 const_labels: {"cluster" => "compute"},
                 var_labels: ["worker_id"],
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 32.0),

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -54,6 +54,9 @@ pub struct ComputeMetrics {
     // doesn't do anything to let you pinpoint _which_ operator or worker isn't
     // yielding, but it should hopefully alert us when there is something to
     // look at.
+    //
+    // There is an equivalent metric in the storage server
+    // (`mz_storage::metrics::StorageMetrics`).
     timely_step_duration_seconds: HistogramVec,
     persist_peek_seconds: HistogramVec,
     stashed_peek_seconds: HistogramVec,

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -74,6 +74,9 @@ pub struct StorageMetrics {
     // doesn't do anything to let you pinpoint _which_ operator or worker isn't
     // yielding, but it should hopefully alert us when there is something to
     // look at.
+    //
+    // This mirrors an equivalent metric in the compute server
+    // (`mz_compute::metrics::ComputeMetrics`).
     timely_step_duration_seconds: HistogramVec,
 }
 
@@ -88,6 +91,10 @@ impl StorageMetrics {
             sink_defs: sink::SinkMetricDefs::register_with(registry),
             source_statistics: SourceStatisticsMetricDefs::register_with(registry),
             sink_statistics: SinkStatisticsMetricDefs::register_with(registry),
+            // NB: This metric must have the same name, help text, and label
+            // names as the equivalent metric in `mz_compute::metrics`, as
+            // Prometheus requires identical metadata for metrics with the same
+            // name.
             timely_step_duration_seconds: registry.register(metric!(
                 name: "mz_timely_step_duration_seconds",
                 help: "The time spent in each step_or_park call",

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -90,7 +90,7 @@ impl StorageMetrics {
             sink_statistics: SinkStatisticsMetricDefs::register_with(registry),
             timely_step_duration_seconds: registry.register(metric!(
                 name: "mz_timely_step_duration_seconds",
-                help: "The time spent in each storage step_or_park call",
+                help: "The time spent in each step_or_park call",
                 const_labels: {"cluster" => "storage"},
                 var_labels: ["worker_id"],
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 32.0),

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -30,8 +30,10 @@
 
 use std::sync::Arc;
 
+use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_repr::GlobalId;
+use prometheus::{Histogram, HistogramVec};
 
 use crate::statistics::{SinkStatisticsMetricDefs, SourceStatisticsMetricDefs};
 use mz_storage_operators::metrics::BackpressureMetrics;
@@ -61,6 +63,18 @@ pub struct StorageMetrics {
     // user-facing data.
     pub(crate) source_statistics: SourceStatisticsMetricDefs,
     pub(crate) sink_statistics: SinkStatisticsMetricDefs,
+
+    // Timings.
+    //
+    // Note that this particular metric unfortunately takes some care to
+    // interpret. It measures the duration of step_or_park calls, which
+    // undesirably includes the parking. This is probably fine because we
+    // regularly send progress information through persist sources, which likely
+    // means the parking is capped at a second or two in practice. It also
+    // doesn't do anything to let you pinpoint _which_ operator or worker isn't
+    // yielding, but it should hopefully alert us when there is something to
+    // look at.
+    timely_step_duration_seconds: HistogramVec,
 }
 
 impl StorageMetrics {
@@ -74,6 +88,23 @@ impl StorageMetrics {
             sink_defs: sink::SinkMetricDefs::register_with(registry),
             source_statistics: SourceStatisticsMetricDefs::register_with(registry),
             sink_statistics: SinkStatisticsMetricDefs::register_with(registry),
+            timely_step_duration_seconds: registry.register(metric!(
+                name: "mz_timely_step_duration_seconds",
+                help: "The time spent in each storage step_or_park call",
+                const_labels: {"cluster" => "storage"},
+                var_labels: ["worker_id"],
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+        }
+    }
+
+    /// Get per-worker metrics for the given worker.
+    pub(crate) fn for_worker(&self, worker_id: usize) -> StorageWorkerMetrics {
+        let worker = worker_id.to_string();
+        StorageWorkerMetrics {
+            timely_step_duration_seconds: self
+                .timely_step_duration_seconds
+                .with_label_values(&[&worker]),
         }
     }
 
@@ -203,4 +234,11 @@ impl StorageMetrics {
     ) -> sink::iceberg::IcebergSinkMetrics {
         sink::iceberg::IcebergSinkMetrics::new(&self.sink_defs.iceberg_defs, sink_id, worker_id)
     }
+}
+
+/// Per-worker metrics for storage.
+#[derive(Clone, Debug)]
+pub struct StorageWorkerMetrics {
+    /// Histogram of Timely step timings.
+    pub(crate) timely_step_duration_seconds: Histogram,
 }


### PR DESCRIPTION
Adds `mz_timely_step_duration_seconds` histogram to the storage server, matching the existing metric in the compute server. Moves the `Metrics` class from the cluster mzcompose test to the python module directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)