### PR TITLE
expr: add stack-machine compiled evaluation for MirScalarExpr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6508,6 +6514,7 @@ version = "0.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "bencher",
  "bytes",
  "bytesize",
  "chrono",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -17,6 +17,10 @@ harness = false
 name = "window_functions"
 harness = false
 
+[[bench]]
+name = "static_eval"
+harness = false
+
 [dependencies]
 aho-corasick = "1.1.4"
 anyhow = "1.0.101"
@@ -71,6 +75,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 smallvec = { version = "1.15.1" }
 
 [dev-dependencies]
+bencher = "0.1.5"
 criterion = { version = "0.8.2" }
 datadriven = "0.9.0"
 insta = "1.45"

--- a/src/expr/benches/static_eval.rs
+++ b/src/expr/benches/static_eval.rs
@@ -1,0 +1,353 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks comparing tree-based `MirScalarExpr::eval` with compiled
+//! `CompiledMirScalarExpr::eval`.
+
+use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use mz_repr::{Datum, RowArena, SqlScalarType};
+
+use mz_expr::func::{AddInt32, IsNull, MulInt32, NegInt32, Not};
+use mz_expr::{CompiledMirScalarExpr, MirScalarExpr, VariadicFunc};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn lit_bool(b: bool) -> MirScalarExpr {
+    MirScalarExpr::literal_ok(Datum::from(b), SqlScalarType::Bool)
+}
+
+fn lit_null_bool() -> MirScalarExpr {
+    MirScalarExpr::literal_ok(Datum::Null, SqlScalarType::Bool)
+}
+
+fn lit_i32(v: i32) -> MirScalarExpr {
+    MirScalarExpr::literal_ok(Datum::Int32(v), SqlScalarType::Int32)
+}
+
+fn lit_null_i32() -> MirScalarExpr {
+    MirScalarExpr::literal_ok(Datum::Null, SqlScalarType::Int32)
+}
+
+fn col(c: usize) -> MirScalarExpr {
+    MirScalarExpr::column(c)
+}
+
+// ---------------------------------------------------------------------------
+// Expression builders
+// ---------------------------------------------------------------------------
+
+/// Column(0) — trivial baseline
+fn expr_column() -> MirScalarExpr {
+    col(0)
+}
+
+/// Column(0) + Column(1)
+fn expr_add() -> MirScalarExpr {
+    col(0).call_binary(col(1), AddInt32)
+}
+
+/// (Column(0) + Column(1)) * Column(2)
+fn expr_arith_3() -> MirScalarExpr {
+    col(0)
+        .call_binary(col(1), AddInt32)
+        .call_binary(col(2), MulInt32)
+}
+
+/// NOT(NOT(IS_NULL(Column(0))))
+fn expr_unary_chain() -> MirScalarExpr {
+    col(0).call_unary(IsNull).call_unary(Not).call_unary(Not)
+}
+
+/// IF Column(0) > 0 THEN Column(0) ELSE -Column(0)
+/// Approximated as: IF NOT(IS_NULL(Column(0))) THEN Column(0) ELSE -Column(0)
+fn expr_if() -> MirScalarExpr {
+    MirScalarExpr::If {
+        cond: Box::new(col(0).call_unary(IsNull).call_unary(Not)),
+        then: Box::new(col(0)),
+        els: Box::new(col(0).call_unary(NegInt32)),
+    }
+}
+
+/// AND(Column(0), Column(1), Column(2), Column(3))
+fn expr_and_4() -> MirScalarExpr {
+    MirScalarExpr::CallVariadic {
+        func: VariadicFunc::And,
+        exprs: vec![col(0), col(1), col(2), col(3)],
+    }
+}
+
+/// OR(Column(0), Column(1), Column(2), Column(3))
+fn expr_or_4() -> MirScalarExpr {
+    MirScalarExpr::CallVariadic {
+        func: VariadicFunc::Or,
+        exprs: vec![col(0), col(1), col(2), col(3)],
+    }
+}
+
+/// COALESCE(Column(0), Column(1), Column(2), Literal(42))
+fn expr_coalesce() -> MirScalarExpr {
+    MirScalarExpr::CallVariadic {
+        func: VariadicFunc::Coalesce,
+        exprs: vec![col(0), col(1), col(2), lit_i32(42)],
+    }
+}
+
+/// GREATEST(Column(0), Column(1), Column(2), Column(3))
+fn expr_greatest() -> MirScalarExpr {
+    MirScalarExpr::CallVariadic {
+        func: VariadicFunc::Greatest,
+        exprs: vec![col(0), col(1), col(2), col(3)],
+    }
+}
+
+/// Nested: IF AND(Col0, Col1) THEN COALESCE(Col2, Col3, 0) ELSE Greatest(Col2, Col3)
+fn expr_nested() -> MirScalarExpr {
+    MirScalarExpr::If {
+        cond: Box::new(MirScalarExpr::CallVariadic {
+            func: VariadicFunc::And,
+            exprs: vec![col(0), col(1)],
+        }),
+        then: Box::new(MirScalarExpr::CallVariadic {
+            func: VariadicFunc::Coalesce,
+            exprs: vec![col(2), col(3), lit_i32(0)],
+        }),
+        els: Box::new(MirScalarExpr::CallVariadic {
+            func: VariadicFunc::Greatest,
+            exprs: vec![col(2), col(3)],
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark runner
+// ---------------------------------------------------------------------------
+
+/// Benchmark tree eval over many rows.
+fn bench_tree(bencher: &mut Bencher, expr: &MirScalarExpr, rows: &[Vec<Datum<'static>>]) {
+    let arena = RowArena::new();
+    bencher.iter(|| {
+        for row in rows {
+            bencher::black_box(expr.eval(row, &arena));
+        }
+    });
+}
+
+/// Benchmark compiled eval over many rows (compilation cost excluded).
+/// Uses `eval_with_stack` to amortize stack allocation across rows.
+fn bench_compiled(
+    bencher: &mut Bencher,
+    compiled: &CompiledMirScalarExpr,
+    rows: &[Vec<Datum<'static>>],
+) {
+    let arena = RowArena::new();
+    let mut stack = Vec::new();
+    bencher.iter(|| {
+        for row in rows {
+            bencher::black_box(compiled.eval_with_stack(row, &arena, &mut stack));
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Row data
+// ---------------------------------------------------------------------------
+
+const N: usize = 1024;
+
+fn int_rows() -> Vec<Vec<Datum<'static>>> {
+    (0..N)
+        .map(|i| {
+            vec![
+                Datum::Int32(i as i32),
+                Datum::Int32((i * 7 + 3) as i32),
+                Datum::Int32((i * 13 + 1) as i32),
+                Datum::Int32((i * 31) as i32),
+            ]
+        })
+        .collect()
+}
+
+fn bool_rows() -> Vec<Vec<Datum<'static>>> {
+    (0..N)
+        .map(|i| {
+            vec![
+                Datum::from(i % 2 == 0),
+                Datum::from(i % 3 == 0),
+                Datum::from(i % 5 == 0),
+                Datum::from(i % 7 == 0),
+            ]
+        })
+        .collect()
+}
+
+fn nullable_int_rows() -> Vec<Vec<Datum<'static>>> {
+    (0..N)
+        .map(|i| {
+            vec![
+                if i % 3 == 0 {
+                    Datum::Null
+                } else {
+                    Datum::Int32(i as i32)
+                },
+                if i % 5 == 0 {
+                    Datum::Null
+                } else {
+                    Datum::Int32((i * 7) as i32)
+                },
+                if i % 7 == 0 {
+                    Datum::Null
+                } else {
+                    Datum::Int32((i * 13) as i32)
+                },
+                Datum::Int32((i * 31) as i32),
+            ]
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Individual benchmarks
+// ---------------------------------------------------------------------------
+
+fn column_tree(b: &mut Bencher) {
+    let expr = expr_column();
+    bench_tree(b, &expr, &int_rows());
+}
+fn column_compiled(b: &mut Bencher) {
+    let expr = expr_column();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
+fn add_tree(b: &mut Bencher) {
+    let expr = expr_add();
+    bench_tree(b, &expr, &int_rows());
+}
+fn add_compiled(b: &mut Bencher) {
+    let expr = expr_add();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
+fn arith3_tree(b: &mut Bencher) {
+    let expr = expr_arith_3();
+    bench_tree(b, &expr, &int_rows());
+}
+fn arith3_compiled(b: &mut Bencher) {
+    let expr = expr_arith_3();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
+fn unary_chain_tree(b: &mut Bencher) {
+    let expr = expr_unary_chain();
+    bench_tree(b, &expr, &int_rows());
+}
+fn unary_chain_compiled(b: &mut Bencher) {
+    let expr = expr_unary_chain();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
+fn if_tree(b: &mut Bencher) {
+    let expr = expr_if();
+    bench_tree(b, &expr, &int_rows());
+}
+fn if_compiled(b: &mut Bencher) {
+    let expr = expr_if();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
+fn and4_tree(b: &mut Bencher) {
+    let expr = expr_and_4();
+    bench_tree(b, &expr, &bool_rows());
+}
+fn and4_compiled(b: &mut Bencher) {
+    let expr = expr_and_4();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &bool_rows());
+}
+
+fn or4_tree(b: &mut Bencher) {
+    let expr = expr_or_4();
+    bench_tree(b, &expr, &bool_rows());
+}
+fn or4_compiled(b: &mut Bencher) {
+    let expr = expr_or_4();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &bool_rows());
+}
+
+fn coalesce_tree(b: &mut Bencher) {
+    let expr = expr_coalesce();
+    bench_tree(b, &expr, &nullable_int_rows());
+}
+fn coalesce_compiled(b: &mut Bencher) {
+    let expr = expr_coalesce();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &nullable_int_rows());
+}
+
+fn greatest_tree(b: &mut Bencher) {
+    let expr = expr_greatest();
+    bench_tree(b, &expr, &nullable_int_rows());
+}
+fn greatest_compiled(b: &mut Bencher) {
+    let expr = expr_greatest();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &nullable_int_rows());
+}
+
+fn nested_tree(b: &mut Bencher) {
+    let expr = expr_nested();
+    bench_tree(b, &expr, &bool_rows());
+}
+fn nested_compiled(b: &mut Bencher) {
+    let expr = expr_nested();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &bool_rows());
+}
+
+// ---------------------------------------------------------------------------
+// Groups & main
+// ---------------------------------------------------------------------------
+
+benchmark_group!(
+    tree,
+    column_tree,
+    add_tree,
+    arith3_tree,
+    unary_chain_tree,
+    if_tree,
+    and4_tree,
+    or4_tree,
+    coalesce_tree,
+    greatest_tree,
+    nested_tree,
+);
+
+benchmark_group!(
+    compiled,
+    column_compiled,
+    add_compiled,
+    arith3_compiled,
+    unary_chain_compiled,
+    if_compiled,
+    and4_compiled,
+    or4_compiled,
+    coalesce_compiled,
+    greatest_compiled,
+    nested_compiled,
+);
+
+benchmark_main!(tree, compiled);

--- a/src/expr/benches/static_eval.rs
+++ b/src/expr/benches/static_eval.rs
@@ -109,6 +109,15 @@ fn expr_greatest() -> MirScalarExpr {
     }
 }
 
+/// Deep: 1024-deep left-leaning adds: ((((1 + 1) + 1) + 1) ... + 1)
+fn expr_deep_add() -> MirScalarExpr {
+    let mut expr = lit_i32(1);
+    for _ in 0..1023 {
+        expr = expr.call_binary(lit_i32(1), AddInt32);
+    }
+    expr
+}
+
 /// Nested: IF AND(Col0, Col1) THEN COALESCE(Col2, Col3, 0) ELSE Greatest(Col2, Col3)
 fn expr_nested() -> MirScalarExpr {
     MirScalarExpr::If {
@@ -308,6 +317,16 @@ fn greatest_compiled(b: &mut Bencher) {
     bench_compiled(b, &compiled, &nullable_int_rows());
 }
 
+fn deep_add_tree(b: &mut Bencher) {
+    let expr = expr_deep_add();
+    bench_tree(b, &expr, &int_rows());
+}
+fn deep_add_compiled(b: &mut Bencher) {
+    let expr = expr_deep_add();
+    let compiled = CompiledMirScalarExpr::from(&expr);
+    bench_compiled(b, &compiled, &int_rows());
+}
+
 fn nested_tree(b: &mut Bencher) {
     let expr = expr_nested();
     bench_tree(b, &expr, &bool_rows());
@@ -333,6 +352,7 @@ benchmark_group!(
     or4_tree,
     coalesce_tree,
     greatest_tree,
+    deep_add_tree,
     nested_tree,
 );
 
@@ -347,6 +367,7 @@ benchmark_group!(
     or4_compiled,
     coalesce_compiled,
     greatest_compiled,
+    deep_add_compiled,
     nested_compiled,
 );
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -22,6 +22,7 @@ mod interpret;
 mod linear;
 mod relation;
 mod scalar;
+mod static_eval;
 
 pub mod explain;
 pub mod row;
@@ -49,6 +50,7 @@ pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, Variad
 pub use scalar::{
     EvalError, FilterCharacteristics, MirScalarExpr, ProtoDomainLimit, ProtoEvalError, like_pattern,
 };
+pub use static_eval::CompiledMirScalarExpr;
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an
 /// `transform::Optimizer`.

--- a/src/expr/src/scalar/func/binary.rs
+++ b/src/expr/src/scalar/func/binary.rs
@@ -23,6 +23,24 @@ pub(crate) trait LazyBinaryFunc {
         temp_storage: &'a RowArena,
         a: &'a MirScalarExpr,
         b: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        self.eval_input(
+            temp_storage,
+            a.eval(datums, temp_storage),
+            b.eval(datums, temp_storage),
+        )
+    }
+
+    /// Evaluate this function on already-evaluated input datums.
+    ///
+    /// This is the primary evaluation entry point for compiled/stack-machine
+    /// evaluation, where the input expressions have already been evaluated
+    /// before the function is applied.
+    fn eval_input<'a>(
+        &'a self,
+        temp_storage: &'a RowArena,
+        a: Result<Datum<'a>, EvalError>,
+        b: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError>;
 
     /// The output SqlColumnType of this function.
@@ -112,16 +130,13 @@ pub(crate) trait EagerBinaryFunc<'a> {
 }
 
 impl<T: for<'a> EagerBinaryFunc<'a>> LazyBinaryFunc for T {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
-        b: &'a MirScalarExpr,
+        a: Result<Datum<'a>, EvalError>,
+        b: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
-        let b = b.eval(datums, temp_storage)?;
-        let a = match T::Input1::try_from_result(Ok(a)) {
+        let a = match T::Input1::try_from_result(a) {
             // If we can convert to the input type then we call the function
             Ok(input) => input,
             // If we can't and we got a non-null datum something went wrong in the planner
@@ -131,7 +146,7 @@ impl<T: for<'a> EagerBinaryFunc<'a>> LazyBinaryFunc for T {
             // Otherwise we just propagate NULLs and errors
             Err(res) => return res,
         };
-        let b = match T::Input2::try_from_result(Ok(b)) {
+        let b = match T::Input2::try_from_result(b) {
             // If we can convert to the input type then we call the function
             Ok(input) => input,
             // If we can't and we got a non-null datum something went wrong in the planner

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -21,13 +21,12 @@ use crate::{EvalError, MirScalarExpr};
 pub struct CastArrayToListOneDim;
 
 impl LazyUnaryFunc for CastArrayToListOneDim {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -93,13 +92,12 @@ pub struct CastArrayToString {
 }
 
 impl LazyUnaryFunc for CastArrayToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -147,11 +145,10 @@ pub struct CastArrayToJsonb {
 }
 
 impl LazyUnaryFunc for CastArrayToJsonb {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
         fn pack<'a>(
             temp_storage: &RowArena,
@@ -182,7 +179,7 @@ impl LazyUnaryFunc for CastArrayToJsonb {
             })
         }
 
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -225,6 +222,14 @@ impl LazyUnaryFunc for CastArrayToJsonb {
     fn is_monotone(&self) -> bool {
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_element]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_element]
+    }
 }
 
 impl fmt::Display for CastArrayToJsonb {
@@ -243,13 +248,12 @@ pub struct CastArrayToArray {
 }
 
 impl LazyUnaryFunc for CastArrayToArray {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -288,6 +292,14 @@ impl LazyUnaryFunc for CastArrayToArray {
 
     fn is_monotone(&self) -> bool {
         false
+    }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -14,7 +14,7 @@ use mz_repr::{Datum, RowArena, SqlColumnType, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
 use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
-use crate::{EvalError, MirScalarExpr};
+use crate::EvalError;
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastInt2VectorToArray;
@@ -22,13 +22,12 @@ pub struct CastInt2VectorToArray;
 // This could be simplified to an EagerUnaryFunc once we have
 // auto-parameterization of array built-in functions.
 impl LazyUnaryFunc for CastInt2VectorToArray {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        a.eval(datums, temp_storage)
+        input
     }
 
     /// The output SqlColumnType of this function
@@ -70,13 +69,12 @@ impl fmt::Display for CastInt2VectorToArray {
 pub struct CastInt2VectorToString;
 
 impl LazyUnaryFunc for CastInt2VectorToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -23,13 +23,12 @@ pub struct CastListToString {
 }
 
 impl LazyUnaryFunc for CastListToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -76,13 +75,12 @@ pub struct CastListToJsonb {
 }
 
 impl LazyUnaryFunc for CastListToJsonb {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -125,6 +123,14 @@ impl LazyUnaryFunc for CastListToJsonb {
     fn is_monotone(&self) -> bool {
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_element]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_element]
+    }
 }
 
 impl fmt::Display for CastListToJsonb {
@@ -144,13 +150,12 @@ pub struct CastList1ToList2 {
 }
 
 impl LazyUnaryFunc for CastList1ToList2 {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -191,6 +196,14 @@ impl LazyUnaryFunc for CastList1ToList2 {
     fn is_monotone(&self) -> bool {
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
+    }
 }
 
 impl fmt::Display for CastList1ToList2 {
@@ -203,13 +216,12 @@ impl fmt::Display for CastList1ToList2 {
 pub struct ListLength;
 
 impl LazyUnaryFunc for ListLength {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -15,7 +15,7 @@ use mz_repr::{Datum, RowArena, SqlColumnType, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
 use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
-use crate::{EvalError, MirScalarExpr};
+use crate::EvalError;
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastMapToString {
@@ -23,13 +23,12 @@ pub struct CastMapToString {
 }
 
 impl LazyUnaryFunc for CastMapToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -74,13 +73,12 @@ impl fmt::Display for CastMapToString {
 pub struct MapLength;
 
 impl LazyUnaryFunc for MapLength {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -128,13 +126,12 @@ pub struct MapBuildFromRecordList {
 }
 
 impl LazyUnaryFunc for MapBuildFromRecordList {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -16,7 +16,7 @@ use mz_repr::{Datum, RowArena, SqlColumnType, SqlScalarType};
 use serde::{Deserialize, Serialize};
 
 use crate::scalar::func::{LazyUnaryFunc, stringify_datum};
-use crate::{EvalError, MirScalarExpr};
+use crate::EvalError;
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct CastRangeToString {
@@ -24,13 +24,12 @@ pub struct CastRangeToString {
 }
 
 impl LazyUnaryFunc for CastRangeToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -75,13 +74,12 @@ impl fmt::Display for CastRangeToString {
 pub struct RangeLower;
 
 impl LazyUnaryFunc for RangeLower {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -130,13 +128,12 @@ impl fmt::Display for RangeLower {
 pub struct RangeUpper;
 
 impl LazyUnaryFunc for RangeUpper {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -23,13 +23,12 @@ pub struct CastRecordToString {
 }
 
 impl LazyUnaryFunc for CastRecordToString {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -79,13 +78,12 @@ pub struct CastRecord1ToRecord2 {
 }
 
 impl LazyUnaryFunc for CastRecord1ToRecord2 {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -125,6 +123,14 @@ impl LazyUnaryFunc for CastRecord1ToRecord2 {
         // track enough information to make that call, though!
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        self.cast_exprs.iter().collect()
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        self.cast_exprs.iter_mut().collect()
+    }
 }
 
 impl fmt::Display for CastRecord1ToRecord2 {
@@ -137,13 +143,12 @@ impl fmt::Display for CastRecord1ToRecord2 {
 pub struct RecordGet(pub usize);
 
 impl LazyUnaryFunc for RecordGet {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
-        temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        _temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -304,13 +304,12 @@ pub struct CastStringToArray {
 }
 
 impl LazyUnaryFunc for CastStringToArray {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -359,6 +358,14 @@ impl LazyUnaryFunc for CastStringToArray {
     fn is_monotone(&self) -> bool {
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
+    }
 }
 
 impl fmt::Display for CastStringToArray {
@@ -377,13 +384,12 @@ pub struct CastStringToList {
 }
 
 impl LazyUnaryFunc for CastStringToList {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -438,6 +444,14 @@ impl LazyUnaryFunc for CastStringToList {
     fn is_monotone(&self) -> bool {
         false
     }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
+    }
 }
 
 impl fmt::Display for CastStringToList {
@@ -456,13 +470,12 @@ pub struct CastStringToMap {
 }
 
 impl LazyUnaryFunc for CastStringToMap {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -522,6 +535,14 @@ impl LazyUnaryFunc for CastStringToMap {
 
     fn is_monotone(&self) -> bool {
         false
+    }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
     }
 }
 
@@ -595,13 +616,12 @@ pub struct CastStringToRange {
 }
 
 impl LazyUnaryFunc for CastStringToRange {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -653,6 +673,14 @@ impl LazyUnaryFunc for CastStringToRange {
 
     fn is_monotone(&self) -> bool {
         false
+    }
+
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![&self.cast_expr]
+    }
+
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![&mut self.cast_expr]
     }
 }
 
@@ -732,13 +760,12 @@ static INT2VECTOR_CAST_EXPR: LazyLock<MirScalarExpr> = LazyLock::new(|| MirScala
 pub struct CastStringToInt2Vector;
 
 impl LazyUnaryFunc for CastStringToInt2Vector {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let a = a.eval(datums, temp_storage)?;
+        let a = input?;
         if a.is_null() {
             return Ok(Datum::Null);
         }
@@ -937,13 +964,12 @@ impl fmt::Display for IsRegexpMatch {
 pub struct RegexpMatch(pub Regex);
 
 impl LazyUnaryFunc for RegexpMatch {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let haystack = a.eval(datums, temp_storage)?;
+        let haystack = input?;
         if haystack.is_null() {
             return Ok(Datum::Null);
         }
@@ -995,13 +1021,12 @@ impl fmt::Display for RegexpMatch {
 pub struct RegexpSplitToArray(pub Regex);
 
 impl LazyUnaryFunc for RegexpSplitToArray {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let haystack = a.eval(datums, temp_storage)?;
+        let haystack = input?;
         if haystack.is_null() {
             return Ok(Datum::Null);
         }
@@ -1058,13 +1083,12 @@ fn panic<'a>(a: &'a str) -> String {
 pub struct QuoteIdent;
 
 impl LazyUnaryFunc for QuoteIdent {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        let d = a.eval(datums, temp_storage)?;
+        let d = input?;
         if d.is_null() {
             return Ok(Datum::Null);
         }

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -262,6 +262,17 @@ macro_rules! derive_binary {
                 }
             }
 
+            pub fn eval_input<'a>(
+                &'a self,
+                temp_storage: &'a RowArena,
+                a: Result<Datum<'a>, EvalError>,
+                b: Result<Datum<'a>, EvalError>,
+            ) -> Result<Datum<'a>, EvalError> {
+                match self {
+                    $(Self::$name(f) => LazyBinaryFunc::eval_input(f, temp_storage, a, b),)*
+                }
+            }
+
             pub fn output_type(
                 &self,
                 input_type_a: SqlColumnType,

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -162,6 +162,16 @@ macro_rules! derive_unary {
                 }
             }
 
+            pub fn eval_input<'a>(
+                &'a self,
+                temp_storage: &'a RowArena,
+                input: Result<Datum<'a>, EvalError>,
+            ) -> Result<Datum<'a>, EvalError> {
+                match self {
+                    $(Self::$name(f) => LazyUnaryFunc::eval_input(f, temp_storage, input),)*
+                }
+            }
+
             pub fn output_type(&self, input_type: SqlColumnType) -> SqlColumnType {
                 match self {
                     $(Self::$name(f) => LazyUnaryFunc::output_type(f, input_type),)*
@@ -195,6 +205,16 @@ macro_rules! derive_unary {
             pub fn could_error(&self) -> bool {
                 match self {
                     $(Self::$name(f) => LazyUnaryFunc::could_error(f),)*
+                }
+            }
+            pub fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+                match self {
+                    $(Self::$name(f) => LazyUnaryFunc::embedded_exprs(f),)*
+                }
+            }
+            pub fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+                match self {
+                    $(Self::$name(f) => LazyUnaryFunc::embedded_exprs_mut(f),)*
                 }
             }
         }

--- a/src/expr/src/scalar/func/unary.rs
+++ b/src/expr/src/scalar/func/unary.rs
@@ -28,6 +28,19 @@ pub trait LazyUnaryFunc {
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
         a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        self.eval_input(temp_storage, a.eval(datums, temp_storage))
+    }
+
+    /// Evaluate this function on an already-evaluated input datum.
+    ///
+    /// This is the primary evaluation entry point for compiled/stack-machine
+    /// evaluation, where the input expression has already been evaluated
+    /// before the function is applied.
+    fn eval_input<'a>(
+        &'a self,
+        temp_storage: &'a RowArena,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError>;
 
     /// The output SqlColumnType of this function.
@@ -95,6 +108,21 @@ pub trait LazyUnaryFunc {
     /// This property describes the behaviour of the function over ranges where the function is defined:
     /// ie. the argument and the result are non-error datums.
     fn is_monotone(&self) -> bool;
+
+    /// Returns any embedded sub-expressions that this function applies
+    /// internally (e.g., element cast expressions in compound-cast functions).
+    ///
+    /// Most functions have no embedded expressions. Functions like
+    /// `CastList1ToList2` or `CastRecord1ToRecord2` contain inner
+    /// `MirScalarExpr` trees that are applied per-element of a compound value.
+    fn embedded_exprs(&self) -> Vec<&MirScalarExpr> {
+        vec![]
+    }
+
+    /// Like [`Self::embedded_exprs`], but returns mutable references.
+    fn embedded_exprs_mut(&mut self) -> Vec<&mut MirScalarExpr> {
+        vec![]
+    }
 }
 
 /// A description of an SQL unary function that operates on eagerly evaluated expressions
@@ -139,13 +167,12 @@ pub trait EagerUnaryFunc<'a> {
 }
 
 impl<T: for<'a> EagerUnaryFunc<'a>> LazyUnaryFunc for T {
-    fn eval<'a>(
+    fn eval_input<'a>(
         &'a self,
-        datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        input: Result<Datum<'a>, EvalError>,
     ) -> Result<Datum<'a>, EvalError> {
-        match T::Input::try_from_result(a.eval(datums, temp_storage)) {
+        match T::Input::try_from_result(input) {
             // If we can convert to the input type then we call the function
             Ok(input) => self.call(input).into_result(temp_storage),
             // If we can't and we got a non-null datum something went wrong in the planner

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -1209,42 +1209,54 @@ impl VariadicFunc {
             return Ok(Datum::Null);
         }
 
-        // Evaluate eager functions
+        self.eval_eager(&ds, temp_storage)
+    }
+
+    /// Evaluate this eager variadic function with pre-evaluated datum values.
+    ///
+    /// Callers must handle null propagation before calling this method.
+    /// Panics for lazy/short-circuiting variadics (Coalesce, Greatest, Least,
+    /// And, Or, ErrorIfNull).
+    pub fn eval_eager<'a>(
+        &'a self,
+        ds: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+    ) -> Result<Datum<'a>, EvalError> {
         match self {
             VariadicFunc::Coalesce
             | VariadicFunc::Greatest
             | VariadicFunc::And
             | VariadicFunc::Or
             | VariadicFunc::ErrorIfNull
-            | VariadicFunc::Least => unreachable!(),
-            VariadicFunc::Concat => text_concat_variadic(&ds, temp_storage),
-            VariadicFunc::ConcatWs => text_concat_ws(&ds, temp_storage),
-            VariadicFunc::MakeTimestamp => make_timestamp(&ds),
-            VariadicFunc::PadLeading => pad_leading(&ds, temp_storage),
-            VariadicFunc::Substr => substr(&ds),
-            VariadicFunc::Replace => replace(&ds, temp_storage),
-            VariadicFunc::Translate => Ok(translate(&ds, temp_storage)),
-            VariadicFunc::JsonbBuildArray => Ok(jsonb_build_array(&ds, temp_storage)),
-            VariadicFunc::JsonbBuildObject => jsonb_build_object(&ds, temp_storage),
-            VariadicFunc::MapBuild { .. } => Ok(map_build(&ds, temp_storage)),
+            | VariadicFunc::Least => unreachable!("called eval_eager on a lazy variadic"),
+            VariadicFunc::Concat => text_concat_variadic(ds, temp_storage),
+            VariadicFunc::ConcatWs => text_concat_ws(ds, temp_storage),
+            VariadicFunc::MakeTimestamp => make_timestamp(ds),
+            VariadicFunc::PadLeading => pad_leading(ds, temp_storage),
+            VariadicFunc::Substr => substr(ds),
+            VariadicFunc::Replace => replace(ds, temp_storage),
+            VariadicFunc::Translate => Ok(translate(ds, temp_storage)),
+            VariadicFunc::JsonbBuildArray => Ok(jsonb_build_array(ds, temp_storage)),
+            VariadicFunc::JsonbBuildObject => jsonb_build_object(ds, temp_storage),
+            VariadicFunc::MapBuild { .. } => Ok(map_build(ds, temp_storage)),
             VariadicFunc::ArrayCreate {
                 elem_type: SqlScalarType::Array(_),
-            } => array_create_multidim(&ds, temp_storage),
-            VariadicFunc::ArrayCreate { .. } => array_create_scalar(&ds, temp_storage),
+            } => array_create_multidim(ds, temp_storage),
+            VariadicFunc::ArrayCreate { .. } => array_create_scalar(ds, temp_storage),
             VariadicFunc::ArrayToString { elem_type } => {
-                array_to_string(&ds, elem_type, temp_storage)
+                array_to_string(ds, elem_type, temp_storage)
             }
-            VariadicFunc::ArrayIndex { offset } => Ok(array_index(&ds, *offset)),
+            VariadicFunc::ArrayIndex { offset } => Ok(array_index(ds, *offset)),
 
             VariadicFunc::ListCreate { .. } | VariadicFunc::RecordCreate { .. } => {
-                Ok(list_create(&ds, temp_storage))
+                Ok(list_create(ds, temp_storage))
             }
-            VariadicFunc::ListIndex => Ok(list_index(&ds)),
-            VariadicFunc::ListSliceLinear => Ok(list_slice_linear(&ds, temp_storage)),
-            VariadicFunc::SplitPart => split_part(&ds),
-            VariadicFunc::RegexpMatch => regexp_match_dynamic(&ds, temp_storage),
-            VariadicFunc::HmacString => hmac_string(&ds, temp_storage),
-            VariadicFunc::HmacBytes => hmac_bytes(&ds, temp_storage),
+            VariadicFunc::ListIndex => Ok(list_index(ds)),
+            VariadicFunc::ListSliceLinear => Ok(list_slice_linear(ds, temp_storage)),
+            VariadicFunc::SplitPart => split_part(ds),
+            VariadicFunc::RegexpMatch => regexp_match_dynamic(ds, temp_storage),
+            VariadicFunc::HmacString => hmac_string(ds, temp_storage),
+            VariadicFunc::HmacBytes => hmac_bytes(ds, temp_storage),
             VariadicFunc::DateBinTimestamp => date_bin(
                 ds[0].unwrap_interval(),
                 ds[1].unwrap_timestamp(),
@@ -1261,11 +1273,11 @@ impl VariadicFunc {
             VariadicFunc::DateDiffTimestampTz => date_diff_timestamptz(ds[0], ds[1], ds[2]),
             VariadicFunc::DateDiffDate => date_diff_date(ds[0], ds[1], ds[2]),
             VariadicFunc::DateDiffTime => date_diff_time(ds[0], ds[1], ds[2]),
-            VariadicFunc::RangeCreate { .. } => create_range(&ds, temp_storage),
-            VariadicFunc::MakeAclItem => make_acl_item(&ds),
-            VariadicFunc::MakeMzAclItem => make_mz_acl_item(&ds),
-            VariadicFunc::ArrayPosition => array_position(&ds),
-            VariadicFunc::ArrayFill { .. } => array_fill(&ds, temp_storage),
+            VariadicFunc::RangeCreate { .. } => create_range(ds, temp_storage),
+            VariadicFunc::MakeAclItem => make_acl_item(ds),
+            VariadicFunc::MakeMzAclItem => make_mz_acl_item(ds),
+            VariadicFunc::ArrayPosition => array_position(ds),
+            VariadicFunc::ArrayFill { .. } => array_fill(ds, temp_storage),
             VariadicFunc::TimezoneTime => parse_timezone(ds[0].unwrap_str(), TimezoneSpec::Posix)
                 .map(|tz| {
                     timezone_time(
@@ -1283,7 +1295,7 @@ impl VariadicFunc {
                 };
                 regexp_split_to_array(ds[0], ds[1], flags, temp_storage)
             }
-            VariadicFunc::RegexpReplace => regexp_replace_dynamic(&ds, temp_storage),
+            VariadicFunc::RegexpReplace => regexp_replace_dynamic(ds, temp_storage),
             VariadicFunc::StringToArray => {
                 let null_string = if ds.len() == 2 { Datum::Null } else { ds[2] };
 

--- a/src/expr/src/static_eval.rs
+++ b/src/expr/src/static_eval.rs
@@ -7,16 +7,38 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Stack-machine-based compiled evaluation of [`MirScalarExpr`].
+//! Compiles a [`MirScalarExpr`] tree into a flat [`CompiledMirScalarExpr`]
+//! instruction sequence, evaluated by a stack machine with a program counter.
 //!
-//! [`CompiledMirScalarExpr`] is a flat instruction sequence compiled from a
-//! [`MirScalarExpr`] tree. It avoids recursive descent through the AST during
-//! evaluation, replacing it with a linear instruction sequence with branching.
+//! # Execution model
 //!
-//! Compound-cast functions (e.g., `CastList1ToList2`, `CastArrayToArray`)
-//! that iterate over collection elements and apply a sub-expression per element
-//! are represented as dedicated instructions, with the inner cast expressions
-//! compiled into sub-programs.
+//! A value stack holds `Result<Datum, EvalError>` entries. Each instruction
+//! pops its inputs, computes, and pushes its output. Branch instructions
+//! (`Skip`, `SkipIfNotTrue`, and the variadic step instructions) modify the
+//! program counter instead of always advancing by one.
+//!
+//! # Compilation
+//!
+//! The expression tree is lowered iteratively using a work stack of
+//! `PendingItem`s (either sub-expressions to recurse into, or
+//! `LabeledInstruction`s to emit). Items are pushed in **reverse execution
+//! order** because the work stack is LIFO. A label-resolution pass then
+//! converts symbolic labels to relative PC offsets.
+//!
+//! # Instruction categories
+//!
+//! - **Leaf**: `Column`, `Literal`, `CallUnmaterializable`.
+//! - **Unary/Binary**: `CallUnary`, `CallBinary` — pop operands, push result.
+//! - **Branching (If)**: `SkipIfNotTrue` (two offsets: false branch, error
+//!   escape) + `Skip` (unconditional jump past else).
+//! - **Inlined variadics**: And/Or use an accumulator on the stack with
+//!   `AndStep`/`OrStep` (short-circuit + three-way null/error merge).
+//!   `Coalesce` and `ErrorIfNull` use `SkipIfNotNull` + `RaiseIfNullError`.
+//!   `Greatest`/`Least` use `GreatestStep`/`LeastStep` with a null
+//!   accumulator. All other (eager) variadics use `CallEagerVariadic`.
+//! - **Compound casts**: `MapListElements`, `MapArrayElements`, `MapRecord`,
+//!   `MapListToJsonb`, `MapArrayToJsonb`, `ParseAndCast` — these contain
+//!   compiled sub-programs applied per collection element.
 
 use std::borrow::Cow;
 use std::sync::LazyLock;
@@ -60,10 +82,6 @@ enum Instruction {
     /// Pop 2 values (first-pushed = left), apply binary function, push result.
     /// Uses `COL_0`/`COL_1` static references to call `BinaryFunc::eval`.
     CallBinary(BinaryFunc),
-    /// Evaluate a variadic function. Non-eager variadics (And, Or, Coalesce,
-    /// etc.) receive their operands as compiled sub-programs since they may
-    /// short-circuit. Eager variadics have their operands as sub-programs too.
-    CallVariadic(Box<(VariadicFunc, Box<[CompiledMirScalarExpr]>)>),
     /// Push an error for an unmaterializable function.
     CallUnmaterializable(UnmaterializableFunc),
     /// Unconditional relative jump. `pc += offset`.
@@ -73,6 +91,33 @@ enum Instruction {
     SkipIfNotTrue {
         false_offset: isize,
         error_offset: isize,
+    },
+
+    // -- Inlined variadic instructions --
+
+    /// Pop operand and accumulator for `And`. If operand is False, push False
+    /// and jump to end. Otherwise merge into accumulator (error > null > true).
+    AndStep(isize),
+    /// Pop operand and accumulator for `Or`. If operand is True, push True
+    /// and jump to end. Otherwise merge into accumulator (error > null > false).
+    OrStep(isize),
+    /// Pop value for `Coalesce`/`ErrorIfNull`. If non-null (including errors),
+    /// push back and jump to end. If null, discard and continue.
+    SkipIfNotNull(isize),
+    /// Pop operand and accumulator for `Greatest`. If operand is an error,
+    /// push error and jump to end. If null, keep accumulator. Otherwise push
+    /// the greater of operand and accumulator.
+    GreatestStep(isize),
+    /// Pop operand and accumulator for `Least`. Same as GreatestStep but keeps
+    /// the lesser value.
+    LeastStep(isize),
+    /// Pop message from stack (for `ErrorIfNull`). Push `Err(IfNullError(msg))`.
+    RaiseIfNullError,
+    /// Pop `arity` values, apply eager variadic function, push result.
+    /// Handles null propagation if `func.propagates_nulls()`.
+    CallEagerVariadic {
+        func: VariadicFunc,
+        arity: usize,
     },
 
     // -- Compound-cast instructions --
@@ -132,8 +177,14 @@ enum LabeledInstruction {
     Literal(usize),
     CallUnary(UnaryFunc),
     CallBinary(BinaryFunc),
-    CallVariadic(Box<(VariadicFunc, Box<[CompiledMirScalarExpr]>)>),
     CallUnmaterializable(UnmaterializableFunc),
+    AndStep(usize),
+    OrStep(usize),
+    SkipIfNotNull(usize),
+    GreatestStep(usize),
+    LeastStep(usize),
+    RaiseIfNullError,
+    CallEagerVariadic { func: VariadicFunc, arity: usize },
     MapListElements(CompiledMirScalarExpr),
     MapArrayElements(CompiledMirScalarExpr),
     MapRecord {
@@ -209,13 +260,124 @@ impl From<&MirScalarExpr> for CompiledMirScalarExpr {
                         todo.push(PendingItem::Expr(expr1));
                     }
                     MirScalarExpr::CallVariadic { func, exprs } => {
-                        // Compile each operand into a sub-program.
-                        let sub_programs: Box<[CompiledMirScalarExpr]> =
-                            exprs.iter().map(CompiledMirScalarExpr::from).collect();
-                        instructions.push(LabeledInstruction::CallVariadic(Box::new((
-                            func.clone(),
-                            sub_programs,
-                        ))));
+                        match func {
+                            VariadicFunc::And => {
+                                // Literal(True), [eval expr, AndStep(end)]*, Label(end)
+                                let end_label = new_label();
+                                let lit_idx = literals.len();
+                                literals.push(Ok(Row::pack_slice(&[Datum::True])));
+                                todo.push(PendingItem::Emit(LabeledInstruction::Label(end_label)));
+                                for expr in exprs.iter().rev() {
+                                    todo.push(PendingItem::Emit(
+                                        LabeledInstruction::AndStep(end_label),
+                                    ));
+                                    todo.push(PendingItem::Expr(expr));
+                                }
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::Literal(lit_idx),
+                                ));
+                            }
+                            VariadicFunc::Or => {
+                                // Literal(False), [eval expr, OrStep(end)]*, Label(end)
+                                let end_label = new_label();
+                                let lit_idx = literals.len();
+                                literals.push(Ok(Row::pack_slice(&[Datum::False])));
+                                todo.push(PendingItem::Emit(LabeledInstruction::Label(end_label)));
+                                for expr in exprs.iter().rev() {
+                                    todo.push(PendingItem::Emit(
+                                        LabeledInstruction::OrStep(end_label),
+                                    ));
+                                    todo.push(PendingItem::Expr(expr));
+                                }
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::Literal(lit_idx),
+                                ));
+                            }
+                            VariadicFunc::Coalesce => {
+                                // [eval expr, SkipIfNotNull(end)]*, eval last, Label(end)
+                                // If no exprs, just push Null.
+                                if exprs.is_empty() {
+                                    let lit_idx = literals.len();
+                                    literals.push(Ok(Row::pack_slice(&[Datum::Null])));
+                                    instructions.push(LabeledInstruction::Literal(lit_idx));
+                                } else {
+                                    let end_label = new_label();
+                                    todo.push(PendingItem::Emit(
+                                        LabeledInstruction::Label(end_label),
+                                    ));
+                                    // Last expr: just evaluate (no SkipIfNotNull)
+                                    todo.push(PendingItem::Expr(exprs.last().unwrap()));
+                                    // All but last: eval + SkipIfNotNull
+                                    for expr in exprs[..exprs.len() - 1].iter().rev() {
+                                        todo.push(PendingItem::Emit(
+                                            LabeledInstruction::SkipIfNotNull(end_label),
+                                        ));
+                                        todo.push(PendingItem::Expr(expr));
+                                    }
+                                }
+                            }
+                            VariadicFunc::ErrorIfNull => {
+                                // eval value, SkipIfNotNull(end), eval msg, RaiseIfNullError, Label(end)
+                                assert_eq!(exprs.len(), 2);
+                                let end_label = new_label();
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::Label(end_label),
+                                ));
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::RaiseIfNullError,
+                                ));
+                                todo.push(PendingItem::Expr(&exprs[1]));
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::SkipIfNotNull(end_label),
+                                ));
+                                todo.push(PendingItem::Expr(&exprs[0]));
+                            }
+                            VariadicFunc::Greatest => {
+                                // Literal(Null), [eval expr, GreatestStep(end)]*, Label(end)
+                                let end_label = new_label();
+                                let lit_idx = literals.len();
+                                literals.push(Ok(Row::pack_slice(&[Datum::Null])));
+                                todo.push(PendingItem::Emit(LabeledInstruction::Label(end_label)));
+                                for expr in exprs.iter().rev() {
+                                    todo.push(PendingItem::Emit(
+                                        LabeledInstruction::GreatestStep(end_label),
+                                    ));
+                                    todo.push(PendingItem::Expr(expr));
+                                }
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::Literal(lit_idx),
+                                ));
+                            }
+                            VariadicFunc::Least => {
+                                // Literal(Null), [eval expr, LeastStep(end)]*, Label(end)
+                                let end_label = new_label();
+                                let lit_idx = literals.len();
+                                literals.push(Ok(Row::pack_slice(&[Datum::Null])));
+                                todo.push(PendingItem::Emit(LabeledInstruction::Label(end_label)));
+                                for expr in exprs.iter().rev() {
+                                    todo.push(PendingItem::Emit(
+                                        LabeledInstruction::LeastStep(end_label),
+                                    ));
+                                    todo.push(PendingItem::Expr(expr));
+                                }
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::Literal(lit_idx),
+                                ));
+                            }
+                            _ => {
+                                // Eager variadics: eval all operands inline, then call func
+                                let arity = exprs.len();
+                                todo.push(PendingItem::Emit(
+                                    LabeledInstruction::CallEagerVariadic {
+                                        func: func.clone(),
+                                        arity,
+                                    },
+                                ));
+                                for expr in exprs.iter().rev() {
+                                    todo.push(PendingItem::Expr(expr));
+                                }
+                            }
+                        }
                     }
                     MirScalarExpr::If { cond, then, els } => {
                         let label_else = new_label();
@@ -267,9 +429,6 @@ impl From<&MirScalarExpr> for CompiledMirScalarExpr {
                 LabeledInstruction::CallBinary(f) => {
                     final_instructions.push(Instruction::CallBinary(f))
                 }
-                LabeledInstruction::CallVariadic(f) => {
-                    final_instructions.push(Instruction::CallVariadic(f))
-                }
                 LabeledInstruction::CallUnmaterializable(f) => {
                     final_instructions.push(Instruction::CallUnmaterializable(f))
                 }
@@ -294,6 +453,32 @@ impl From<&MirScalarExpr> for CompiledMirScalarExpr {
                 }
                 LabeledInstruction::ParseAndCast(k) => {
                     final_instructions.push(Instruction::ParseAndCast(k))
+                }
+                LabeledInstruction::AndStep(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::AndStep(offset));
+                }
+                LabeledInstruction::OrStep(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::OrStep(offset));
+                }
+                LabeledInstruction::SkipIfNotNull(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::SkipIfNotNull(offset));
+                }
+                LabeledInstruction::GreatestStep(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::GreatestStep(offset));
+                }
+                LabeledInstruction::LeastStep(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::LeastStep(offset));
+                }
+                LabeledInstruction::RaiseIfNullError => {
+                    final_instructions.push(Instruction::RaiseIfNullError)
+                }
+                LabeledInstruction::CallEagerVariadic { func, arity } => {
+                    final_instructions.push(Instruction::CallEagerVariadic { func, arity })
                 }
                 LabeledInstruction::Skip(label) => {
                     let offset = label_positions[label] as isize - current_pos as isize;
@@ -429,11 +614,6 @@ impl CompiledMirScalarExpr {
                     }
                     pc += 1;
                 }
-                Instruction::CallVariadic(boxed) => {
-                    let (func, sub_programs) = boxed.as_ref();
-                    stack.push(eval_variadic(func, sub_programs, datums, temp_storage));
-                    pc += 1;
-                }
                 Instruction::CallUnmaterializable(func) => {
                     stack.push(Err(EvalError::Internal(
                         format!("cannot evaluate unmaterializable function: {func:?}").into(),
@@ -458,6 +638,162 @@ impl CompiledMirScalarExpr {
                             pc = (pc as isize + error_offset) as usize;
                         }
                     }
+                }
+                Instruction::AndStep(end_offset) => {
+                    let operand = stack.pop().expect("stack underflow");
+                    let accumulator = stack.pop().expect("stack underflow");
+                    match operand {
+                        Ok(Datum::False) => {
+                            // False short-circuits And, even over accumulated errors
+                            stack.push(Ok(Datum::False));
+                            pc = (pc as isize + end_offset) as usize;
+                        }
+                        Ok(Datum::True) => {
+                            // True doesn't change the accumulator
+                            stack.push(accumulator);
+                            pc += 1;
+                        }
+                        Ok(Datum::Null) => {
+                            // Null: upgrade accumulator (error stays, true→null)
+                            match accumulator {
+                                Err(_) => stack.push(accumulator),
+                                _ => stack.push(Ok(Datum::Null)),
+                            }
+                            pc += 1;
+                        }
+                        Err(e) => {
+                            // Error: merge with accumulator (max of errors)
+                            match accumulator {
+                                Err(e2) => stack.push(Err(std::cmp::max(e, e2))),
+                                _ => stack.push(Err(e)),
+                            }
+                            pc += 1;
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                Instruction::OrStep(end_offset) => {
+                    let operand = stack.pop().expect("stack underflow");
+                    let accumulator = stack.pop().expect("stack underflow");
+                    match operand {
+                        Ok(Datum::True) => {
+                            // True short-circuits Or, even over accumulated errors
+                            stack.push(Ok(Datum::True));
+                            pc = (pc as isize + end_offset) as usize;
+                        }
+                        Ok(Datum::False) => {
+                            // False doesn't change the accumulator
+                            stack.push(accumulator);
+                            pc += 1;
+                        }
+                        Ok(Datum::Null) => {
+                            match accumulator {
+                                Err(_) => stack.push(accumulator),
+                                _ => stack.push(Ok(Datum::Null)),
+                            }
+                            pc += 1;
+                        }
+                        Err(e) => {
+                            match accumulator {
+                                Err(e2) => stack.push(Err(std::cmp::max(e, e2))),
+                                _ => stack.push(Err(e)),
+                            }
+                            pc += 1;
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                Instruction::SkipIfNotNull(end_offset) => {
+                    let value = stack.pop().expect("stack underflow");
+                    match value {
+                        Ok(Datum::Null) => {
+                            // Null: discard and continue to next operand
+                            pc += 1;
+                        }
+                        _ => {
+                            // Non-null or error: push back and jump to end
+                            stack.push(value);
+                            pc = (pc as isize + end_offset) as usize;
+                        }
+                    }
+                }
+                Instruction::GreatestStep(end_offset) => {
+                    let operand = stack.pop().expect("stack underflow");
+                    let accumulator = stack.pop().expect("stack underflow");
+                    match operand {
+                        Err(e) => {
+                            // Errors propagate immediately
+                            stack.push(Err(e));
+                            pc = (pc as isize + end_offset) as usize;
+                        }
+                        Ok(d) if d.is_null() => {
+                            // Null operand: keep accumulator unchanged
+                            stack.push(accumulator);
+                            pc += 1;
+                        }
+                        Ok(d) => {
+                            // Non-null: update max (accumulator is always Ok)
+                            match &accumulator {
+                                Ok(acc) if !acc.is_null() && *acc >= d => {
+                                    stack.push(accumulator)
+                                }
+                                _ => stack.push(Ok(d)),
+                            }
+                            pc += 1;
+                        }
+                    }
+                }
+                Instruction::LeastStep(end_offset) => {
+                    let operand = stack.pop().expect("stack underflow");
+                    let accumulator = stack.pop().expect("stack underflow");
+                    match operand {
+                        Err(e) => {
+                            stack.push(Err(e));
+                            pc = (pc as isize + end_offset) as usize;
+                        }
+                        Ok(d) if d.is_null() => {
+                            stack.push(accumulator);
+                            pc += 1;
+                        }
+                        Ok(d) => {
+                            match &accumulator {
+                                Ok(acc) if !acc.is_null() && *acc <= d => {
+                                    stack.push(accumulator)
+                                }
+                                _ => stack.push(Ok(d)),
+                            }
+                            pc += 1;
+                        }
+                    }
+                }
+                Instruction::RaiseIfNullError => {
+                    let msg = stack.pop().expect("stack underflow");
+                    match msg {
+                        Err(e) => stack.push(Err(e)),
+                        Ok(Datum::Null) => stack.push(Err(EvalError::Internal(
+                            "unexpected NULL in error side of error_if_null".into(),
+                        ))),
+                        Ok(d) => {
+                            stack.push(Err(EvalError::IfNullError(d.unwrap_str().into())))
+                        }
+                    }
+                    pc += 1;
+                }
+                Instruction::CallEagerVariadic { func, arity } => {
+                    let start = stack.len() - arity;
+                    let args: Result<Vec<Datum<'a>>, EvalError> =
+                        stack.drain(start..).collect();
+                    match args {
+                        Err(e) => stack.push(Err(e)),
+                        Ok(ds) => {
+                            if func.propagates_nulls() && ds.iter().any(|d| d.is_null()) {
+                                stack.push(Ok(Datum::Null));
+                            } else {
+                                stack.push(func.eval_eager(&ds, temp_storage));
+                            }
+                        }
+                    }
+                    pc += 1;
                 }
                 Instruction::MapListElements(cast_program) => {
                     let input = stack.pop().expect("stack underflow");
@@ -633,121 +969,6 @@ fn pack_array_to_jsonb<'a>(
 }
 
 // ---------------------------------------------------------------------------
-// Variadic evaluation
-// ---------------------------------------------------------------------------
-
-/// Evaluate a variadic function with compiled sub-program operands.
-fn eval_variadic<'a>(
-    func: &'a VariadicFunc,
-    sub_programs: &'a [CompiledMirScalarExpr],
-    datums: &[Datum<'a>],
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    // Non-eager variadics need to evaluate operands one at a time.
-    match func {
-        VariadicFunc::Coalesce => {
-            for prog in sub_programs {
-                let d = prog.eval(datums, temp_storage)?;
-                if !d.is_null() {
-                    return Ok(d);
-                }
-            }
-            Ok(Datum::Null)
-        }
-        VariadicFunc::Greatest => {
-            let mut max: Option<Datum<'a>> = None;
-            for prog in sub_programs {
-                let d = prog.eval(datums, temp_storage)?;
-                if !d.is_null() {
-                    max = Some(match max {
-                        Some(m) if m >= d => m,
-                        _ => d,
-                    });
-                }
-            }
-            Ok(max.unwrap_or(Datum::Null))
-        }
-        VariadicFunc::Least => {
-            let mut min: Option<Datum<'a>> = None;
-            for prog in sub_programs {
-                let d = prog.eval(datums, temp_storage)?;
-                if !d.is_null() {
-                    min = Some(match min {
-                        Some(m) if m <= d => m,
-                        _ => d,
-                    });
-                }
-            }
-            Ok(min.unwrap_or(Datum::Null))
-        }
-        VariadicFunc::And => {
-            let mut null = false;
-            let mut err = None;
-            for prog in sub_programs {
-                match prog.eval(datums, temp_storage) {
-                    Ok(Datum::False) => return Ok(Datum::False),
-                    Ok(Datum::True) => {}
-                    Ok(Datum::Null) => null = true,
-                    Err(e) => err = std::cmp::max(err.take(), Some(e)),
-                    _ => unreachable!(),
-                }
-            }
-            match (err, null) {
-                (Some(err), _) => Err(err),
-                (None, true) => Ok(Datum::Null),
-                (None, false) => Ok(Datum::True),
-            }
-        }
-        VariadicFunc::Or => {
-            let mut null = false;
-            let mut err = None;
-            for prog in sub_programs {
-                match prog.eval(datums, temp_storage) {
-                    Ok(Datum::False) => {}
-                    Ok(Datum::True) => return Ok(Datum::True),
-                    Ok(Datum::Null) => null = true,
-                    Err(e) => err = std::cmp::max(err.take(), Some(e)),
-                    _ => unreachable!(),
-                }
-            }
-            match (err, null) {
-                (Some(err), _) => Err(err),
-                (None, true) => Ok(Datum::Null),
-                (None, false) => Ok(Datum::False),
-            }
-        }
-        VariadicFunc::ErrorIfNull => {
-            let first = sub_programs[0].eval(datums, temp_storage)?;
-            match first {
-                Datum::Null => {
-                    let err_msg = match sub_programs[1].eval(datums, temp_storage)? {
-                        Datum::Null => {
-                            return Err(EvalError::Internal(
-                                "unexpected NULL in error side of error_if_null".into(),
-                            ))
-                        }
-                        o => o.unwrap_str(),
-                    };
-                    Err(EvalError::IfNullError(err_msg.into()))
-                }
-                _ => Ok(first),
-            }
-        }
-        _ => {
-            // Eager variadics: evaluate all operands, then call the function.
-            let ds = sub_programs
-                .iter()
-                .map(|p| p.eval(datums, temp_storage))
-                .collect::<Result<Vec<_>, _>>()?;
-            if func.propagates_nulls() && ds.iter().any(|d| d.is_null()) {
-                return Ok(Datum::Null);
-            }
-            func.eval_eager(&ds, temp_storage)
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Parse-and-cast evaluation
 // ---------------------------------------------------------------------------
 
@@ -849,7 +1070,6 @@ fn eval_parse_and_cast<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::SqlColumnType;
 
     /// Test that compiled evaluation produces the same result as direct evaluation
     /// for basic expressions.
@@ -1082,5 +1302,243 @@ mod tests {
         let direct_result = expr.eval(datums, &arena);
         assert!(compiled_result.is_err());
         assert!(direct_result.is_err());
+    }
+
+    // -- Variadic tests --
+
+    /// Helper to make a variadic expression.
+    fn variadic(func: VariadicFunc, exprs: Vec<MirScalarExpr>) -> MirScalarExpr {
+        MirScalarExpr::CallVariadic { func, exprs }
+    }
+
+    fn lit_bool(b: bool) -> MirScalarExpr {
+        MirScalarExpr::literal_ok(Datum::from(b), SqlScalarType::Bool)
+    }
+
+    fn lit_null_bool() -> MirScalarExpr {
+        MirScalarExpr::literal_ok(Datum::Null, SqlScalarType::Bool)
+    }
+
+    fn lit_i32(v: i32) -> MirScalarExpr {
+        MirScalarExpr::literal_ok(Datum::Int32(v), SqlScalarType::Int32)
+    }
+
+    fn lit_null_i32() -> MirScalarExpr {
+        MirScalarExpr::literal_ok(Datum::Null, SqlScalarType::Int32)
+    }
+
+    fn lit_err() -> MirScalarExpr {
+        MirScalarExpr::literal(
+            Err(EvalError::Internal("test error".into())),
+            SqlScalarType::Bool,
+        )
+    }
+
+    #[mz_ore::test]
+    fn test_and_basic() {
+        // And(true, true) = true
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(true), lit_bool(true)]), &[]);
+        // And(true, false) = false
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(true), lit_bool(false)]), &[]);
+        // And(false, true) = false
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(false), lit_bool(true)]), &[]);
+        // And(false, false) = false
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(false), lit_bool(false)]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_and_null() {
+        // And(true, null) = null
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(true), lit_null_bool()]), &[]);
+        // And(null, true) = null
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_null_bool(), lit_bool(true)]), &[]);
+        // And(null, false) = false (false short-circuits)
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_null_bool(), lit_bool(false)]), &[]);
+        // And(false, null) = false
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_bool(false), lit_null_bool()]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_and_error() {
+        // And(error, false) = false (false short-circuits over errors)
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_err(), lit_bool(false)]), &[]);
+        // And(error, true) = error
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_err(), lit_bool(true)]), &[]);
+        // And(error, null) = error (error > null)
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_err(), lit_null_bool()]), &[]);
+        // And(null, error) = error
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![lit_null_bool(), lit_err()]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_and_empty() {
+        // And() = true (identity element)
+        assert_eval_eq(&variadic(VariadicFunc::And, vec![]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_or_basic() {
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(false), lit_bool(false)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(false), lit_bool(true)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(true), lit_bool(false)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(true), lit_bool(true)]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_or_null() {
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(false), lit_null_bool()]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_null_bool(), lit_bool(false)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_null_bool(), lit_bool(true)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_bool(true), lit_null_bool()]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_or_error() {
+        // Or(error, true) = true (true short-circuits over errors)
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_err(), lit_bool(true)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_err(), lit_bool(false)]), &[]);
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![lit_err(), lit_null_bool()]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_or_empty() {
+        // Or() = false (identity element)
+        assert_eval_eq(&variadic(VariadicFunc::Or, vec![]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_coalesce() {
+        // Coalesce(null, null, 42) = 42
+        assert_eval_eq(
+            &variadic(VariadicFunc::Coalesce, vec![lit_null_i32(), lit_null_i32(), lit_i32(42)]),
+            &[],
+        );
+        // Coalesce(1, 2) = 1
+        assert_eval_eq(
+            &variadic(VariadicFunc::Coalesce, vec![lit_i32(1), lit_i32(2)]),
+            &[],
+        );
+        // Coalesce(null) = null
+        assert_eval_eq(
+            &variadic(VariadicFunc::Coalesce, vec![lit_null_i32()]),
+            &[],
+        );
+        // Coalesce() = null
+        assert_eval_eq(&variadic(VariadicFunc::Coalesce, vec![]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_coalesce_with_columns() {
+        // Coalesce(Column(0), Column(1))
+        let expr = variadic(
+            VariadicFunc::Coalesce,
+            vec![MirScalarExpr::column(0), MirScalarExpr::column(1)],
+        );
+        assert_eval_eq(&expr, &[Datum::Null, Datum::Int32(5)]);
+        assert_eval_eq(&expr, &[Datum::Int32(3), Datum::Int32(5)]);
+        assert_eval_eq(&expr, &[Datum::Null, Datum::Null]);
+    }
+
+    #[mz_ore::test]
+    fn test_error_if_null_non_null() {
+        // ErrorIfNull(42, "oops") = 42
+        let expr = variadic(
+            VariadicFunc::ErrorIfNull,
+            vec![
+                lit_i32(42),
+                MirScalarExpr::literal_ok(Datum::String("oops"), SqlScalarType::String),
+            ],
+        );
+        assert_eval_eq(&expr, &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_error_if_null_null() {
+        // ErrorIfNull(null, "oops") = error
+        let expr = variadic(
+            VariadicFunc::ErrorIfNull,
+            vec![
+                lit_null_i32(),
+                MirScalarExpr::literal_ok(Datum::String("oops"), SqlScalarType::String),
+            ],
+        );
+        assert_eval_eq(&expr, &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_greatest() {
+        assert_eval_eq(
+            &variadic(VariadicFunc::Greatest, vec![lit_i32(1), lit_i32(3), lit_i32(2)]),
+            &[],
+        );
+        assert_eval_eq(
+            &variadic(VariadicFunc::Greatest, vec![lit_i32(5), lit_null_i32(), lit_i32(3)]),
+            &[],
+        );
+        assert_eval_eq(
+            &variadic(VariadicFunc::Greatest, vec![lit_null_i32(), lit_null_i32()]),
+            &[],
+        );
+        assert_eval_eq(&variadic(VariadicFunc::Greatest, vec![]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_least() {
+        assert_eval_eq(
+            &variadic(VariadicFunc::Least, vec![lit_i32(3), lit_i32(1), lit_i32(2)]),
+            &[],
+        );
+        assert_eval_eq(
+            &variadic(VariadicFunc::Least, vec![lit_i32(5), lit_null_i32(), lit_i32(3)]),
+            &[],
+        );
+        assert_eval_eq(
+            &variadic(VariadicFunc::Least, vec![lit_null_i32(), lit_null_i32()]),
+            &[],
+        );
+        assert_eval_eq(&variadic(VariadicFunc::Least, vec![]), &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_eager_variadic_array_create() {
+        // ArrayCreate([1, 2, 3])
+        let expr = MirScalarExpr::CallVariadic {
+            func: VariadicFunc::ArrayCreate {
+                elem_type: SqlScalarType::Int32,
+            },
+            exprs: vec![lit_i32(1), lit_i32(2), lit_i32(3)],
+        };
+        assert_eval_eq(&expr, &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_eager_variadic_list_create() {
+        // ListCreate([1, null, 3])
+        let expr = MirScalarExpr::CallVariadic {
+            func: VariadicFunc::ListCreate {
+                elem_type: SqlScalarType::Int32,
+            },
+            exprs: vec![lit_i32(1), lit_null_i32(), lit_i32(3)],
+        };
+        assert_eval_eq(&expr, &[]);
+    }
+
+    #[mz_ore::test]
+    fn test_and_three_operands() {
+        // And(true, true, true) = true
+        assert_eval_eq(
+            &variadic(VariadicFunc::And, vec![lit_bool(true), lit_bool(true), lit_bool(true)]),
+            &[],
+        );
+        // And(true, null, false) = false
+        assert_eval_eq(
+            &variadic(VariadicFunc::And, vec![lit_bool(true), lit_null_bool(), lit_bool(false)]),
+            &[],
+        );
+        // And(true, null, true) = null
+        assert_eval_eq(
+            &variadic(VariadicFunc::And, vec![lit_bool(true), lit_null_bool(), lit_bool(true)]),
+            &[],
+        );
     }
 }

--- a/src/expr/src/static_eval.rs
+++ b/src/expr/src/static_eval.rs
@@ -41,20 +41,11 @@
 //!   compiled sub-programs applied per collection element.
 
 use std::borrow::Cow;
-use std::sync::LazyLock;
 
-use mz_ore::treat_as_equal::TreatAsEqual;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::{Datum, Row, RowArena, SqlScalarType, strconv};
 
 use crate::{BinaryFunc, EvalError, MirScalarExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc};
-
-/// Static column-reference expressions for calling `BinaryFunc::eval` with
-/// pre-evaluated datum values (avoids lifetime issues with local temporaries).
-static COL_0: LazyLock<MirScalarExpr> =
-    LazyLock::new(|| MirScalarExpr::Column(0, TreatAsEqual(None)));
-static COL_1: LazyLock<MirScalarExpr> =
-    LazyLock::new(|| MirScalarExpr::Column(1, TreatAsEqual(None)));
 
 /// A compiled representation of a [`MirScalarExpr`] for efficient evaluation.
 ///
@@ -82,8 +73,8 @@ enum Instruction {
     Literal(usize),
     /// Pop 1 value, apply unary function, push result.
     CallUnary(UnaryFunc),
-    /// Pop 2 values (first-pushed = left), apply binary function, push result.
-    /// Uses `COL_0`/`COL_1` static references to call `BinaryFunc::eval`.
+    /// Pop 2 values (first-pushed = left), apply binary function via
+    /// `eval_input`, push result.
     CallBinary(BinaryFunc),
     /// Push an error for an unmaterializable function.
     CallUnmaterializable(UnmaterializableFunc),
@@ -719,14 +710,7 @@ impl CompiledMirScalarExpr {
                 Instruction::CallBinary(func) => {
                     let b = stack.pop().expect("stack underflow");
                     let a = stack.pop().expect("stack underflow");
-                    match (a, b) {
-                        (Ok(a), Ok(b)) => {
-                            // Use static column references to call BinaryFunc::eval
-                            // with pre-evaluated datums.
-                            stack.push(func.eval(&[a, b], temp_storage, &COL_0, &COL_1));
-                        }
-                        (Err(e), _) | (_, Err(e)) => stack.push(Err(e)),
-                    }
+                    stack.push(func.eval_input(temp_storage, a, b));
                     pc += 1;
                 }
                 Instruction::CallUnmaterializable(func) => {
@@ -1181,6 +1165,7 @@ fn eval_parse_and_cast<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mz_ore::treat_as_equal::TreatAsEqual;
 
     /// Test that compiled evaluation produces the same result as direct evaluation
     /// for basic expressions.

--- a/src/expr/src/static_eval.rs
+++ b/src/expr/src/static_eval.rs
@@ -65,6 +65,9 @@ pub struct CompiledMirScalarExpr {
     instructions: Vec<Instruction>,
     /// Literal values referenced by [`Instruction::Literal`] instructions.
     literals: Vec<Result<Row, EvalError>>,
+    /// Upper bound on the evaluation stack depth. Used to pre-allocate
+    /// the stack vector so that evaluation never re-allocates.
+    max_stack_depth: usize,
 }
 
 /// Instructions for the stack machine.
@@ -134,7 +137,6 @@ enum Instruction {
     /// Used by `CastRecord1ToRecord2`.
     MapRecord {
         cast_programs: Box<[CompiledMirScalarExpr]>,
-        return_ty: SqlScalarType,
     },
     /// Map a sub-program over list elements, converting SQL Null to JsonNull.
     /// Used by `CastListToJsonb`.
@@ -189,7 +191,6 @@ enum LabeledInstruction {
     MapArrayElements(CompiledMirScalarExpr),
     MapRecord {
         cast_programs: Box<[CompiledMirScalarExpr]>,
-        return_ty: SqlScalarType,
     },
     MapListToJsonb(CompiledMirScalarExpr),
     MapArrayToJsonb(CompiledMirScalarExpr),
@@ -440,10 +441,8 @@ impl From<&MirScalarExpr> for CompiledMirScalarExpr {
                 }
                 LabeledInstruction::MapRecord {
                     cast_programs,
-                    return_ty,
                 } => final_instructions.push(Instruction::MapRecord {
                     cast_programs,
-                    return_ty,
                 }),
                 LabeledInstruction::MapListToJsonb(p) => {
                     final_instructions.push(Instruction::MapListToJsonb(p))
@@ -501,9 +500,107 @@ impl From<&MirScalarExpr> for CompiledMirScalarExpr {
             current_pos += 1;
         }
 
+        let max_stack_depth = max_stack_depth(expr);
+
         CompiledMirScalarExpr {
             instructions: final_instructions,
             literals,
+            max_stack_depth,
+        }
+    }
+}
+
+/// Compute the maximum stack depth needed to evaluate an expression.
+///
+/// TODO: Rewrite this function in terms of the `Visit` trait
+/// (`MirScalarExpr` implements `VisitChildren<MirScalarExpr>`, which gives it
+/// `Visit`). The visitor infrastructure in `visit.rs` provides stack-safe
+/// traversal with `RecursionGuard` limits, whereas this manual recursive match
+/// could overflow the call stack on deeply-nested expressions.
+///
+/// Each leaf (`Column`, `Literal`, `CallUnmaterializable`) pushes 1.
+/// `CallUnary` consumes 1, produces 1 → net 0, peak = child + 0.
+/// `CallBinary` consumes 2, produces 1 → evaluate left, then right on top, then pop both.
+///   Peak = max(left, left_result + right) = max(depth_left, 1 + depth_right).
+/// `If` evaluates cond (leaves 1), then evaluates one branch (leaves 1) → peak is
+///   max(depth_cond, 1 + max(depth_then, depth_else)) but the cond result is consumed
+///   by SkipIfNotTrue (or pushed as error), so peak = max(depth_cond, depth_then, depth_else).
+///   Actually: cond pushes 1, SkipIfNotTrue pops it (or replaces with error → still 1), then
+///   branch pushes 1 → max(depth_cond, 1 + depth_then, 1 + depth_else) but error path
+///   leaves one value already. Let's be conservative: cond can leave 1 on error, then
+///   branch adds on top. So peak = max(depth_cond, 1 + max(depth_then, depth_else)).
+/// `CallVariadic(And/Or)`: accumulator(1) + each operand evaluated on top.
+///   Peak = 1 + max(depth of each operand).
+/// `CallVariadic(Coalesce)`: each operand evaluated sequentially, at most 1 on stack.
+///   Peak = max(depth of each operand).
+/// `CallVariadic(ErrorIfNull)`: value + message. Peak = max(depth_value, depth_message).
+/// `CallVariadic(Greatest/Least)`: accumulator(1) + each operand on top.
+///   Peak = 1 + max(depth of each operand).
+/// `CallVariadic(eager)`: all operands on stack simultaneously + 1 result.
+///   Peak = sum of all operand depths? No — operands are evaluated left to right, each
+///   leaving 1 value. Peak = k + depth_of_kth_operand for the k-th operand evaluated.
+///   = max over k of (k + depth_operand_k). Simplified: n + max_operand_depth would be
+///   an overcount; exact is max(i + depth_i for i in 0..n). But conservatively: n is fine
+///   since each operand is at least depth 1.
+fn max_stack_depth(expr: &MirScalarExpr) -> usize {
+    match expr {
+        MirScalarExpr::Column(_, _)
+        | MirScalarExpr::Literal(_, _)
+        | MirScalarExpr::CallUnmaterializable(_) => 1,
+        MirScalarExpr::CallUnary { expr: child, .. } => {
+            // Evaluate child (pushes 1), then apply func in-place.
+            max_stack_depth(child)
+        }
+        MirScalarExpr::CallBinary { expr1, expr2, .. } => {
+            // Evaluate expr1 (leaves 1 on stack), then expr2 on top.
+            let d1 = max_stack_depth(expr1);
+            let d2 = max_stack_depth(expr2);
+            std::cmp::max(d1, 1 + d2)
+        }
+        MirScalarExpr::If { cond, then, els } => {
+            let dc = max_stack_depth(cond);
+            let dt = max_stack_depth(then);
+            let de = max_stack_depth(els);
+            // Cond evaluated first. On error, cond result stays on stack (1) and we skip
+            // to end, so peak during cond is dc. After cond is consumed/error-pushed,
+            // we evaluate one branch which can push up to dt or de. On the error path
+            // there's 1 value already on stack, but we skip both branches.
+            // Conservative: max(dc, 1 + max(dt, de))
+            // The 1 accounts for the error value that might remain on stack.
+            std::cmp::max(dc, 1 + std::cmp::max(dt, de))
+        }
+        MirScalarExpr::CallVariadic { func, exprs } => {
+            match func {
+                VariadicFunc::And | VariadicFunc::Or => {
+                    // Accumulator (1) + max operand depth
+                    let max_child = exprs.iter().map(max_stack_depth).max().unwrap_or(0);
+                    1 + max_child
+                }
+                VariadicFunc::Coalesce => {
+                    // Operands evaluated sequentially, each leaving at most 1.
+                    exprs.iter().map(max_stack_depth).max().unwrap_or(1)
+                }
+                VariadicFunc::ErrorIfNull => {
+                    // value, then maybe message
+                    let max_child = exprs.iter().map(max_stack_depth).max().unwrap_or(1);
+                    max_child
+                }
+                VariadicFunc::Greatest | VariadicFunc::Least => {
+                    // Accumulator (1) + max operand depth
+                    let max_child = exprs.iter().map(max_stack_depth).max().unwrap_or(0);
+                    1 + max_child
+                }
+                _ => {
+                    // Eager variadics: operands evaluated left to right, results accumulate.
+                    // When evaluating operand i, there are already i values on the stack.
+                    let mut peak = 0;
+                    for (i, child) in exprs.iter().enumerate() {
+                        peak = std::cmp::max(peak, i + max_stack_depth(child));
+                    }
+                    // After all operands, there are n values; the call replaces with 1.
+                    std::cmp::max(peak, exprs.len())
+                }
+            }
         }
     }
 }
@@ -530,7 +627,6 @@ fn compile_compound_instruction(func: &UnaryFunc) -> LabeledInstruction {
                 .collect();
             LabeledInstruction::MapRecord {
                 cast_programs,
-                return_ty: inner.return_ty.clone(),
             }
         }
         UnaryFunc::CastListToJsonb(inner) => {
@@ -575,12 +671,31 @@ fn compile_compound_instruction(func: &UnaryFunc) -> LabeledInstruction {
 
 impl CompiledMirScalarExpr {
     /// Evaluate this compiled expression against the given datum columns.
+    ///
+    /// This allocates a fresh stack on each call. For hot loops that evaluate
+    /// many rows, prefer [`Self::eval_with_stack`] to amortize the allocation.
     pub fn eval<'a>(
         &'a self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
     ) -> Result<Datum<'a>, EvalError> {
-        let mut stack: Vec<Result<Datum<'a>, EvalError>> = Vec::new();
+        let mut stack: Vec<Result<Datum<'a>, EvalError>> =
+            Vec::with_capacity(self.max_stack_depth);
+        self.eval_with_stack(datums, temp_storage, &mut stack)
+    }
+
+    /// Evaluate this compiled expression, reusing an externally-provided stack.
+    ///
+    /// The stack is cleared before use. By passing the same `Vec` across many
+    /// rows the caller avoids a per-row allocation — only the very first call
+    /// (or a call with a deeper expression) may need to grow the vector.
+    pub fn eval_with_stack<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        stack: &mut Vec<Result<Datum<'a>, EvalError>>,
+    ) -> Result<Datum<'a>, EvalError> {
+        stack.clear();
         let mut pc = 0usize;
 
         while pc < self.instructions.len() {
@@ -640,32 +755,32 @@ impl CompiledMirScalarExpr {
                     }
                 }
                 Instruction::AndStep(end_offset) => {
+                    // Pop operand, peek accumulator (avoid pop+push on common path).
                     let operand = stack.pop().expect("stack underflow");
-                    let accumulator = stack.pop().expect("stack underflow");
                     match operand {
                         Ok(Datum::False) => {
                             // False short-circuits And, even over accumulated errors
-                            stack.push(Ok(Datum::False));
+                            *stack.last_mut().expect("stack underflow") = Ok(Datum::False);
                             pc = (pc as isize + end_offset) as usize;
                         }
                         Ok(Datum::True) => {
-                            // True doesn't change the accumulator
-                            stack.push(accumulator);
+                            // True: accumulator unchanged
                             pc += 1;
                         }
                         Ok(Datum::Null) => {
                             // Null: upgrade accumulator (error stays, true→null)
-                            match accumulator {
-                                Err(_) => stack.push(accumulator),
-                                _ => stack.push(Ok(Datum::Null)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            if acc.is_ok() {
+                                *acc = Ok(Datum::Null);
                             }
                             pc += 1;
                         }
                         Err(e) => {
                             // Error: merge with accumulator (max of errors)
-                            match accumulator {
-                                Err(e2) => stack.push(Err(std::cmp::max(e, e2))),
-                                _ => stack.push(Err(e)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            match acc {
+                                Err(e2) if *e2 >= e => {}
+                                _ => *acc = Err(e),
                             }
                             pc += 1;
                         }
@@ -674,29 +789,28 @@ impl CompiledMirScalarExpr {
                 }
                 Instruction::OrStep(end_offset) => {
                     let operand = stack.pop().expect("stack underflow");
-                    let accumulator = stack.pop().expect("stack underflow");
                     match operand {
                         Ok(Datum::True) => {
                             // True short-circuits Or, even over accumulated errors
-                            stack.push(Ok(Datum::True));
+                            *stack.last_mut().expect("stack underflow") = Ok(Datum::True);
                             pc = (pc as isize + end_offset) as usize;
                         }
                         Ok(Datum::False) => {
-                            // False doesn't change the accumulator
-                            stack.push(accumulator);
+                            // False: accumulator unchanged
                             pc += 1;
                         }
                         Ok(Datum::Null) => {
-                            match accumulator {
-                                Err(_) => stack.push(accumulator),
-                                _ => stack.push(Ok(Datum::Null)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            if acc.is_ok() {
+                                *acc = Ok(Datum::Null);
                             }
                             pc += 1;
                         }
                         Err(e) => {
-                            match accumulator {
-                                Err(e2) => stack.push(Err(std::cmp::max(e, e2))),
-                                _ => stack.push(Err(e)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            match acc {
+                                Err(e2) if *e2 >= e => {}
+                                _ => *acc = Err(e),
                             }
                             pc += 1;
                         }
@@ -704,40 +818,35 @@ impl CompiledMirScalarExpr {
                     }
                 }
                 Instruction::SkipIfNotNull(end_offset) => {
-                    let value = stack.pop().expect("stack underflow");
-                    match value {
+                    // Peek: non-null values stay on the stack.
+                    match stack.last().expect("stack underflow") {
                         Ok(Datum::Null) => {
-                            // Null: discard and continue to next operand
+                            stack.pop();
                             pc += 1;
                         }
                         _ => {
-                            // Non-null or error: push back and jump to end
-                            stack.push(value);
                             pc = (pc as isize + end_offset) as usize;
                         }
                     }
                 }
                 Instruction::GreatestStep(end_offset) => {
+                    // Pop operand, peek accumulator.
                     let operand = stack.pop().expect("stack underflow");
-                    let accumulator = stack.pop().expect("stack underflow");
                     match operand {
                         Err(e) => {
-                            // Errors propagate immediately
-                            stack.push(Err(e));
+                            // Errors propagate immediately, replace accumulator
+                            *stack.last_mut().expect("stack underflow") = Err(e);
                             pc = (pc as isize + end_offset) as usize;
                         }
                         Ok(d) if d.is_null() => {
-                            // Null operand: keep accumulator unchanged
-                            stack.push(accumulator);
+                            // Null operand: accumulator unchanged
                             pc += 1;
                         }
                         Ok(d) => {
-                            // Non-null: update max (accumulator is always Ok)
-                            match &accumulator {
-                                Ok(acc) if !acc.is_null() && *acc >= d => {
-                                    stack.push(accumulator)
-                                }
-                                _ => stack.push(Ok(d)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            match acc {
+                                Ok(acc_d) if !acc_d.is_null() && *acc_d >= d => {}
+                                _ => *acc = Ok(d),
                             }
                             pc += 1;
                         }
@@ -745,22 +854,19 @@ impl CompiledMirScalarExpr {
                 }
                 Instruction::LeastStep(end_offset) => {
                     let operand = stack.pop().expect("stack underflow");
-                    let accumulator = stack.pop().expect("stack underflow");
                     match operand {
                         Err(e) => {
-                            stack.push(Err(e));
+                            *stack.last_mut().expect("stack underflow") = Err(e);
                             pc = (pc as isize + end_offset) as usize;
                         }
                         Ok(d) if d.is_null() => {
-                            stack.push(accumulator);
                             pc += 1;
                         }
                         Ok(d) => {
-                            match &accumulator {
-                                Ok(acc) if !acc.is_null() && *acc <= d => {
-                                    stack.push(accumulator)
-                                }
-                                _ => stack.push(Ok(d)),
+                            let acc = stack.last_mut().expect("stack underflow");
+                            match acc {
+                                Ok(acc_d) if !acc_d.is_null() && *acc_d <= d => {}
+                                _ => *acc = Ok(d),
                             }
                             pc += 1;
                         }
@@ -807,7 +913,6 @@ impl CompiledMirScalarExpr {
                 }
                 Instruction::MapRecord {
                     cast_programs,
-                    return_ty: _,
                 } => {
                     let input = stack.pop().expect("stack underflow");
                     stack.push(eval_map_record(input, cast_programs, temp_storage));
@@ -831,6 +936,12 @@ impl CompiledMirScalarExpr {
             }
         }
 
+        debug_assert!(
+            stack.capacity() == self.max_stack_depth,
+            "stack was re-allocated: capacity {} vs computed max {}",
+            stack.capacity(),
+            self.max_stack_depth,
+        );
         stack.pop().expect("stack should have one result")
     }
 }

--- a/src/expr/src/static_eval.rs
+++ b/src/expr/src/static_eval.rs
@@ -1,0 +1,1086 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Stack-machine-based compiled evaluation of [`MirScalarExpr`].
+//!
+//! [`CompiledMirScalarExpr`] is a flat instruction sequence compiled from a
+//! [`MirScalarExpr`] tree. It avoids recursive descent through the AST during
+//! evaluation, replacing it with a linear instruction sequence with branching.
+//!
+//! Compound-cast functions (e.g., `CastList1ToList2`, `CastArrayToArray`)
+//! that iterate over collection elements and apply a sub-expression per element
+//! are represented as dedicated instructions, with the inner cast expressions
+//! compiled into sub-programs.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use mz_ore::treat_as_equal::TreatAsEqual;
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::{Datum, Row, RowArena, SqlScalarType, strconv};
+
+use crate::{BinaryFunc, EvalError, MirScalarExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc};
+
+/// Static column-reference expressions for calling `BinaryFunc::eval` with
+/// pre-evaluated datum values (avoids lifetime issues with local temporaries).
+static COL_0: LazyLock<MirScalarExpr> =
+    LazyLock::new(|| MirScalarExpr::Column(0, TreatAsEqual(None)));
+static COL_1: LazyLock<MirScalarExpr> =
+    LazyLock::new(|| MirScalarExpr::Column(1, TreatAsEqual(None)));
+
+/// A compiled representation of a [`MirScalarExpr`] for efficient evaluation.
+///
+/// Instead of recursively matching on enum variants, evaluation walks a flat
+/// instruction sequence using a value stack and a program counter.
+#[derive(Debug, Clone)]
+pub struct CompiledMirScalarExpr {
+    instructions: Vec<Instruction>,
+    /// Literal values referenced by [`Instruction::Literal`] instructions.
+    literals: Vec<Result<Row, EvalError>>,
+}
+
+/// Instructions for the stack machine.
+///
+/// Most instructions pop their inputs from the stack and push their result.
+/// Branch instructions (`Skip`, `SkipIfNotTrue`) modify the program counter.
+#[derive(Debug, Clone)]
+enum Instruction {
+    /// Push `datums[column]` onto the stack.
+    Column(usize),
+    /// Push the literal at the given index onto the stack.
+    Literal(usize),
+    /// Pop 1 value, apply unary function, push result.
+    CallUnary(UnaryFunc),
+    /// Pop 2 values (first-pushed = left), apply binary function, push result.
+    /// Uses `COL_0`/`COL_1` static references to call `BinaryFunc::eval`.
+    CallBinary(BinaryFunc),
+    /// Evaluate a variadic function. Non-eager variadics (And, Or, Coalesce,
+    /// etc.) receive their operands as compiled sub-programs since they may
+    /// short-circuit. Eager variadics have their operands as sub-programs too.
+    CallVariadic(Box<(VariadicFunc, Box<[CompiledMirScalarExpr]>)>),
+    /// Push an error for an unmaterializable function.
+    CallUnmaterializable(UnmaterializableFunc),
+    /// Unconditional relative jump. `pc += offset`.
+    Skip(isize),
+    /// Pop 1 value; if True, continue. If False/Null, jump by `false_offset`.
+    /// If Error, push error back and jump by `error_offset` (skips entire If).
+    SkipIfNotTrue {
+        false_offset: isize,
+        error_offset: isize,
+    },
+
+    // -- Compound-cast instructions --
+    // These pop 1 input from the stack, iterate over its elements, apply
+    // a compiled sub-program per element, and push the result.
+
+    /// Map a compiled sub-program over each element of a list.
+    /// Used by `CastList1ToList2`.
+    MapListElements(CompiledMirScalarExpr),
+    /// Map a compiled sub-program over each element of an array, preserving
+    /// dimensions. Used by `CastArrayToArray`.
+    MapArrayElements(CompiledMirScalarExpr),
+    /// Zip per-field sub-programs over a record's fields.
+    /// Used by `CastRecord1ToRecord2`.
+    MapRecord {
+        cast_programs: Box<[CompiledMirScalarExpr]>,
+        return_ty: SqlScalarType,
+    },
+    /// Map a sub-program over list elements, converting SQL Null to JsonNull.
+    /// Used by `CastListToJsonb`.
+    MapListToJsonb(CompiledMirScalarExpr),
+    /// Map a sub-program over array elements respecting multi-dim structure,
+    /// converting SQL Null to JsonNull. Used by `CastArrayToJsonb`.
+    MapArrayToJsonb(CompiledMirScalarExpr),
+    /// Parse a string into a compound value, applying a compiled cast
+    /// sub-program to each parsed element.
+    ParseAndCast(ParseAndCastKind),
+}
+
+/// Variants for parse-and-cast operations on string inputs.
+#[derive(Debug, Clone)]
+enum ParseAndCastKind {
+    StringToArray {
+        cast_program: CompiledMirScalarExpr,
+    },
+    StringToList {
+        return_ty: SqlScalarType,
+        cast_program: CompiledMirScalarExpr,
+    },
+    StringToMap {
+        return_ty: SqlScalarType,
+        cast_program: CompiledMirScalarExpr,
+    },
+    StringToRange {
+        cast_program: CompiledMirScalarExpr,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Compilation: MirScalarExpr -> CompiledMirScalarExpr
+// ---------------------------------------------------------------------------
+
+/// An instruction with symbolic labels, used during compilation before
+/// label resolution.
+enum LabeledInstruction {
+    Column(usize),
+    Literal(usize),
+    CallUnary(UnaryFunc),
+    CallBinary(BinaryFunc),
+    CallVariadic(Box<(VariadicFunc, Box<[CompiledMirScalarExpr]>)>),
+    CallUnmaterializable(UnmaterializableFunc),
+    MapListElements(CompiledMirScalarExpr),
+    MapArrayElements(CompiledMirScalarExpr),
+    MapRecord {
+        cast_programs: Box<[CompiledMirScalarExpr]>,
+        return_ty: SqlScalarType,
+    },
+    MapListToJsonb(CompiledMirScalarExpr),
+    MapArrayToJsonb(CompiledMirScalarExpr),
+    ParseAndCast(ParseAndCastKind),
+    Label(usize),
+    Skip(usize),
+    SkipIfNotTrue { false_label: usize, error_label: usize },
+}
+
+/// Work items for the compilation loop.
+enum PendingItem<'a> {
+    Expr(&'a MirScalarExpr),
+    Emit(LabeledInstruction),
+}
+
+impl From<&MirScalarExpr> for CompiledMirScalarExpr {
+    fn from(expr: &MirScalarExpr) -> Self {
+        let mut instructions: Vec<LabeledInstruction> = Vec::new();
+        let mut literals: Vec<Result<Row, EvalError>> = Vec::new();
+        let mut label_count: usize = 0;
+        let mut new_label = || {
+            let l = label_count;
+            label_count += 1;
+            l
+        };
+
+        // We process the expression tree iteratively using a work stack.
+        // Items are pushed in REVERSE execution order because the stack is LIFO.
+        let mut todo = vec![PendingItem::Expr(expr)];
+
+        while let Some(item) = todo.pop() {
+            match item {
+                PendingItem::Expr(expr) => match expr {
+                    MirScalarExpr::Column(col, _name) => {
+                        instructions.push(LabeledInstruction::Column(*col));
+                    }
+                    MirScalarExpr::Literal(res, _) => {
+                        let idx = literals.len();
+                        literals.push(res.clone());
+                        instructions.push(LabeledInstruction::Literal(idx));
+                    }
+                    MirScalarExpr::CallUnmaterializable(f) => {
+                        instructions.push(LabeledInstruction::CallUnmaterializable(f.clone()));
+                    }
+                    MirScalarExpr::CallUnary { func, expr: child } => {
+                        if !func.embedded_exprs().is_empty() {
+                            // Compound-cast: compile cast sub-expr(s) into sub-programs,
+                            // then emit the child inline followed by the compound instruction.
+                            let compound_instr = compile_compound_instruction(func);
+                            // Push in reverse: compound instr last (popped last = emitted last)
+                            todo.push(PendingItem::Emit(compound_instr));
+                            todo.push(PendingItem::Expr(child));
+                        } else {
+                            // Normal unary: child first (on stack), then apply func.
+                            todo.push(PendingItem::Emit(
+                                LabeledInstruction::CallUnary(func.clone()),
+                            ));
+                            todo.push(PendingItem::Expr(child));
+                        }
+                    }
+                    MirScalarExpr::CallBinary { func, expr1, expr2 } => {
+                        // Result: [expr1_instrs, expr2_instrs, CallBinary]
+                        // Push in reverse execution order:
+                        todo.push(PendingItem::Emit(
+                            LabeledInstruction::CallBinary(func.clone()),
+                        ));
+                        todo.push(PendingItem::Expr(expr2));
+                        todo.push(PendingItem::Expr(expr1));
+                    }
+                    MirScalarExpr::CallVariadic { func, exprs } => {
+                        // Compile each operand into a sub-program.
+                        let sub_programs: Box<[CompiledMirScalarExpr]> =
+                            exprs.iter().map(CompiledMirScalarExpr::from).collect();
+                        instructions.push(LabeledInstruction::CallVariadic(Box::new((
+                            func.clone(),
+                            sub_programs,
+                        ))));
+                    }
+                    MirScalarExpr::If { cond, then, els } => {
+                        let label_else = new_label();
+                        let label_end = new_label();
+                        // Desired instruction order:
+                        //   [cond, SkipIfNotTrue, then, Skip(end), label_else, els, label_end]
+                        // Push in reverse for LIFO:
+                        todo.push(PendingItem::Emit(LabeledInstruction::Label(label_end)));
+                        todo.push(PendingItem::Expr(els));
+                        todo.push(PendingItem::Emit(LabeledInstruction::Label(label_else)));
+                        todo.push(PendingItem::Emit(LabeledInstruction::Skip(label_end)));
+                        todo.push(PendingItem::Expr(then));
+                        todo.push(PendingItem::Emit(LabeledInstruction::SkipIfNotTrue {
+                            false_label: label_else,
+                            error_label: label_end,
+                        }));
+                        todo.push(PendingItem::Expr(cond));
+                    }
+                },
+                PendingItem::Emit(instr) => {
+                    instructions.push(instr);
+                }
+            }
+        }
+
+        // Resolve labels to relative offsets.
+        // First, record position of each label (not counting labels themselves).
+        let mut label_positions = vec![0usize; label_count];
+        let mut pos = 0;
+        for instr in &instructions {
+            if let LabeledInstruction::Label(l) = instr {
+                label_positions[*l] = pos;
+            } else {
+                pos += 1;
+            }
+        }
+
+        // Remove labels and convert to final instructions.
+        let mut final_instructions = Vec::with_capacity(pos);
+        let mut current_pos = 0;
+        for instr in instructions {
+            match instr {
+                LabeledInstruction::Label(_) => continue,
+                LabeledInstruction::Column(c) => final_instructions.push(Instruction::Column(c)),
+                LabeledInstruction::Literal(l) => final_instructions.push(Instruction::Literal(l)),
+                LabeledInstruction::CallUnary(f) => {
+                    final_instructions.push(Instruction::CallUnary(f))
+                }
+                LabeledInstruction::CallBinary(f) => {
+                    final_instructions.push(Instruction::CallBinary(f))
+                }
+                LabeledInstruction::CallVariadic(f) => {
+                    final_instructions.push(Instruction::CallVariadic(f))
+                }
+                LabeledInstruction::CallUnmaterializable(f) => {
+                    final_instructions.push(Instruction::CallUnmaterializable(f))
+                }
+                LabeledInstruction::MapListElements(p) => {
+                    final_instructions.push(Instruction::MapListElements(p))
+                }
+                LabeledInstruction::MapArrayElements(p) => {
+                    final_instructions.push(Instruction::MapArrayElements(p))
+                }
+                LabeledInstruction::MapRecord {
+                    cast_programs,
+                    return_ty,
+                } => final_instructions.push(Instruction::MapRecord {
+                    cast_programs,
+                    return_ty,
+                }),
+                LabeledInstruction::MapListToJsonb(p) => {
+                    final_instructions.push(Instruction::MapListToJsonb(p))
+                }
+                LabeledInstruction::MapArrayToJsonb(p) => {
+                    final_instructions.push(Instruction::MapArrayToJsonb(p))
+                }
+                LabeledInstruction::ParseAndCast(k) => {
+                    final_instructions.push(Instruction::ParseAndCast(k))
+                }
+                LabeledInstruction::Skip(label) => {
+                    let offset = label_positions[label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::Skip(offset));
+                }
+                LabeledInstruction::SkipIfNotTrue {
+                    false_label,
+                    error_label,
+                } => {
+                    let false_offset =
+                        label_positions[false_label] as isize - current_pos as isize;
+                    let error_offset =
+                        label_positions[error_label] as isize - current_pos as isize;
+                    final_instructions.push(Instruction::SkipIfNotTrue {
+                        false_offset,
+                        error_offset,
+                    });
+                }
+            }
+            current_pos += 1;
+        }
+
+        CompiledMirScalarExpr {
+            instructions: final_instructions,
+            literals,
+        }
+    }
+}
+
+/// Compile a compound-cast `UnaryFunc` into its corresponding instruction.
+/// The embedded cast sub-expressions are compiled into sub-programs.
+/// The child (input) expression is NOT handled here; the caller must ensure
+/// it is evaluated onto the stack before this instruction executes.
+fn compile_compound_instruction(func: &UnaryFunc) -> LabeledInstruction {
+    match func {
+        UnaryFunc::CastList1ToList2(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::MapListElements(cast_program)
+        }
+        UnaryFunc::CastArrayToArray(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::MapArrayElements(cast_program)
+        }
+        UnaryFunc::CastRecord1ToRecord2(inner) => {
+            let cast_programs: Box<[CompiledMirScalarExpr]> = inner
+                .cast_exprs
+                .iter()
+                .map(CompiledMirScalarExpr::from)
+                .collect();
+            LabeledInstruction::MapRecord {
+                cast_programs,
+                return_ty: inner.return_ty.clone(),
+            }
+        }
+        UnaryFunc::CastListToJsonb(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_element.as_ref());
+            LabeledInstruction::MapListToJsonb(cast_program)
+        }
+        UnaryFunc::CastArrayToJsonb(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_element.as_ref());
+            LabeledInstruction::MapArrayToJsonb(cast_program)
+        }
+        UnaryFunc::CastStringToArray(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::ParseAndCast(ParseAndCastKind::StringToArray { cast_program })
+        }
+        UnaryFunc::CastStringToList(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::ParseAndCast(ParseAndCastKind::StringToList {
+                return_ty: inner.return_ty.clone(),
+                cast_program,
+            })
+        }
+        UnaryFunc::CastStringToMap(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::ParseAndCast(ParseAndCastKind::StringToMap {
+                return_ty: inner.return_ty.clone(),
+                cast_program,
+            })
+        }
+        UnaryFunc::CastStringToRange(inner) => {
+            let cast_program = CompiledMirScalarExpr::from(inner.cast_expr.as_ref());
+            LabeledInstruction::ParseAndCast(ParseAndCastKind::StringToRange { cast_program })
+        }
+        _ => unreachable!(
+            "compile_compound_instruction called on non-compound function: {func}"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+impl CompiledMirScalarExpr {
+    /// Evaluate this compiled expression against the given datum columns.
+    pub fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+    ) -> Result<Datum<'a>, EvalError> {
+        let mut stack: Vec<Result<Datum<'a>, EvalError>> = Vec::new();
+        let mut pc = 0usize;
+
+        while pc < self.instructions.len() {
+            match &self.instructions[pc] {
+                Instruction::Column(col) => {
+                    stack.push(Ok(datums[*col]));
+                    pc += 1;
+                }
+                Instruction::Literal(idx) => {
+                    stack.push(match &self.literals[*idx] {
+                        Ok(row) => Ok(row.unpack_first()),
+                        Err(e) => Err(e.clone()),
+                    });
+                    pc += 1;
+                }
+                Instruction::CallUnary(func) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(func.eval_input(temp_storage, input));
+                    pc += 1;
+                }
+                Instruction::CallBinary(func) => {
+                    let b = stack.pop().expect("stack underflow");
+                    let a = stack.pop().expect("stack underflow");
+                    match (a, b) {
+                        (Ok(a), Ok(b)) => {
+                            // Use static column references to call BinaryFunc::eval
+                            // with pre-evaluated datums.
+                            stack.push(func.eval(&[a, b], temp_storage, &COL_0, &COL_1));
+                        }
+                        (Err(e), _) | (_, Err(e)) => stack.push(Err(e)),
+                    }
+                    pc += 1;
+                }
+                Instruction::CallVariadic(boxed) => {
+                    let (func, sub_programs) = boxed.as_ref();
+                    stack.push(eval_variadic(func, sub_programs, datums, temp_storage));
+                    pc += 1;
+                }
+                Instruction::CallUnmaterializable(func) => {
+                    stack.push(Err(EvalError::Internal(
+                        format!("cannot evaluate unmaterializable function: {func:?}").into(),
+                    )));
+                    pc += 1;
+                }
+                Instruction::Skip(offset) => {
+                    pc = (pc as isize + offset) as usize;
+                }
+                Instruction::SkipIfNotTrue {
+                    false_offset,
+                    error_offset,
+                } => {
+                    let val = stack.pop().expect("stack underflow");
+                    match val {
+                        Ok(Datum::True) => pc += 1,
+                        Ok(_) => pc = (pc as isize + false_offset) as usize,
+                        Err(e) => {
+                            // Cond errored: push error and skip entire If
+                            // (past both then and else branches).
+                            stack.push(Err(e));
+                            pc = (pc as isize + error_offset) as usize;
+                        }
+                    }
+                }
+                Instruction::MapListElements(cast_program) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_map_list_elements(input, cast_program, temp_storage));
+                    pc += 1;
+                }
+                Instruction::MapArrayElements(cast_program) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_map_array_elements(input, cast_program, temp_storage));
+                    pc += 1;
+                }
+                Instruction::MapRecord {
+                    cast_programs,
+                    return_ty: _,
+                } => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_map_record(input, cast_programs, temp_storage));
+                    pc += 1;
+                }
+                Instruction::MapListToJsonb(cast_program) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_map_list_to_jsonb(input, cast_program, temp_storage));
+                    pc += 1;
+                }
+                Instruction::MapArrayToJsonb(cast_program) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_map_array_to_jsonb(input, cast_program, temp_storage));
+                    pc += 1;
+                }
+                Instruction::ParseAndCast(kind) => {
+                    let input = stack.pop().expect("stack underflow");
+                    stack.push(eval_parse_and_cast(input, kind, temp_storage));
+                    pc += 1;
+                }
+            }
+        }
+
+        stack.pop().expect("stack should have one result")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compound-cast evaluation helpers
+// ---------------------------------------------------------------------------
+
+fn eval_map_list_elements<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    cast_program: &'a CompiledMirScalarExpr,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    let cast_datums = a
+        .unwrap_list()
+        .iter()
+        .map(|el| cast_program.eval(&[el], temp_storage))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
+}
+
+fn eval_map_array_elements<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    cast_program: &'a CompiledMirScalarExpr,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    let arr = a.unwrap_array();
+    let dims: Vec<ArrayDimension> = arr.dims().into_iter().collect();
+    let casted = arr
+        .elements()
+        .iter()
+        .map(|el| cast_program.eval(&[el], temp_storage))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, casted))?)
+}
+
+fn eval_map_record<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    cast_programs: &'a [CompiledMirScalarExpr],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    let mut cast_datums = Vec::new();
+    for (el, prog) in a.unwrap_list().iter().zip(cast_programs.iter()) {
+        cast_datums.push(prog.eval(&[el], temp_storage)?);
+    }
+    Ok(temp_storage.make_datum(|packer| packer.push_list(cast_datums)))
+}
+
+fn eval_map_list_to_jsonb<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    cast_program: &'a CompiledMirScalarExpr,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    let mut row = Row::default();
+    row.packer().push_list_with(|packer| {
+        for elem in a.unwrap_list().iter() {
+            let elem = match cast_program.eval(&[elem], temp_storage)? {
+                Datum::Null => Datum::JsonNull,
+                d => d,
+            };
+            packer.push(elem);
+        }
+        Ok::<_, EvalError>(())
+    })?;
+    Ok(temp_storage.push_unary_row(row))
+}
+
+fn eval_map_array_to_jsonb<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    cast_program: &'a CompiledMirScalarExpr,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    let arr = a.unwrap_array();
+    let elements = arr.elements();
+    let dims: Vec<ArrayDimension> = arr.dims().into_iter().collect();
+    let mut row = Row::default();
+    pack_array_to_jsonb(
+        temp_storage,
+        &mut elements.into_iter(),
+        &dims,
+        cast_program,
+        &mut row.packer(),
+    )?;
+    Ok(temp_storage.push_unary_row(row))
+}
+
+/// Recursive helper for `MapArrayToJsonb` that mirrors the original
+/// `CastArrayToJsonb::pack` function.
+fn pack_array_to_jsonb<'a>(
+    temp_storage: &RowArena,
+    elems: &mut impl Iterator<Item = Datum<'a>>,
+    dims: &[ArrayDimension],
+    cast_program: &CompiledMirScalarExpr,
+    packer: &mut mz_repr::RowPacker,
+) -> Result<(), EvalError> {
+    packer.push_list_with(|packer| match dims {
+        [] => Ok(()),
+        [dim] => {
+            for _ in 0..dim.length {
+                let elem = elems.next().unwrap();
+                let elem = match cast_program.eval(&[elem], temp_storage)? {
+                    Datum::Null => Datum::JsonNull,
+                    d => d,
+                };
+                packer.push(elem);
+            }
+            Ok(())
+        }
+        [dim, rest @ ..] => {
+            for _ in 0..dim.length {
+                pack_array_to_jsonb(temp_storage, elems, rest, cast_program, packer)?;
+            }
+            Ok(())
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Variadic evaluation
+// ---------------------------------------------------------------------------
+
+/// Evaluate a variadic function with compiled sub-program operands.
+fn eval_variadic<'a>(
+    func: &'a VariadicFunc,
+    sub_programs: &'a [CompiledMirScalarExpr],
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    // Non-eager variadics need to evaluate operands one at a time.
+    match func {
+        VariadicFunc::Coalesce => {
+            for prog in sub_programs {
+                let d = prog.eval(datums, temp_storage)?;
+                if !d.is_null() {
+                    return Ok(d);
+                }
+            }
+            Ok(Datum::Null)
+        }
+        VariadicFunc::Greatest => {
+            let mut max: Option<Datum<'a>> = None;
+            for prog in sub_programs {
+                let d = prog.eval(datums, temp_storage)?;
+                if !d.is_null() {
+                    max = Some(match max {
+                        Some(m) if m >= d => m,
+                        _ => d,
+                    });
+                }
+            }
+            Ok(max.unwrap_or(Datum::Null))
+        }
+        VariadicFunc::Least => {
+            let mut min: Option<Datum<'a>> = None;
+            for prog in sub_programs {
+                let d = prog.eval(datums, temp_storage)?;
+                if !d.is_null() {
+                    min = Some(match min {
+                        Some(m) if m <= d => m,
+                        _ => d,
+                    });
+                }
+            }
+            Ok(min.unwrap_or(Datum::Null))
+        }
+        VariadicFunc::And => {
+            let mut null = false;
+            let mut err = None;
+            for prog in sub_programs {
+                match prog.eval(datums, temp_storage) {
+                    Ok(Datum::False) => return Ok(Datum::False),
+                    Ok(Datum::True) => {}
+                    Ok(Datum::Null) => null = true,
+                    Err(e) => err = std::cmp::max(err.take(), Some(e)),
+                    _ => unreachable!(),
+                }
+            }
+            match (err, null) {
+                (Some(err), _) => Err(err),
+                (None, true) => Ok(Datum::Null),
+                (None, false) => Ok(Datum::True),
+            }
+        }
+        VariadicFunc::Or => {
+            let mut null = false;
+            let mut err = None;
+            for prog in sub_programs {
+                match prog.eval(datums, temp_storage) {
+                    Ok(Datum::False) => {}
+                    Ok(Datum::True) => return Ok(Datum::True),
+                    Ok(Datum::Null) => null = true,
+                    Err(e) => err = std::cmp::max(err.take(), Some(e)),
+                    _ => unreachable!(),
+                }
+            }
+            match (err, null) {
+                (Some(err), _) => Err(err),
+                (None, true) => Ok(Datum::Null),
+                (None, false) => Ok(Datum::False),
+            }
+        }
+        VariadicFunc::ErrorIfNull => {
+            let first = sub_programs[0].eval(datums, temp_storage)?;
+            match first {
+                Datum::Null => {
+                    let err_msg = match sub_programs[1].eval(datums, temp_storage)? {
+                        Datum::Null => {
+                            return Err(EvalError::Internal(
+                                "unexpected NULL in error side of error_if_null".into(),
+                            ))
+                        }
+                        o => o.unwrap_str(),
+                    };
+                    Err(EvalError::IfNullError(err_msg.into()))
+                }
+                _ => Ok(first),
+            }
+        }
+        _ => {
+            // Eager variadics: evaluate all operands, then call the function.
+            let ds = sub_programs
+                .iter()
+                .map(|p| p.eval(datums, temp_storage))
+                .collect::<Result<Vec<_>, _>>()?;
+            if func.propagates_nulls() && ds.iter().any(|d| d.is_null()) {
+                return Ok(Datum::Null);
+            }
+            func.eval_eager(&ds, temp_storage)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parse-and-cast evaluation
+// ---------------------------------------------------------------------------
+
+fn eval_parse_and_cast<'a>(
+    input: Result<Datum<'a>, EvalError>,
+    kind: &'a ParseAndCastKind,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let a = input?;
+    if a.is_null() {
+        return Ok(Datum::Null);
+    }
+    match kind {
+        ParseAndCastKind::StringToArray { cast_program } => {
+            let (datums, dims) = strconv::parse_array(
+                a.unwrap_str(),
+                || Datum::Null,
+                |elem_text| {
+                    let elem_text = match elem_text {
+                        Cow::Owned(s) => temp_storage.push_string(s),
+                        Cow::Borrowed(s) => s,
+                    };
+                    cast_program.eval(&[Datum::String(elem_text)], temp_storage)
+                },
+            )?;
+            Ok(temp_storage.try_make_datum(|packer| packer.try_push_array(&dims, datums))?)
+        }
+        ParseAndCastKind::StringToList {
+            return_ty,
+            cast_program,
+        } => {
+            let parsed_datums = strconv::parse_list(
+                a.unwrap_str(),
+                matches!(
+                    return_ty.unwrap_list_element_type(),
+                    SqlScalarType::List { .. }
+                ),
+                || Datum::Null,
+                |elem_text| {
+                    let elem_text = match elem_text {
+                        Cow::Owned(s) => temp_storage.push_string(s),
+                        Cow::Borrowed(s) => s,
+                    };
+                    cast_program.eval(&[Datum::String(elem_text)], temp_storage)
+                },
+            )?;
+            Ok(temp_storage.make_datum(|packer| packer.push_list(parsed_datums)))
+        }
+        ParseAndCastKind::StringToMap {
+            return_ty,
+            cast_program,
+        } => {
+            let parsed_map = strconv::parse_map(
+                a.unwrap_str(),
+                matches!(
+                    return_ty.unwrap_map_value_type(),
+                    SqlScalarType::Map { .. }
+                ),
+                |value_text| -> Result<Datum, EvalError> {
+                    let value_text = match value_text {
+                        Some(Cow::Owned(s)) => Datum::String(temp_storage.push_string(s)),
+                        Some(Cow::Borrowed(s)) => Datum::String(s),
+                        None => Datum::Null,
+                    };
+                    cast_program.eval(&[value_text], temp_storage)
+                },
+            )?;
+            let mut pairs: Vec<(String, Datum)> =
+                parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
+            pairs.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+            pairs.dedup_by(|(k1, _), (k2, _)| k1 == k2);
+            Ok(temp_storage.make_datum(|packer| {
+                packer.push_dict_with(|packer| {
+                    for (k, v) in pairs {
+                        packer.push(Datum::String(&k));
+                        packer.push(v);
+                    }
+                })
+            }))
+        }
+        ParseAndCastKind::StringToRange { cast_program } => {
+            let mut range = strconv::parse_range(a.unwrap_str(), |elem_text| {
+                let elem_text = match elem_text {
+                    Cow::Owned(s) => temp_storage.push_string(s),
+                    Cow::Borrowed(s) => s,
+                };
+                cast_program.eval(&[Datum::String(elem_text)], temp_storage)
+            })?;
+            range.canonicalize()?;
+            Ok(temp_storage.make_datum(|packer| {
+                packer
+                    .push_range(range)
+                    .expect("must have already handled errors")
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mz_repr::SqlColumnType;
+
+    /// Test that compiled evaluation produces the same result as direct evaluation
+    /// for basic expressions.
+    #[mz_ore::test]
+    fn test_column() {
+        let arena = RowArena::new();
+        let expr = MirScalarExpr::Column(1, TreatAsEqual(None));
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[Datum::Int32(10), Datum::Int32(42)];
+
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_literal() {
+        let arena = RowArena::new();
+        let expr = MirScalarExpr::literal_ok(Datum::String("hello"), SqlScalarType::String);
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[];
+
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_if_true_branch() {
+        let arena = RowArena::new();
+        // If(Column(0), Literal(1), Literal(2))
+        let expr = MirScalarExpr::If {
+            cond: Box::new(MirScalarExpr::literal_ok(
+                Datum::True,
+                SqlScalarType::Bool,
+            )),
+            then: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(1),
+                SqlScalarType::Int32,
+            )),
+            els: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(2),
+                SqlScalarType::Int32,
+            )),
+        };
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[];
+
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_if_false_branch() {
+        let arena = RowArena::new();
+        let expr = MirScalarExpr::If {
+            cond: Box::new(MirScalarExpr::literal_ok(
+                Datum::False,
+                SqlScalarType::Bool,
+            )),
+            then: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(1),
+                SqlScalarType::Int32,
+            )),
+            els: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(2),
+                SqlScalarType::Int32,
+            )),
+        };
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[];
+
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_if_null_goes_to_else() {
+        let arena = RowArena::new();
+        let expr = MirScalarExpr::If {
+            cond: Box::new(MirScalarExpr::literal_ok(
+                Datum::Null,
+                SqlScalarType::Bool,
+            )),
+            then: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(1),
+                SqlScalarType::Int32,
+            )),
+            els: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(2),
+                SqlScalarType::Int32,
+            )),
+        };
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[];
+
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+        );
+    }
+
+    /// Helper: assert compiled and direct evaluation produce the same result.
+    fn assert_eval_eq(expr: &MirScalarExpr, datums: &[Datum]) {
+        let arena = RowArena::new();
+        let compiled = CompiledMirScalarExpr::from(expr);
+        assert_eq!(
+            compiled.eval(datums, &arena),
+            expr.eval(datums, &arena),
+            "mismatch for expr: {expr:?} with datums: {datums:?}",
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_call_unary_not() {
+        use crate::func::Not;
+        // NOT(Column(0))
+        let expr = MirScalarExpr::column(0).call_unary(Not);
+        assert_eval_eq(&expr, &[Datum::True]);
+        assert_eval_eq(&expr, &[Datum::False]);
+        assert_eval_eq(&expr, &[Datum::Null]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_unary_is_null() {
+        use crate::func::IsNull;
+        // IS_NULL(Column(0))
+        let expr = MirScalarExpr::column(0).call_unary(IsNull);
+        assert_eval_eq(&expr, &[Datum::Null]);
+        assert_eval_eq(&expr, &[Datum::Int32(42)]);
+        assert_eval_eq(&expr, &[Datum::String("hello")]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_unary_neg_int32() {
+        use crate::func::NegInt32;
+        // -Column(0)
+        let expr = MirScalarExpr::column(0).call_unary(NegInt32);
+        assert_eval_eq(&expr, &[Datum::Int32(42)]);
+        assert_eval_eq(&expr, &[Datum::Int32(-1)]);
+        assert_eval_eq(&expr, &[Datum::Int32(0)]);
+        assert_eval_eq(&expr, &[Datum::Null]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_unary_nested() {
+        use crate::func::Not;
+        // NOT(NOT(Column(0)))
+        let expr = MirScalarExpr::column(0).call_unary(Not).call_unary(Not);
+        assert_eval_eq(&expr, &[Datum::True]);
+        assert_eval_eq(&expr, &[Datum::False]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_binary_add_int32() {
+        use crate::func::AddInt32;
+        // Column(0) + Column(1)
+        let expr = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(1), AddInt32);
+        assert_eval_eq(&expr, &[Datum::Int32(10), Datum::Int32(32)]);
+        assert_eval_eq(&expr, &[Datum::Int32(-5), Datum::Int32(5)]);
+        assert_eval_eq(&expr, &[Datum::Null, Datum::Int32(1)]);
+        assert_eval_eq(&expr, &[Datum::Int32(1), Datum::Null]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_binary_add_literal() {
+        use crate::func::AddInt32;
+        // Column(0) + Literal(100)
+        let expr = MirScalarExpr::column(0).call_binary(
+            MirScalarExpr::literal_ok(Datum::Int32(100), SqlScalarType::Int32),
+            AddInt32,
+        );
+        assert_eval_eq(&expr, &[Datum::Int32(1)]);
+        assert_eval_eq(&expr, &[Datum::Int32(-50)]);
+    }
+
+    #[mz_ore::test]
+    fn test_call_binary_overflow() {
+        use crate::func::AddInt32;
+        // i32::MAX + 1 should produce an error in both paths
+        let expr = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(1), AddInt32);
+        let datums = &[Datum::Int32(i32::MAX), Datum::Int32(1)];
+        let arena = RowArena::new();
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let compiled_result = compiled.eval(datums, &arena);
+        let direct_result = expr.eval(datums, &arena);
+        assert!(compiled_result.is_err());
+        assert!(direct_result.is_err());
+    }
+
+    #[mz_ore::test]
+    fn test_binary_with_unary() {
+        use crate::func::{AddInt32, NegInt32};
+        // (-Column(0)) + Column(1)
+        let expr = MirScalarExpr::column(0)
+            .call_unary(NegInt32)
+            .call_binary(MirScalarExpr::column(1), AddInt32);
+        assert_eval_eq(&expr, &[Datum::Int32(10), Datum::Int32(3)]);
+        assert_eval_eq(&expr, &[Datum::Int32(0), Datum::Int32(7)]);
+    }
+
+    #[mz_ore::test]
+    fn test_if_error_in_cond() {
+        let arena = RowArena::new();
+        let expr = MirScalarExpr::If {
+            cond: Box::new(MirScalarExpr::literal(
+                Err(EvalError::Internal("test error".into())),
+                SqlScalarType::Bool,
+            )),
+            then: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(1),
+                SqlScalarType::Int32,
+            )),
+            els: Box::new(MirScalarExpr::literal_ok(
+                Datum::Int32(2),
+                SqlScalarType::Int32,
+            )),
+        };
+        let compiled = CompiledMirScalarExpr::from(&expr);
+        let datums = &[];
+
+        // Both should return the error
+        let compiled_result = compiled.eval(datums, &arena);
+        let direct_result = expr.eval(datums, &arena);
+        assert!(compiled_result.is_err());
+        assert!(direct_result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Split `LazyUnaryFunc::eval` into `eval` + `eval_input` so unary functions can be called with pre-evaluated datums, avoiding re-evaluation in a stack machine context
- Add `embedded_exprs()` / `embedded_exprs_mut()` to `LazyUnaryFunc` for the 9 compound-cast functions that contain embedded `MirScalarExpr` sub-expressions
- Extract `VariadicFunc::eval_eager()` for calling eager variadic functions with pre-evaluated datum slices
- Implement `CompiledMirScalarExpr` — a flat instruction sequence compiled from `MirScalarExpr` trees that replaces recursive AST descent with a linear instruction stream using a value stack and program counter

## Details

The `CompiledMirScalarExpr` handles all `MirScalarExpr` variants:
- **Column/Literal**: push directly onto the stack
- **CallUnary**: inline operand evaluation, pop + apply via `eval_input`
- **CallBinary**: inline operand evaluation, pop 2 + apply via static column references
- **CallVariadic**: sub-program compilation for each operand (supports short-circuiting for And/Or/Coalesce/etc.)
- **If**: compiled to SkipIfNotTrue with two offsets (false→else, error→end) for correct error propagation
- **Compound casts** (CastList1ToList2, CastArrayToArray, CastRecord1ToRecord2, CastListToJsonb, CastArrayToJsonb, CastStringToArray/List/Map/Range): dedicated instructions with compiled sub-programs for inner cast expressions

## Test plan

- [x] Unit tests for Column, Literal, If (true/false/null/error branches) pass
- [x] `cargo check -p mz-expr -p mz-transform -p mz-compute` builds cleanly
- [ ] Integration with MFP evaluation (follow-up)
- [ ] Performance benchmarks (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)