### PR TITLE
expr: add scalar function benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,12 +1466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bencher"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
 name = "bigdecimal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6543,7 +6537,6 @@ version = "0.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
- "bencher",
  "bytes",
  "bytesize",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,6 +6543,7 @@ version = "0.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "bencher",
  "bytes",
  "bytesize",
  "chrono",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -279,6 +279,14 @@ steps:
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
 
+      - id: scalar-benchmark
+        label: "Scalar function benchmark regression"
+        depends_on: []
+        timeout_in_minutes: 120
+        command: bin/ci-builder run stable ci/test/bench-scalar-regression.sh
+        agents:
+          queue: hetzner-x86-64-dedi-8cpu-32gb
+
   - group: Kafka
     key: kafka
     steps:

--- a/ci/test/bench-scalar-regression.sh
+++ b/ci/test/bench-scalar-regression.sh
@@ -2,26 +2,42 @@
 
 # Scalar function benchmark regression test.
 #
-# Runs criterion benchmarks on upstream/main and the current branch,
+# Runs criterion benchmarks on a base ref and the current branch,
 # then compares results. Criterion reports per-benchmark changes with
 # statistical confidence; exit code is always 0 (regressions are
 # informational, not gating) unless a build fails.
 #
 # Usage:
-#   ci/test/bench-scalar-regression.sh [--bench-filter FILTER]
+#   ci/test/bench-scalar-regression.sh [--base-ref REF] [--bench-filter FILTER]
+#                                      [--offline]
 #
 # Options:
+#   --base-ref REF          Git ref to compare against. Default: latest
+#                           release tag (excluding release candidates).
 #   --bench-filter FILTER   Only run benchmarks matching FILTER (passed to
 #                           criterion via `-- FILTER`). Default: run all.
-#
-# The script expects `upstream/main` to be a valid ref (fetch it first
-# with `git fetch upstream`).
+#   --offline               Skip `git fetch --tags` when resolving the
+#                           default base ref. Useful for local runs.
 
 set -euo pipefail
 
+latest_release_tag() {
+    git tag --sort=-version:refname | grep -v '\-rc' | head -1
+}
+
 BENCH_FILTER=""
+BASE_REF=""
+OFFLINE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --offline)
+            OFFLINE=true
+            shift
+            ;;
+        --base-ref)
+            BASE_REF="$2"
+            shift 2
+            ;;
         --bench-filter)
             BENCH_FILTER="$2"
             shift 2
@@ -32,6 +48,17 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ -z "$BASE_REF" ]]; then
+    if ! $OFFLINE; then
+        git fetch --tags
+    fi
+    BASE_REF=$(latest_release_tag)
+    if [[ -z "$BASE_REF" ]]; then
+        echo "No release tag found; pass --base-ref explicitly." >&2
+        exit 1
+    fi
+fi
 
 BENCH_TARGETS=(
     --bench bench_unary
@@ -46,11 +73,10 @@ if [[ -n "$BENCH_FILTER" ]]; then
 fi
 
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-MAIN_REF="upstream/main"
 
 echo "--- Benchmark regression test"
 echo "PR branch:  $PR_BRANCH"
-echo "Base ref:   $MAIN_REF"
+echo "Base ref:   $BASE_REF"
 
 # Stash any uncommitted changes so checkout is clean.
 STASHED=false
@@ -70,8 +96,8 @@ trap cleanup EXIT
 
 # ---- Phase 1: baseline on main ----
 
-echo "--- Building and benchmarking on $MAIN_REF"
-git checkout "$MAIN_REF"
+echo "--- Building and benchmarking on $BASE_REF"
+git checkout "$BASE_REF"
 
 cargo bench -p mz-expr "${BENCH_TARGETS[@]}" -- --save-baseline main "${CRITERION_ARGS[@]}"
 

--- a/ci/test/bench-scalar-regression.sh
+++ b/ci/test/bench-scalar-regression.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Scalar function benchmark regression test.
+#
+# Runs criterion benchmarks on upstream/main and the current branch,
+# then compares results. Criterion reports per-benchmark changes with
+# statistical confidence; exit code is always 0 (regressions are
+# informational, not gating) unless a build fails.
+#
+# Usage:
+#   ci/test/bench-scalar-regression.sh [--bench-filter FILTER]
+#
+# Options:
+#   --bench-filter FILTER   Only run benchmarks matching FILTER (passed to
+#                           criterion via `-- FILTER`). Default: run all.
+#
+# The script expects `upstream/main` to be a valid ref (fetch it first
+# with `git fetch upstream`).
+
+set -euo pipefail
+
+BENCH_FILTER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bench-filter)
+            BENCH_FILTER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+BENCH_TARGETS=(
+    --bench bench_unary
+    --bench bench_binary
+    --bench bench_variadic
+    --bench bench_array
+)
+
+CRITERION_ARGS=()
+if [[ -n "$BENCH_FILTER" ]]; then
+    CRITERION_ARGS+=("$BENCH_FILTER")
+fi
+
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+MAIN_REF="upstream/main"
+
+echo "--- Benchmark regression test"
+echo "PR branch:  $PR_BRANCH"
+echo "Base ref:   $MAIN_REF"
+
+# Stash any uncommitted changes so checkout is clean.
+STASHED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    git stash push -m "bench-scalar-regression: auto-stash"
+    STASHED=true
+fi
+
+cleanup() {
+    echo "--- Returning to $PR_BRANCH"
+    git checkout "$PR_BRANCH"
+    if $STASHED; then
+        git stash pop
+    fi
+}
+trap cleanup EXIT
+
+# ---- Phase 1: baseline on main ----
+
+echo "--- Building and benchmarking on $MAIN_REF"
+git checkout "$MAIN_REF"
+
+cargo bench -p mz-expr "${BENCH_TARGETS[@]}" -- --save-baseline main "${CRITERION_ARGS[@]}"
+
+# ---- Phase 2: PR branch ----
+
+echo "--- Building and benchmarking on $PR_BRANCH"
+git checkout "$PR_BRANCH"
+if $STASHED; then
+    git stash pop
+    STASHED=false
+fi
+
+cargo bench -p mz-expr "${BENCH_TARGETS[@]}" -- --baseline main "${CRITERION_ARGS[@]}"
+
+echo "--- Benchmark comparison complete"
+echo "Criterion reports per-benchmark changes above. Look for 'regressed' lines."

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -87,7 +87,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 smallvec = { version = "1.15.1" }
 
 [dev-dependencies]
-bencher = "0.1.5"
 criterion = { version = "0.8.2" }
 datadriven = "0.9.0"
 insta = "1.45"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -17,6 +17,22 @@ harness = false
 name = "window_functions"
 harness = false
 
+[[bench]]
+name = "bench_binary"
+harness = false
+
+[[bench]]
+name = "bench_unary"
+harness = false
+
+[[bench]]
+name = "bench_variadic"
+harness = false
+
+[[bench]]
+name = "bench_array"
+harness = false
+
 [dependencies]
 aho-corasick = "1.1.4"
 anyhow = "1.0.101"
@@ -71,6 +87,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 smallvec = { version = "1.15.1" }
 
 [dev-dependencies]
+bencher = "0.1.5"
 criterion = { version = "0.8.2" }
 datadriven = "0.9.0"
 insta = "1.45"

--- a/src/expr/benches/bench_array.rs
+++ b/src/expr/benches/bench_array.rs
@@ -9,7 +9,8 @@
 
 //! Benchmarks for Array and List scalar functions (binary, unary, and variadic).
 
-use bencher::{Bencher, benchmark_group, benchmark_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use mz_expr::func::variadic as v;
 use mz_expr::{BinaryFunc, MirScalarExpr, UnaryFunc, VariadicFunc, func};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::{Datum, RowArena, SqlScalarType};
@@ -40,337 +41,309 @@ fn make_int32_list<'a>(arena: &'a RowArena, elems: &[i32]) -> Datum<'a> {
 // Binary — Array functions
 // ===========================================================================
 
-fn bench_array_contains_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayContains(func::ArrayContains);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::Int32(30), arr];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+fn binary_array_benches(c: &mut Criterion) {
+    c.bench_function("bench_array_contains_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayContains(func::ArrayContains);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::Int32(30), arr];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_contains_array_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr_a = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
-    let arr_b = make_int32_array(&sa, &[1, 3, 5]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayContainsArray(func::ArrayContainsArray);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr_a, arr_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_contains_array_happy", |b| {
+        let sa = RowArena::new();
+        let arr_a = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+        let arr_b = make_int32_array(&sa, &[1, 3, 5]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayContainsArray(func::ArrayContainsArray);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr_a, arr_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_contains_array_rev_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr_a = make_int32_array(&sa, &[1, 3, 5]);
-    let arr_b = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayContainsArrayRev(func::ArrayContainsArrayRev);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr_a, arr_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_contains_array_rev_happy", |b| {
+        let sa = RowArena::new();
+        let arr_a = make_int32_array(&sa, &[1, 3, 5]);
+        let arr_b = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayContainsArrayRev(func::ArrayContainsArrayRev);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr_a, arr_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_length_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayLength(func::ArrayLength);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr, Datum::Int64(1)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_length_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayLength(func::ArrayLength);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr, Datum::Int64(1)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_lower_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayLower(func::ArrayLower);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr, Datum::Int64(1)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_lower_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayLower(func::ArrayLower);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr, Datum::Int64(1)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_upper_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayUpper(func::ArrayUpper);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr, Datum::Int64(1)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_upper_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayUpper(func::ArrayUpper);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr, Datum::Int64(1)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_remove_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayRemove(func::ArrayRemove);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr, Datum::Int32(3)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_array_remove_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayRemove(func::ArrayRemove);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr, Datum::Int32(3)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_array_array_concat_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr_a = make_int32_array(&sa, &[1, 2, 3]);
-    let arr_b = make_int32_array(&sa, &[4, 5, 6]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ArrayArrayConcat(func::ArrayArrayConcat);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[arr_a, arr_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
+    c.bench_function("bench_array_array_concat_happy", |b| {
+        let sa = RowArena::new();
+        let arr_a = make_int32_array(&sa, &[1, 2, 3]);
+        let arr_b = make_int32_array(&sa, &[4, 5, 6]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ArrayArrayConcat(func::ArrayArrayConcat);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[arr_a, arr_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 }
 
 // ===========================================================================
 // Binary — List functions
 // ===========================================================================
 
-fn bench_list_list_concat_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list_a = make_int32_list(&sa, &[1, 2, 3]);
-    let list_b = make_int32_list(&sa, &[4, 5, 6]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListListConcat(func::ListListConcat);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list_a, list_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+fn binary_list_benches(c: &mut Criterion) {
+    c.bench_function("bench_list_list_concat_happy", |b| {
+        let sa = RowArena::new();
+        let list_a = make_int32_list(&sa, &[1, 2, 3]);
+        let list_b = make_int32_list(&sa, &[4, 5, 6]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListListConcat(func::ListListConcat);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list_a, list_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_list_element_concat_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[1, 2, 3]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListElementConcat(func::ListElementConcat);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list, Datum::Int32(4)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_list_element_concat_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[1, 2, 3]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListElementConcat(func::ListElementConcat);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list, Datum::Int32(4)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_element_list_concat_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[2, 3, 4]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ElementListConcat(func::ElementListConcat);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::Int32(1), list];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_element_list_concat_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[2, 3, 4]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ElementListConcat(func::ElementListConcat);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::Int32(1), list];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_list_remove_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[1, 2, 3, 2, 4]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListRemove(func::ListRemove);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list, Datum::Int32(2)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_list_remove_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[1, 2, 3, 2, 4]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListRemove(func::ListRemove);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list, Datum::Int32(2)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_list_contains_list_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list_a = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
-    let list_b = make_int32_list(&sa, &[1, 3, 5]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListContainsList(func::ListContainsList);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list_a, list_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_list_contains_list_happy", |b| {
+        let sa = RowArena::new();
+        let list_a = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
+        let list_b = make_int32_list(&sa, &[1, 3, 5]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListContainsList(func::ListContainsList);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list_a, list_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_list_contains_list_rev_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list_a = make_int32_list(&sa, &[1, 3, 5]);
-    let list_b = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListContainsListRev(func::ListContainsListRev);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list_a, list_b];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_list_contains_list_rev_happy", |b| {
+        let sa = RowArena::new();
+        let list_a = make_int32_list(&sa, &[1, 3, 5]);
+        let list_b = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListContainsListRev(func::ListContainsListRev);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list_a, list_b];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn bench_list_length_max_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let f = BinaryFunc::ListLengthMax(func::ListLengthMax { max_layer: 1 });
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list, Datum::Int64(1)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("bench_list_length_max_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let f = BinaryFunc::ListLengthMax(func::ListLengthMax { max_layer: 1 });
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list, Datum::Int64(1)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// ===========================================================================
-// Unary — List functions
-// ===========================================================================
+    // ===========================================================================
+    // Unary — List functions
+    // ===========================================================================
 
-fn bench_list_length_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
-    let f = UnaryFunc::ListLength(func::ListLength);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[list];
-    b.iter(|| f.eval(datums, &arena, &a));
+    c.bench_function("bench_list_length_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+        let f = UnaryFunc::ListLength(func::ListLength);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[list];
+        b.iter(|| f.eval(datums, &arena, &a));
+    });
 }
 
 // ===========================================================================
 // Variadic — Array / List functions
 // ===========================================================================
 
-fn bench_array_create_happy(b: &mut Bencher) {
-    let func = VariadicFunc::ArrayCreate {
-        elem_type: SqlScalarType::Int32,
-    };
-    let datums: &[Datum] = &[
-        Datum::Int32(1),
-        Datum::Int32(2),
-        Datum::Int32(3),
-        Datum::Int32(4),
-        Datum::Int32(5),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+fn variadic_array_list_benches(c: &mut Criterion) {
+    c.bench_function("bench_array_create_happy", |b| {
+        let func = VariadicFunc::from(v::ArrayCreate {
+            elem_type: SqlScalarType::Int32,
+        });
+        let datums: &[Datum] = &[
+            Datum::Int32(1),
+            Datum::Int32(2),
+            Datum::Int32(3),
+            Datum::Int32(4),
+            Datum::Int32(5),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_list_create_happy(b: &mut Bencher) {
-    let func = VariadicFunc::ListCreate {
-        elem_type: SqlScalarType::Int32,
-    };
-    let datums: &[Datum] = &[
-        Datum::Int32(1),
-        Datum::Int32(2),
-        Datum::Int32(3),
-        Datum::Int32(4),
-        Datum::Int32(5),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_list_create_happy", |b| {
+        let func = VariadicFunc::from(v::ListCreate {
+            elem_type: SqlScalarType::Int32,
+        });
+        let datums: &[Datum] = &[
+            Datum::Int32(1),
+            Datum::Int32(2),
+            Datum::Int32(3),
+            Datum::Int32(4),
+            Datum::Int32(5),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_array_to_string_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
-    let func = VariadicFunc::ArrayToString {
-        elem_type: SqlScalarType::Int32,
-    };
-    let datums: &[Datum] = &[arr, Datum::String(",")];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_array_to_string_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+        let func = VariadicFunc::from(v::ArrayToString {
+            elem_type: SqlScalarType::Int32,
+        });
+        let datums: &[Datum] = &[arr, Datum::String(",")];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_array_index_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let func = VariadicFunc::ArrayIndex { offset: 0 };
-    let datums: &[Datum] = &[arr, Datum::Int64(3)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_array_index_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let func = VariadicFunc::from(v::ArrayIndex { offset: 0 });
+        let datums: &[Datum] = &[arr, Datum::Int64(3)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_list_index_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
-    let func = VariadicFunc::ListIndex;
-    let datums: &[Datum] = &[list, Datum::Int64(3)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_list_index_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+        let func = VariadicFunc::from(v::ListIndex);
+        let datums: &[Datum] = &[list, Datum::Int64(3)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_list_slice_linear_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
-    let func = VariadicFunc::ListSliceLinear;
-    let datums: &[Datum] = &[list, Datum::Int64(2), Datum::Int64(4)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_list_slice_linear_happy", |b| {
+        let sa = RowArena::new();
+        let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+        let func = VariadicFunc::from(v::ListSliceLinear);
+        let datums: &[Datum] = &[list, Datum::Int64(2), Datum::Int64(4)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_array_position_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
-    let func = VariadicFunc::ArrayPosition;
-    let datums: &[Datum] = &[arr, Datum::Int32(30)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+    c.bench_function("bench_array_position_happy", |b| {
+        let sa = RowArena::new();
+        let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+        let func = VariadicFunc::from(v::ArrayPosition);
+        let datums: &[Datum] = &[arr, Datum::Int32(30)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 
-fn bench_array_fill_happy(b: &mut Bencher) {
-    let sa = RowArena::new();
-    let dims = make_int32_array(&sa, &[5]);
-    let func = VariadicFunc::ArrayFill {
-        elem_type: SqlScalarType::Int32,
-    };
-    let datums: &[Datum] = &[Datum::Int32(42), dims];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
+    c.bench_function("bench_array_fill_happy", |b| {
+        let sa = RowArena::new();
+        let dims = make_int32_array(&sa, &[5]);
+        let func = VariadicFunc::from(v::ArrayFill {
+            elem_type: SqlScalarType::Int32,
+        });
+        let datums: &[Datum] = &[Datum::Int32(42), dims];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 }
 
 // ===========================================================================
 // Benchmark registration
 // ===========================================================================
 
-benchmark_group!(
-    binary_array_benches,
-    bench_array_contains_happy,
-    bench_array_contains_array_happy,
-    bench_array_contains_array_rev_happy,
-    bench_array_length_happy,
-    bench_array_lower_happy,
-    bench_array_upper_happy,
-    bench_array_remove_happy,
-    bench_array_array_concat_happy
-);
-
-benchmark_group!(
-    binary_list_benches,
-    bench_list_list_concat_happy,
-    bench_list_element_concat_happy,
-    bench_element_list_concat_happy,
-    bench_list_remove_happy,
-    bench_list_contains_list_happy,
-    bench_list_contains_list_rev_happy,
-    bench_list_length_max_happy,
-    bench_list_length_happy
-);
-
-benchmark_group!(
-    variadic_array_list_benches,
-    bench_array_create_happy,
-    bench_list_create_happy,
-    bench_array_to_string_happy,
-    bench_array_index_happy,
-    bench_list_index_happy,
-    bench_list_slice_linear_happy,
-    bench_array_position_happy,
-    bench_array_fill_happy
-);
-
-benchmark_main!(
+criterion_group!(
+    benches,
     binary_array_benches,
     binary_list_benches,
     variadic_array_list_benches
 );
+criterion_main!(benches);

--- a/src/expr/benches/bench_array.rs
+++ b/src/expr/benches/bench_array.rs
@@ -1,0 +1,376 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks for Array and List scalar functions (binary, unary, and variadic).
+
+use bencher::{Bencher, benchmark_group, benchmark_main};
+use mz_expr::{BinaryFunc, MirScalarExpr, UnaryFunc, VariadicFunc, func};
+use mz_repr::adt::array::ArrayDimension;
+use mz_repr::{Datum, RowArena, SqlScalarType};
+
+/// Build a 1-D Int32 array datum (borrows from `arena`).
+fn make_int32_array<'a>(arena: &'a RowArena, elems: &[i32]) -> Datum<'a> {
+    let datums: Vec<Datum> = elems.iter().map(|&v| Datum::Int32(v)).collect();
+    arena.make_datum(|packer| {
+        packer
+            .try_push_array(
+                &[ArrayDimension {
+                    lower_bound: 1,
+                    length: elems.len(),
+                }],
+                &datums,
+            )
+            .unwrap()
+    })
+}
+
+/// Build an Int32 list datum (borrows from `arena`).
+fn make_int32_list<'a>(arena: &'a RowArena, elems: &[i32]) -> Datum<'a> {
+    let datums: Vec<Datum> = elems.iter().map(|&v| Datum::Int32(v)).collect();
+    arena.make_datum(|packer| packer.push_list(&datums))
+}
+
+// ===========================================================================
+// Binary — Array functions
+// ===========================================================================
+
+fn bench_array_contains_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayContains(func::ArrayContains);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::Int32(30), arr];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_contains_array_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr_a = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+    let arr_b = make_int32_array(&sa, &[1, 3, 5]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayContainsArray(func::ArrayContainsArray);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr_a, arr_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_contains_array_rev_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr_a = make_int32_array(&sa, &[1, 3, 5]);
+    let arr_b = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayContainsArrayRev(func::ArrayContainsArrayRev);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr_a, arr_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_length_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayLength(func::ArrayLength);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr, Datum::Int64(1)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_lower_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayLower(func::ArrayLower);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr, Datum::Int64(1)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_upper_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayUpper(func::ArrayUpper);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr, Datum::Int64(1)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_remove_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayRemove(func::ArrayRemove);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr, Datum::Int32(3)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_array_array_concat_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr_a = make_int32_array(&sa, &[1, 2, 3]);
+    let arr_b = make_int32_array(&sa, &[4, 5, 6]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ArrayArrayConcat(func::ArrayArrayConcat);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[arr_a, arr_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// ===========================================================================
+// Binary — List functions
+// ===========================================================================
+
+fn bench_list_list_concat_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list_a = make_int32_list(&sa, &[1, 2, 3]);
+    let list_b = make_int32_list(&sa, &[4, 5, 6]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListListConcat(func::ListListConcat);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list_a, list_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_list_element_concat_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[1, 2, 3]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListElementConcat(func::ListElementConcat);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list, Datum::Int32(4)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_element_list_concat_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[2, 3, 4]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ElementListConcat(func::ElementListConcat);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::Int32(1), list];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_list_remove_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[1, 2, 3, 2, 4]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListRemove(func::ListRemove);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list, Datum::Int32(2)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_list_contains_list_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list_a = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
+    let list_b = make_int32_list(&sa, &[1, 3, 5]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListContainsList(func::ListContainsList);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list_a, list_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_list_contains_list_rev_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list_a = make_int32_list(&sa, &[1, 3, 5]);
+    let list_b = make_int32_list(&sa, &[1, 2, 3, 4, 5]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListContainsListRev(func::ListContainsListRev);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list_a, list_b];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn bench_list_length_max_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let f = BinaryFunc::ListLengthMax(func::ListLengthMax { max_layer: 1 });
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list, Datum::Int64(1)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// ===========================================================================
+// Unary — List functions
+// ===========================================================================
+
+fn bench_list_length_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+    let f = UnaryFunc::ListLength(func::ListLength);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[list];
+    b.iter(|| f.eval(datums, &arena, &a));
+}
+
+// ===========================================================================
+// Variadic — Array / List functions
+// ===========================================================================
+
+fn bench_array_create_happy(b: &mut Bencher) {
+    let func = VariadicFunc::ArrayCreate {
+        elem_type: SqlScalarType::Int32,
+    };
+    let datums: &[Datum] = &[
+        Datum::Int32(1),
+        Datum::Int32(2),
+        Datum::Int32(3),
+        Datum::Int32(4),
+        Datum::Int32(5),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_list_create_happy(b: &mut Bencher) {
+    let func = VariadicFunc::ListCreate {
+        elem_type: SqlScalarType::Int32,
+    };
+    let datums: &[Datum] = &[
+        Datum::Int32(1),
+        Datum::Int32(2),
+        Datum::Int32(3),
+        Datum::Int32(4),
+        Datum::Int32(5),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_array_to_string_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[1, 2, 3, 4, 5]);
+    let func = VariadicFunc::ArrayToString {
+        elem_type: SqlScalarType::Int32,
+    };
+    let datums: &[Datum] = &[arr, Datum::String(",")];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_array_index_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let func = VariadicFunc::ArrayIndex { offset: 0 };
+    let datums: &[Datum] = &[arr, Datum::Int64(3)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_list_index_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+    let func = VariadicFunc::ListIndex;
+    let datums: &[Datum] = &[list, Datum::Int64(3)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_list_slice_linear_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let list = make_int32_list(&sa, &[10, 20, 30, 40, 50]);
+    let func = VariadicFunc::ListSliceLinear;
+    let datums: &[Datum] = &[list, Datum::Int64(2), Datum::Int64(4)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_array_position_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let arr = make_int32_array(&sa, &[10, 20, 30, 40, 50]);
+    let func = VariadicFunc::ArrayPosition;
+    let datums: &[Datum] = &[arr, Datum::Int32(30)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_array_fill_happy(b: &mut Bencher) {
+    let sa = RowArena::new();
+    let dims = make_int32_array(&sa, &[5]);
+    let func = VariadicFunc::ArrayFill {
+        elem_type: SqlScalarType::Int32,
+    };
+    let datums: &[Datum] = &[Datum::Int32(42), dims];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+// ===========================================================================
+// Benchmark registration
+// ===========================================================================
+
+benchmark_group!(
+    binary_array_benches,
+    bench_array_contains_happy,
+    bench_array_contains_array_happy,
+    bench_array_contains_array_rev_happy,
+    bench_array_length_happy,
+    bench_array_lower_happy,
+    bench_array_upper_happy,
+    bench_array_remove_happy,
+    bench_array_array_concat_happy
+);
+
+benchmark_group!(
+    binary_list_benches,
+    bench_list_list_concat_happy,
+    bench_list_element_concat_happy,
+    bench_element_list_concat_happy,
+    bench_list_remove_happy,
+    bench_list_contains_list_happy,
+    bench_list_contains_list_rev_happy,
+    bench_list_length_max_happy,
+    bench_list_length_happy
+);
+
+benchmark_group!(
+    variadic_array_list_benches,
+    bench_array_create_happy,
+    bench_list_create_happy,
+    bench_array_to_string_happy,
+    bench_array_index_happy,
+    bench_list_index_happy,
+    bench_list_slice_linear_happy,
+    bench_array_position_happy,
+    bench_array_fill_happy
+);
+
+benchmark_main!(
+    binary_array_benches,
+    binary_list_benches,
+    variadic_array_list_benches
+);

--- a/src/expr/benches/bench_binary.rs
+++ b/src/expr/benches/bench_binary.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bencher::{Bencher, TestFn, benchmark_group, benchmark_main};
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use criterion::{Criterion, criterion_group, criterion_main};
 use mz_expr::{BinaryFunc, MirScalarExpr, func};
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
@@ -18,1385 +18,1245 @@ use mz_repr::{Datum, RowArena};
 use uuid::Uuid;
 
 macro_rules! bench_binary {
-    ($bench_name:ident, $struct_expr:expr,
+    ($c:expr, $bench_name:ident, $struct_expr:expr,
      $a_datum:expr, $b_datum:expr $(,)? ) => {
-        fn $bench_name(b: &mut Bencher) {
+        $c.bench_function(stringify!($bench_name), |b| {
             let f = BinaryFunc::from($struct_expr);
             let a = MirScalarExpr::column(0);
             let e = MirScalarExpr::column(1);
             let arena = RowArena::new();
             let datums: &[Datum] = &[($a_datum).into(), ($b_datum).into()];
-            b.iter(|| f.eval(datums, &arena, &a, &e));
-        }
+            b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+        });
     };
 }
 
-/// Generates a `_group` function that returns individual benchmark entries
+/// Generates a criterion benchmark group with individual benchmark entries
 /// for each input pair, so they show up as separate lines in benchmark output.
 macro_rules! bench_binary_multi {
-    ($bench_name:ident, $struct_expr:expr,
+    ($c:expr, $bench_name:ident, $struct_expr:expr,
      [ $( ($a_datum:expr, $b_datum:expr) ),+ $(,)? ]) => {
-        paste::paste! {
-            fn [<$bench_name _group>]() -> Vec<bencher::TestDescAndFn> {
-                use bencher::{TestDescAndFn, TestDesc};
-                use std::borrow::Cow;
-                let mut benches = Vec::new();
-                $(
-                    benches.push(TestDescAndFn {
-                        desc: TestDesc {
-                            name: Cow::from(concat!(
-                                stringify!($bench_name), "(", stringify!($a_datum), ", ", stringify!($b_datum), ")"
-                            )),
-                            ignore: false,
-                        },
-                        testfn: TestFn::StaticBenchFn({
-                            fn run(b: &mut bencher::Bencher) {
-                                let f = BinaryFunc::from($struct_expr);
-                                let a = MirScalarExpr::column(0);
-                                let e = MirScalarExpr::column(1);
-                                let arena = RowArena::new();
-                                let datums: &[Datum] = &[($a_datum).into(), ($b_datum).into()];
-                                b.iter(|| f.eval(datums, &arena, &a, &e));
-                            }
-                            run
-                        }),
-                    });
-                )+
-                benches
-            }
+        {
+            let mut group = $c.benchmark_group(stringify!($bench_name));
+            $(
+                group.bench_function(
+                    &format!("({}, {})", stringify!($a_datum), stringify!($b_datum)),
+                    |b| {
+                        let f = BinaryFunc::from($struct_expr);
+                        let a = MirScalarExpr::column(0);
+                        let e = MirScalarExpr::column(1);
+                        let arena = RowArena::new();
+                        let datums: &[Datum] = &[($a_datum).into(), ($b_datum).into()];
+                        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+                    },
+                );
+            )+
+            group.finish();
         }
     };
 }
 
 // Arithmetic functions
 
-// Add
-bench_binary!(add_int16, func::AddInt16, 1i16, 2i16);
-bench_binary!(add_int16_error, func::AddInt16, i16::MAX, 1i16);
-bench_binary!(add_int32, func::AddInt32, 1i32, 2i32);
-bench_binary!(add_int32_error, func::AddInt32, i32::MAX, 1i32);
-bench_binary!(add_int64, func::AddInt64, 1i64, 2i64);
-bench_binary!(add_int64_error, func::AddInt64, i64::MAX, 1i64);
-bench_binary!(add_uint16, func::AddUint16, 1u16, 2u16);
-bench_binary!(add_uint16_error, func::AddUint16, u16::MAX, 1u16);
-bench_binary!(add_uint32, func::AddUint32, 1u32, 2u32);
-bench_binary!(add_uint32_error, func::AddUint32, u32::MAX, 1u32);
-bench_binary!(add_uint64, func::AddUint64, 1u64, 2u64);
-bench_binary!(add_uint64_error, func::AddUint64, u64::MAX, 1u64);
-bench_binary!(add_float32, func::AddFloat32, 1.0f32, 2.0f32);
-bench_binary!(add_float32_error, func::AddFloat32, f32::MAX, f32::MAX);
-bench_binary!(add_float64, func::AddFloat64, 1.0f64, 2.0f64);
-bench_binary!(add_float64_error, func::AddFloat64, f64::MAX, f64::MAX);
-bench_binary!(
-    add_numeric,
-    func::AddNumeric,
-    Numeric::from(1),
-    Numeric::from(2)
-);
-bench_binary!(
-    add_interval,
-    func::AddInterval,
-    Interval::new(1, 2, 3_000_000),
-    Interval::new(0, 1, 1_000_000)
-);
+fn arithmetic_benches(c: &mut Criterion) {
+    // Add
+    bench_binary!(c, add_int16, func::AddInt16, 1i16, 2i16);
+    bench_binary!(c, add_int16_error, func::AddInt16, i16::MAX, 1i16);
+    bench_binary!(c, add_int32, func::AddInt32, 1i32, 2i32);
+    bench_binary!(c, add_int32_error, func::AddInt32, i32::MAX, 1i32);
+    bench_binary!(c, add_int64, func::AddInt64, 1i64, 2i64);
+    bench_binary!(c, add_int64_error, func::AddInt64, i64::MAX, 1i64);
+    bench_binary!(c, add_uint16, func::AddUint16, 1u16, 2u16);
+    bench_binary!(c, add_uint16_error, func::AddUint16, u16::MAX, 1u16);
+    bench_binary!(c, add_uint32, func::AddUint32, 1u32, 2u32);
+    bench_binary!(c, add_uint32_error, func::AddUint32, u32::MAX, 1u32);
+    bench_binary!(c, add_uint64, func::AddUint64, 1u64, 2u64);
+    bench_binary!(c, add_uint64_error, func::AddUint64, u64::MAX, 1u64);
+    bench_binary!(c, add_float32, func::AddFloat32, 1.0f32, 2.0f32);
+    bench_binary!(c, add_float32_error, func::AddFloat32, f32::MAX, f32::MAX);
+    bench_binary!(c, add_float64, func::AddFloat64, 1.0f64, 2.0f64);
+    bench_binary!(c, add_float64_error, func::AddFloat64, f64::MAX, f64::MAX);
+    bench_binary!(
+        c,
+        add_numeric,
+        func::AddNumeric,
+        Numeric::from(1),
+        Numeric::from(2)
+    );
+    bench_binary!(
+        c,
+        add_interval,
+        func::AddInterval,
+        Interval::new(1, 2, 3_000_000),
+        Interval::new(0, 1, 1_000_000)
+    );
 
-fn add_timestamp_interval(b: &mut Bencher) {
-    let f = BinaryFunc::AddTimestampInterval(func::AddTimestampInterval);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Timestamp(ts),
-        Datum::Interval(Interval::new(0, 1, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("add_timestamp_interval", |b| {
+        let f = BinaryFunc::AddTimestampInterval(func::AddTimestampInterval);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Timestamp(ts),
+            Datum::Interval(Interval::new(0, 1, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn add_timestamp_tz_interval(b: &mut Bencher) {
-    let f = BinaryFunc::AddTimestampTzInterval(func::AddTimestampTzInterval);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::TimestampTz(ts),
-        Datum::Interval(Interval::new(0, 1, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("add_timestamp_tz_interval", |b| {
+        let f = BinaryFunc::AddTimestampTzInterval(func::AddTimestampTzInterval);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::TimestampTz(ts),
+            Datum::Interval(Interval::new(0, 1, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn add_date_interval(b: &mut Bencher) {
-    let f = BinaryFunc::AddDateInterval(func::AddDateInterval);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Date(Date::from_pg_epoch(0).unwrap()),
-        Datum::Interval(Interval::new(1, 0, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("add_date_interval", |b| {
+        let f = BinaryFunc::AddDateInterval(func::AddDateInterval);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Date(Date::from_pg_epoch(0).unwrap()),
+            Datum::Interval(Interval::new(1, 0, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn add_date_time(b: &mut Bencher) {
-    let f = BinaryFunc::AddDateTime(func::AddDateTime);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Date(Date::from_pg_epoch(0).unwrap()),
-        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("add_date_time", |b| {
+        let f = BinaryFunc::AddDateTime(func::AddDateTime);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Date(Date::from_pg_epoch(0).unwrap()),
+            Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn add_time_interval(b: &mut Bencher) {
-    let f = BinaryFunc::AddTimeInterval(func::AddTimeInterval);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("add_time_interval", |b| {
+        let f = BinaryFunc::AddTimeInterval(func::AddTimeInterval);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// Sub
-bench_binary!(sub_int16, func::SubInt16, 10i16, 3i16);
-bench_binary!(sub_int16_error, func::SubInt16, i16::MIN, 1i16);
-bench_binary!(sub_int32, func::SubInt32, 10i32, 3i32);
-bench_binary!(sub_int32_error, func::SubInt32, i32::MIN, 1i32);
-bench_binary!(sub_int64, func::SubInt64, 10i64, 3i64);
-bench_binary!(sub_int64_error, func::SubInt64, i64::MIN, 1i64);
-bench_binary!(sub_uint16, func::SubUint16, 10u16, 3u16);
-bench_binary!(sub_uint16_error, func::SubUint16, 0u16, 1u16);
-bench_binary!(sub_uint32, func::SubUint32, 10u32, 3u32);
-bench_binary!(sub_uint32_error, func::SubUint32, 0u32, 1u32);
-bench_binary!(sub_uint64, func::SubUint64, 10u64, 3u64);
-bench_binary!(sub_uint64_error, func::SubUint64, 0u64, 1u64);
-bench_binary!(sub_float32, func::SubFloat32, 10.0f32, 3.0f32);
-bench_binary!(sub_float64, func::SubFloat64, 10.0f64, 3.0f64);
-bench_binary!(
-    sub_numeric,
-    func::SubNumeric,
-    Numeric::from(10),
-    Numeric::from(3)
-);
-bench_binary!(
-    sub_interval,
-    func::SubInterval,
-    Interval::new(1, 2, 3_000_000),
-    Interval::new(0, 1, 1_000_000)
-);
+    // Sub
+    bench_binary!(c, sub_int16, func::SubInt16, 10i16, 3i16);
+    bench_binary!(c, sub_int16_error, func::SubInt16, i16::MIN, 1i16);
+    bench_binary!(c, sub_int32, func::SubInt32, 10i32, 3i32);
+    bench_binary!(c, sub_int32_error, func::SubInt32, i32::MIN, 1i32);
+    bench_binary!(c, sub_int64, func::SubInt64, 10i64, 3i64);
+    bench_binary!(c, sub_int64_error, func::SubInt64, i64::MIN, 1i64);
+    bench_binary!(c, sub_uint16, func::SubUint16, 10u16, 3u16);
+    bench_binary!(c, sub_uint16_error, func::SubUint16, 0u16, 1u16);
+    bench_binary!(c, sub_uint32, func::SubUint32, 10u32, 3u32);
+    bench_binary!(c, sub_uint32_error, func::SubUint32, 0u32, 1u32);
+    bench_binary!(c, sub_uint64, func::SubUint64, 10u64, 3u64);
+    bench_binary!(c, sub_uint64_error, func::SubUint64, 0u64, 1u64);
+    bench_binary!(c, sub_float32, func::SubFloat32, 10.0f32, 3.0f32);
+    bench_binary!(c, sub_float64, func::SubFloat64, 10.0f64, 3.0f64);
+    bench_binary!(
+        c,
+        sub_numeric,
+        func::SubNumeric,
+        Numeric::from(10),
+        Numeric::from(3)
+    );
+    bench_binary!(
+        c,
+        sub_interval,
+        func::SubInterval,
+        Interval::new(1, 2, 3_000_000),
+        Interval::new(0, 1, 1_000_000)
+    );
 
-fn sub_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::SubTimestamp(func::SubTimestamp);
-    let ts1 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 6, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let ts2 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_timestamp", |b| {
+        let f = BinaryFunc::SubTimestamp(func::SubTimestamp);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 6, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn sub_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::SubTimestampTz(func::SubTimestampTz);
-    let ts1 =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let ts2 =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_timestamp_tz", |b| {
+        let f = BinaryFunc::SubTimestampTz(func::SubTimestampTz);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn sub_timestamp_interval(b: &mut Bencher) {
-    let f = BinaryFunc::SubTimestampInterval(func::SubTimestampInterval);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 6, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Timestamp(ts),
-        Datum::Interval(Interval::new(0, 1, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_timestamp_interval", |b| {
+        let f = BinaryFunc::SubTimestampInterval(func::SubTimestampInterval);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 6, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Timestamp(ts),
+            Datum::Interval(Interval::new(0, 1, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn sub_timestamp_tz_interval(b: &mut Bencher) {
-    let f = BinaryFunc::SubTimestampTzInterval(func::SubTimestampTzInterval);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::TimestampTz(ts),
-        Datum::Interval(Interval::new(0, 1, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_timestamp_tz_interval", |b| {
+        let f = BinaryFunc::SubTimestampTzInterval(func::SubTimestampTzInterval);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::TimestampTz(ts),
+            Datum::Interval(Interval::new(0, 1, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-bench_binary!(
-    sub_date,
-    func::SubDate,
-    Date::from_pg_epoch(100).unwrap(),
-    Date::from_pg_epoch(0).unwrap()
-);
+    bench_binary!(
+        c,
+        sub_date,
+        func::SubDate,
+        Date::from_pg_epoch(100).unwrap(),
+        Date::from_pg_epoch(0).unwrap()
+    );
 
-fn sub_date_interval(b: &mut Bencher) {
-    let f = BinaryFunc::SubDateInterval(func::SubDateInterval);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Date(Date::from_pg_epoch(100).unwrap()),
-        Datum::Interval(Interval::new(1, 0, 0)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_date_interval", |b| {
+        let f = BinaryFunc::SubDateInterval(func::SubDateInterval);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Date(Date::from_pg_epoch(100).unwrap()),
+            Datum::Interval(Interval::new(1, 0, 0)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn sub_time(b: &mut Bencher) {
-    let f = BinaryFunc::SubTime(func::SubTime);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
-        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_time", |b| {
+        let f = BinaryFunc::SubTime(func::SubTime);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
+            Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn sub_time_interval(b: &mut Bencher) {
-    let f = BinaryFunc::SubTimeInterval(func::SubTimeInterval);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("sub_time_interval", |b| {
+        let f = BinaryFunc::SubTimeInterval(func::SubTimeInterval);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// Mul
-bench_binary!(mul_int16, func::MulInt16, 3i16, 4i16);
-bench_binary!(mul_int16_error, func::MulInt16, i16::MAX, 2i16);
-bench_binary!(mul_int32, func::MulInt32, 3i32, 4i32);
-bench_binary!(mul_int32_error, func::MulInt32, i32::MAX, 2i32);
-bench_binary!(mul_int64, func::MulInt64, 3i64, 4i64);
-bench_binary!(mul_int64_error, func::MulInt64, i64::MAX, 2i64);
-bench_binary!(mul_uint16, func::MulUint16, 3u16, 4u16);
-bench_binary!(mul_uint16_error, func::MulUint16, u16::MAX, 2u16);
-bench_binary!(mul_uint32, func::MulUint32, 3u32, 4u32);
-bench_binary!(mul_uint32_error, func::MulUint32, u32::MAX, 2u32);
-bench_binary!(mul_uint64, func::MulUint64, 3u64, 4u64);
-bench_binary!(mul_uint64_error, func::MulUint64, u64::MAX, 2u64);
-bench_binary!(mul_float32, func::MulFloat32, 3.0f32, 4.0f32);
-bench_binary!(mul_float32_error, func::MulFloat32, f32::MAX, 2.0f32);
-bench_binary!(mul_float64, func::MulFloat64, 3.0f64, 4.0f64);
-bench_binary!(mul_float64_error, func::MulFloat64, f64::MAX, 2.0f64);
-bench_binary!(
-    mul_numeric,
-    func::MulNumeric,
-    Numeric::from(3),
-    Numeric::from(4)
-);
-bench_binary!(
-    mul_interval,
-    func::MulInterval,
-    Interval::new(1, 0, 0),
-    2.0f64
-);
+    // Mul
+    bench_binary!(c, mul_int16, func::MulInt16, 3i16, 4i16);
+    bench_binary!(c, mul_int16_error, func::MulInt16, i16::MAX, 2i16);
+    bench_binary!(c, mul_int32, func::MulInt32, 3i32, 4i32);
+    bench_binary!(c, mul_int32_error, func::MulInt32, i32::MAX, 2i32);
+    bench_binary!(c, mul_int64, func::MulInt64, 3i64, 4i64);
+    bench_binary!(c, mul_int64_error, func::MulInt64, i64::MAX, 2i64);
+    bench_binary!(c, mul_uint16, func::MulUint16, 3u16, 4u16);
+    bench_binary!(c, mul_uint16_error, func::MulUint16, u16::MAX, 2u16);
+    bench_binary!(c, mul_uint32, func::MulUint32, 3u32, 4u32);
+    bench_binary!(c, mul_uint32_error, func::MulUint32, u32::MAX, 2u32);
+    bench_binary!(c, mul_uint64, func::MulUint64, 3u64, 4u64);
+    bench_binary!(c, mul_uint64_error, func::MulUint64, u64::MAX, 2u64);
+    bench_binary!(c, mul_float32, func::MulFloat32, 3.0f32, 4.0f32);
+    bench_binary!(c, mul_float32_error, func::MulFloat32, f32::MAX, 2.0f32);
+    bench_binary!(c, mul_float64, func::MulFloat64, 3.0f64, 4.0f64);
+    bench_binary!(c, mul_float64_error, func::MulFloat64, f64::MAX, 2.0f64);
+    bench_binary!(
+        c,
+        mul_numeric,
+        func::MulNumeric,
+        Numeric::from(3),
+        Numeric::from(4)
+    );
+    bench_binary!(
+        c,
+        mul_interval,
+        func::MulInterval,
+        Interval::new(1, 0, 0),
+        2.0f64
+    );
 
-// Div
-bench_binary_multi!(
-    div_int16,
-    func::DivInt16,
-    [
-        (10i16, 3i16),
-        (100i16, 7i16),
-        (-50i16, 3i16),
-        (i16::MAX, 13i16),
-        (1i16, 1i16),
-        (0i16, 42i16),
-        (32000i16, 127i16),
-        (9999i16, 100i16),
-    ]
-);
-bench_binary!(div_int16_divzero, func::DivInt16, 10i16, 0i16);
-bench_binary_multi!(
-    div_int32,
-    func::DivInt32,
-    [
-        (10i32, 3i32),
-        (1000000i32, 7i32),
-        (-500i32, 3i32),
-        (i32::MAX, 13i32),
-        (1i32, 1i32),
-        (0i32, 42i32),
-        (999999999i32, 127i32),
-        (123456789i32, 9876i32),
-    ]
-);
-bench_binary!(div_int32_divzero, func::DivInt32, 10i32, 0i32);
-bench_binary_multi!(
-    div_int64,
-    func::DivInt64,
-    [
-        (10i64, 3i64),
-        (1000000000000i64, 7i64),
-        (-500i64, 3i64),
-        (i64::MAX, 13i64),
-        (1i64, 1i64),
-        (0i64, 42i64),
-        (999999999999i64, 127i64),
-        (123456789012345i64, 9876543i64),
-    ]
-);
-bench_binary!(div_int64_divzero, func::DivInt64, 10i64, 0i64);
-bench_binary_multi!(
-    div_uint16,
-    func::DivUint16,
-    [
-        (10u16, 3u16),
-        (100u16, 7u16),
-        (u16::MAX, 13u16),
-        (1u16, 1u16),
-        (0u16, 42u16),
-        (60000u16, 127u16),
-    ]
-);
-bench_binary!(div_uint16_divzero, func::DivUint16, 10u16, 0u16);
-bench_binary_multi!(
-    div_uint32,
-    func::DivUint32,
-    [
-        (10u32, 3u32),
-        (1000000u32, 7u32),
-        (u32::MAX, 13u32),
-        (1u32, 1u32),
-        (0u32, 42u32),
-        (999999999u32, 127u32),
-    ]
-);
-bench_binary!(div_uint32_divzero, func::DivUint32, 10u32, 0u32);
-bench_binary_multi!(
-    div_uint64,
-    func::DivUint64,
-    [
-        (10u64, 3u64),
-        (1000000000000u64, 7u64),
-        (u64::MAX, 13u64),
-        (1u64, 1u64),
-        (0u64, 42u64),
-        (999999999999u64, 127u64),
-    ]
-);
-bench_binary!(div_uint64_divzero, func::DivUint64, 10u64, 0u64);
-bench_binary_multi!(
-    div_float32,
-    func::DivFloat32,
-    [
-        (10.0f32, 3.0f32),
-        (1.0f32, 7.0f32),
-        (1e10f32, 0.001f32),
-        (-42.5f32, 3.7f32),
-        (0.001f32, 1000.0f32),
-        (999.999f32, 1.001f32),
-    ]
-);
-bench_binary!(div_float32_divzero, func::DivFloat32, 10.0f32, 0.0f32);
-bench_binary_multi!(
-    div_float64,
-    func::DivFloat64,
-    [
-        (10.0f64, 3.0f64),
-        (1.0f64, 7.0f64),
-        (1e15f64, 0.00001f64),
-        (-42.5f64, 3.7f64),
-        (0.001f64, 1000.0f64),
-        (999.999f64, 1.001f64),
-        (1.7976931e100f64, 1.23456789f64),
-        (std::f64::consts::PI, std::f64::consts::E),
-    ]
-);
-bench_binary!(div_float64_divzero, func::DivFloat64, 10.0f64, 0.0f64);
-bench_binary_multi!(
-    div_numeric,
-    func::DivNumeric,
-    [
-        (Numeric::from(10), Numeric::from(3)),
-        (Numeric::from(1), Numeric::from(7)),
-        (Numeric::from(1000000), Numeric::from(13)),
-        (Numeric::from(999999), Numeric::from(42)),
-        (Numeric::from(-50), Numeric::from(3)),
-        (Numeric::from(1), Numeric::from(1)),
-    ]
-);
-bench_binary!(
-    div_numeric_divzero,
-    func::DivNumeric,
-    Numeric::from(10),
-    Numeric::from(0)
-);
-bench_binary!(
-    div_interval,
-    func::DivInterval,
-    Interval::new(2, 0, 0),
-    2.0f64
-);
-bench_binary!(
-    div_interval_divzero,
-    func::DivInterval,
-    Interval::new(2, 0, 0),
-    0.0f64
-);
+    // Div
+    bench_binary_multi!(
+        c,
+        div_int16,
+        func::DivInt16,
+        [
+            (10i16, 3i16),
+            (100i16, 7i16),
+            (-50i16, 3i16),
+            (i16::MAX, 13i16),
+            (1i16, 1i16),
+            (0i16, 42i16),
+            (32000i16, 127i16),
+            (9999i16, 100i16),
+        ]
+    );
+    bench_binary!(c, div_int16_divzero, func::DivInt16, 10i16, 0i16);
+    bench_binary_multi!(
+        c,
+        div_int32,
+        func::DivInt32,
+        [
+            (10i32, 3i32),
+            (1000000i32, 7i32),
+            (-500i32, 3i32),
+            (i32::MAX, 13i32),
+            (1i32, 1i32),
+            (0i32, 42i32),
+            (999999999i32, 127i32),
+            (123456789i32, 9876i32),
+        ]
+    );
+    bench_binary!(c, div_int32_divzero, func::DivInt32, 10i32, 0i32);
+    bench_binary_multi!(
+        c,
+        div_int64,
+        func::DivInt64,
+        [
+            (10i64, 3i64),
+            (1000000000000i64, 7i64),
+            (-500i64, 3i64),
+            (i64::MAX, 13i64),
+            (1i64, 1i64),
+            (0i64, 42i64),
+            (999999999999i64, 127i64),
+            (123456789012345i64, 9876543i64),
+        ]
+    );
+    bench_binary!(c, div_int64_divzero, func::DivInt64, 10i64, 0i64);
+    bench_binary_multi!(
+        c,
+        div_uint16,
+        func::DivUint16,
+        [
+            (10u16, 3u16),
+            (100u16, 7u16),
+            (u16::MAX, 13u16),
+            (1u16, 1u16),
+            (0u16, 42u16),
+            (60000u16, 127u16),
+        ]
+    );
+    bench_binary!(c, div_uint16_divzero, func::DivUint16, 10u16, 0u16);
+    bench_binary_multi!(
+        c,
+        div_uint32,
+        func::DivUint32,
+        [
+            (10u32, 3u32),
+            (1000000u32, 7u32),
+            (u32::MAX, 13u32),
+            (1u32, 1u32),
+            (0u32, 42u32),
+            (999999999u32, 127u32),
+        ]
+    );
+    bench_binary!(c, div_uint32_divzero, func::DivUint32, 10u32, 0u32);
+    bench_binary_multi!(
+        c,
+        div_uint64,
+        func::DivUint64,
+        [
+            (10u64, 3u64),
+            (1000000000000u64, 7u64),
+            (u64::MAX, 13u64),
+            (1u64, 1u64),
+            (0u64, 42u64),
+            (999999999999u64, 127u64),
+        ]
+    );
+    bench_binary!(c, div_uint64_divzero, func::DivUint64, 10u64, 0u64);
+    bench_binary_multi!(
+        c,
+        div_float32,
+        func::DivFloat32,
+        [
+            (10.0f32, 3.0f32),
+            (1.0f32, 7.0f32),
+            (1e10f32, 0.001f32),
+            (-42.5f32, 3.7f32),
+            (0.001f32, 1000.0f32),
+            (999.999f32, 1.001f32),
+        ]
+    );
+    bench_binary!(c, div_float32_divzero, func::DivFloat32, 10.0f32, 0.0f32);
+    bench_binary_multi!(
+        c,
+        div_float64,
+        func::DivFloat64,
+        [
+            (10.0f64, 3.0f64),
+            (1.0f64, 7.0f64),
+            (1e15f64, 0.00001f64),
+            (-42.5f64, 3.7f64),
+            (0.001f64, 1000.0f64),
+            (999.999f64, 1.001f64),
+            (1.7976931e100f64, 1.23456789f64),
+            (std::f64::consts::PI, std::f64::consts::E),
+        ]
+    );
+    bench_binary!(c, div_float64_divzero, func::DivFloat64, 10.0f64, 0.0f64);
+    bench_binary_multi!(
+        c,
+        div_numeric,
+        func::DivNumeric,
+        [
+            (Numeric::from(10), Numeric::from(3)),
+            (Numeric::from(1), Numeric::from(7)),
+            (Numeric::from(1000000), Numeric::from(13)),
+            (Numeric::from(999999), Numeric::from(42)),
+            (Numeric::from(-50), Numeric::from(3)),
+            (Numeric::from(1), Numeric::from(1)),
+        ]
+    );
+    bench_binary!(
+        c,
+        div_numeric_divzero,
+        func::DivNumeric,
+        Numeric::from(10),
+        Numeric::from(0)
+    );
+    bench_binary!(
+        c,
+        div_interval,
+        func::DivInterval,
+        Interval::new(2, 0, 0),
+        2.0f64
+    );
+    bench_binary!(
+        c,
+        div_interval_divzero,
+        func::DivInterval,
+        Interval::new(2, 0, 0),
+        0.0f64
+    );
 
-// Mod
-bench_binary!(mod_int16, func::ModInt16, 10i16, 3i16);
-bench_binary!(mod_int16_divzero, func::ModInt16, 10i16, 0i16);
-bench_binary!(mod_int32, func::ModInt32, 10i32, 3i32);
-bench_binary!(mod_int32_divzero, func::ModInt32, 10i32, 0i32);
-bench_binary!(mod_int64, func::ModInt64, 10i64, 3i64);
-bench_binary!(mod_int64_divzero, func::ModInt64, 10i64, 0i64);
-bench_binary!(mod_uint16, func::ModUint16, 10u16, 3u16);
-bench_binary!(mod_uint32, func::ModUint32, 10u32, 3u32);
-bench_binary!(mod_uint64, func::ModUint64, 10u64, 3u64);
-bench_binary!(mod_float32, func::ModFloat32, 10.0f32, 3.0f32);
-bench_binary!(mod_float64, func::ModFloat64, 10.0f64, 3.0f64);
-bench_binary!(
-    mod_numeric,
-    func::ModNumeric,
-    Numeric::from(10),
-    Numeric::from(3)
-);
+    // Mod
+    bench_binary!(c, mod_int16, func::ModInt16, 10i16, 3i16);
+    bench_binary!(c, mod_int16_divzero, func::ModInt16, 10i16, 0i16);
+    bench_binary!(c, mod_int32, func::ModInt32, 10i32, 3i32);
+    bench_binary!(c, mod_int32_divzero, func::ModInt32, 10i32, 0i32);
+    bench_binary!(c, mod_int64, func::ModInt64, 10i64, 3i64);
+    bench_binary!(c, mod_int64_divzero, func::ModInt64, 10i64, 0i64);
+    bench_binary!(c, mod_uint16, func::ModUint16, 10u16, 3u16);
+    bench_binary!(c, mod_uint32, func::ModUint32, 10u32, 3u32);
+    bench_binary!(c, mod_uint64, func::ModUint64, 10u64, 3u64);
+    bench_binary!(c, mod_float32, func::ModFloat32, 10.0f32, 3.0f32);
+    bench_binary!(c, mod_float64, func::ModFloat64, 10.0f64, 3.0f64);
+    bench_binary!(
+        c,
+        mod_numeric,
+        func::ModNumeric,
+        Numeric::from(10),
+        Numeric::from(3)
+    );
 
-// RoundNumeric (binary)
-bench_binary!(
-    round_numeric,
-    func::RoundNumericBinary,
-    Numeric::from(314),
-    2i32
-);
+    // RoundNumeric (binary)
+    bench_binary!(
+        c,
+        round_numeric,
+        func::RoundNumericBinary,
+        Numeric::from(314),
+        2i32
+    );
 
-// Age
-fn age_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::AgeTimestamp(func::AgeTimestamp);
-    let ts1 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 6, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let ts2 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // Age
+    c.bench_function("age_timestamp", |b| {
+        let f = BinaryFunc::AgeTimestamp(func::AgeTimestamp);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 6, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn age_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::AgeTimestampTz(func::AgeTimestampTz);
-    let ts1 =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let ts2 =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
+    c.bench_function("age_timestamp_tz", |b| {
+        let f = BinaryFunc::AgeTimestampTz(func::AgeTimestampTz);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
+
+    // Numeric operations
+    bench_binary_multi!(
+        c,
+        log_numeric,
+        func::LogBaseNumeric,
+        [
+            (Numeric::from(10), Numeric::from(100)),
+            (Numeric::from(2), Numeric::from(1024)),
+            (Numeric::from(10), Numeric::from(42)),
+            (Numeric::from(3), Numeric::from(81)),
+            (Numeric::from(7), Numeric::from(999999)),
+        ]
+    );
+    bench_binary_multi!(
+        c,
+        power,
+        func::Power,
+        [
+            (2.0f64, 10.0f64),
+            (2.0f64, 0.5f64),
+            (10.0f64, 3.0f64),
+            (1.5f64, 7.3f64),
+            (0.5f64, 20.0f64),
+            (100.0f64, 0.1f64),
+            (std::f64::consts::E, 3.0f64),
+            (9.0f64, 0.5f64),
+        ]
+    );
+    bench_binary_multi!(
+        c,
+        power_numeric,
+        func::PowerNumeric,
+        [
+            (Numeric::from(2), Numeric::from(10)),
+            (Numeric::from(10), Numeric::from(3)),
+            (Numeric::from(3), Numeric::from(7)),
+            (Numeric::from(7), Numeric::from(5)),
+            (Numeric::from(100), Numeric::from(2)),
+        ]
+    );
 }
 
 // comparison, and shift functions
 
-// BitAnd
-bench_binary!(
-    bit_and_int16,
-    func::BitAndInt16,
-    Datum::Int16(0x0F0F),
-    Datum::Int16(0x00FF)
-);
-bench_binary!(
-    bit_and_int32,
-    func::BitAndInt32,
-    Datum::Int32(0x0F0F0F0F),
-    Datum::Int32(0x00FF00FF)
-);
-bench_binary!(
-    bit_and_int64,
-    func::BitAndInt64,
-    Datum::Int64(0x0F0F),
-    Datum::Int64(0x00FF)
-);
-bench_binary!(
-    bit_and_uint16,
-    func::BitAndUint16,
-    Datum::UInt16(0x0F0F),
-    Datum::UInt16(0x00FF)
-);
-bench_binary!(
-    bit_and_uint32,
-    func::BitAndUint32,
-    Datum::UInt32(0x0F0F),
-    Datum::UInt32(0x00FF)
-);
-bench_binary!(
-    bit_and_uint64,
-    func::BitAndUint64,
-    Datum::UInt64(0x0F0F),
-    Datum::UInt64(0x00FF)
-);
+fn bitwise_comparison_benches(c: &mut Criterion) {
+    // BitAnd
+    bench_binary!(
+        c,
+        bit_and_int16,
+        func::BitAndInt16,
+        Datum::Int16(0x0F0F),
+        Datum::Int16(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_and_int32,
+        func::BitAndInt32,
+        Datum::Int32(0x0F0F0F0F),
+        Datum::Int32(0x00FF00FF)
+    );
+    bench_binary!(
+        c,
+        bit_and_int64,
+        func::BitAndInt64,
+        Datum::Int64(0x0F0F),
+        Datum::Int64(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_and_uint16,
+        func::BitAndUint16,
+        Datum::UInt16(0x0F0F),
+        Datum::UInt16(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_and_uint32,
+        func::BitAndUint32,
+        Datum::UInt32(0x0F0F),
+        Datum::UInt32(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_and_uint64,
+        func::BitAndUint64,
+        Datum::UInt64(0x0F0F),
+        Datum::UInt64(0x00FF)
+    );
 
-// BitOr
-bench_binary!(
-    bit_or_int16,
-    func::BitOrInt16,
-    Datum::Int16(0x0F00),
-    Datum::Int16(0x00F0)
-);
-bench_binary!(
-    bit_or_int32,
-    func::BitOrInt32,
-    Datum::Int32(0x0F00),
-    Datum::Int32(0x00F0)
-);
-bench_binary!(
-    bit_or_int64,
-    func::BitOrInt64,
-    Datum::Int64(0x0F00),
-    Datum::Int64(0x00F0)
-);
-bench_binary!(
-    bit_or_uint16,
-    func::BitOrUint16,
-    Datum::UInt16(0x0F00),
-    Datum::UInt16(0x00F0)
-);
-bench_binary!(
-    bit_or_uint32,
-    func::BitOrUint32,
-    Datum::UInt32(0x0F00),
-    Datum::UInt32(0x00F0)
-);
-bench_binary!(
-    bit_or_uint64,
-    func::BitOrUint64,
-    Datum::UInt64(0x0F00),
-    Datum::UInt64(0x00F0)
-);
+    // BitOr
+    bench_binary!(
+        c,
+        bit_or_int16,
+        func::BitOrInt16,
+        Datum::Int16(0x0F00),
+        Datum::Int16(0x00F0)
+    );
+    bench_binary!(
+        c,
+        bit_or_int32,
+        func::BitOrInt32,
+        Datum::Int32(0x0F00),
+        Datum::Int32(0x00F0)
+    );
+    bench_binary!(
+        c,
+        bit_or_int64,
+        func::BitOrInt64,
+        Datum::Int64(0x0F00),
+        Datum::Int64(0x00F0)
+    );
+    bench_binary!(
+        c,
+        bit_or_uint16,
+        func::BitOrUint16,
+        Datum::UInt16(0x0F00),
+        Datum::UInt16(0x00F0)
+    );
+    bench_binary!(
+        c,
+        bit_or_uint32,
+        func::BitOrUint32,
+        Datum::UInt32(0x0F00),
+        Datum::UInt32(0x00F0)
+    );
+    bench_binary!(
+        c,
+        bit_or_uint64,
+        func::BitOrUint64,
+        Datum::UInt64(0x0F00),
+        Datum::UInt64(0x00F0)
+    );
 
-// BitXor
-bench_binary!(
-    bit_xor_int16,
-    func::BitXorInt16,
-    Datum::Int16(0x0FF0),
-    Datum::Int16(0x00FF)
-);
-bench_binary!(
-    bit_xor_int32,
-    func::BitXorInt32,
-    Datum::Int32(0x0FF0),
-    Datum::Int32(0x00FF)
-);
-bench_binary!(
-    bit_xor_int64,
-    func::BitXorInt64,
-    Datum::Int64(0x0FF0),
-    Datum::Int64(0x00FF)
-);
-bench_binary!(
-    bit_xor_uint16,
-    func::BitXorUint16,
-    Datum::UInt16(0x0FF0),
-    Datum::UInt16(0x00FF)
-);
-bench_binary!(
-    bit_xor_uint32,
-    func::BitXorUint32,
-    Datum::UInt32(0x0FF0),
-    Datum::UInt32(0x00FF)
-);
-bench_binary!(
-    bit_xor_uint64,
-    func::BitXorUint64,
-    Datum::UInt64(0x0FF0),
-    Datum::UInt64(0x00FF)
-);
+    // BitXor
+    bench_binary!(
+        c,
+        bit_xor_int16,
+        func::BitXorInt16,
+        Datum::Int16(0x0FF0),
+        Datum::Int16(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_xor_int32,
+        func::BitXorInt32,
+        Datum::Int32(0x0FF0),
+        Datum::Int32(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_xor_int64,
+        func::BitXorInt64,
+        Datum::Int64(0x0FF0),
+        Datum::Int64(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_xor_uint16,
+        func::BitXorUint16,
+        Datum::UInt16(0x0FF0),
+        Datum::UInt16(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_xor_uint32,
+        func::BitXorUint32,
+        Datum::UInt32(0x0FF0),
+        Datum::UInt32(0x00FF)
+    );
+    bench_binary!(
+        c,
+        bit_xor_uint64,
+        func::BitXorUint64,
+        Datum::UInt64(0x0FF0),
+        Datum::UInt64(0x00FF)
+    );
 
-// BitShiftLeft
-bench_binary!(bit_shift_left_int16, func::BitShiftLeftInt16, 1i16, 4i32);
-bench_binary!(bit_shift_left_int32, func::BitShiftLeftInt32, 1i32, 4i32);
-bench_binary!(bit_shift_left_int64, func::BitShiftLeftInt64, 1i64, 4i32);
-bench_binary!(bit_shift_left_uint16, func::BitShiftLeftUint16, 1u16, 4u32);
-bench_binary!(bit_shift_left_uint32, func::BitShiftLeftUint32, 1u32, 4u32);
-bench_binary!(bit_shift_left_uint64, func::BitShiftLeftUint64, 1u64, 4u32);
+    // BitShiftLeft
+    bench_binary!(c, bit_shift_left_int16, func::BitShiftLeftInt16, 1i16, 4i32);
+    bench_binary!(c, bit_shift_left_int32, func::BitShiftLeftInt32, 1i32, 4i32);
+    bench_binary!(c, bit_shift_left_int64, func::BitShiftLeftInt64, 1i64, 4i32);
+    bench_binary!(
+        c,
+        bit_shift_left_uint16,
+        func::BitShiftLeftUint16,
+        1u16,
+        4u32
+    );
+    bench_binary!(
+        c,
+        bit_shift_left_uint32,
+        func::BitShiftLeftUint32,
+        1u32,
+        4u32
+    );
+    bench_binary!(
+        c,
+        bit_shift_left_uint64,
+        func::BitShiftLeftUint64,
+        1u64,
+        4u32
+    );
 
-// BitShiftRight
-bench_binary!(
-    bit_shift_right_int16,
-    func::BitShiftRightInt16,
-    256i16,
-    4i32
-);
-bench_binary!(
-    bit_shift_right_int32,
-    func::BitShiftRightInt32,
-    256i32,
-    4i32
-);
-bench_binary!(
-    bit_shift_right_int64,
-    func::BitShiftRightInt64,
-    256i64,
-    4i32
-);
-bench_binary!(
-    bit_shift_right_uint16,
-    func::BitShiftRightUint16,
-    256u16,
-    4u32
-);
-bench_binary!(
-    bit_shift_right_uint32,
-    func::BitShiftRightUint32,
-    256u32,
-    4u32
-);
-bench_binary!(
-    bit_shift_right_uint64,
-    func::BitShiftRightUint64,
-    256u64,
-    4u32
-);
+    // BitShiftRight
+    bench_binary!(
+        c,
+        bit_shift_right_int16,
+        func::BitShiftRightInt16,
+        256i16,
+        4i32
+    );
+    bench_binary!(
+        c,
+        bit_shift_right_int32,
+        func::BitShiftRightInt32,
+        256i32,
+        4i32
+    );
+    bench_binary!(
+        c,
+        bit_shift_right_int64,
+        func::BitShiftRightInt64,
+        256i64,
+        4i32
+    );
+    bench_binary!(
+        c,
+        bit_shift_right_uint16,
+        func::BitShiftRightUint16,
+        256u16,
+        4u32
+    );
+    bench_binary!(
+        c,
+        bit_shift_right_uint32,
+        func::BitShiftRightUint32,
+        256u32,
+        4u32
+    );
+    bench_binary!(
+        c,
+        bit_shift_right_uint64,
+        func::BitShiftRightUint64,
+        256u64,
+        4u32
+    );
 
-// Comparison
-bench_binary!(eq, func::Eq, 42i32, 42i32);
-bench_binary!(not_eq, func::NotEq, 42i32, 43i32);
-bench_binary!(lt, func::Lt, 1i32, 2i32);
-bench_binary!(lte, func::Lte, 1i32, 2i32);
-bench_binary!(gt, func::Gt, 2i32, 1i32);
-bench_binary!(gte, func::Gte, 2i32, 1i32);
+    // Comparison
+    bench_binary!(c, eq, func::Eq, 42i32, 42i32);
+    bench_binary!(c, not_eq, func::NotEq, 42i32, 43i32);
+    bench_binary!(c, lt, func::Lt, 1i32, 2i32);
+    bench_binary!(c, lte, func::Lte, 1i32, 2i32);
+    bench_binary!(c, gt, func::Gt, 2i32, 1i32);
+    bench_binary!(c, gte, func::Gte, 2i32, 1i32);
+}
 
 // Step 5: Remaining binary functions
 
-// String functions
-bench_binary!(text_concat, func::TextConcatBinary, "hello", " world");
-bench_binary!(position, func::Position, "hello world", "world");
-bench_binary!(left, func::Left, "hello world", 5i32);
-bench_binary!(right, func::Right, "hello world", 5i32);
-bench_binary!(repeat_string, func::RepeatString, "ab", 3i32);
-bench_binary!(trim, func::Trim, "  hello  ", " ");
-bench_binary!(trim_leading, func::TrimLeading, "  hello  ", " ");
-bench_binary!(trim_trailing, func::TrimTrailing, "  hello  ", " ");
-bench_binary!(normalize, func::Normalize, "hello", "NFC");
-bench_binary!(starts_with, func::StartsWith, "hello world", "hello");
-bench_binary!(
-    encoded_bytes_char_length,
-    func::EncodedBytesCharLength,
-    b"hello",
-    "utf-8"
-);
+fn remaining_benches(c: &mut Criterion) {
+    // String functions
+    bench_binary!(c, text_concat, func::TextConcatBinary, "hello", " world");
+    bench_binary!(c, position, func::Position, "hello world", "world");
+    bench_binary!(c, left, func::Left, "hello world", 5i32);
+    bench_binary!(c, right, func::Right, "hello world", 5i32);
+    bench_binary!(c, repeat_string, func::RepeatString, "ab", 3i32);
+    bench_binary!(c, trim, func::Trim, "  hello  ", " ");
+    bench_binary!(c, trim_leading, func::TrimLeading, "  hello  ", " ");
+    bench_binary!(c, trim_trailing, func::TrimTrailing, "  hello  ", " ");
+    bench_binary!(c, normalize, func::Normalize, "hello", "NFC");
+    bench_binary!(c, starts_with, func::StartsWith, "hello world", "hello");
+    bench_binary!(
+        c,
+        encoded_bytes_char_length,
+        func::EncodedBytesCharLength,
+        b"hello",
+        "utf-8"
+    );
 
-// Pattern matching
-bench_binary!(like_escape, func::LikeEscape, "100%", "\\");
-bench_binary!(
-    is_like_match_case_sensitive,
-    func::IsLikeMatchCaseSensitive,
-    "hello world",
-    "%world"
-);
-bench_binary!(
-    is_like_match_case_insensitive,
-    func::IsLikeMatchCaseInsensitive,
-    "Hello World",
-    "%world"
-);
-bench_binary!(
-    is_regexp_match_case_sensitive,
-    func::IsRegexpMatchCaseSensitive,
-    "hello world",
-    "w.rld"
-);
-bench_binary!(
-    is_regexp_match_case_insensitive,
-    func::IsRegexpMatchCaseInsensitive,
-    "Hello World",
-    "w.rld"
-);
+    // Pattern matching
+    bench_binary!(c, like_escape, func::LikeEscape, "100%", "\\");
+    bench_binary!(
+        c,
+        is_like_match_case_sensitive,
+        func::IsLikeMatchCaseSensitive,
+        "hello world",
+        "%world"
+    );
+    bench_binary!(
+        c,
+        is_like_match_case_insensitive,
+        func::IsLikeMatchCaseInsensitive,
+        "Hello World",
+        "%world"
+    );
+    bench_binary!(
+        c,
+        is_regexp_match_case_sensitive,
+        func::IsRegexpMatchCaseSensitive,
+        "hello world",
+        "w.rld"
+    );
+    bench_binary!(
+        c,
+        is_regexp_match_case_insensitive,
+        func::IsRegexpMatchCaseInsensitive,
+        "Hello World",
+        "w.rld"
+    );
 
-// Encoding
-bench_binary!(convert_from, func::ConvertFrom, b"hello", "utf8");
-bench_binary!(encode, func::Encode, b"hello", "base64");
-bench_binary!(decode, func::Decode, "aGVsbG8=", "base64");
+    // Encoding
+    bench_binary!(c, convert_from, func::ConvertFrom, b"hello", "utf8");
+    bench_binary!(c, encode, func::Encode, b"hello", "base64");
+    bench_binary!(c, decode, func::Decode, "aGVsbG8=", "base64");
 
-// Digest
-bench_binary!(digest_string, func::DigestString, "hello", "md5");
-bench_binary!(digest_bytes, func::DigestBytes, b"hello", "md5");
+    // Digest
+    bench_binary!(c, digest_string, func::DigestString, "hello", "md5");
+    bench_binary!(c, digest_bytes, func::DigestBytes, b"hello", "md5");
 
-// Numeric operations
-bench_binary_multi!(
-    log_numeric,
-    func::LogBaseNumeric,
-    [
-        (Numeric::from(10), Numeric::from(100)),
-        (Numeric::from(2), Numeric::from(1024)),
-        (Numeric::from(10), Numeric::from(42)),
-        (Numeric::from(3), Numeric::from(81)),
-        (Numeric::from(7), Numeric::from(999999)),
-    ]
-);
-bench_binary_multi!(
-    power,
-    func::Power,
-    [
-        (2.0f64, 10.0f64),
-        (2.0f64, 0.5f64),
-        (10.0f64, 3.0f64),
-        (1.5f64, 7.3f64),
-        (0.5f64, 20.0f64),
-        (100.0f64, 0.1f64),
-        (std::f64::consts::E, 3.0f64),
-        (9.0f64, 0.5f64),
-    ]
-);
-bench_binary_multi!(
-    power_numeric,
-    func::PowerNumeric,
-    [
-        (Numeric::from(2), Numeric::from(10)),
-        (Numeric::from(10), Numeric::from(3)),
-        (Numeric::from(3), Numeric::from(7)),
-        (Numeric::from(7), Numeric::from(5)),
-        (Numeric::from(100), Numeric::from(2)),
-    ]
-);
+    // Numeric operations (happy paths are in *_group functions via benchmark_main)
+    // Byte operations
+    bench_binary!(c, get_bit, func::GetBit, b"\xff", 3i32);
+    bench_binary!(c, get_byte, func::GetByte, b"hello", 0i32);
+    bench_binary!(
+        c,
+        constant_time_eq_bytes,
+        func::ConstantTimeEqBytes,
+        b"hello",
+        b"hello"
+    );
+    bench_binary!(
+        c,
+        constant_time_eq_string,
+        func::ConstantTimeEqString,
+        "hello",
+        "hello"
+    );
 
-// Byte operations
-bench_binary!(get_bit, func::GetBit, b"\xff", 3i32);
-bench_binary!(get_byte, func::GetByte, b"hello", 0i32);
-bench_binary!(
-    constant_time_eq_bytes,
-    func::ConstantTimeEqBytes,
-    b"hello",
-    b"hello"
-);
-bench_binary!(
-    constant_time_eq_string,
-    func::ConstantTimeEqString,
-    "hello",
-    "hello"
-);
+    // MzRenderTypmod
+    bench_binary!(c, mz_render_typmod, func::MzRenderTypmod, 23u32, -1i32);
 
-// MzRenderTypmod
-bench_binary!(mz_render_typmod, func::MzRenderTypmod, 23u32, -1i32);
+    // ParseIdent
+    bench_binary!(c, parse_ident, func::ParseIdent, "myschema.mytable", true);
 
-// ParseIdent
-bench_binary!(parse_ident, func::ParseIdent, "myschema.mytable", true);
+    // PrettySql
+    bench_binary!(c, pretty_sql, func::PrettySql, "SELECT 1", 80i32);
 
-// PrettySql
-bench_binary!(pretty_sql, func::PrettySql, "SELECT 1", 80i32);
+    // RegexpReplace
+    c.bench_function("regexp_replace", |b| {
+        let regex = mz_repr::adt::regex::Regex::new("world", false).unwrap();
+        let f = BinaryFunc::RegexpReplace(func::RegexpReplace { regex, limit: 0 });
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["hello world".into(), "earth".into()];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// RegexpReplace
-fn regexp_replace(b: &mut Bencher) {
-    let regex = mz_repr::adt::regex::Regex::new("world", false).unwrap();
-    let f = BinaryFunc::RegexpReplace(func::RegexpReplace { regex, limit: 0 });
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["hello world".into(), "earth".into()];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // UuidGenerateV5
+    bench_binary!(
+        c,
+        uuid_generate_v5,
+        func::UuidGenerateV5,
+        Uuid::nil(),
+        "test"
+    );
 
-// UuidGenerateV5
-bench_binary!(uuid_generate_v5, func::UuidGenerateV5, Uuid::nil(), "test");
+    // MzAclItemContainsPrivilege
+    // Skipped: requires MzAclItem datum construction
 
-// MzAclItemContainsPrivilege
-// Skipped: requires MzAclItem datum construction
+    // ToChar
+    c.bench_function("to_char_timestamp", |b| {
+        let f = BinaryFunc::ToCharTimestamp(func::ToCharTimestampFormat);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::Timestamp(ts), "YYYY-MM-DD HH24:MI:SS".into()];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// ToChar
-fn to_char_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::ToCharTimestamp(func::ToCharTimestampFormat);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 30, 45)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::Timestamp(ts), "YYYY-MM-DD HH24:MI:SS".into()];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("to_char_timestamp_tz", |b| {
+        let f = BinaryFunc::ToCharTimestampTz(func::ToCharTimestampTzFormat);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[Datum::TimestampTz(ts), "YYYY-MM-DD HH24:MI:SS".into()];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn to_char_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::ToCharTimestampTz(func::ToCharTimestampTzFormat);
-    let ts = CheckedTimestamp::from_timestamplike(
-        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[Datum::TimestampTz(ts), "YYYY-MM-DD HH24:MI:SS".into()];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // DateBin
+    c.bench_function("date_bin_timestamp", |b| {
+        let f = BinaryFunc::DateBinTimestamp(func::DateBinTimestamp);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+            Datum::Timestamp(ts),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// DateBin
-fn date_bin_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::DateBinTimestamp(func::DateBinTimestamp);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 30, 45)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-        Datum::Timestamp(ts),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_bin_timestamp_tz", |b| {
+        let f = BinaryFunc::DateBinTimestampTz(func::DateBinTimestampTz);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+            Datum::TimestampTz(ts),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_bin_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::DateBinTimestampTz(func::DateBinTimestampTz);
-    let ts = CheckedTimestamp::from_timestamplike(
-        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-        Datum::TimestampTz(ts),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // Extract/DatePart
+    c.bench_function("extract_interval", |b| {
+        let f = BinaryFunc::ExtractInterval(func::DatePartIntervalNumeric);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["epoch".into(), Interval::new(1, 2, 3_000_000).into()];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// Extract/DatePart
-fn extract_interval(b: &mut Bencher) {
-    let f = BinaryFunc::ExtractInterval(func::DatePartIntervalNumeric);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["epoch".into(), Interval::new(1, 2, 3_000_000).into()];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("extract_time", |b| {
+        let f = BinaryFunc::ExtractTime(func::DatePartTimeNumeric);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            "hour".into(),
+            Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn extract_time(b: &mut Bencher) {
-    let f = BinaryFunc::ExtractTime(func::DatePartTimeNumeric);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        "hour".into(),
-        Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("extract_timestamp", |b| {
+        let f = BinaryFunc::ExtractTimestamp(func::DatePartTimestampTimestampNumeric);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn extract_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::ExtractTimestamp(func::DatePartTimestampTimestampNumeric);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("extract_timestamp_tz", |b| {
+        let f = BinaryFunc::ExtractTimestampTz(func::DatePartTimestampTimestampTzNumeric);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn extract_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::ExtractTimestampTz(func::DatePartTimestampTimestampTzNumeric);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("extract_date", |b| {
+        let f = BinaryFunc::ExtractDate(func::ExtractDateUnits);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["year".into(), Datum::Date(Date::from_pg_epoch(0).unwrap())];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn extract_date(b: &mut Bencher) {
-    let f = BinaryFunc::ExtractDate(func::ExtractDateUnits);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["year".into(), Datum::Date(Date::from_pg_epoch(0).unwrap())];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_part_interval", |b| {
+        let f = BinaryFunc::DatePartInterval(func::DatePartIntervalF64);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            "epoch".into(),
+            Datum::Interval(Interval::new(1, 2, 3_000_000)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_part_interval(b: &mut Bencher) {
-    let f = BinaryFunc::DatePartInterval(func::DatePartIntervalF64);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        "epoch".into(),
-        Datum::Interval(Interval::new(1, 2, 3_000_000)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_part_time", |b| {
+        let f = BinaryFunc::DatePartTime(func::DatePartTimeF64);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            "hour".into(),
+            Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_part_time(b: &mut Bencher) {
-    let f = BinaryFunc::DatePartTime(func::DatePartTimeF64);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        "hour".into(),
-        Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_part_timestamp", |b| {
+        let f = BinaryFunc::DatePartTimestamp(func::DatePartTimestampTimestampF64);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_part_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::DatePartTimestamp(func::DatePartTimestampTimestampF64);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_part_timestamp_tz", |b| {
+        let f = BinaryFunc::DatePartTimestampTz(func::DatePartTimestampTimestampTzF64);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_part_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::DatePartTimestampTz(func::DatePartTimestampTimestampTzF64);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // DateTrunc
+    c.bench_function("date_trunc_timestamp", |b| {
+        let f = BinaryFunc::DateTruncTimestamp(func::DateTruncUnitsTimestamp);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["hour".into(), Datum::Timestamp(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// DateTrunc
-fn date_trunc_timestamp(b: &mut Bencher) {
-    let f = BinaryFunc::DateTruncTimestamp(func::DateTruncUnitsTimestamp);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 30, 45)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["hour".into(), Datum::Timestamp(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_trunc_timestamp_tz", |b| {
+        let f = BinaryFunc::DateTruncTimestampTz(func::DateTruncUnitsTimestampTz);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["hour".into(), Datum::TimestampTz(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_trunc_timestamp_tz(b: &mut Bencher) {
-    let f = BinaryFunc::DateTruncTimestampTz(func::DateTruncUnitsTimestampTz);
-    let ts = CheckedTimestamp::from_timestamplike(
-        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["hour".into(), Datum::TimestampTz(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("date_trunc_interval", |b| {
+        let f = BinaryFunc::DateTruncInterval(func::DateTruncInterval);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            "hour".into(),
+            Datum::Interval(Interval::new(0, 0, 5_400_000_000)),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn date_trunc_interval(b: &mut Bencher) {
-    let f = BinaryFunc::DateTruncInterval(func::DateTruncInterval);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        "hour".into(),
-        Datum::Interval(Interval::new(0, 0, 5_400_000_000)),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    // Timezone
+    c.bench_function("timezone_timestamp_binary", |b| {
+        let f = BinaryFunc::TimezoneTimestampBinary(func::TimezoneTimestampBinary);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["UTC".into(), Datum::Timestamp(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-// Timezone
-fn timezone_timestamp_binary(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneTimestampBinary(func::TimezoneTimestampBinary);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["UTC".into(), Datum::Timestamp(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("timezone_timestamp_tz_binary", |b| {
+        let f = BinaryFunc::TimezoneTimestampTzBinary(func::TimezoneTimestampTzBinary);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn timezone_timestamp_tz_binary(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneTimestampTzBinary(func::TimezoneTimestampTzBinary);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("timezone_interval_timestamp_binary", |b| {
+        let f = BinaryFunc::TimezoneIntervalTimestampBinary(func::TimezoneIntervalTimestampBinary);
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+            Datum::Timestamp(ts),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn timezone_interval_timestamp_binary(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneIntervalTimestampBinary(func::TimezoneIntervalTimestampBinary);
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-        Datum::Timestamp(ts),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("timezone_interval_timestamp_tz_binary", |b| {
+        let f =
+            BinaryFunc::TimezoneIntervalTimestampTzBinary(func::TimezoneIntervalTimestampTzBinary);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+            Datum::TimestampTz(ts),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn timezone_interval_timestamp_tz_binary(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneIntervalTimestampTzBinary(func::TimezoneIntervalTimestampTzBinary);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-        Datum::TimestampTz(ts),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
+    c.bench_function("timezone_interval_time_binary", |b| {
+        let f = BinaryFunc::TimezoneIntervalTimeBinary(func::TimezoneIntervalTimeBinary);
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &[
+            Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+            Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        ];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 
-fn timezone_interval_time_binary(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneIntervalTimeBinary(func::TimezoneIntervalTimeBinary);
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &[
-        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
-        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
-    ];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
-}
-
-fn timezone_offset(b: &mut Bencher) {
-    let f = BinaryFunc::TimezoneOffset(func::TimezoneOffset);
-    let ts =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let a = MirScalarExpr::column(0);
-    let e = MirScalarExpr::column(1);
-    let arena = RowArena::new();
-    let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
-    b.iter(|| f.eval(datums, &arena, &a, &e));
+    c.bench_function("timezone_offset", |b| {
+        let f = BinaryFunc::TimezoneOffset(func::TimezoneOffset);
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let a = MirScalarExpr::column(0);
+        let e = MirScalarExpr::column(1);
+        let arena = RowArena::new();
+        let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
+        b.iter(|| f.eval(datums, &arena, &[&a, &e]));
+    });
 }
 
 // Benchmark registration
 
-benchmark_group!(
-    arithmetic_benches,
-    // Add
-    add_int16,
-    add_int16_error,
-    add_int32,
-    add_int32_error,
-    add_int64,
-    add_int64_error,
-    add_uint16,
-    add_uint16_error,
-    add_uint32,
-    add_uint32_error,
-    add_uint64,
-    add_uint64_error,
-    add_float32,
-    add_float32_error,
-    add_float64,
-    add_float64_error,
-    add_numeric,
-    add_interval,
-    add_timestamp_interval,
-    add_timestamp_tz_interval,
-    add_date_interval,
-    add_date_time,
-    add_time_interval,
-    // Sub
-    sub_int16,
-    sub_int16_error,
-    sub_int32,
-    sub_int32_error,
-    sub_int64,
-    sub_int64_error,
-    sub_uint16,
-    sub_uint16_error,
-    sub_uint32,
-    sub_uint32_error,
-    sub_uint64,
-    sub_uint64_error,
-    sub_float32,
-    sub_float64,
-    sub_numeric,
-    sub_interval,
-    sub_timestamp,
-    sub_timestamp_tz,
-    sub_timestamp_interval,
-    sub_timestamp_tz_interval,
-    sub_date,
-    sub_date_interval,
-    sub_time,
-    sub_time_interval,
-    // Mul
-    mul_int16,
-    mul_int16_error,
-    mul_int32,
-    mul_int32_error,
-    mul_int64,
-    mul_int64_error,
-    mul_uint16,
-    mul_uint16_error,
-    mul_uint32,
-    mul_uint32_error,
-    mul_uint64,
-    mul_uint64_error,
-    mul_float32,
-    mul_float32_error,
-    mul_float64,
-    mul_float64_error,
-    mul_numeric,
-    mul_interval,
-    // Div (happy paths are in *_group functions via benchmark_main)
-    div_int16_divzero,
-    div_int32_divzero,
-    div_int64_divzero,
-    div_uint16_divzero,
-    div_uint32_divzero,
-    div_uint64_divzero,
-    div_float32_divzero,
-    div_float64_divzero,
-    div_numeric_divzero,
-    div_interval,
-    div_interval_divzero,
-    // Mod
-    mod_int16,
-    mod_int16_divzero,
-    mod_int32,
-    mod_int32_divzero,
-    mod_int64,
-    mod_int64_divzero,
-    mod_uint16,
-    mod_uint32,
-    mod_uint64,
-    mod_float32,
-    mod_float64,
-    mod_numeric,
-    // Round, Age
-    round_numeric,
-    age_timestamp,
-    age_timestamp_tz
-);
-
-benchmark_group!(
-    bitwise_comparison_benches,
-    // BitAnd
-    bit_and_int16,
-    bit_and_int32,
-    bit_and_int64,
-    bit_and_uint16,
-    bit_and_uint32,
-    bit_and_uint64,
-    // BitOr
-    bit_or_int16,
-    bit_or_int32,
-    bit_or_int64,
-    bit_or_uint16,
-    bit_or_uint32,
-    bit_or_uint64,
-    // BitXor
-    bit_xor_int16,
-    bit_xor_int32,
-    bit_xor_int64,
-    bit_xor_uint16,
-    bit_xor_uint32,
-    bit_xor_uint64,
-    // BitShiftLeft
-    bit_shift_left_int16,
-    bit_shift_left_int32,
-    bit_shift_left_int64,
-    bit_shift_left_uint16,
-    bit_shift_left_uint32,
-    bit_shift_left_uint64,
-    // BitShiftRight
-    bit_shift_right_int16,
-    bit_shift_right_int32,
-    bit_shift_right_int64,
-    bit_shift_right_uint16,
-    bit_shift_right_uint32,
-    bit_shift_right_uint64,
-    // Comparison
-    eq,
-    not_eq,
-    lt,
-    lte,
-    gt,
-    gte
-);
-
-benchmark_group!(
-    remaining_benches,
-    // String
-    text_concat,
-    position,
-    left,
-    right,
-    repeat_string,
-    trim,
-    trim_leading,
-    trim_trailing,
-    normalize,
-    starts_with,
-    encoded_bytes_char_length,
-    // Pattern matching
-    like_escape,
-    is_like_match_case_sensitive,
-    is_like_match_case_insensitive,
-    is_regexp_match_case_sensitive,
-    is_regexp_match_case_insensitive,
-    // Encoding
-    convert_from,
-    encode,
-    decode,
-    // Digest
-    digest_string,
-    digest_bytes,
-    // Numeric operations (happy paths are in *_group functions via benchmark_main)
-    // Byte operations
-    get_bit,
-    get_byte,
-    constant_time_eq_bytes,
-    constant_time_eq_string,
-    // Misc
-    mz_render_typmod,
-    parse_ident,
-    pretty_sql,
-    regexp_replace,
-    uuid_generate_v5,
-    // ToChar
-    to_char_timestamp,
-    to_char_timestamp_tz,
-    // DateBin
-    date_bin_timestamp,
-    date_bin_timestamp_tz,
-    // Extract/DatePart
-    extract_interval,
-    extract_time,
-    extract_timestamp,
-    extract_timestamp_tz,
-    extract_date,
-    date_part_interval,
-    date_part_time,
-    date_part_timestamp,
-    date_part_timestamp_tz,
-    // DateTrunc
-    date_trunc_timestamp,
-    date_trunc_timestamp_tz,
-    date_trunc_interval,
-    // Timezone
-    timezone_timestamp_binary,
-    timezone_timestamp_tz_binary,
-    timezone_interval_timestamp_binary,
-    timezone_interval_timestamp_tz_binary,
-    timezone_interval_time_binary,
-    timezone_offset
-);
-
-benchmark_main!(
+criterion_group!(
+    benches,
     arithmetic_benches,
     bitwise_comparison_benches,
-    remaining_benches,
-    // Multi-input benchmark groups (each input is a separate benchmark entry)
-    div_int16_group,
-    div_int32_group,
-    div_int64_group,
-    div_uint16_group,
-    div_uint32_group,
-    div_uint64_group,
-    div_float32_group,
-    div_float64_group,
-    div_numeric_group,
-    log_numeric_group,
-    power_group,
-    power_numeric_group
+    remaining_benches
 );
+criterion_main!(benches);

--- a/src/expr/benches/bench_binary.rs
+++ b/src/expr/benches/bench_binary.rs
@@ -1,0 +1,1402 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bencher::{Bencher, TestFn, benchmark_group, benchmark_main};
+use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use mz_expr::{BinaryFunc, MirScalarExpr, func};
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, RowArena};
+use uuid::Uuid;
+
+macro_rules! bench_binary {
+    ($bench_name:ident, $struct_expr:expr,
+     $a_datum:expr, $b_datum:expr $(,)? ) => {
+        fn $bench_name(b: &mut Bencher) {
+            let f = BinaryFunc::from($struct_expr);
+            let a = MirScalarExpr::column(0);
+            let e = MirScalarExpr::column(1);
+            let arena = RowArena::new();
+            let datums: &[Datum] = &[($a_datum).into(), ($b_datum).into()];
+            b.iter(|| f.eval(datums, &arena, &a, &e));
+        }
+    };
+}
+
+/// Generates a `_group` function that returns individual benchmark entries
+/// for each input pair, so they show up as separate lines in benchmark output.
+macro_rules! bench_binary_multi {
+    ($bench_name:ident, $struct_expr:expr,
+     [ $( ($a_datum:expr, $b_datum:expr) ),+ $(,)? ]) => {
+        paste::paste! {
+            fn [<$bench_name _group>]() -> Vec<bencher::TestDescAndFn> {
+                use bencher::{TestDescAndFn, TestDesc};
+                use std::borrow::Cow;
+                let mut benches = Vec::new();
+                $(
+                    benches.push(TestDescAndFn {
+                        desc: TestDesc {
+                            name: Cow::from(concat!(
+                                stringify!($bench_name), "(", stringify!($a_datum), ", ", stringify!($b_datum), ")"
+                            )),
+                            ignore: false,
+                        },
+                        testfn: TestFn::StaticBenchFn({
+                            fn run(b: &mut bencher::Bencher) {
+                                let f = BinaryFunc::from($struct_expr);
+                                let a = MirScalarExpr::column(0);
+                                let e = MirScalarExpr::column(1);
+                                let arena = RowArena::new();
+                                let datums: &[Datum] = &[($a_datum).into(), ($b_datum).into()];
+                                b.iter(|| f.eval(datums, &arena, &a, &e));
+                            }
+                            run
+                        }),
+                    });
+                )+
+                benches
+            }
+        }
+    };
+}
+
+// Arithmetic functions
+
+// Add
+bench_binary!(add_int16, func::AddInt16, 1i16, 2i16);
+bench_binary!(add_int16_error, func::AddInt16, i16::MAX, 1i16);
+bench_binary!(add_int32, func::AddInt32, 1i32, 2i32);
+bench_binary!(add_int32_error, func::AddInt32, i32::MAX, 1i32);
+bench_binary!(add_int64, func::AddInt64, 1i64, 2i64);
+bench_binary!(add_int64_error, func::AddInt64, i64::MAX, 1i64);
+bench_binary!(add_uint16, func::AddUint16, 1u16, 2u16);
+bench_binary!(add_uint16_error, func::AddUint16, u16::MAX, 1u16);
+bench_binary!(add_uint32, func::AddUint32, 1u32, 2u32);
+bench_binary!(add_uint32_error, func::AddUint32, u32::MAX, 1u32);
+bench_binary!(add_uint64, func::AddUint64, 1u64, 2u64);
+bench_binary!(add_uint64_error, func::AddUint64, u64::MAX, 1u64);
+bench_binary!(add_float32, func::AddFloat32, 1.0f32, 2.0f32);
+bench_binary!(add_float32_error, func::AddFloat32, f32::MAX, f32::MAX);
+bench_binary!(add_float64, func::AddFloat64, 1.0f64, 2.0f64);
+bench_binary!(add_float64_error, func::AddFloat64, f64::MAX, f64::MAX);
+bench_binary!(
+    add_numeric,
+    func::AddNumeric,
+    Numeric::from(1),
+    Numeric::from(2)
+);
+bench_binary!(
+    add_interval,
+    func::AddInterval,
+    Interval::new(1, 2, 3_000_000),
+    Interval::new(0, 1, 1_000_000)
+);
+
+fn add_timestamp_interval(b: &mut Bencher) {
+    let f = BinaryFunc::AddTimestampInterval(func::AddTimestampInterval);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Timestamp(ts),
+        Datum::Interval(Interval::new(0, 1, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn add_timestamp_tz_interval(b: &mut Bencher) {
+    let f = BinaryFunc::AddTimestampTzInterval(func::AddTimestampTzInterval);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::TimestampTz(ts),
+        Datum::Interval(Interval::new(0, 1, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn add_date_interval(b: &mut Bencher) {
+    let f = BinaryFunc::AddDateInterval(func::AddDateInterval);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Date(Date::from_pg_epoch(0).unwrap()),
+        Datum::Interval(Interval::new(1, 0, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn add_date_time(b: &mut Bencher) {
+    let f = BinaryFunc::AddDateTime(func::AddDateTime);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Date(Date::from_pg_epoch(0).unwrap()),
+        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn add_time_interval(b: &mut Bencher) {
+    let f = BinaryFunc::AddTimeInterval(func::AddTimeInterval);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// Sub
+bench_binary!(sub_int16, func::SubInt16, 10i16, 3i16);
+bench_binary!(sub_int16_error, func::SubInt16, i16::MIN, 1i16);
+bench_binary!(sub_int32, func::SubInt32, 10i32, 3i32);
+bench_binary!(sub_int32_error, func::SubInt32, i32::MIN, 1i32);
+bench_binary!(sub_int64, func::SubInt64, 10i64, 3i64);
+bench_binary!(sub_int64_error, func::SubInt64, i64::MIN, 1i64);
+bench_binary!(sub_uint16, func::SubUint16, 10u16, 3u16);
+bench_binary!(sub_uint16_error, func::SubUint16, 0u16, 1u16);
+bench_binary!(sub_uint32, func::SubUint32, 10u32, 3u32);
+bench_binary!(sub_uint32_error, func::SubUint32, 0u32, 1u32);
+bench_binary!(sub_uint64, func::SubUint64, 10u64, 3u64);
+bench_binary!(sub_uint64_error, func::SubUint64, 0u64, 1u64);
+bench_binary!(sub_float32, func::SubFloat32, 10.0f32, 3.0f32);
+bench_binary!(sub_float64, func::SubFloat64, 10.0f64, 3.0f64);
+bench_binary!(
+    sub_numeric,
+    func::SubNumeric,
+    Numeric::from(10),
+    Numeric::from(3)
+);
+bench_binary!(
+    sub_interval,
+    func::SubInterval,
+    Interval::new(1, 2, 3_000_000),
+    Interval::new(0, 1, 1_000_000)
+);
+
+fn sub_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::SubTimestamp(func::SubTimestamp);
+    let ts1 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 6, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let ts2 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn sub_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::SubTimestampTz(func::SubTimestampTz);
+    let ts1 =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let ts2 =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn sub_timestamp_interval(b: &mut Bencher) {
+    let f = BinaryFunc::SubTimestampInterval(func::SubTimestampInterval);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 6, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Timestamp(ts),
+        Datum::Interval(Interval::new(0, 1, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn sub_timestamp_tz_interval(b: &mut Bencher) {
+    let f = BinaryFunc::SubTimestampTzInterval(func::SubTimestampTzInterval);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::TimestampTz(ts),
+        Datum::Interval(Interval::new(0, 1, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+bench_binary!(
+    sub_date,
+    func::SubDate,
+    Date::from_pg_epoch(100).unwrap(),
+    Date::from_pg_epoch(0).unwrap()
+);
+
+fn sub_date_interval(b: &mut Bencher) {
+    let f = BinaryFunc::SubDateInterval(func::SubDateInterval);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Date(Date::from_pg_epoch(100).unwrap()),
+        Datum::Interval(Interval::new(1, 0, 0)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn sub_time(b: &mut Bencher) {
+    let f = BinaryFunc::SubTime(func::SubTime);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
+        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn sub_time_interval(b: &mut Bencher) {
+    let f = BinaryFunc::SubTimeInterval(func::SubTimeInterval);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Time(NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// Mul
+bench_binary!(mul_int16, func::MulInt16, 3i16, 4i16);
+bench_binary!(mul_int16_error, func::MulInt16, i16::MAX, 2i16);
+bench_binary!(mul_int32, func::MulInt32, 3i32, 4i32);
+bench_binary!(mul_int32_error, func::MulInt32, i32::MAX, 2i32);
+bench_binary!(mul_int64, func::MulInt64, 3i64, 4i64);
+bench_binary!(mul_int64_error, func::MulInt64, i64::MAX, 2i64);
+bench_binary!(mul_uint16, func::MulUint16, 3u16, 4u16);
+bench_binary!(mul_uint16_error, func::MulUint16, u16::MAX, 2u16);
+bench_binary!(mul_uint32, func::MulUint32, 3u32, 4u32);
+bench_binary!(mul_uint32_error, func::MulUint32, u32::MAX, 2u32);
+bench_binary!(mul_uint64, func::MulUint64, 3u64, 4u64);
+bench_binary!(mul_uint64_error, func::MulUint64, u64::MAX, 2u64);
+bench_binary!(mul_float32, func::MulFloat32, 3.0f32, 4.0f32);
+bench_binary!(mul_float32_error, func::MulFloat32, f32::MAX, 2.0f32);
+bench_binary!(mul_float64, func::MulFloat64, 3.0f64, 4.0f64);
+bench_binary!(mul_float64_error, func::MulFloat64, f64::MAX, 2.0f64);
+bench_binary!(
+    mul_numeric,
+    func::MulNumeric,
+    Numeric::from(3),
+    Numeric::from(4)
+);
+bench_binary!(
+    mul_interval,
+    func::MulInterval,
+    Interval::new(1, 0, 0),
+    2.0f64
+);
+
+// Div
+bench_binary_multi!(
+    div_int16,
+    func::DivInt16,
+    [
+        (10i16, 3i16),
+        (100i16, 7i16),
+        (-50i16, 3i16),
+        (i16::MAX, 13i16),
+        (1i16, 1i16),
+        (0i16, 42i16),
+        (32000i16, 127i16),
+        (9999i16, 100i16),
+    ]
+);
+bench_binary!(div_int16_divzero, func::DivInt16, 10i16, 0i16);
+bench_binary_multi!(
+    div_int32,
+    func::DivInt32,
+    [
+        (10i32, 3i32),
+        (1000000i32, 7i32),
+        (-500i32, 3i32),
+        (i32::MAX, 13i32),
+        (1i32, 1i32),
+        (0i32, 42i32),
+        (999999999i32, 127i32),
+        (123456789i32, 9876i32),
+    ]
+);
+bench_binary!(div_int32_divzero, func::DivInt32, 10i32, 0i32);
+bench_binary_multi!(
+    div_int64,
+    func::DivInt64,
+    [
+        (10i64, 3i64),
+        (1000000000000i64, 7i64),
+        (-500i64, 3i64),
+        (i64::MAX, 13i64),
+        (1i64, 1i64),
+        (0i64, 42i64),
+        (999999999999i64, 127i64),
+        (123456789012345i64, 9876543i64),
+    ]
+);
+bench_binary!(div_int64_divzero, func::DivInt64, 10i64, 0i64);
+bench_binary_multi!(
+    div_uint16,
+    func::DivUint16,
+    [
+        (10u16, 3u16),
+        (100u16, 7u16),
+        (u16::MAX, 13u16),
+        (1u16, 1u16),
+        (0u16, 42u16),
+        (60000u16, 127u16),
+    ]
+);
+bench_binary!(div_uint16_divzero, func::DivUint16, 10u16, 0u16);
+bench_binary_multi!(
+    div_uint32,
+    func::DivUint32,
+    [
+        (10u32, 3u32),
+        (1000000u32, 7u32),
+        (u32::MAX, 13u32),
+        (1u32, 1u32),
+        (0u32, 42u32),
+        (999999999u32, 127u32),
+    ]
+);
+bench_binary!(div_uint32_divzero, func::DivUint32, 10u32, 0u32);
+bench_binary_multi!(
+    div_uint64,
+    func::DivUint64,
+    [
+        (10u64, 3u64),
+        (1000000000000u64, 7u64),
+        (u64::MAX, 13u64),
+        (1u64, 1u64),
+        (0u64, 42u64),
+        (999999999999u64, 127u64),
+    ]
+);
+bench_binary!(div_uint64_divzero, func::DivUint64, 10u64, 0u64);
+bench_binary_multi!(
+    div_float32,
+    func::DivFloat32,
+    [
+        (10.0f32, 3.0f32),
+        (1.0f32, 7.0f32),
+        (1e10f32, 0.001f32),
+        (-42.5f32, 3.7f32),
+        (0.001f32, 1000.0f32),
+        (999.999f32, 1.001f32),
+    ]
+);
+bench_binary!(div_float32_divzero, func::DivFloat32, 10.0f32, 0.0f32);
+bench_binary_multi!(
+    div_float64,
+    func::DivFloat64,
+    [
+        (10.0f64, 3.0f64),
+        (1.0f64, 7.0f64),
+        (1e15f64, 0.00001f64),
+        (-42.5f64, 3.7f64),
+        (0.001f64, 1000.0f64),
+        (999.999f64, 1.001f64),
+        (1.7976931e100f64, 1.23456789f64),
+        (std::f64::consts::PI, std::f64::consts::E),
+    ]
+);
+bench_binary!(div_float64_divzero, func::DivFloat64, 10.0f64, 0.0f64);
+bench_binary_multi!(
+    div_numeric,
+    func::DivNumeric,
+    [
+        (Numeric::from(10), Numeric::from(3)),
+        (Numeric::from(1), Numeric::from(7)),
+        (Numeric::from(1000000), Numeric::from(13)),
+        (Numeric::from(999999), Numeric::from(42)),
+        (Numeric::from(-50), Numeric::from(3)),
+        (Numeric::from(1), Numeric::from(1)),
+    ]
+);
+bench_binary!(
+    div_numeric_divzero,
+    func::DivNumeric,
+    Numeric::from(10),
+    Numeric::from(0)
+);
+bench_binary!(
+    div_interval,
+    func::DivInterval,
+    Interval::new(2, 0, 0),
+    2.0f64
+);
+bench_binary!(
+    div_interval_divzero,
+    func::DivInterval,
+    Interval::new(2, 0, 0),
+    0.0f64
+);
+
+// Mod
+bench_binary!(mod_int16, func::ModInt16, 10i16, 3i16);
+bench_binary!(mod_int16_divzero, func::ModInt16, 10i16, 0i16);
+bench_binary!(mod_int32, func::ModInt32, 10i32, 3i32);
+bench_binary!(mod_int32_divzero, func::ModInt32, 10i32, 0i32);
+bench_binary!(mod_int64, func::ModInt64, 10i64, 3i64);
+bench_binary!(mod_int64_divzero, func::ModInt64, 10i64, 0i64);
+bench_binary!(mod_uint16, func::ModUint16, 10u16, 3u16);
+bench_binary!(mod_uint32, func::ModUint32, 10u32, 3u32);
+bench_binary!(mod_uint64, func::ModUint64, 10u64, 3u64);
+bench_binary!(mod_float32, func::ModFloat32, 10.0f32, 3.0f32);
+bench_binary!(mod_float64, func::ModFloat64, 10.0f64, 3.0f64);
+bench_binary!(
+    mod_numeric,
+    func::ModNumeric,
+    Numeric::from(10),
+    Numeric::from(3)
+);
+
+// RoundNumeric (binary)
+bench_binary!(
+    round_numeric,
+    func::RoundNumericBinary,
+    Numeric::from(314),
+    2i32
+);
+
+// Age
+fn age_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::AgeTimestamp(func::AgeTimestamp);
+    let ts1 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 6, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let ts2 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn age_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::AgeTimestampTz(func::AgeTimestampTz);
+    let ts1 =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let ts2 =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::TimestampTz(ts1), Datum::TimestampTz(ts2)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// comparison, and shift functions
+
+// BitAnd
+bench_binary!(
+    bit_and_int16,
+    func::BitAndInt16,
+    Datum::Int16(0x0F0F),
+    Datum::Int16(0x00FF)
+);
+bench_binary!(
+    bit_and_int32,
+    func::BitAndInt32,
+    Datum::Int32(0x0F0F0F0F),
+    Datum::Int32(0x00FF00FF)
+);
+bench_binary!(
+    bit_and_int64,
+    func::BitAndInt64,
+    Datum::Int64(0x0F0F),
+    Datum::Int64(0x00FF)
+);
+bench_binary!(
+    bit_and_uint16,
+    func::BitAndUint16,
+    Datum::UInt16(0x0F0F),
+    Datum::UInt16(0x00FF)
+);
+bench_binary!(
+    bit_and_uint32,
+    func::BitAndUint32,
+    Datum::UInt32(0x0F0F),
+    Datum::UInt32(0x00FF)
+);
+bench_binary!(
+    bit_and_uint64,
+    func::BitAndUint64,
+    Datum::UInt64(0x0F0F),
+    Datum::UInt64(0x00FF)
+);
+
+// BitOr
+bench_binary!(
+    bit_or_int16,
+    func::BitOrInt16,
+    Datum::Int16(0x0F00),
+    Datum::Int16(0x00F0)
+);
+bench_binary!(
+    bit_or_int32,
+    func::BitOrInt32,
+    Datum::Int32(0x0F00),
+    Datum::Int32(0x00F0)
+);
+bench_binary!(
+    bit_or_int64,
+    func::BitOrInt64,
+    Datum::Int64(0x0F00),
+    Datum::Int64(0x00F0)
+);
+bench_binary!(
+    bit_or_uint16,
+    func::BitOrUint16,
+    Datum::UInt16(0x0F00),
+    Datum::UInt16(0x00F0)
+);
+bench_binary!(
+    bit_or_uint32,
+    func::BitOrUint32,
+    Datum::UInt32(0x0F00),
+    Datum::UInt32(0x00F0)
+);
+bench_binary!(
+    bit_or_uint64,
+    func::BitOrUint64,
+    Datum::UInt64(0x0F00),
+    Datum::UInt64(0x00F0)
+);
+
+// BitXor
+bench_binary!(
+    bit_xor_int16,
+    func::BitXorInt16,
+    Datum::Int16(0x0FF0),
+    Datum::Int16(0x00FF)
+);
+bench_binary!(
+    bit_xor_int32,
+    func::BitXorInt32,
+    Datum::Int32(0x0FF0),
+    Datum::Int32(0x00FF)
+);
+bench_binary!(
+    bit_xor_int64,
+    func::BitXorInt64,
+    Datum::Int64(0x0FF0),
+    Datum::Int64(0x00FF)
+);
+bench_binary!(
+    bit_xor_uint16,
+    func::BitXorUint16,
+    Datum::UInt16(0x0FF0),
+    Datum::UInt16(0x00FF)
+);
+bench_binary!(
+    bit_xor_uint32,
+    func::BitXorUint32,
+    Datum::UInt32(0x0FF0),
+    Datum::UInt32(0x00FF)
+);
+bench_binary!(
+    bit_xor_uint64,
+    func::BitXorUint64,
+    Datum::UInt64(0x0FF0),
+    Datum::UInt64(0x00FF)
+);
+
+// BitShiftLeft
+bench_binary!(bit_shift_left_int16, func::BitShiftLeftInt16, 1i16, 4i32);
+bench_binary!(bit_shift_left_int32, func::BitShiftLeftInt32, 1i32, 4i32);
+bench_binary!(bit_shift_left_int64, func::BitShiftLeftInt64, 1i64, 4i32);
+bench_binary!(bit_shift_left_uint16, func::BitShiftLeftUint16, 1u16, 4u32);
+bench_binary!(bit_shift_left_uint32, func::BitShiftLeftUint32, 1u32, 4u32);
+bench_binary!(bit_shift_left_uint64, func::BitShiftLeftUint64, 1u64, 4u32);
+
+// BitShiftRight
+bench_binary!(
+    bit_shift_right_int16,
+    func::BitShiftRightInt16,
+    256i16,
+    4i32
+);
+bench_binary!(
+    bit_shift_right_int32,
+    func::BitShiftRightInt32,
+    256i32,
+    4i32
+);
+bench_binary!(
+    bit_shift_right_int64,
+    func::BitShiftRightInt64,
+    256i64,
+    4i32
+);
+bench_binary!(
+    bit_shift_right_uint16,
+    func::BitShiftRightUint16,
+    256u16,
+    4u32
+);
+bench_binary!(
+    bit_shift_right_uint32,
+    func::BitShiftRightUint32,
+    256u32,
+    4u32
+);
+bench_binary!(
+    bit_shift_right_uint64,
+    func::BitShiftRightUint64,
+    256u64,
+    4u32
+);
+
+// Comparison
+bench_binary!(eq, func::Eq, 42i32, 42i32);
+bench_binary!(not_eq, func::NotEq, 42i32, 43i32);
+bench_binary!(lt, func::Lt, 1i32, 2i32);
+bench_binary!(lte, func::Lte, 1i32, 2i32);
+bench_binary!(gt, func::Gt, 2i32, 1i32);
+bench_binary!(gte, func::Gte, 2i32, 1i32);
+
+// Step 5: Remaining binary functions
+
+// String functions
+bench_binary!(text_concat, func::TextConcatBinary, "hello", " world");
+bench_binary!(position, func::Position, "hello world", "world");
+bench_binary!(left, func::Left, "hello world", 5i32);
+bench_binary!(right, func::Right, "hello world", 5i32);
+bench_binary!(repeat_string, func::RepeatString, "ab", 3i32);
+bench_binary!(trim, func::Trim, "  hello  ", " ");
+bench_binary!(trim_leading, func::TrimLeading, "  hello  ", " ");
+bench_binary!(trim_trailing, func::TrimTrailing, "  hello  ", " ");
+bench_binary!(normalize, func::Normalize, "hello", "NFC");
+bench_binary!(starts_with, func::StartsWith, "hello world", "hello");
+bench_binary!(
+    encoded_bytes_char_length,
+    func::EncodedBytesCharLength,
+    b"hello",
+    "utf-8"
+);
+
+// Pattern matching
+bench_binary!(like_escape, func::LikeEscape, "100%", "\\");
+bench_binary!(
+    is_like_match_case_sensitive,
+    func::IsLikeMatchCaseSensitive,
+    "hello world",
+    "%world"
+);
+bench_binary!(
+    is_like_match_case_insensitive,
+    func::IsLikeMatchCaseInsensitive,
+    "Hello World",
+    "%world"
+);
+bench_binary!(
+    is_regexp_match_case_sensitive,
+    func::IsRegexpMatchCaseSensitive,
+    "hello world",
+    "w.rld"
+);
+bench_binary!(
+    is_regexp_match_case_insensitive,
+    func::IsRegexpMatchCaseInsensitive,
+    "Hello World",
+    "w.rld"
+);
+
+// Encoding
+bench_binary!(convert_from, func::ConvertFrom, b"hello", "utf8");
+bench_binary!(encode, func::Encode, b"hello", "base64");
+bench_binary!(decode, func::Decode, "aGVsbG8=", "base64");
+
+// Digest
+bench_binary!(digest_string, func::DigestString, "hello", "md5");
+bench_binary!(digest_bytes, func::DigestBytes, b"hello", "md5");
+
+// Numeric operations
+bench_binary_multi!(
+    log_numeric,
+    func::LogBaseNumeric,
+    [
+        (Numeric::from(10), Numeric::from(100)),
+        (Numeric::from(2), Numeric::from(1024)),
+        (Numeric::from(10), Numeric::from(42)),
+        (Numeric::from(3), Numeric::from(81)),
+        (Numeric::from(7), Numeric::from(999999)),
+    ]
+);
+bench_binary_multi!(
+    power,
+    func::Power,
+    [
+        (2.0f64, 10.0f64),
+        (2.0f64, 0.5f64),
+        (10.0f64, 3.0f64),
+        (1.5f64, 7.3f64),
+        (0.5f64, 20.0f64),
+        (100.0f64, 0.1f64),
+        (std::f64::consts::E, 3.0f64),
+        (9.0f64, 0.5f64),
+    ]
+);
+bench_binary_multi!(
+    power_numeric,
+    func::PowerNumeric,
+    [
+        (Numeric::from(2), Numeric::from(10)),
+        (Numeric::from(10), Numeric::from(3)),
+        (Numeric::from(3), Numeric::from(7)),
+        (Numeric::from(7), Numeric::from(5)),
+        (Numeric::from(100), Numeric::from(2)),
+    ]
+);
+
+// Byte operations
+bench_binary!(get_bit, func::GetBit, b"\xff", 3i32);
+bench_binary!(get_byte, func::GetByte, b"hello", 0i32);
+bench_binary!(
+    constant_time_eq_bytes,
+    func::ConstantTimeEqBytes,
+    b"hello",
+    b"hello"
+);
+bench_binary!(
+    constant_time_eq_string,
+    func::ConstantTimeEqString,
+    "hello",
+    "hello"
+);
+
+// MzRenderTypmod
+bench_binary!(mz_render_typmod, func::MzRenderTypmod, 23u32, -1i32);
+
+// ParseIdent
+bench_binary!(parse_ident, func::ParseIdent, "myschema.mytable", true);
+
+// PrettySql
+bench_binary!(pretty_sql, func::PrettySql, "SELECT 1", 80i32);
+
+// RegexpReplace
+fn regexp_replace(b: &mut Bencher) {
+    let regex = mz_repr::adt::regex::Regex::new("world", false).unwrap();
+    let f = BinaryFunc::RegexpReplace(func::RegexpReplace { regex, limit: 0 });
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["hello world".into(), "earth".into()];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// UuidGenerateV5
+bench_binary!(uuid_generate_v5, func::UuidGenerateV5, Uuid::nil(), "test");
+
+// MzAclItemContainsPrivilege
+// Skipped: requires MzAclItem datum construction
+
+// ToChar
+fn to_char_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::ToCharTimestamp(func::ToCharTimestampFormat);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::Timestamp(ts), "YYYY-MM-DD HH24:MI:SS".into()];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn to_char_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::ToCharTimestampTz(func::ToCharTimestampTzFormat);
+    let ts = CheckedTimestamp::from_timestamplike(
+        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[Datum::TimestampTz(ts), "YYYY-MM-DD HH24:MI:SS".into()];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// DateBin
+fn date_bin_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::DateBinTimestamp(func::DateBinTimestamp);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        Datum::Timestamp(ts),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_bin_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::DateBinTimestampTz(func::DateBinTimestampTz);
+    let ts = CheckedTimestamp::from_timestamplike(
+        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        Datum::TimestampTz(ts),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// Extract/DatePart
+fn extract_interval(b: &mut Bencher) {
+    let f = BinaryFunc::ExtractInterval(func::DatePartIntervalNumeric);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["epoch".into(), Interval::new(1, 2, 3_000_000).into()];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn extract_time(b: &mut Bencher) {
+    let f = BinaryFunc::ExtractTime(func::DatePartTimeNumeric);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        "hour".into(),
+        Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn extract_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::ExtractTimestamp(func::DatePartTimestampTimestampNumeric);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn extract_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::ExtractTimestampTz(func::DatePartTimestampTimestampTzNumeric);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn extract_date(b: &mut Bencher) {
+    let f = BinaryFunc::ExtractDate(func::ExtractDateUnits);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["year".into(), Datum::Date(Date::from_pg_epoch(0).unwrap())];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_part_interval(b: &mut Bencher) {
+    let f = BinaryFunc::DatePartInterval(func::DatePartIntervalF64);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        "epoch".into(),
+        Datum::Interval(Interval::new(1, 2, 3_000_000)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_part_time(b: &mut Bencher) {
+    let f = BinaryFunc::DatePartTime(func::DatePartTimeF64);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        "hour".into(),
+        Datum::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap()),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_part_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::DatePartTimestamp(func::DatePartTimestampTimestampF64);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["year".into(), Datum::Timestamp(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_part_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::DatePartTimestampTz(func::DatePartTimestampTimestampTzF64);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["year".into(), Datum::TimestampTz(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// DateTrunc
+fn date_trunc_timestamp(b: &mut Bencher) {
+    let f = BinaryFunc::DateTruncTimestamp(func::DateTruncUnitsTimestamp);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["hour".into(), Datum::Timestamp(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_trunc_timestamp_tz(b: &mut Bencher) {
+    let f = BinaryFunc::DateTruncTimestampTz(func::DateTruncUnitsTimestampTz);
+    let ts = CheckedTimestamp::from_timestamplike(
+        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["hour".into(), Datum::TimestampTz(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn date_trunc_interval(b: &mut Bencher) {
+    let f = BinaryFunc::DateTruncInterval(func::DateTruncInterval);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        "hour".into(),
+        Datum::Interval(Interval::new(0, 0, 5_400_000_000)),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// Timezone
+fn timezone_timestamp_binary(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneTimestampBinary(func::TimezoneTimestampBinary);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["UTC".into(), Datum::Timestamp(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn timezone_timestamp_tz_binary(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneTimestampTzBinary(func::TimezoneTimestampTzBinary);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn timezone_interval_timestamp_binary(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneIntervalTimestampBinary(func::TimezoneIntervalTimestampBinary);
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        Datum::Timestamp(ts),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn timezone_interval_timestamp_tz_binary(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneIntervalTimestampTzBinary(func::TimezoneIntervalTimestampTzBinary);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        Datum::TimestampTz(ts),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn timezone_interval_time_binary(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneIntervalTimeBinary(func::TimezoneIntervalTimeBinary);
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &[
+        Datum::Interval(Interval::new(0, 0, 3_600_000_000)),
+        Datum::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+    ];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+fn timezone_offset(b: &mut Bencher) {
+    let f = BinaryFunc::TimezoneOffset(func::TimezoneOffset);
+    let ts =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let a = MirScalarExpr::column(0);
+    let e = MirScalarExpr::column(1);
+    let arena = RowArena::new();
+    let datums: &[Datum] = &["UTC".into(), Datum::TimestampTz(ts)];
+    b.iter(|| f.eval(datums, &arena, &a, &e));
+}
+
+// Benchmark registration
+
+benchmark_group!(
+    arithmetic_benches,
+    // Add
+    add_int16,
+    add_int16_error,
+    add_int32,
+    add_int32_error,
+    add_int64,
+    add_int64_error,
+    add_uint16,
+    add_uint16_error,
+    add_uint32,
+    add_uint32_error,
+    add_uint64,
+    add_uint64_error,
+    add_float32,
+    add_float32_error,
+    add_float64,
+    add_float64_error,
+    add_numeric,
+    add_interval,
+    add_timestamp_interval,
+    add_timestamp_tz_interval,
+    add_date_interval,
+    add_date_time,
+    add_time_interval,
+    // Sub
+    sub_int16,
+    sub_int16_error,
+    sub_int32,
+    sub_int32_error,
+    sub_int64,
+    sub_int64_error,
+    sub_uint16,
+    sub_uint16_error,
+    sub_uint32,
+    sub_uint32_error,
+    sub_uint64,
+    sub_uint64_error,
+    sub_float32,
+    sub_float64,
+    sub_numeric,
+    sub_interval,
+    sub_timestamp,
+    sub_timestamp_tz,
+    sub_timestamp_interval,
+    sub_timestamp_tz_interval,
+    sub_date,
+    sub_date_interval,
+    sub_time,
+    sub_time_interval,
+    // Mul
+    mul_int16,
+    mul_int16_error,
+    mul_int32,
+    mul_int32_error,
+    mul_int64,
+    mul_int64_error,
+    mul_uint16,
+    mul_uint16_error,
+    mul_uint32,
+    mul_uint32_error,
+    mul_uint64,
+    mul_uint64_error,
+    mul_float32,
+    mul_float32_error,
+    mul_float64,
+    mul_float64_error,
+    mul_numeric,
+    mul_interval,
+    // Div (happy paths are in *_group functions via benchmark_main)
+    div_int16_divzero,
+    div_int32_divzero,
+    div_int64_divzero,
+    div_uint16_divzero,
+    div_uint32_divzero,
+    div_uint64_divzero,
+    div_float32_divzero,
+    div_float64_divzero,
+    div_numeric_divzero,
+    div_interval,
+    div_interval_divzero,
+    // Mod
+    mod_int16,
+    mod_int16_divzero,
+    mod_int32,
+    mod_int32_divzero,
+    mod_int64,
+    mod_int64_divzero,
+    mod_uint16,
+    mod_uint32,
+    mod_uint64,
+    mod_float32,
+    mod_float64,
+    mod_numeric,
+    // Round, Age
+    round_numeric,
+    age_timestamp,
+    age_timestamp_tz
+);
+
+benchmark_group!(
+    bitwise_comparison_benches,
+    // BitAnd
+    bit_and_int16,
+    bit_and_int32,
+    bit_and_int64,
+    bit_and_uint16,
+    bit_and_uint32,
+    bit_and_uint64,
+    // BitOr
+    bit_or_int16,
+    bit_or_int32,
+    bit_or_int64,
+    bit_or_uint16,
+    bit_or_uint32,
+    bit_or_uint64,
+    // BitXor
+    bit_xor_int16,
+    bit_xor_int32,
+    bit_xor_int64,
+    bit_xor_uint16,
+    bit_xor_uint32,
+    bit_xor_uint64,
+    // BitShiftLeft
+    bit_shift_left_int16,
+    bit_shift_left_int32,
+    bit_shift_left_int64,
+    bit_shift_left_uint16,
+    bit_shift_left_uint32,
+    bit_shift_left_uint64,
+    // BitShiftRight
+    bit_shift_right_int16,
+    bit_shift_right_int32,
+    bit_shift_right_int64,
+    bit_shift_right_uint16,
+    bit_shift_right_uint32,
+    bit_shift_right_uint64,
+    // Comparison
+    eq,
+    not_eq,
+    lt,
+    lte,
+    gt,
+    gte
+);
+
+benchmark_group!(
+    remaining_benches,
+    // String
+    text_concat,
+    position,
+    left,
+    right,
+    repeat_string,
+    trim,
+    trim_leading,
+    trim_trailing,
+    normalize,
+    starts_with,
+    encoded_bytes_char_length,
+    // Pattern matching
+    like_escape,
+    is_like_match_case_sensitive,
+    is_like_match_case_insensitive,
+    is_regexp_match_case_sensitive,
+    is_regexp_match_case_insensitive,
+    // Encoding
+    convert_from,
+    encode,
+    decode,
+    // Digest
+    digest_string,
+    digest_bytes,
+    // Numeric operations (happy paths are in *_group functions via benchmark_main)
+    // Byte operations
+    get_bit,
+    get_byte,
+    constant_time_eq_bytes,
+    constant_time_eq_string,
+    // Misc
+    mz_render_typmod,
+    parse_ident,
+    pretty_sql,
+    regexp_replace,
+    uuid_generate_v5,
+    // ToChar
+    to_char_timestamp,
+    to_char_timestamp_tz,
+    // DateBin
+    date_bin_timestamp,
+    date_bin_timestamp_tz,
+    // Extract/DatePart
+    extract_interval,
+    extract_time,
+    extract_timestamp,
+    extract_timestamp_tz,
+    extract_date,
+    date_part_interval,
+    date_part_time,
+    date_part_timestamp,
+    date_part_timestamp_tz,
+    // DateTrunc
+    date_trunc_timestamp,
+    date_trunc_timestamp_tz,
+    date_trunc_interval,
+    // Timezone
+    timezone_timestamp_binary,
+    timezone_timestamp_tz_binary,
+    timezone_interval_timestamp_binary,
+    timezone_interval_timestamp_tz_binary,
+    timezone_interval_time_binary,
+    timezone_offset
+);
+
+benchmark_main!(
+    arithmetic_benches,
+    bitwise_comparison_benches,
+    remaining_benches,
+    // Multi-input benchmark groups (each input is a separate benchmark entry)
+    div_int16_group,
+    div_int32_group,
+    div_int64_group,
+    div_uint16_group,
+    div_uint32_group,
+    div_uint64_group,
+    div_float32_group,
+    div_float64_group,
+    div_numeric_group,
+    log_numeric_group,
+    power_group,
+    power_numeric_group
+);

--- a/src/expr/benches/bench_unary.rs
+++ b/src/expr/benches/bench_unary.rs
@@ -1,0 +1,1829 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bencher::{Bencher, benchmark_group, benchmark_main};
+use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use mz_expr::like_pattern;
+use mz_expr::{MirScalarExpr, UnaryFunc, func as f};
+use mz_repr::adt::date::Date;
+use mz_repr::adt::datetime::DateTimeUnits;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::mz_acl_item::{AclItem, AclMode, MzAclItem};
+use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
+use mz_repr::adt::regex::Regex;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::role_id::RoleId;
+use mz_repr::adt::system::Oid;
+use mz_repr::{Datum as D, RowArena, Timestamp};
+use ordered_float::OrderedFloat;
+use uuid::Uuid;
+
+macro_rules! bench_unary {
+    ($bench_name:ident, $struct_expr:expr,
+     $a_datum:expr $(,)?) => {
+        fn $bench_name(b: &mut Bencher) {
+            let f = UnaryFunc::from($struct_expr);
+            let a = MirScalarExpr::column(0);
+            let arena = RowArena::new();
+            let datums: &[D] = &[($a_datum).into()];
+            b.iter(|| f.eval(datums, &arena, &a));
+        }
+    };
+}
+
+/// Generates a `_group` function that returns individual benchmark entries
+/// for each input, so they show up as separate lines in benchmark output.
+macro_rules! bench_unary_multi {
+    ($bench_name:ident, $struct_expr:expr,
+     [ $( $a_datum:expr ),+ $(,)? ]) => {
+        paste::paste! {
+            fn [<$bench_name _group>]() -> Vec<bencher::TestDescAndFn> {
+                use bencher::{TestDescAndFn, TestFn, TestDesc};
+                use std::borrow::Cow;
+                let mut benches = Vec::new();
+                $(
+                    benches.push(TestDescAndFn {
+                        desc: TestDesc {
+                            name: Cow::from(concat!(
+                                stringify!($bench_name), "(", stringify!($a_datum), ")"
+                            )),
+                            ignore: false,
+                        },
+                        testfn: TestFn::StaticBenchFn({
+                            fn run(b: &mut bencher::Bencher) {
+                                let f = UnaryFunc::from($struct_expr);
+                                let a = MirScalarExpr::column(0);
+                                let arena = RowArena::new();
+                                let datums: &[D] = &[($a_datum).into()];
+                                b.iter(|| f.eval(datums, &arena, &a));
+                            }
+                            run
+                        }),
+                    });
+                )+
+                benches
+            }
+        }
+    };
+}
+
+// Unary arithmetic + bitwise functions
+
+// Boolean
+bench_unary!(not, f::Not, true);
+bench_unary!(is_null, f::IsNull, D::Int32(42));
+bench_unary!(is_true, f::IsTrue, true);
+bench_unary!(is_false, f::IsFalse, false);
+
+// Neg
+bench_unary!(neg_int16, f::NegInt16, 42i16);
+bench_unary!(neg_int16_error, f::NegInt16, i16::MIN);
+bench_unary!(neg_int32, f::NegInt32, 42i32);
+bench_unary!(neg_int32_error, f::NegInt32, i32::MIN);
+bench_unary!(neg_int64, f::NegInt64, 42i64);
+bench_unary!(neg_int64_error, f::NegInt64, i64::MIN);
+bench_unary!(neg_float32, f::NegFloat32, 42.0f32);
+bench_unary!(neg_float64, f::NegFloat64, 42.0f64);
+bench_unary!(neg_numeric, f::NegNumeric, Numeric::from(42));
+bench_unary!(neg_interval, f::NegInterval, Interval::new(1, 2, 3_000_000));
+
+// Abs
+bench_unary!(abs_int16, f::AbsInt16, -42i16);
+bench_unary!(abs_int32, f::AbsInt32, -42i32);
+bench_unary!(abs_int64, f::AbsInt64, -42i64);
+bench_unary!(abs_float32, f::AbsFloat32, -42.0f32);
+bench_unary!(abs_float64, f::AbsFloat64, -42.0f64);
+bench_unary!(abs_numeric, f::AbsNumeric, Numeric::from(-42));
+
+// BitNot
+bench_unary!(bit_not_int16, f::BitNotInt16, D::Int16(0x0F0F));
+bench_unary!(bit_not_int32, f::BitNotInt32, D::Int32(0x0F0F0F0F));
+bench_unary!(bit_not_int64, f::BitNotInt64, D::Int64(0x0F0F0F0F));
+bench_unary!(bit_not_uint16, f::BitNotUint16, D::UInt16(0x0F0F));
+bench_unary!(bit_not_uint32, f::BitNotUint32, D::UInt32(0x0F0F));
+bench_unary!(bit_not_uint64, f::BitNotUint64, D::UInt64(0x0F0F));
+
+// Sqrt/Cbrt (8 diverse inputs each: perfect squares, primes, tiny, huge, fractional)
+bench_unary_multi!(
+    sqrt_float64,
+    f::SqrtFloat64,
+    [
+        0.0f64,
+        0.001f64,
+        2.0f64,
+        16.0f64,
+        17.3f64,
+        999.999f64,
+        1e12f64,
+        1.7976931348623157e100f64,
+    ]
+);
+bench_unary_multi!(
+    sqrt_numeric,
+    f::SqrtNumeric,
+    [
+        Numeric::from(2),
+        Numeric::from(16),
+        Numeric::from(17),
+        Numeric::from(9999),
+        Numeric::from(1000000),
+        Numeric::from(999999999),
+    ]
+);
+bench_unary_multi!(
+    cbrt_float64,
+    f::CbrtFloat64,
+    [
+        0.0f64, 0.001f64, 2.0f64, 27.0f64, 30.7f64, 1e9f64, 1.5e100f64, -8.0f64,
+    ]
+);
+
+// Ceil/Floor/Round/Trunc (diverse fractional values)
+bench_unary_multi!(
+    ceil_float32,
+    f::CeilFloat32,
+    [
+        0.0f32, 0.1f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 1e10f32, 0.5f32,
+    ]
+);
+bench_unary_multi!(
+    ceil_float64,
+    f::CeilFloat64,
+    [
+        0.0f64, 0.1f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 1e15f64, 0.5f64,
+    ]
+);
+bench_unary_multi!(
+    ceil_numeric,
+    f::CeilNumeric,
+    [
+        Numeric::from(0),
+        Numeric::from(314),
+        Numeric::from(-42),
+        Numeric::from(999999),
+        Numeric::from(1),
+        Numeric::from(-1),
+    ]
+);
+bench_unary_multi!(
+    floor_float32,
+    f::FloorFloat32,
+    [0.0f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 0.5f32,]
+);
+bench_unary_multi!(
+    floor_float64,
+    f::FloorFloat64,
+    [0.0f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 0.5f64,]
+);
+bench_unary_multi!(
+    floor_numeric,
+    f::FloorNumeric,
+    [
+        Numeric::from(0),
+        Numeric::from(314),
+        Numeric::from(-42),
+        Numeric::from(999999),
+    ]
+);
+bench_unary_multi!(
+    round_float32,
+    f::RoundFloat32,
+    [0.0f32, 3.17f32, -2.7f32, 0.5f32, 999.999f32, -0.5f32,]
+);
+bench_unary_multi!(
+    round_float64,
+    f::RoundFloat64,
+    [0.0f64, 3.17f64, -2.7f64, 0.5f64, 999.999f64, -0.5f64,]
+);
+bench_unary_multi!(
+    round_numeric,
+    f::RoundNumeric,
+    [
+        Numeric::from(0),
+        Numeric::from(314),
+        Numeric::from(-42),
+        Numeric::from(999999),
+    ]
+);
+bench_unary_multi!(
+    trunc_float32,
+    f::TruncFloat32,
+    [0.0f32, 3.17f32, -2.7f32, 999.999f32,]
+);
+bench_unary_multi!(
+    trunc_float64,
+    f::TruncFloat64,
+    [0.0f64, 3.17f64, -2.7f64, 999.999f64,]
+);
+bench_unary_multi!(
+    trunc_numeric,
+    f::TruncNumeric,
+    [
+        Numeric::from(0),
+        Numeric::from(314),
+        Numeric::from(-42),
+        Numeric::from(999999),
+    ]
+);
+
+// Log/Ln/Exp (diverse magnitudes)
+bench_unary_multi!(
+    log10,
+    f::Log10,
+    [
+        0.001f64,
+        1.0f64,
+        10.0f64,
+        100.0f64,
+        99999.9f64,
+        1e15f64,
+        0.123456789f64,
+        42.42f64,
+    ]
+);
+bench_unary_multi!(
+    log10_numeric,
+    f::Log10Numeric,
+    [
+        Numeric::from(1),
+        Numeric::from(10),
+        Numeric::from(100),
+        Numeric::from(99999),
+        Numeric::from(42),
+    ]
+);
+bench_unary_multi!(
+    ln,
+    f::Ln,
+    [
+        0.001f64,
+        1.0f64,
+        std::f64::consts::E,
+        100.0f64,
+        99999.9f64,
+        1e15f64,
+        0.123456789f64,
+        42.42f64,
+    ]
+);
+bench_unary_multi!(
+    ln_numeric,
+    f::LnNumeric,
+    [
+        Numeric::from(1),
+        Numeric::from(3),
+        Numeric::from(100),
+        Numeric::from(99999),
+        Numeric::from(42),
+    ]
+);
+bench_unary_multi!(
+    exp,
+    f::Exp,
+    [
+        0.0f64, 1.0f64, 2.0f64, -1.0f64, 10.0f64, 0.5f64, -5.0f64, 20.0f64,
+    ]
+);
+bench_unary_multi!(
+    exp_numeric,
+    f::ExpNumeric,
+    [
+        Numeric::from(0),
+        Numeric::from(1),
+        Numeric::from(2),
+        Numeric::from(10),
+        Numeric::from(-1),
+    ]
+);
+
+// Trig (diverse angles spanning the domain)
+bench_unary_multi!(
+    cos,
+    f::Cos,
+    [
+        0.0f64,
+        0.5f64,
+        1.0f64,
+        std::f64::consts::PI,
+        std::f64::consts::FRAC_PI_2,
+        2.5f64,
+        -1.0f64,
+        100.0f64,
+    ]
+);
+bench_unary_multi!(
+    acos,
+    f::Acos,
+    [
+        -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
+    ]
+);
+bench_unary_multi!(
+    cosh,
+    f::Cosh,
+    [
+        0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
+    ]
+);
+bench_unary_multi!(
+    acosh,
+    f::Acosh,
+    [
+        1.0f64, 1.5f64, 2.0f64, 5.0f64, 10.0f64, 100.0f64, 1.001f64, 50.0f64,
+    ]
+);
+bench_unary_multi!(
+    sin,
+    f::Sin,
+    [
+        0.0f64,
+        0.5f64,
+        1.0f64,
+        std::f64::consts::PI,
+        std::f64::consts::FRAC_PI_2,
+        2.5f64,
+        -1.0f64,
+        100.0f64,
+    ]
+);
+bench_unary_multi!(
+    asin,
+    f::Asin,
+    [
+        -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
+    ]
+);
+bench_unary_multi!(
+    sinh,
+    f::Sinh,
+    [
+        0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
+    ]
+);
+bench_unary_multi!(
+    asinh,
+    f::Asinh,
+    [
+        0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -10.0f64, 0.001f64,
+    ]
+);
+bench_unary_multi!(
+    tan,
+    f::Tan,
+    [
+        0.0f64, 0.5f64, 1.0f64, 0.785f64, // ~pi/4
+        -1.0f64, 1.5f64, // close to pi/2
+        3.0f64, 100.0f64,
+    ]
+);
+bench_unary_multi!(
+    atan,
+    f::Atan,
+    [
+        0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -100.0f64, 0.001f64,
+    ]
+);
+bench_unary_multi!(
+    tanh,
+    f::Tanh,
+    [
+        0.0f64, 0.5f64, 1.0f64, 5.0f64, -1.0f64, -5.0f64, 20.0f64, 0.001f64,
+    ]
+);
+bench_unary_multi!(
+    atanh,
+    f::Atanh,
+    [
+        0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.99f64, -0.5f64, -0.9f64, 0.001f64,
+    ]
+);
+bench_unary_multi!(
+    cot,
+    f::Cot,
+    [
+        0.1f64,
+        0.5f64,
+        1.0f64,
+        std::f64::consts::FRAC_PI_4,
+        2.0f64,
+        3.0f64,
+        -1.0f64,
+        0.01f64,
+    ]
+);
+bench_unary_multi!(
+    degrees,
+    f::Degrees,
+    [
+        0.0f64,
+        std::f64::consts::PI,
+        std::f64::consts::FRAC_PI_2,
+        1.0f64,
+        -std::f64::consts::PI,
+        6.37f64,
+        0.001f64,
+        100.0f64,
+    ]
+);
+bench_unary_multi!(
+    radians,
+    f::Radians,
+    [
+        0.0f64, 45.0f64, 90.0f64, 180.0f64, 360.0f64, -180.0f64, 1.0f64, 0.001f64,
+    ]
+);
+
+// Unary cast functions (unit struct casts only)
+
+// Bool casts
+bench_unary!(cast_bool_to_string, f::CastBoolToString, true);
+bench_unary!(
+    cast_bool_to_string_nonstandard,
+    f::CastBoolToStringNonstandard,
+    true,
+);
+bench_unary!(cast_bool_to_int32, f::CastBoolToInt32, true);
+bench_unary!(cast_bool_to_int64, f::CastBoolToInt64, true);
+
+// Int16 casts
+bench_unary!(cast_int16_to_float32, f::CastInt16ToFloat32, D::Int16(42));
+bench_unary!(cast_int16_to_float64, f::CastInt16ToFloat64, D::Int16(42));
+bench_unary!(cast_int16_to_int32, f::CastInt16ToInt32, D::Int16(42));
+bench_unary!(cast_int16_to_int64, f::CastInt16ToInt64, D::Int16(42));
+bench_unary!(cast_int16_to_uint16, f::CastInt16ToUint16, D::Int16(42));
+bench_unary!(cast_int16_to_uint32, f::CastInt16ToUint32, D::Int16(42));
+bench_unary!(cast_int16_to_uint64, f::CastInt16ToUint64, D::Int16(42));
+bench_unary!(cast_int16_to_string, f::CastInt16ToString, D::Int16(42));
+
+// Int32 casts
+bench_unary!(cast_int32_to_bool, f::CastInt32ToBool, D::Int32(1));
+bench_unary!(cast_int32_to_float32, f::CastInt32ToFloat32, D::Int32(42));
+bench_unary!(cast_int32_to_float64, f::CastInt32ToFloat64, D::Int32(42));
+bench_unary!(cast_int32_to_int16, f::CastInt32ToInt16, D::Int32(42));
+bench_unary!(cast_int32_to_int64, f::CastInt32ToInt64, D::Int32(42));
+bench_unary!(cast_int32_to_uint16, f::CastInt32ToUint16, D::Int32(42));
+bench_unary!(cast_int32_to_uint32, f::CastInt32ToUint32, D::Int32(42));
+bench_unary!(cast_int32_to_uint64, f::CastInt32ToUint64, D::Int32(42));
+bench_unary!(cast_int32_to_string, f::CastInt32ToString, D::Int32(42));
+bench_unary!(cast_int32_to_oid, f::CastInt32ToOid, D::Int32(42));
+
+// Int64 casts
+bench_unary!(cast_int64_to_int16, f::CastInt64ToInt16, D::Int64(42));
+bench_unary!(cast_int64_to_int32, f::CastInt64ToInt32, D::Int64(42));
+bench_unary!(cast_int64_to_uint16, f::CastInt64ToUint16, D::Int64(42));
+bench_unary!(cast_int64_to_uint32, f::CastInt64ToUint32, D::Int64(42));
+bench_unary!(cast_int64_to_uint64, f::CastInt64ToUint64, D::Int64(42));
+bench_unary!(cast_int64_to_bool, f::CastInt64ToBool, D::Int64(1));
+bench_unary!(cast_int64_to_float32, f::CastInt64ToFloat32, D::Int64(42));
+bench_unary!(cast_int64_to_float64, f::CastInt64ToFloat64, D::Int64(42));
+bench_unary!(cast_int64_to_string, f::CastInt64ToString, D::Int64(42));
+bench_unary!(cast_int64_to_oid, f::CastInt64ToOid, D::Int64(42));
+
+// Uint16 casts
+bench_unary!(cast_uint16_to_uint32, f::CastUint16ToUint32, D::UInt16(42));
+bench_unary!(cast_uint16_to_uint64, f::CastUint16ToUint64, D::UInt16(42));
+bench_unary!(cast_uint16_to_int16, f::CastUint16ToInt16, D::UInt16(42));
+bench_unary!(cast_uint16_to_int32, f::CastUint16ToInt32, D::UInt16(42));
+bench_unary!(cast_uint16_to_int64, f::CastUint16ToInt64, D::UInt16(42));
+bench_unary!(cast_uint16_to_float32, f::CastUint16ToFloat32, 42u16);
+bench_unary!(cast_uint16_to_float64, f::CastUint16ToFloat64, 42u16);
+bench_unary!(cast_uint16_to_string, f::CastUint16ToString, D::UInt16(42));
+
+// Uint32 casts
+bench_unary!(cast_uint32_to_uint16, f::CastUint32ToUint16, D::UInt32(42));
+bench_unary!(cast_uint32_to_uint64, f::CastUint32ToUint64, D::UInt32(42));
+bench_unary!(cast_uint32_to_int16, f::CastUint32ToInt16, D::UInt32(42));
+bench_unary!(cast_uint32_to_int32, f::CastUint32ToInt32, D::UInt32(42));
+bench_unary!(cast_uint32_to_int64, f::CastUint32ToInt64, D::UInt32(42));
+bench_unary!(cast_uint32_to_float32, f::CastUint32ToFloat32, 42u32);
+bench_unary!(cast_uint32_to_float64, f::CastUint32ToFloat64, 42u32);
+bench_unary!(cast_uint32_to_string, f::CastUint32ToString, D::UInt32(42));
+
+// Uint64 casts
+bench_unary!(cast_uint64_to_uint16, f::CastUint64ToUint16, D::UInt64(42));
+bench_unary!(cast_uint64_to_uint32, f::CastUint64ToUint32, D::UInt64(42));
+bench_unary!(cast_uint64_to_int16, f::CastUint64ToInt16, D::UInt64(42));
+bench_unary!(cast_uint64_to_int32, f::CastUint64ToInt32, D::UInt64(42));
+bench_unary!(cast_uint64_to_int64, f::CastUint64ToInt64, D::UInt64(42));
+bench_unary!(cast_uint64_to_float32, f::CastUint64ToFloat32, 42u64);
+bench_unary!(cast_uint64_to_float64, f::CastUint64ToFloat64, 42u64);
+bench_unary!(cast_uint64_to_string, f::CastUint64ToString, D::UInt64(42));
+
+// Float32 casts
+bench_unary!(cast_float32_to_int16, f::CastFloat32ToInt16, 42.0f32);
+bench_unary!(cast_float32_to_int32, f::CastFloat32ToInt32, 42.0f32);
+bench_unary!(cast_float32_to_int64, f::CastFloat32ToInt64, 42.0f32);
+bench_unary!(cast_float32_to_uint16, f::CastFloat32ToUint16, 42.0f32);
+bench_unary!(cast_float32_to_uint32, f::CastFloat32ToUint32, 42.0f32);
+bench_unary!(cast_float32_to_uint64, f::CastFloat32ToUint64, 42.0f32);
+bench_unary!(cast_float32_to_float64, f::CastFloat32ToFloat64, 42.0f32);
+bench_unary!(cast_float32_to_string, f::CastFloat32ToString, 42.0f32);
+
+// Float64 casts
+bench_unary!(cast_float64_to_int16, f::CastFloat64ToInt16, 42.0f64);
+bench_unary!(cast_float64_to_int32, f::CastFloat64ToInt32, 42.0f64);
+bench_unary!(cast_float64_to_int64, f::CastFloat64ToInt64, 42.0f64);
+bench_unary!(cast_float64_to_uint16, f::CastFloat64ToUint16, 42.0f64);
+bench_unary!(cast_float64_to_uint32, f::CastFloat64ToUint32, 42.0f64);
+bench_unary!(cast_float64_to_uint64, f::CastFloat64ToUint64, 42.0f64);
+bench_unary!(cast_float64_to_float32, f::CastFloat64ToFloat32, 42.0f64);
+bench_unary!(cast_float64_to_string, f::CastFloat64ToString, 42.0f64);
+
+// Numeric casts
+bench_unary!(
+    cast_numeric_to_float32,
+    f::CastNumericToFloat32,
+    Numeric::from(42)
+);
+bench_unary!(
+    cast_numeric_to_float64,
+    f::CastNumericToFloat64,
+    Numeric::from(42)
+);
+bench_unary!(
+    cast_numeric_to_int16,
+    f::CastNumericToInt16,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_int32,
+    f::CastNumericToInt32,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_int64,
+    f::CastNumericToInt64,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_uint16,
+    f::CastNumericToUint16,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_uint32,
+    f::CastNumericToUint32,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_uint64,
+    f::CastNumericToUint64,
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_numeric_to_string,
+    f::CastNumericToString,
+    Numeric::from(42),
+);
+
+// Parameterized casts (XToNumeric)
+bench_unary!(cast_int16_to_numeric, f::CastInt16ToNumeric(None), 42i16);
+bench_unary!(cast_int32_to_numeric, f::CastInt32ToNumeric(None), 42i32);
+bench_unary!(cast_int64_to_numeric, f::CastInt64ToNumeric(None), 42i64);
+bench_unary!(cast_uint16_to_numeric, f::CastUint16ToNumeric(None), 42u16);
+bench_unary!(cast_uint32_to_numeric, f::CastUint32ToNumeric(None), 42u32);
+bench_unary!(cast_uint64_to_numeric, f::CastUint64ToNumeric(None), 42u64);
+bench_unary!(
+    cast_float32_to_numeric,
+    f::CastFloat32ToNumeric(None),
+    42f32
+);
+bench_unary!(
+    cast_float64_to_numeric,
+    f::CastFloat64ToNumeric(None),
+    42f64
+);
+
+// String parsing casts
+bench_unary!(cast_string_to_bool, f::CastStringToBool, "true");
+bench_unary!(cast_string_to_int16, f::CastStringToInt16, "42");
+bench_unary!(cast_string_to_int32, f::CastStringToInt32, "42");
+bench_unary!(cast_string_to_int64, f::CastStringToInt64, "42");
+bench_unary!(cast_string_to_uint16, f::CastStringToUint16, "42");
+bench_unary!(cast_string_to_uint32, f::CastStringToUint32, "42");
+bench_unary!(cast_string_to_uint64, f::CastStringToUint64, "42");
+bench_unary!(cast_string_to_float32, f::CastStringToFloat32, "42.0");
+bench_unary!(cast_string_to_float64, f::CastStringToFloat64, "42.0");
+bench_unary!(cast_string_to_date, f::CastStringToDate, "2024-01-15");
+bench_unary!(cast_string_to_time, f::CastStringToTime, "12:30:45");
+bench_unary!(
+    cast_string_to_timestamp,
+    f::CastStringToTimestamp(None),
+    "2024-01-15 12:30:45"
+);
+bench_unary!(
+    cast_string_to_timestamp_tz,
+    f::CastStringToTimestampTz(None),
+    "2024-01-15 12:30:45+00"
+);
+bench_unary!(
+    cast_string_to_interval,
+    f::CastStringToInterval,
+    "1 day 2 hours"
+);
+bench_unary!(
+    cast_string_to_uuid,
+    f::CastStringToUuid,
+    "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+);
+bench_unary!(cast_string_to_jsonb, f::CastStringToJsonb, "42");
+bench_unary!(cast_string_to_bytes, f::CastStringToBytes, "\\xDEADBEEF");
+
+// Other casts
+bench_unary!(cast_oid_to_int32, f::CastOidToInt32, D::UInt32(42));
+bench_unary!(cast_oid_to_int64, f::CastOidToInt64, D::UInt32(42));
+bench_unary!(cast_oid_to_string, f::CastOidToString, D::UInt32(42));
+bench_unary!(cast_uuid_to_string, f::CastUuidToString, Uuid::nil());
+bench_unary!(cast_bytes_to_string, f::CastBytesToString, b"hello");
+bench_unary!(cast_jsonb_to_string, f::CastJsonbToString, "hello");
+bench_unary!(cast_jsonb_to_int16, f::CastJsonbToInt16, 42f64);
+bench_unary!(cast_jsonb_to_int32, f::CastJsonbToInt32, 42f64);
+bench_unary!(cast_jsonb_to_int64, f::CastJsonbToInt64, 42f64);
+bench_unary!(cast_jsonb_to_float32, f::CastJsonbToFloat32, 42f64);
+bench_unary!(cast_jsonb_to_float64, f::CastJsonbToFloat64, 42f64);
+bench_unary!(cast_jsonb_to_bool, f::CastJsonbToBool, true);
+
+// Remaining unary functions
+
+// String operations
+bench_unary!(upper, f::Upper, "hello");
+bench_unary!(lower, f::Lower, "HELLO");
+bench_unary!(initcap, f::Initcap, "hello world");
+bench_unary!(trim_whitespace, f::TrimWhitespace, "  hello  ");
+bench_unary!(
+    trim_leading_whitespace,
+    f::TrimLeadingWhitespace,
+    "  hello  "
+);
+bench_unary!(
+    trim_trailing_whitespace,
+    f::TrimTrailingWhitespace,
+    "  hello  "
+);
+bench_unary!(ascii, f::Ascii, "hello");
+bench_unary!(char_length, f::CharLength, "hello");
+bench_unary!(bit_length_bytes, f::BitLengthBytes, b"hello");
+bench_unary!(bit_length_string, f::BitLengthString, "hello");
+bench_unary!(byte_length_bytes, f::ByteLengthBytes, b"hello");
+bench_unary!(byte_length_string, f::ByteLengthString, "hello");
+bench_unary!(bit_count_bytes, f::BitCountBytes, b"\xff");
+bench_unary!(chr, f::Chr, D::Int32(65));
+bench_unary!(reverse, f::Reverse, "hello");
+bench_unary!(quote_ident, f::QuoteIdent, "my_table");
+bench_unary!(pg_size_pretty, f::PgSizePretty, Numeric::from(1048576));
+
+// Jsonb
+bench_unary!(jsonb_typeof, f::JsonbTypeof, D::Float64(OrderedFloat(42.0)));
+bench_unary!(jsonb_pretty, f::JsonbPretty, "hello");
+
+// Date/time
+bench_unary!(justify_days, f::JustifyDays, Interval::new(0, 35, 0));
+bench_unary!(
+    justify_hours,
+    f::JustifyHours,
+    Interval::new(0, 0, 30 * 3_600_000_000)
+);
+bench_unary!(
+    justify_interval,
+    f::JustifyInterval,
+    Interval::new(0, 35, 30 * 3_600_000_000)
+);
+bench_unary!(
+    cast_date_to_string,
+    f::CastDateToString,
+    Date::from_pg_epoch(0).unwrap(),
+);
+bench_unary!(
+    cast_time_to_string,
+    f::CastTimeToString,
+    NaiveTime::from_hms_opt(12, 30, 45).unwrap(),
+);
+bench_unary!(
+    cast_interval_to_string,
+    f::CastIntervalToString,
+    Interval::new(1, 2, 3_000_000)
+);
+bench_unary!(
+    cast_interval_to_time,
+    f::CastIntervalToTime,
+    Interval::new(0, 0, 45_000_000_000)
+);
+bench_unary!(
+    cast_time_to_interval,
+    f::CastTimeToInterval,
+    NaiveTime::from_hms_opt(12, 30, 45).unwrap()
+);
+
+// Hash functions
+bench_unary!(crc32_bytes, f::Crc32Bytes, b"hello");
+bench_unary!(crc32_string, f::Crc32String, "hello");
+bench_unary!(kafka_murmur2_bytes, f::KafkaMurmur2Bytes, b"hello");
+bench_unary!(kafka_murmur2_string, f::KafkaMurmur2String, "hello");
+bench_unary!(seahash_bytes, f::SeahashBytes, b"hello");
+bench_unary!(seahash_string, f::SeahashString, "hello");
+
+// --- Helpers for constructing complex datums ---
+
+fn make_ts() -> CheckedTimestamp<chrono::NaiveDateTime> {
+    CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+fn make_tstz() -> CheckedTimestamp<chrono::DateTime<Utc>> {
+    CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap())
+        .unwrap()
+}
+
+// --- Timestamp/Date casts ---
+
+bench_unary!(
+    cast_date_to_timestamp,
+    f::CastDateToTimestamp(None),
+    Date::from_pg_epoch(8_415).unwrap(),
+);
+bench_unary!(
+    cast_date_to_timestamp_tz,
+    f::CastDateToTimestampTz(None),
+    Date::from_pg_epoch(8_415).unwrap(),
+);
+
+fn cast_timestamp_to_date(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampToDate);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_to_time(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampToTime);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_to_string(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampToString);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_to_timestamp_tz(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampToTimestampTz {
+        from: None,
+        to: None,
+    });
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_tz_to_date(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampTzToDate);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_tz_to_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampTzToTimestamp {
+        from: None,
+        to: None,
+    });
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_tz_to_string(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampTzToString);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_tz_to_time(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampTzToTime);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+bench_unary!(to_timestamp, f::ToTimestamp, 1705312245.0f64);
+
+// --- MzTimestamp casts ---
+
+bench_unary!(
+    cast_mz_timestamp_to_string,
+    f::CastMzTimestampToString,
+    D::MzTimestamp(Timestamp::from(1705312245000u64)),
+);
+bench_unary!(
+    cast_mz_timestamp_to_timestamp,
+    f::CastMzTimestampToTimestamp,
+    D::MzTimestamp(Timestamp::from(1705312245000u64)),
+);
+bench_unary!(
+    cast_mz_timestamp_to_timestamp_tz,
+    f::CastMzTimestampToTimestampTz,
+    D::MzTimestamp(Timestamp::from(1705312245000u64)),
+);
+bench_unary!(
+    cast_string_to_mz_timestamp,
+    f::CastStringToMzTimestamp,
+    "1705312245000",
+);
+bench_unary!(
+    cast_uint64_to_mz_timestamp,
+    f::CastUint64ToMzTimestamp,
+    D::UInt64(1705312245000),
+);
+bench_unary!(
+    cast_uint32_to_mz_timestamp,
+    f::CastUint32ToMzTimestamp,
+    D::UInt32(1705312245),
+);
+bench_unary!(
+    cast_int64_to_mz_timestamp,
+    f::CastInt64ToMzTimestamp,
+    D::Int64(1705312245000),
+);
+bench_unary!(
+    cast_int32_to_mz_timestamp,
+    f::CastInt32ToMzTimestamp,
+    D::Int32(1705312245),
+);
+bench_unary!(
+    cast_numeric_to_mz_timestamp,
+    f::CastNumericToMzTimestamp,
+    Numeric::from(1705312245000i64),
+);
+
+fn cast_timestamp_to_mz_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampToMzTimestamp);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_timestamp_tz_to_mz_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastTimestampTzToMzTimestamp);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+bench_unary!(
+    cast_date_to_mz_timestamp,
+    f::CastDateToMzTimestamp,
+    Date::from_pg_epoch(8_415).unwrap(),
+);
+
+bench_unary!(
+    step_mz_timestamp,
+    f::StepMzTimestamp,
+    D::MzTimestamp(Timestamp::from(1705312245000u64)),
+);
+
+// --- PgLegacyChar / Char / VarChar casts ---
+
+bench_unary!(cast_int32_to_pg_legacy_char, f::CastInt32ToPgLegacyChar, D::Int32(65));
+bench_unary!(cast_string_to_pg_legacy_char, f::CastStringToPgLegacyChar, "A");
+bench_unary!(cast_string_to_pg_legacy_name, f::CastStringToPgLegacyName, "my_table");
+bench_unary!(cast_pg_legacy_char_to_string, f::CastPgLegacyCharToString, D::UInt8(65));
+bench_unary!(cast_pg_legacy_char_to_char, f::CastPgLegacyCharToChar, D::UInt8(65));
+bench_unary!(cast_pg_legacy_char_to_var_char, f::CastPgLegacyCharToVarChar, D::UInt8(65));
+bench_unary!(cast_pg_legacy_char_to_int32, f::CastPgLegacyCharToInt32, D::UInt8(65));
+
+bench_unary!(
+    cast_string_to_char,
+    f::CastStringToChar {
+        length: None,
+        fail_on_len: false,
+    },
+    "hello",
+);
+bench_unary!(
+    cast_string_to_var_char,
+    f::CastStringToVarChar {
+        length: None,
+        fail_on_len: false,
+    },
+    "hello",
+);
+bench_unary!(cast_char_to_string, f::CastCharToString, "hello");
+bench_unary!(cast_var_char_to_string, f::CastVarCharToString, "hello");
+bench_unary!(pad_char, f::PadChar { length: None }, "hello");
+
+// --- OID / Reg* casts ---
+
+bench_unary!(cast_oid_to_reg_class, f::CastOidToRegClass, D::UInt32(42));
+bench_unary!(cast_reg_class_to_oid, f::CastRegClassToOid, D::UInt32(42));
+bench_unary!(cast_oid_to_reg_proc, f::CastOidToRegProc, D::UInt32(42));
+bench_unary!(cast_reg_proc_to_oid, f::CastRegProcToOid, D::UInt32(42));
+bench_unary!(cast_oid_to_reg_type, f::CastOidToRegType, D::UInt32(42));
+bench_unary!(cast_reg_type_to_oid, f::CastRegTypeToOid, D::UInt32(42));
+bench_unary!(cast_string_to_oid, f::CastStringToOid, "42");
+
+// --- Jsonb extras ---
+
+fn jsonb_array_length(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::JsonbArrayLength);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let arr = sa.make_datum(|packer| {
+        packer.push_list(&[D::Float64(OrderedFloat(1.0)), D::Float64(OrderedFloat(2.0)), D::Float64(OrderedFloat(3.0))]);
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[arr];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn jsonb_strip_nulls(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::JsonbStripNulls);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let obj = sa.make_datum(|packer| {
+        packer.push_dict_with(|packer| {
+            packer.push(D::String("a"));
+            packer.push(D::Float64(OrderedFloat(1.0)));
+            packer.push(D::String("b"));
+            packer.push(D::Null);
+        });
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[obj];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+bench_unary!(cast_jsonbable_to_jsonb, f::CastJsonbableToJsonb, 42f64);
+bench_unary!(
+    cast_jsonb_to_numeric,
+    f::CastJsonbToNumeric(None),
+    42f64,
+);
+
+// --- Numeric extras ---
+
+bench_unary!(
+    adjust_numeric_scale,
+    f::AdjustNumericScale(NumericMaxScale::try_from(2i64).unwrap()),
+    Numeric::from(42),
+);
+bench_unary!(
+    cast_string_to_numeric,
+    f::CastStringToNumeric(None),
+    "42.5",
+);
+
+// --- Extract / DatePart / DateTrunc ---
+
+fn extract_interval(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ExtractInterval(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn extract_time(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ExtractTime(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn extract_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ExtractTimestamp(DateTimeUnits::Year));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn extract_timestamp_tz(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ExtractTimestampTz(DateTimeUnits::Year));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn extract_date(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ExtractDate(DateTimeUnits::Year));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Date(Date::from_pg_epoch(8_415).unwrap())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_part_interval(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DatePartInterval(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_part_time(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DatePartTime(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_part_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DatePartTimestamp(DateTimeUnits::Year));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_part_timestamp_tz(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DatePartTimestampTz(DateTimeUnits::Year));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_trunc_timestamp(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DateTruncTimestamp(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn date_trunc_timestamp_tz(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::DateTruncTimestampTz(DateTimeUnits::Hour));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn adjust_timestamp_precision(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::AdjustTimestampPrecision {
+        from: None,
+        to: None,
+    });
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn adjust_timestamp_tz_precision(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::AdjustTimestampTzPrecision {
+        from: None,
+        to: None,
+    });
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Timezone ---
+
+fn timezone_timestamp(b: &mut Bencher) {
+    use mz_pgtz::timezone::Timezone;
+    let func = UnaryFunc::from(f::TimezoneTimestamp(Timezone::Tz(chrono_tz::UTC)));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Timestamp(make_ts())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn timezone_timestamp_tz(b: &mut Bencher) {
+    use mz_pgtz::timezone::Timezone;
+    let func = UnaryFunc::from(f::TimezoneTimestampTz(Timezone::Tz(chrono_tz::UTC)));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::TimestampTz(make_tstz())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn timezone_time(b: &mut Bencher) {
+    use mz_pgtz::timezone::Timezone;
+    let func = UnaryFunc::from(f::TimezoneTime {
+        tz: Timezone::Tz(chrono_tz::UTC),
+        wall_time: NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
+    });
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 0).unwrap())];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Pattern matching ---
+
+fn is_like_match(b: &mut Bencher) {
+    let matcher = like_pattern::compile("%world%", false).unwrap();
+    let func = UnaryFunc::from(f::IsLikeMatch(matcher));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::String("hello world")];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn is_regexp_match(b: &mut Bencher) {
+    let regex = Regex::new("\\d+", false).unwrap();
+    let func = UnaryFunc::from(f::IsRegexpMatch(regex));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::String("hello 42 world")];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn regexp_match_unary(b: &mut Bencher) {
+    let regex = Regex::new("(\\d+)", false).unwrap();
+    let func = UnaryFunc::from(f::RegexpMatch(regex));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::String("hello 42 world")];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn regexp_split_to_array_unary(b: &mut Bencher) {
+    let regex = Regex::new("\\d", false).unwrap();
+    let func = UnaryFunc::from(f::RegexpSplitToArray(regex));
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::String("one1two2three")];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Range functions ---
+
+fn bench_range_empty(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeEmpty);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_lower_inc(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeLowerInc);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_upper_inc(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeUpperInc);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_lower_inf(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeLowerInf);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_upper_inf(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeUpperInf);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_lower(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeLower);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn bench_range_upper(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::RangeUpper);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let range = sa.make_datum(|packer| {
+        packer
+            .push_range(mz_repr::adt::range::Range::new(Some((
+                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+            ))))
+            .unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[range];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Collection ops ---
+
+fn list_length(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::ListLength);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let list = sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
+    let arena = RowArena::new();
+    let datums: &[D] = &[list];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn map_length(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::MapLength);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let map = sa.make_datum(|packer| {
+        packer.push_dict_with(|packer| {
+            packer.push(D::String("a"));
+            packer.push(D::Int32(1));
+            packer.push(D::String("b"));
+            packer.push(D::Int32(2));
+        });
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[map];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- ACL / privileges ---
+
+fn mz_acl_item_grantor(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::MzAclItemGrantor);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = MzAclItem {
+        grantee: RoleId::User(1),
+        grantor: RoleId::User(2),
+        acl_mode: AclMode::empty(),
+    };
+    let datums: &[D] = &[D::MzAclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn mz_acl_item_grantee(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::MzAclItemGrantee);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = MzAclItem {
+        grantee: RoleId::User(1),
+        grantor: RoleId::User(2),
+        acl_mode: AclMode::empty(),
+    };
+    let datums: &[D] = &[D::MzAclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn mz_acl_item_privileges(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::MzAclItemPrivileges);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = MzAclItem {
+        grantee: RoleId::User(1),
+        grantor: RoleId::User(2),
+        acl_mode: AclMode::empty(),
+    };
+    let datums: &[D] = &[D::MzAclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+bench_unary!(mz_format_privileges, f::MzFormatPrivileges, "r");
+bench_unary!(mz_validate_privileges, f::MzValidatePrivileges, "r");
+bench_unary!(mz_validate_role_privilege, f::MzValidateRolePrivilege, "USAGE");
+
+fn acl_item_grantor(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::AclItemGrantor);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = AclItem::empty(Oid(1), Oid(2));
+    let datums: &[D] = &[D::AclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn acl_item_grantee(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::AclItemGrantee);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = AclItem::empty(Oid(1), Oid(2));
+    let datums: &[D] = &[D::AclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn acl_item_privileges(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::AclItemPrivileges);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let item = AclItem::empty(Oid(1), Oid(2));
+    let datums: &[D] = &[D::AclItem(item)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Misc ---
+
+bench_unary!(mz_type_name, f::MzTypeName, D::UInt32(25)); // text oid
+bench_unary!(
+    try_parse_monotonic_iso8601_timestamp,
+    f::TryParseMonotonicIso8601Timestamp,
+    "2024-01-15T12:30:45Z",
+);
+
+fn pg_column_size(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::PgColumnSize);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::Int32(42)];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn mz_row_size(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::MzRowSize);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let list = sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
+    let arena = RowArena::new();
+    let datums: &[D] = &[list];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// --- Int2Vector / String casts ---
+
+fn cast_string_to_int2_vector(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastStringToInt2Vector);
+    let a = MirScalarExpr::column(0);
+    let arena = RowArena::new();
+    let datums: &[D] = &[D::String("1 2 3")];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_int2_vector_to_string(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastInt2VectorToString);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let vec = sa.make_datum(|packer| {
+        packer.try_push_array(&[mz_repr::adt::array::ArrayDimension { lower_bound: 1, length: 3 }], &[D::Int16(1), D::Int16(2), D::Int16(3)]).unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[vec];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+fn cast_int2_vector_to_array(b: &mut Bencher) {
+    let func = UnaryFunc::from(f::CastInt2VectorToArray);
+    let a = MirScalarExpr::column(0);
+    let sa = RowArena::new();
+    let vec = sa.make_datum(|packer| {
+        packer.try_push_array(&[mz_repr::adt::array::ArrayDimension { lower_bound: 1, length: 3 }], &[D::Int16(1), D::Int16(2), D::Int16(3)]).unwrap();
+    });
+    let arena = RowArena::new();
+    let datums: &[D] = &[vec];
+    b.iter(|| func.eval(datums, &arena, &a));
+}
+
+// Benchmark registration
+
+benchmark_group!(
+    arithmetic_benches,
+    // Boolean
+    not,
+    is_null,
+    is_true,
+    is_false,
+    // Neg
+    neg_int16,
+    neg_int16_error,
+    neg_int32,
+    neg_int32_error,
+    neg_int64,
+    neg_int64_error,
+    neg_float32,
+    neg_float64,
+    neg_numeric,
+    neg_interval,
+    // Abs
+    abs_int16,
+    abs_int32,
+    abs_int64,
+    abs_float32,
+    abs_float64,
+    abs_numeric,
+    // BitNot
+    bit_not_int16,
+    bit_not_int32,
+    bit_not_int64,
+    bit_not_uint16,
+    bit_not_uint32,
+    bit_not_uint64 // Sqrt/Cbrt, Ceil/Floor/Round/Trunc, Log/Ln/Exp, Trig, Degrees/Radians
+                   // are in *_group functions via benchmark_main
+);
+
+benchmark_group!(
+    cast_benches,
+    // Bool
+    cast_bool_to_string,
+    cast_bool_to_string_nonstandard,
+    cast_bool_to_int32,
+    cast_bool_to_int64,
+    // Int16
+    cast_int16_to_float32,
+    cast_int16_to_float64,
+    cast_int16_to_int32,
+    cast_int16_to_int64,
+    cast_int16_to_uint16,
+    cast_int16_to_uint32,
+    cast_int16_to_uint64,
+    cast_int16_to_string,
+    cast_int16_to_numeric,
+    // Int32
+    cast_int32_to_bool,
+    cast_int32_to_float32,
+    cast_int32_to_float64,
+    cast_int32_to_int16,
+    cast_int32_to_int64,
+    cast_int32_to_uint16,
+    cast_int32_to_uint32,
+    cast_int32_to_uint64,
+    cast_int32_to_string,
+    cast_int32_to_oid,
+    cast_int32_to_numeric,
+    // Int64
+    cast_int64_to_int16,
+    cast_int64_to_int32,
+    cast_int64_to_uint16,
+    cast_int64_to_uint32,
+    cast_int64_to_uint64,
+    cast_int64_to_bool,
+    cast_int64_to_float32,
+    cast_int64_to_float64,
+    cast_int64_to_string,
+    cast_int64_to_oid,
+    cast_int64_to_numeric,
+    // Uint16
+    cast_uint16_to_uint32,
+    cast_uint16_to_uint64,
+    cast_uint16_to_int16,
+    cast_uint16_to_int32,
+    cast_uint16_to_int64,
+    cast_uint16_to_float32,
+    cast_uint16_to_float64,
+    cast_uint16_to_string,
+    cast_uint16_to_numeric,
+    // Uint32
+    cast_uint32_to_uint16,
+    cast_uint32_to_uint64,
+    cast_uint32_to_int16,
+    cast_uint32_to_int32,
+    cast_uint32_to_int64,
+    cast_uint32_to_float32,
+    cast_uint32_to_float64,
+    cast_uint32_to_string,
+    cast_uint32_to_numeric,
+    // Uint64
+    cast_uint64_to_uint16,
+    cast_uint64_to_uint32,
+    cast_uint64_to_int16,
+    cast_uint64_to_int32,
+    cast_uint64_to_int64,
+    cast_uint64_to_float32,
+    cast_uint64_to_float64,
+    cast_uint64_to_string,
+    cast_uint64_to_numeric,
+    // Float32
+    cast_float32_to_int16,
+    cast_float32_to_int32,
+    cast_float32_to_int64,
+    cast_float32_to_uint16,
+    cast_float32_to_uint32,
+    cast_float32_to_uint64,
+    cast_float32_to_float64,
+    cast_float32_to_string,
+    cast_float32_to_numeric,
+    // Float64
+    cast_float64_to_int16,
+    cast_float64_to_int32,
+    cast_float64_to_int64,
+    cast_float64_to_uint16,
+    cast_float64_to_uint32,
+    cast_float64_to_uint64,
+    cast_float64_to_float32,
+    cast_float64_to_string,
+    cast_float64_to_numeric,
+    // Numeric
+    cast_numeric_to_float32,
+    cast_numeric_to_float64,
+    cast_numeric_to_int16,
+    cast_numeric_to_int32,
+    cast_numeric_to_int64,
+    cast_numeric_to_uint16,
+    cast_numeric_to_uint32,
+    cast_numeric_to_uint64,
+    cast_numeric_to_string,
+    // String parsing
+    cast_string_to_bool,
+    cast_string_to_int16,
+    cast_string_to_int32,
+    cast_string_to_int64,
+    cast_string_to_uint16,
+    cast_string_to_uint32,
+    cast_string_to_uint64,
+    cast_string_to_float32,
+    cast_string_to_float64,
+    cast_string_to_date,
+    cast_string_to_time,
+    cast_string_to_timestamp,
+    cast_string_to_timestamp_tz,
+    cast_string_to_interval,
+    cast_string_to_uuid,
+    cast_string_to_jsonb,
+    cast_string_to_bytes,
+    // Other casts
+    cast_oid_to_int32,
+    cast_oid_to_int64,
+    cast_oid_to_string,
+    cast_uuid_to_string,
+    cast_bytes_to_string,
+    cast_jsonb_to_string,
+    cast_jsonb_to_int16,
+    cast_jsonb_to_int32,
+    cast_jsonb_to_int64,
+    cast_jsonb_to_float32,
+    cast_jsonb_to_float64,
+    cast_jsonb_to_bool,
+    // Timestamp/Date casts
+    cast_date_to_timestamp,
+    cast_date_to_timestamp_tz,
+    cast_timestamp_to_date,
+    cast_timestamp_to_time,
+    cast_timestamp_to_string,
+    cast_timestamp_to_timestamp_tz,
+    cast_timestamp_tz_to_date,
+    cast_timestamp_tz_to_timestamp,
+    cast_timestamp_tz_to_string,
+    cast_timestamp_tz_to_time,
+    to_timestamp,
+    // MzTimestamp casts
+    cast_mz_timestamp_to_string,
+    cast_mz_timestamp_to_timestamp,
+    cast_mz_timestamp_to_timestamp_tz,
+    cast_string_to_mz_timestamp,
+    cast_uint64_to_mz_timestamp,
+    cast_uint32_to_mz_timestamp,
+    cast_int64_to_mz_timestamp,
+    cast_int32_to_mz_timestamp,
+    cast_numeric_to_mz_timestamp,
+    cast_timestamp_to_mz_timestamp,
+    cast_timestamp_tz_to_mz_timestamp,
+    cast_date_to_mz_timestamp,
+    step_mz_timestamp,
+    // PgLegacyChar / Char / VarChar
+    cast_int32_to_pg_legacy_char,
+    cast_string_to_pg_legacy_char,
+    cast_string_to_pg_legacy_name,
+    cast_pg_legacy_char_to_string,
+    cast_pg_legacy_char_to_char,
+    cast_pg_legacy_char_to_var_char,
+    cast_pg_legacy_char_to_int32,
+    cast_string_to_char,
+    cast_string_to_var_char,
+    cast_char_to_string,
+    cast_var_char_to_string,
+    pad_char,
+    // OID / Reg*
+    cast_oid_to_reg_class,
+    cast_reg_class_to_oid,
+    cast_oid_to_reg_proc,
+    cast_reg_proc_to_oid,
+    cast_oid_to_reg_type,
+    cast_reg_type_to_oid,
+    cast_string_to_oid,
+    // Jsonb extras
+    jsonb_array_length,
+    jsonb_strip_nulls,
+    cast_jsonbable_to_jsonb,
+    cast_jsonb_to_numeric,
+    // Numeric extras
+    adjust_numeric_scale,
+    cast_string_to_numeric,
+    // Int2Vector
+    cast_string_to_int2_vector,
+    cast_int2_vector_to_string,
+    cast_int2_vector_to_array
+);
+
+benchmark_group!(
+    remaining_benches,
+    // String operations
+    upper,
+    lower,
+    initcap,
+    trim_whitespace,
+    trim_leading_whitespace,
+    trim_trailing_whitespace,
+    ascii,
+    char_length,
+    bit_length_bytes,
+    bit_length_string,
+    byte_length_bytes,
+    byte_length_string,
+    bit_count_bytes,
+    chr,
+    reverse,
+    quote_ident,
+    pg_size_pretty,
+    // Jsonb
+    jsonb_typeof,
+    jsonb_pretty,
+    // Date/time
+    justify_days,
+    justify_hours,
+    justify_interval,
+    cast_date_to_string,
+    cast_time_to_string,
+    cast_interval_to_string,
+    cast_interval_to_time,
+    cast_time_to_interval,
+    // Hash functions
+    crc32_bytes,
+    crc32_string,
+    kafka_murmur2_bytes,
+    kafka_murmur2_string,
+    seahash_bytes,
+    seahash_string,
+    // Extract / DatePart / DateTrunc
+    extract_interval,
+    extract_time,
+    extract_timestamp,
+    extract_timestamp_tz,
+    extract_date,
+    date_part_interval,
+    date_part_time,
+    date_part_timestamp,
+    date_part_timestamp_tz,
+    date_trunc_timestamp,
+    date_trunc_timestamp_tz,
+    adjust_timestamp_precision,
+    adjust_timestamp_tz_precision,
+    // Timezone
+    timezone_timestamp,
+    timezone_timestamp_tz,
+    timezone_time,
+    // Pattern matching
+    is_like_match,
+    is_regexp_match,
+    regexp_match_unary,
+    regexp_split_to_array_unary,
+    // Range
+    bench_range_empty,
+    bench_range_lower_inc,
+    bench_range_upper_inc,
+    bench_range_lower_inf,
+    bench_range_upper_inf,
+    bench_range_lower,
+    bench_range_upper,
+    // Collection ops
+    list_length,
+    map_length,
+    // ACL / privileges
+    mz_acl_item_grantor,
+    mz_acl_item_grantee,
+    mz_acl_item_privileges,
+    mz_format_privileges,
+    mz_validate_privileges,
+    mz_validate_role_privilege,
+    acl_item_grantor,
+    acl_item_grantee,
+    acl_item_privileges,
+    // Misc
+    mz_type_name,
+    try_parse_monotonic_iso8601_timestamp,
+    pg_column_size,
+    mz_row_size
+);
+
+benchmark_main!(
+    arithmetic_benches,
+    cast_benches,
+    remaining_benches,
+    // Multi-input benchmark groups (each input is a separate benchmark entry)
+    sqrt_float64_group,
+    sqrt_numeric_group,
+    cbrt_float64_group,
+    ceil_float32_group,
+    ceil_float64_group,
+    ceil_numeric_group,
+    floor_float32_group,
+    floor_float64_group,
+    floor_numeric_group,
+    round_float32_group,
+    round_float64_group,
+    round_numeric_group,
+    trunc_float32_group,
+    trunc_float64_group,
+    trunc_numeric_group,
+    log10_group,
+    log10_numeric_group,
+    ln_group,
+    ln_numeric_group,
+    exp_group,
+    exp_numeric_group,
+    cos_group,
+    acos_group,
+    cosh_group,
+    acosh_group,
+    sin_group,
+    asin_group,
+    sinh_group,
+    asinh_group,
+    tan_group,
+    atan_group,
+    tanh_group,
+    atanh_group,
+    cot_group,
+    degrees_group,
+    radians_group
+);

--- a/src/expr/benches/bench_unary.rs
+++ b/src/expr/benches/bench_unary.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bencher::{Bencher, benchmark_group, benchmark_main};
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use criterion::{Criterion, criterion_group, criterion_main};
 use mz_expr::like_pattern;
 use mz_expr::{MirScalarExpr, UnaryFunc, func as f};
 use mz_repr::adt::date::Date;
@@ -17,716 +17,46 @@ use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{AclItem, AclMode, MzAclItem};
 use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
 use mz_repr::adt::regex::Regex;
+use mz_repr::adt::system::Oid;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::role_id::RoleId;
-use mz_repr::adt::system::Oid;
 use mz_repr::{Datum as D, RowArena, Timestamp};
 use ordered_float::OrderedFloat;
 use uuid::Uuid;
 
 macro_rules! bench_unary {
-    ($bench_name:ident, $struct_expr:expr,
+    ($c:expr, $bench_name:ident, $struct_expr:expr,
      $a_datum:expr $(,)?) => {
-        fn $bench_name(b: &mut Bencher) {
+        $c.bench_function(stringify!($bench_name), |b| {
             let f = UnaryFunc::from($struct_expr);
             let a = MirScalarExpr::column(0);
             let arena = RowArena::new();
             let datums: &[D] = &[($a_datum).into()];
             b.iter(|| f.eval(datums, &arena, &a));
-        }
+        });
     };
 }
 
-/// Generates a `_group` function that returns individual benchmark entries
+/// Generates a criterion benchmark group with individual benchmark entries
 /// for each input, so they show up as separate lines in benchmark output.
 macro_rules! bench_unary_multi {
-    ($bench_name:ident, $struct_expr:expr,
+    ($c:expr, $bench_name:ident, $struct_expr:expr,
      [ $( $a_datum:expr ),+ $(,)? ]) => {
-        paste::paste! {
-            fn [<$bench_name _group>]() -> Vec<bencher::TestDescAndFn> {
-                use bencher::{TestDescAndFn, TestFn, TestDesc};
-                use std::borrow::Cow;
-                let mut benches = Vec::new();
-                $(
-                    benches.push(TestDescAndFn {
-                        desc: TestDesc {
-                            name: Cow::from(concat!(
-                                stringify!($bench_name), "(", stringify!($a_datum), ")"
-                            )),
-                            ignore: false,
-                        },
-                        testfn: TestFn::StaticBenchFn({
-                            fn run(b: &mut bencher::Bencher) {
-                                let f = UnaryFunc::from($struct_expr);
-                                let a = MirScalarExpr::column(0);
-                                let arena = RowArena::new();
-                                let datums: &[D] = &[($a_datum).into()];
-                                b.iter(|| f.eval(datums, &arena, &a));
-                            }
-                            run
-                        }),
-                    });
-                )+
-                benches
-            }
+        {
+            let mut group = $c.benchmark_group(stringify!($bench_name));
+            $(
+                group.bench_function(stringify!($a_datum), |b| {
+                    let f = UnaryFunc::from($struct_expr);
+                    let a = MirScalarExpr::column(0);
+                    let arena = RowArena::new();
+                    let datums: &[D] = &[($a_datum).into()];
+                    b.iter(|| f.eval(datums, &arena, &a));
+                });
+            )+
+            group.finish();
         }
     };
 }
-
-// Unary arithmetic + bitwise functions
-
-// Boolean
-bench_unary!(not, f::Not, true);
-bench_unary!(is_null, f::IsNull, D::Int32(42));
-bench_unary!(is_true, f::IsTrue, true);
-bench_unary!(is_false, f::IsFalse, false);
-
-// Neg
-bench_unary!(neg_int16, f::NegInt16, 42i16);
-bench_unary!(neg_int16_error, f::NegInt16, i16::MIN);
-bench_unary!(neg_int32, f::NegInt32, 42i32);
-bench_unary!(neg_int32_error, f::NegInt32, i32::MIN);
-bench_unary!(neg_int64, f::NegInt64, 42i64);
-bench_unary!(neg_int64_error, f::NegInt64, i64::MIN);
-bench_unary!(neg_float32, f::NegFloat32, 42.0f32);
-bench_unary!(neg_float64, f::NegFloat64, 42.0f64);
-bench_unary!(neg_numeric, f::NegNumeric, Numeric::from(42));
-bench_unary!(neg_interval, f::NegInterval, Interval::new(1, 2, 3_000_000));
-
-// Abs
-bench_unary!(abs_int16, f::AbsInt16, -42i16);
-bench_unary!(abs_int32, f::AbsInt32, -42i32);
-bench_unary!(abs_int64, f::AbsInt64, -42i64);
-bench_unary!(abs_float32, f::AbsFloat32, -42.0f32);
-bench_unary!(abs_float64, f::AbsFloat64, -42.0f64);
-bench_unary!(abs_numeric, f::AbsNumeric, Numeric::from(-42));
-
-// BitNot
-bench_unary!(bit_not_int16, f::BitNotInt16, D::Int16(0x0F0F));
-bench_unary!(bit_not_int32, f::BitNotInt32, D::Int32(0x0F0F0F0F));
-bench_unary!(bit_not_int64, f::BitNotInt64, D::Int64(0x0F0F0F0F));
-bench_unary!(bit_not_uint16, f::BitNotUint16, D::UInt16(0x0F0F));
-bench_unary!(bit_not_uint32, f::BitNotUint32, D::UInt32(0x0F0F));
-bench_unary!(bit_not_uint64, f::BitNotUint64, D::UInt64(0x0F0F));
-
-// Sqrt/Cbrt (8 diverse inputs each: perfect squares, primes, tiny, huge, fractional)
-bench_unary_multi!(
-    sqrt_float64,
-    f::SqrtFloat64,
-    [
-        0.0f64,
-        0.001f64,
-        2.0f64,
-        16.0f64,
-        17.3f64,
-        999.999f64,
-        1e12f64,
-        1.7976931348623157e100f64,
-    ]
-);
-bench_unary_multi!(
-    sqrt_numeric,
-    f::SqrtNumeric,
-    [
-        Numeric::from(2),
-        Numeric::from(16),
-        Numeric::from(17),
-        Numeric::from(9999),
-        Numeric::from(1000000),
-        Numeric::from(999999999),
-    ]
-);
-bench_unary_multi!(
-    cbrt_float64,
-    f::CbrtFloat64,
-    [
-        0.0f64, 0.001f64, 2.0f64, 27.0f64, 30.7f64, 1e9f64, 1.5e100f64, -8.0f64,
-    ]
-);
-
-// Ceil/Floor/Round/Trunc (diverse fractional values)
-bench_unary_multi!(
-    ceil_float32,
-    f::CeilFloat32,
-    [
-        0.0f32, 0.1f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 1e10f32, 0.5f32,
-    ]
-);
-bench_unary_multi!(
-    ceil_float64,
-    f::CeilFloat64,
-    [
-        0.0f64, 0.1f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 1e15f64, 0.5f64,
-    ]
-);
-bench_unary_multi!(
-    ceil_numeric,
-    f::CeilNumeric,
-    [
-        Numeric::from(0),
-        Numeric::from(314),
-        Numeric::from(-42),
-        Numeric::from(999999),
-        Numeric::from(1),
-        Numeric::from(-1),
-    ]
-);
-bench_unary_multi!(
-    floor_float32,
-    f::FloorFloat32,
-    [0.0f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 0.5f32,]
-);
-bench_unary_multi!(
-    floor_float64,
-    f::FloorFloat64,
-    [0.0f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 0.5f64,]
-);
-bench_unary_multi!(
-    floor_numeric,
-    f::FloorNumeric,
-    [
-        Numeric::from(0),
-        Numeric::from(314),
-        Numeric::from(-42),
-        Numeric::from(999999),
-    ]
-);
-bench_unary_multi!(
-    round_float32,
-    f::RoundFloat32,
-    [0.0f32, 3.17f32, -2.7f32, 0.5f32, 999.999f32, -0.5f32,]
-);
-bench_unary_multi!(
-    round_float64,
-    f::RoundFloat64,
-    [0.0f64, 3.17f64, -2.7f64, 0.5f64, 999.999f64, -0.5f64,]
-);
-bench_unary_multi!(
-    round_numeric,
-    f::RoundNumeric,
-    [
-        Numeric::from(0),
-        Numeric::from(314),
-        Numeric::from(-42),
-        Numeric::from(999999),
-    ]
-);
-bench_unary_multi!(
-    trunc_float32,
-    f::TruncFloat32,
-    [0.0f32, 3.17f32, -2.7f32, 999.999f32,]
-);
-bench_unary_multi!(
-    trunc_float64,
-    f::TruncFloat64,
-    [0.0f64, 3.17f64, -2.7f64, 999.999f64,]
-);
-bench_unary_multi!(
-    trunc_numeric,
-    f::TruncNumeric,
-    [
-        Numeric::from(0),
-        Numeric::from(314),
-        Numeric::from(-42),
-        Numeric::from(999999),
-    ]
-);
-
-// Log/Ln/Exp (diverse magnitudes)
-bench_unary_multi!(
-    log10,
-    f::Log10,
-    [
-        0.001f64,
-        1.0f64,
-        10.0f64,
-        100.0f64,
-        99999.9f64,
-        1e15f64,
-        0.123456789f64,
-        42.42f64,
-    ]
-);
-bench_unary_multi!(
-    log10_numeric,
-    f::Log10Numeric,
-    [
-        Numeric::from(1),
-        Numeric::from(10),
-        Numeric::from(100),
-        Numeric::from(99999),
-        Numeric::from(42),
-    ]
-);
-bench_unary_multi!(
-    ln,
-    f::Ln,
-    [
-        0.001f64,
-        1.0f64,
-        std::f64::consts::E,
-        100.0f64,
-        99999.9f64,
-        1e15f64,
-        0.123456789f64,
-        42.42f64,
-    ]
-);
-bench_unary_multi!(
-    ln_numeric,
-    f::LnNumeric,
-    [
-        Numeric::from(1),
-        Numeric::from(3),
-        Numeric::from(100),
-        Numeric::from(99999),
-        Numeric::from(42),
-    ]
-);
-bench_unary_multi!(
-    exp,
-    f::Exp,
-    [
-        0.0f64, 1.0f64, 2.0f64, -1.0f64, 10.0f64, 0.5f64, -5.0f64, 20.0f64,
-    ]
-);
-bench_unary_multi!(
-    exp_numeric,
-    f::ExpNumeric,
-    [
-        Numeric::from(0),
-        Numeric::from(1),
-        Numeric::from(2),
-        Numeric::from(10),
-        Numeric::from(-1),
-    ]
-);
-
-// Trig (diverse angles spanning the domain)
-bench_unary_multi!(
-    cos,
-    f::Cos,
-    [
-        0.0f64,
-        0.5f64,
-        1.0f64,
-        std::f64::consts::PI,
-        std::f64::consts::FRAC_PI_2,
-        2.5f64,
-        -1.0f64,
-        100.0f64,
-    ]
-);
-bench_unary_multi!(
-    acos,
-    f::Acos,
-    [
-        -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
-    ]
-);
-bench_unary_multi!(
-    cosh,
-    f::Cosh,
-    [
-        0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
-    ]
-);
-bench_unary_multi!(
-    acosh,
-    f::Acosh,
-    [
-        1.0f64, 1.5f64, 2.0f64, 5.0f64, 10.0f64, 100.0f64, 1.001f64, 50.0f64,
-    ]
-);
-bench_unary_multi!(
-    sin,
-    f::Sin,
-    [
-        0.0f64,
-        0.5f64,
-        1.0f64,
-        std::f64::consts::PI,
-        std::f64::consts::FRAC_PI_2,
-        2.5f64,
-        -1.0f64,
-        100.0f64,
-    ]
-);
-bench_unary_multi!(
-    asin,
-    f::Asin,
-    [
-        -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
-    ]
-);
-bench_unary_multi!(
-    sinh,
-    f::Sinh,
-    [
-        0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
-    ]
-);
-bench_unary_multi!(
-    asinh,
-    f::Asinh,
-    [
-        0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -10.0f64, 0.001f64,
-    ]
-);
-bench_unary_multi!(
-    tan,
-    f::Tan,
-    [
-        0.0f64, 0.5f64, 1.0f64, 0.785f64, // ~pi/4
-        -1.0f64, 1.5f64, // close to pi/2
-        3.0f64, 100.0f64,
-    ]
-);
-bench_unary_multi!(
-    atan,
-    f::Atan,
-    [
-        0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -100.0f64, 0.001f64,
-    ]
-);
-bench_unary_multi!(
-    tanh,
-    f::Tanh,
-    [
-        0.0f64, 0.5f64, 1.0f64, 5.0f64, -1.0f64, -5.0f64, 20.0f64, 0.001f64,
-    ]
-);
-bench_unary_multi!(
-    atanh,
-    f::Atanh,
-    [
-        0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.99f64, -0.5f64, -0.9f64, 0.001f64,
-    ]
-);
-bench_unary_multi!(
-    cot,
-    f::Cot,
-    [
-        0.1f64,
-        0.5f64,
-        1.0f64,
-        std::f64::consts::FRAC_PI_4,
-        2.0f64,
-        3.0f64,
-        -1.0f64,
-        0.01f64,
-    ]
-);
-bench_unary_multi!(
-    degrees,
-    f::Degrees,
-    [
-        0.0f64,
-        std::f64::consts::PI,
-        std::f64::consts::FRAC_PI_2,
-        1.0f64,
-        -std::f64::consts::PI,
-        6.37f64,
-        0.001f64,
-        100.0f64,
-    ]
-);
-bench_unary_multi!(
-    radians,
-    f::Radians,
-    [
-        0.0f64, 45.0f64, 90.0f64, 180.0f64, 360.0f64, -180.0f64, 1.0f64, 0.001f64,
-    ]
-);
-
-// Unary cast functions (unit struct casts only)
-
-// Bool casts
-bench_unary!(cast_bool_to_string, f::CastBoolToString, true);
-bench_unary!(
-    cast_bool_to_string_nonstandard,
-    f::CastBoolToStringNonstandard,
-    true,
-);
-bench_unary!(cast_bool_to_int32, f::CastBoolToInt32, true);
-bench_unary!(cast_bool_to_int64, f::CastBoolToInt64, true);
-
-// Int16 casts
-bench_unary!(cast_int16_to_float32, f::CastInt16ToFloat32, D::Int16(42));
-bench_unary!(cast_int16_to_float64, f::CastInt16ToFloat64, D::Int16(42));
-bench_unary!(cast_int16_to_int32, f::CastInt16ToInt32, D::Int16(42));
-bench_unary!(cast_int16_to_int64, f::CastInt16ToInt64, D::Int16(42));
-bench_unary!(cast_int16_to_uint16, f::CastInt16ToUint16, D::Int16(42));
-bench_unary!(cast_int16_to_uint32, f::CastInt16ToUint32, D::Int16(42));
-bench_unary!(cast_int16_to_uint64, f::CastInt16ToUint64, D::Int16(42));
-bench_unary!(cast_int16_to_string, f::CastInt16ToString, D::Int16(42));
-
-// Int32 casts
-bench_unary!(cast_int32_to_bool, f::CastInt32ToBool, D::Int32(1));
-bench_unary!(cast_int32_to_float32, f::CastInt32ToFloat32, D::Int32(42));
-bench_unary!(cast_int32_to_float64, f::CastInt32ToFloat64, D::Int32(42));
-bench_unary!(cast_int32_to_int16, f::CastInt32ToInt16, D::Int32(42));
-bench_unary!(cast_int32_to_int64, f::CastInt32ToInt64, D::Int32(42));
-bench_unary!(cast_int32_to_uint16, f::CastInt32ToUint16, D::Int32(42));
-bench_unary!(cast_int32_to_uint32, f::CastInt32ToUint32, D::Int32(42));
-bench_unary!(cast_int32_to_uint64, f::CastInt32ToUint64, D::Int32(42));
-bench_unary!(cast_int32_to_string, f::CastInt32ToString, D::Int32(42));
-bench_unary!(cast_int32_to_oid, f::CastInt32ToOid, D::Int32(42));
-
-// Int64 casts
-bench_unary!(cast_int64_to_int16, f::CastInt64ToInt16, D::Int64(42));
-bench_unary!(cast_int64_to_int32, f::CastInt64ToInt32, D::Int64(42));
-bench_unary!(cast_int64_to_uint16, f::CastInt64ToUint16, D::Int64(42));
-bench_unary!(cast_int64_to_uint32, f::CastInt64ToUint32, D::Int64(42));
-bench_unary!(cast_int64_to_uint64, f::CastInt64ToUint64, D::Int64(42));
-bench_unary!(cast_int64_to_bool, f::CastInt64ToBool, D::Int64(1));
-bench_unary!(cast_int64_to_float32, f::CastInt64ToFloat32, D::Int64(42));
-bench_unary!(cast_int64_to_float64, f::CastInt64ToFloat64, D::Int64(42));
-bench_unary!(cast_int64_to_string, f::CastInt64ToString, D::Int64(42));
-bench_unary!(cast_int64_to_oid, f::CastInt64ToOid, D::Int64(42));
-
-// Uint16 casts
-bench_unary!(cast_uint16_to_uint32, f::CastUint16ToUint32, D::UInt16(42));
-bench_unary!(cast_uint16_to_uint64, f::CastUint16ToUint64, D::UInt16(42));
-bench_unary!(cast_uint16_to_int16, f::CastUint16ToInt16, D::UInt16(42));
-bench_unary!(cast_uint16_to_int32, f::CastUint16ToInt32, D::UInt16(42));
-bench_unary!(cast_uint16_to_int64, f::CastUint16ToInt64, D::UInt16(42));
-bench_unary!(cast_uint16_to_float32, f::CastUint16ToFloat32, 42u16);
-bench_unary!(cast_uint16_to_float64, f::CastUint16ToFloat64, 42u16);
-bench_unary!(cast_uint16_to_string, f::CastUint16ToString, D::UInt16(42));
-
-// Uint32 casts
-bench_unary!(cast_uint32_to_uint16, f::CastUint32ToUint16, D::UInt32(42));
-bench_unary!(cast_uint32_to_uint64, f::CastUint32ToUint64, D::UInt32(42));
-bench_unary!(cast_uint32_to_int16, f::CastUint32ToInt16, D::UInt32(42));
-bench_unary!(cast_uint32_to_int32, f::CastUint32ToInt32, D::UInt32(42));
-bench_unary!(cast_uint32_to_int64, f::CastUint32ToInt64, D::UInt32(42));
-bench_unary!(cast_uint32_to_float32, f::CastUint32ToFloat32, 42u32);
-bench_unary!(cast_uint32_to_float64, f::CastUint32ToFloat64, 42u32);
-bench_unary!(cast_uint32_to_string, f::CastUint32ToString, D::UInt32(42));
-
-// Uint64 casts
-bench_unary!(cast_uint64_to_uint16, f::CastUint64ToUint16, D::UInt64(42));
-bench_unary!(cast_uint64_to_uint32, f::CastUint64ToUint32, D::UInt64(42));
-bench_unary!(cast_uint64_to_int16, f::CastUint64ToInt16, D::UInt64(42));
-bench_unary!(cast_uint64_to_int32, f::CastUint64ToInt32, D::UInt64(42));
-bench_unary!(cast_uint64_to_int64, f::CastUint64ToInt64, D::UInt64(42));
-bench_unary!(cast_uint64_to_float32, f::CastUint64ToFloat32, 42u64);
-bench_unary!(cast_uint64_to_float64, f::CastUint64ToFloat64, 42u64);
-bench_unary!(cast_uint64_to_string, f::CastUint64ToString, D::UInt64(42));
-
-// Float32 casts
-bench_unary!(cast_float32_to_int16, f::CastFloat32ToInt16, 42.0f32);
-bench_unary!(cast_float32_to_int32, f::CastFloat32ToInt32, 42.0f32);
-bench_unary!(cast_float32_to_int64, f::CastFloat32ToInt64, 42.0f32);
-bench_unary!(cast_float32_to_uint16, f::CastFloat32ToUint16, 42.0f32);
-bench_unary!(cast_float32_to_uint32, f::CastFloat32ToUint32, 42.0f32);
-bench_unary!(cast_float32_to_uint64, f::CastFloat32ToUint64, 42.0f32);
-bench_unary!(cast_float32_to_float64, f::CastFloat32ToFloat64, 42.0f32);
-bench_unary!(cast_float32_to_string, f::CastFloat32ToString, 42.0f32);
-
-// Float64 casts
-bench_unary!(cast_float64_to_int16, f::CastFloat64ToInt16, 42.0f64);
-bench_unary!(cast_float64_to_int32, f::CastFloat64ToInt32, 42.0f64);
-bench_unary!(cast_float64_to_int64, f::CastFloat64ToInt64, 42.0f64);
-bench_unary!(cast_float64_to_uint16, f::CastFloat64ToUint16, 42.0f64);
-bench_unary!(cast_float64_to_uint32, f::CastFloat64ToUint32, 42.0f64);
-bench_unary!(cast_float64_to_uint64, f::CastFloat64ToUint64, 42.0f64);
-bench_unary!(cast_float64_to_float32, f::CastFloat64ToFloat32, 42.0f64);
-bench_unary!(cast_float64_to_string, f::CastFloat64ToString, 42.0f64);
-
-// Numeric casts
-bench_unary!(
-    cast_numeric_to_float32,
-    f::CastNumericToFloat32,
-    Numeric::from(42)
-);
-bench_unary!(
-    cast_numeric_to_float64,
-    f::CastNumericToFloat64,
-    Numeric::from(42)
-);
-bench_unary!(
-    cast_numeric_to_int16,
-    f::CastNumericToInt16,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_int32,
-    f::CastNumericToInt32,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_int64,
-    f::CastNumericToInt64,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_uint16,
-    f::CastNumericToUint16,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_uint32,
-    f::CastNumericToUint32,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_uint64,
-    f::CastNumericToUint64,
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_numeric_to_string,
-    f::CastNumericToString,
-    Numeric::from(42),
-);
-
-// Parameterized casts (XToNumeric)
-bench_unary!(cast_int16_to_numeric, f::CastInt16ToNumeric(None), 42i16);
-bench_unary!(cast_int32_to_numeric, f::CastInt32ToNumeric(None), 42i32);
-bench_unary!(cast_int64_to_numeric, f::CastInt64ToNumeric(None), 42i64);
-bench_unary!(cast_uint16_to_numeric, f::CastUint16ToNumeric(None), 42u16);
-bench_unary!(cast_uint32_to_numeric, f::CastUint32ToNumeric(None), 42u32);
-bench_unary!(cast_uint64_to_numeric, f::CastUint64ToNumeric(None), 42u64);
-bench_unary!(
-    cast_float32_to_numeric,
-    f::CastFloat32ToNumeric(None),
-    42f32
-);
-bench_unary!(
-    cast_float64_to_numeric,
-    f::CastFloat64ToNumeric(None),
-    42f64
-);
-
-// String parsing casts
-bench_unary!(cast_string_to_bool, f::CastStringToBool, "true");
-bench_unary!(cast_string_to_int16, f::CastStringToInt16, "42");
-bench_unary!(cast_string_to_int32, f::CastStringToInt32, "42");
-bench_unary!(cast_string_to_int64, f::CastStringToInt64, "42");
-bench_unary!(cast_string_to_uint16, f::CastStringToUint16, "42");
-bench_unary!(cast_string_to_uint32, f::CastStringToUint32, "42");
-bench_unary!(cast_string_to_uint64, f::CastStringToUint64, "42");
-bench_unary!(cast_string_to_float32, f::CastStringToFloat32, "42.0");
-bench_unary!(cast_string_to_float64, f::CastStringToFloat64, "42.0");
-bench_unary!(cast_string_to_date, f::CastStringToDate, "2024-01-15");
-bench_unary!(cast_string_to_time, f::CastStringToTime, "12:30:45");
-bench_unary!(
-    cast_string_to_timestamp,
-    f::CastStringToTimestamp(None),
-    "2024-01-15 12:30:45"
-);
-bench_unary!(
-    cast_string_to_timestamp_tz,
-    f::CastStringToTimestampTz(None),
-    "2024-01-15 12:30:45+00"
-);
-bench_unary!(
-    cast_string_to_interval,
-    f::CastStringToInterval,
-    "1 day 2 hours"
-);
-bench_unary!(
-    cast_string_to_uuid,
-    f::CastStringToUuid,
-    "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
-);
-bench_unary!(cast_string_to_jsonb, f::CastStringToJsonb, "42");
-bench_unary!(cast_string_to_bytes, f::CastStringToBytes, "\\xDEADBEEF");
-
-// Other casts
-bench_unary!(cast_oid_to_int32, f::CastOidToInt32, D::UInt32(42));
-bench_unary!(cast_oid_to_int64, f::CastOidToInt64, D::UInt32(42));
-bench_unary!(cast_oid_to_string, f::CastOidToString, D::UInt32(42));
-bench_unary!(cast_uuid_to_string, f::CastUuidToString, Uuid::nil());
-bench_unary!(cast_bytes_to_string, f::CastBytesToString, b"hello");
-bench_unary!(cast_jsonb_to_string, f::CastJsonbToString, "hello");
-bench_unary!(cast_jsonb_to_int16, f::CastJsonbToInt16, 42f64);
-bench_unary!(cast_jsonb_to_int32, f::CastJsonbToInt32, 42f64);
-bench_unary!(cast_jsonb_to_int64, f::CastJsonbToInt64, 42f64);
-bench_unary!(cast_jsonb_to_float32, f::CastJsonbToFloat32, 42f64);
-bench_unary!(cast_jsonb_to_float64, f::CastJsonbToFloat64, 42f64);
-bench_unary!(cast_jsonb_to_bool, f::CastJsonbToBool, true);
-
-// Remaining unary functions
-
-// String operations
-bench_unary!(upper, f::Upper, "hello");
-bench_unary!(lower, f::Lower, "HELLO");
-bench_unary!(initcap, f::Initcap, "hello world");
-bench_unary!(trim_whitespace, f::TrimWhitespace, "  hello  ");
-bench_unary!(
-    trim_leading_whitespace,
-    f::TrimLeadingWhitespace,
-    "  hello  "
-);
-bench_unary!(
-    trim_trailing_whitespace,
-    f::TrimTrailingWhitespace,
-    "  hello  "
-);
-bench_unary!(ascii, f::Ascii, "hello");
-bench_unary!(char_length, f::CharLength, "hello");
-bench_unary!(bit_length_bytes, f::BitLengthBytes, b"hello");
-bench_unary!(bit_length_string, f::BitLengthString, "hello");
-bench_unary!(byte_length_bytes, f::ByteLengthBytes, b"hello");
-bench_unary!(byte_length_string, f::ByteLengthString, "hello");
-bench_unary!(bit_count_bytes, f::BitCountBytes, b"\xff");
-bench_unary!(chr, f::Chr, D::Int32(65));
-bench_unary!(reverse, f::Reverse, "hello");
-bench_unary!(quote_ident, f::QuoteIdent, "my_table");
-bench_unary!(pg_size_pretty, f::PgSizePretty, Numeric::from(1048576));
-
-// Jsonb
-bench_unary!(jsonb_typeof, f::JsonbTypeof, D::Float64(OrderedFloat(42.0)));
-bench_unary!(jsonb_pretty, f::JsonbPretty, "hello");
-
-// Date/time
-bench_unary!(justify_days, f::JustifyDays, Interval::new(0, 35, 0));
-bench_unary!(
-    justify_hours,
-    f::JustifyHours,
-    Interval::new(0, 0, 30 * 3_600_000_000)
-);
-bench_unary!(
-    justify_interval,
-    f::JustifyInterval,
-    Interval::new(0, 35, 30 * 3_600_000_000)
-);
-bench_unary!(
-    cast_date_to_string,
-    f::CastDateToString,
-    Date::from_pg_epoch(0).unwrap(),
-);
-bench_unary!(
-    cast_time_to_string,
-    f::CastTimeToString,
-    NaiveTime::from_hms_opt(12, 30, 45).unwrap(),
-);
-bench_unary!(
-    cast_interval_to_string,
-    f::CastIntervalToString,
-    Interval::new(1, 2, 3_000_000)
-);
-bench_unary!(
-    cast_interval_to_time,
-    f::CastIntervalToTime,
-    Interval::new(0, 0, 45_000_000_000)
-);
-bench_unary!(
-    cast_time_to_interval,
-    f::CastTimeToInterval,
-    NaiveTime::from_hms_opt(12, 30, 45).unwrap()
-);
-
-// Hash functions
-bench_unary!(crc32_bytes, f::Crc32Bytes, b"hello");
-bench_unary!(crc32_string, f::Crc32String, "hello");
-bench_unary!(kafka_murmur2_bytes, f::KafkaMurmur2Bytes, b"hello");
-bench_unary!(kafka_murmur2_string, f::KafkaMurmur2String, "hello");
-bench_unary!(seahash_bytes, f::SeahashBytes, b"hello");
-bench_unary!(seahash_string, f::SeahashString, "hello");
 
 // --- Helpers for constructing complex datums ---
 
@@ -745,1085 +75,1635 @@ fn make_tstz() -> CheckedTimestamp<chrono::DateTime<Utc>> {
         .unwrap()
 }
 
-// --- Timestamp/Date casts ---
+// Unary arithmetic + bitwise functions
 
-bench_unary!(
-    cast_date_to_timestamp,
-    f::CastDateToTimestamp(None),
-    Date::from_pg_epoch(8_415).unwrap(),
-);
-bench_unary!(
-    cast_date_to_timestamp_tz,
-    f::CastDateToTimestampTz(None),
-    Date::from_pg_epoch(8_415).unwrap(),
-);
+fn arithmetic_benches(c: &mut Criterion) {
+    // Boolean
+    bench_unary!(c, not, f::Not, true);
+    bench_unary!(c, is_null, f::IsNull, D::Int32(42));
+    bench_unary!(c, is_true, f::IsTrue, true);
+    bench_unary!(c, is_false, f::IsFalse, false);
 
-fn cast_timestamp_to_date(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampToDate);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
+    // Neg
+    bench_unary!(c, neg_int16, f::NegInt16, 42i16);
+    bench_unary!(c, neg_int16_error, f::NegInt16, i16::MIN);
+    bench_unary!(c, neg_int32, f::NegInt32, 42i32);
+    bench_unary!(c, neg_int32_error, f::NegInt32, i32::MIN);
+    bench_unary!(c, neg_int64, f::NegInt64, 42i64);
+    bench_unary!(c, neg_int64_error, f::NegInt64, i64::MIN);
+    bench_unary!(c, neg_float32, f::NegFloat32, 42.0f32);
+    bench_unary!(c, neg_float64, f::NegFloat64, 42.0f64);
+    bench_unary!(c, neg_numeric, f::NegNumeric, Numeric::from(42));
+    bench_unary!(
+        c,
+        neg_interval,
+        f::NegInterval,
+        Interval::new(1, 2, 3_000_000)
+    );
+
+    // Abs
+    bench_unary!(c, abs_int16, f::AbsInt16, -42i16);
+    bench_unary!(c, abs_int32, f::AbsInt32, -42i32);
+    bench_unary!(c, abs_int64, f::AbsInt64, -42i64);
+    bench_unary!(c, abs_float32, f::AbsFloat32, -42.0f32);
+    bench_unary!(c, abs_float64, f::AbsFloat64, -42.0f64);
+    bench_unary!(c, abs_numeric, f::AbsNumeric, Numeric::from(-42));
+
+    // BitNot
+    bench_unary!(c, bit_not_int16, f::BitNotInt16, D::Int16(0x0F0F));
+    bench_unary!(c, bit_not_int32, f::BitNotInt32, D::Int32(0x0F0F0F0F));
+    bench_unary!(c, bit_not_int64, f::BitNotInt64, D::Int64(0x0F0F0F0F));
+    bench_unary!(c, bit_not_uint16, f::BitNotUint16, D::UInt16(0x0F0F));
+    bench_unary!(c, bit_not_uint32, f::BitNotUint32, D::UInt32(0x0F0F));
+    bench_unary!(c, bit_not_uint64, f::BitNotUint64, D::UInt64(0x0F0F));
+
+    // Sqrt/Cbrt (8 diverse inputs each: perfect squares, primes, tiny, huge, fractional)
+    bench_unary_multi!(
+        c,
+        sqrt_float64,
+        f::SqrtFloat64,
+        [
+            0.0f64,
+            0.001f64,
+            2.0f64,
+            16.0f64,
+            17.3f64,
+            999.999f64,
+            1e12f64,
+            1.7976931348623157e100f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        sqrt_numeric,
+        f::SqrtNumeric,
+        [
+            Numeric::from(2),
+            Numeric::from(16),
+            Numeric::from(17),
+            Numeric::from(9999),
+            Numeric::from(1000000),
+            Numeric::from(999999999),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        cbrt_float64,
+        f::CbrtFloat64,
+        [
+            0.0f64, 0.001f64, 2.0f64, 27.0f64, 30.7f64, 1e9f64, 1.5e100f64, -8.0f64,
+        ]
+    );
+
+    // Ceil/Floor/Round/Trunc (diverse fractional values)
+    bench_unary_multi!(
+        c,
+        ceil_float32,
+        f::CeilFloat32,
+        [
+            0.0f32, 0.1f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 1e10f32, 0.5f32,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        ceil_float64,
+        f::CeilFloat64,
+        [
+            0.0f64, 0.1f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 1e15f64, 0.5f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        ceil_numeric,
+        f::CeilNumeric,
+        [
+            Numeric::from(0),
+            Numeric::from(314),
+            Numeric::from(-42),
+            Numeric::from(999999),
+            Numeric::from(1),
+            Numeric::from(-1),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        floor_float32,
+        f::FloorFloat32,
+        [0.0f32, 3.17f32, -2.7f32, 999.999f32, -0.001f32, 0.5f32,]
+    );
+    bench_unary_multi!(
+        c,
+        floor_float64,
+        f::FloorFloat64,
+        [0.0f64, 3.17f64, -2.7f64, 999.999f64, -0.001f64, 0.5f64,]
+    );
+    bench_unary_multi!(
+        c,
+        floor_numeric,
+        f::FloorNumeric,
+        [
+            Numeric::from(0),
+            Numeric::from(314),
+            Numeric::from(-42),
+            Numeric::from(999999),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        round_float32,
+        f::RoundFloat32,
+        [0.0f32, 3.17f32, -2.7f32, 0.5f32, 999.999f32, -0.5f32,]
+    );
+    bench_unary_multi!(
+        c,
+        round_float64,
+        f::RoundFloat64,
+        [0.0f64, 3.17f64, -2.7f64, 0.5f64, 999.999f64, -0.5f64,]
+    );
+    bench_unary_multi!(
+        c,
+        round_numeric,
+        f::RoundNumeric,
+        [
+            Numeric::from(0),
+            Numeric::from(314),
+            Numeric::from(-42),
+            Numeric::from(999999),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        trunc_float32,
+        f::TruncFloat32,
+        [0.0f32, 3.17f32, -2.7f32, 999.999f32,]
+    );
+    bench_unary_multi!(
+        c,
+        trunc_float64,
+        f::TruncFloat64,
+        [0.0f64, 3.17f64, -2.7f64, 999.999f64,]
+    );
+    bench_unary_multi!(
+        c,
+        trunc_numeric,
+        f::TruncNumeric,
+        [
+            Numeric::from(0),
+            Numeric::from(314),
+            Numeric::from(-42),
+            Numeric::from(999999),
+        ]
+    );
+
+    // Log/Ln/Exp (diverse magnitudes)
+    bench_unary_multi!(
+        c,
+        log10,
+        f::Log10,
+        [
+            0.001f64,
+            1.0f64,
+            10.0f64,
+            100.0f64,
+            99999.9f64,
+            1e15f64,
+            0.123456789f64,
+            42.42f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        log10_numeric,
+        f::Log10Numeric,
+        [
+            Numeric::from(1),
+            Numeric::from(10),
+            Numeric::from(100),
+            Numeric::from(99999),
+            Numeric::from(42),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        ln,
+        f::Ln,
+        [
+            0.001f64,
+            1.0f64,
+            std::f64::consts::E,
+            100.0f64,
+            99999.9f64,
+            1e15f64,
+            0.123456789f64,
+            42.42f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        ln_numeric,
+        f::LnNumeric,
+        [
+            Numeric::from(1),
+            Numeric::from(3),
+            Numeric::from(100),
+            Numeric::from(99999),
+            Numeric::from(42),
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        exp,
+        f::Exp,
+        [
+            0.0f64, 1.0f64, 2.0f64, -1.0f64, 10.0f64, 0.5f64, -5.0f64, 20.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        exp_numeric,
+        f::ExpNumeric,
+        [
+            Numeric::from(0),
+            Numeric::from(1),
+            Numeric::from(2),
+            Numeric::from(10),
+            Numeric::from(-1),
+        ]
+    );
+
+    // Trig (diverse angles spanning the domain)
+    bench_unary_multi!(
+        c,
+        cos,
+        f::Cos,
+        [
+            0.0f64,
+            0.5f64,
+            1.0f64,
+            std::f64::consts::PI,
+            std::f64::consts::FRAC_PI_2,
+            2.5f64,
+            -1.0f64,
+            100.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        acos,
+        f::Acos,
+        [
+            -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        cosh,
+        f::Cosh,
+        [
+            0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        acosh,
+        f::Acosh,
+        [
+            1.0f64, 1.5f64, 2.0f64, 5.0f64, 10.0f64, 100.0f64, 1.001f64, 50.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        sin,
+        f::Sin,
+        [
+            0.0f64,
+            0.5f64,
+            1.0f64,
+            std::f64::consts::PI,
+            std::f64::consts::FRAC_PI_2,
+            2.5f64,
+            -1.0f64,
+            100.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        asin,
+        f::Asin,
+        [
+            -1.0f64, -0.5f64, 0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.999f64, 1.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        sinh,
+        f::Sinh,
+        [
+            0.0f64, 0.5f64, 1.0f64, 2.0f64, 5.0f64, -1.0f64, 10.0f64, -5.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        asinh,
+        f::Asinh,
+        [
+            0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -10.0f64, 0.001f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        tan,
+        f::Tan,
+        [
+            0.0f64, 0.5f64, 1.0f64, 0.785f64, // ~pi/4
+            -1.0f64, 1.5f64, // close to pi/2
+            3.0f64, 100.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        atan,
+        f::Atan,
+        [
+            0.0f64, 0.5f64, 1.0f64, 10.0f64, 100.0f64, -1.0f64, -100.0f64, 0.001f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        tanh,
+        f::Tanh,
+        [
+            0.0f64, 0.5f64, 1.0f64, 5.0f64, -1.0f64, -5.0f64, 20.0f64, 0.001f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        atanh,
+        f::Atanh,
+        [
+            0.0f64, 0.1f64, 0.5f64, 0.9f64, 0.99f64, -0.5f64, -0.9f64, 0.001f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        cot,
+        f::Cot,
+        [
+            0.1f64,
+            0.5f64,
+            1.0f64,
+            std::f64::consts::FRAC_PI_4,
+            2.0f64,
+            3.0f64,
+            -1.0f64,
+            0.01f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        degrees,
+        f::Degrees,
+        [
+            0.0f64,
+            std::f64::consts::PI,
+            std::f64::consts::FRAC_PI_2,
+            1.0f64,
+            -std::f64::consts::PI,
+            6.37f64,
+            0.001f64,
+            100.0f64,
+        ]
+    );
+    bench_unary_multi!(
+        c,
+        radians,
+        f::Radians,
+        [
+            0.0f64, 45.0f64, 90.0f64, 180.0f64, 360.0f64, -180.0f64, 1.0f64, 0.001f64,
+        ]
+    );
 }
 
-fn cast_timestamp_to_time(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampToTime);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
+// Unary cast functions (unit struct casts only)
 
-fn cast_timestamp_to_string(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampToString);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
+fn cast_benches(c: &mut Criterion) {
+    // Bool casts
+    bench_unary!(c, cast_bool_to_string, f::CastBoolToString, true);
+    bench_unary!(
+        c,
+        cast_bool_to_string_nonstandard,
+        f::CastBoolToStringNonstandard,
+        true,
+    );
+    bench_unary!(c, cast_bool_to_int32, f::CastBoolToInt32, true);
+    bench_unary!(c, cast_bool_to_int64, f::CastBoolToInt64, true);
 
-fn cast_timestamp_to_timestamp_tz(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampToTimestampTz {
-        from: None,
-        to: None,
+    // Int16 casts
+    bench_unary!(
+        c,
+        cast_int16_to_float32,
+        f::CastInt16ToFloat32,
+        D::Int16(42)
+    );
+    bench_unary!(
+        c,
+        cast_int16_to_float64,
+        f::CastInt16ToFloat64,
+        D::Int16(42)
+    );
+    bench_unary!(c, cast_int16_to_int32, f::CastInt16ToInt32, D::Int16(42));
+    bench_unary!(c, cast_int16_to_int64, f::CastInt16ToInt64, D::Int16(42));
+    bench_unary!(c, cast_int16_to_uint16, f::CastInt16ToUint16, D::Int16(42));
+    bench_unary!(c, cast_int16_to_uint32, f::CastInt16ToUint32, D::Int16(42));
+    bench_unary!(c, cast_int16_to_uint64, f::CastInt16ToUint64, D::Int16(42));
+    bench_unary!(c, cast_int16_to_string, f::CastInt16ToString, D::Int16(42));
+
+    // Int32 casts
+    bench_unary!(c, cast_int32_to_bool, f::CastInt32ToBool, D::Int32(1));
+    bench_unary!(
+        c,
+        cast_int32_to_float32,
+        f::CastInt32ToFloat32,
+        D::Int32(42)
+    );
+    bench_unary!(
+        c,
+        cast_int32_to_float64,
+        f::CastInt32ToFloat64,
+        D::Int32(42)
+    );
+    bench_unary!(c, cast_int32_to_int16, f::CastInt32ToInt16, D::Int32(42));
+    bench_unary!(c, cast_int32_to_int64, f::CastInt32ToInt64, D::Int32(42));
+    bench_unary!(c, cast_int32_to_uint16, f::CastInt32ToUint16, D::Int32(42));
+    bench_unary!(c, cast_int32_to_uint32, f::CastInt32ToUint32, D::Int32(42));
+    bench_unary!(c, cast_int32_to_uint64, f::CastInt32ToUint64, D::Int32(42));
+    bench_unary!(c, cast_int32_to_string, f::CastInt32ToString, D::Int32(42));
+    bench_unary!(c, cast_int32_to_oid, f::CastInt32ToOid, D::Int32(42));
+
+    // Int64 casts
+    bench_unary!(c, cast_int64_to_int16, f::CastInt64ToInt16, D::Int64(42));
+    bench_unary!(c, cast_int64_to_int32, f::CastInt64ToInt32, D::Int64(42));
+    bench_unary!(c, cast_int64_to_uint16, f::CastInt64ToUint16, D::Int64(42));
+    bench_unary!(c, cast_int64_to_uint32, f::CastInt64ToUint32, D::Int64(42));
+    bench_unary!(c, cast_int64_to_uint64, f::CastInt64ToUint64, D::Int64(42));
+    bench_unary!(c, cast_int64_to_bool, f::CastInt64ToBool, D::Int64(1));
+    bench_unary!(
+        c,
+        cast_int64_to_float32,
+        f::CastInt64ToFloat32,
+        D::Int64(42)
+    );
+    bench_unary!(
+        c,
+        cast_int64_to_float64,
+        f::CastInt64ToFloat64,
+        D::Int64(42)
+    );
+    bench_unary!(c, cast_int64_to_string, f::CastInt64ToString, D::Int64(42));
+    bench_unary!(c, cast_int64_to_oid, f::CastInt64ToOid, D::Int64(42));
+
+    // Uint16 casts
+    bench_unary!(
+        c,
+        cast_uint16_to_uint32,
+        f::CastUint16ToUint32,
+        D::UInt16(42)
+    );
+    bench_unary!(
+        c,
+        cast_uint16_to_uint64,
+        f::CastUint16ToUint64,
+        D::UInt16(42)
+    );
+    bench_unary!(c, cast_uint16_to_int16, f::CastUint16ToInt16, D::UInt16(42));
+    bench_unary!(c, cast_uint16_to_int32, f::CastUint16ToInt32, D::UInt16(42));
+    bench_unary!(c, cast_uint16_to_int64, f::CastUint16ToInt64, D::UInt16(42));
+    bench_unary!(c, cast_uint16_to_float32, f::CastUint16ToFloat32, 42u16);
+    bench_unary!(c, cast_uint16_to_float64, f::CastUint16ToFloat64, 42u16);
+    bench_unary!(
+        c,
+        cast_uint16_to_string,
+        f::CastUint16ToString,
+        D::UInt16(42)
+    );
+
+    // Uint32 casts
+    bench_unary!(
+        c,
+        cast_uint32_to_uint16,
+        f::CastUint32ToUint16,
+        D::UInt32(42)
+    );
+    bench_unary!(
+        c,
+        cast_uint32_to_uint64,
+        f::CastUint32ToUint64,
+        D::UInt32(42)
+    );
+    bench_unary!(c, cast_uint32_to_int16, f::CastUint32ToInt16, D::UInt32(42));
+    bench_unary!(c, cast_uint32_to_int32, f::CastUint32ToInt32, D::UInt32(42));
+    bench_unary!(c, cast_uint32_to_int64, f::CastUint32ToInt64, D::UInt32(42));
+    bench_unary!(c, cast_uint32_to_float32, f::CastUint32ToFloat32, 42u32);
+    bench_unary!(c, cast_uint32_to_float64, f::CastUint32ToFloat64, 42u32);
+    bench_unary!(
+        c,
+        cast_uint32_to_string,
+        f::CastUint32ToString,
+        D::UInt32(42)
+    );
+
+    // Uint64 casts
+    bench_unary!(
+        c,
+        cast_uint64_to_uint16,
+        f::CastUint64ToUint16,
+        D::UInt64(42)
+    );
+    bench_unary!(
+        c,
+        cast_uint64_to_uint32,
+        f::CastUint64ToUint32,
+        D::UInt64(42)
+    );
+    bench_unary!(c, cast_uint64_to_int16, f::CastUint64ToInt16, D::UInt64(42));
+    bench_unary!(c, cast_uint64_to_int32, f::CastUint64ToInt32, D::UInt64(42));
+    bench_unary!(c, cast_uint64_to_int64, f::CastUint64ToInt64, D::UInt64(42));
+    bench_unary!(c, cast_uint64_to_float32, f::CastUint64ToFloat32, 42u64);
+    bench_unary!(c, cast_uint64_to_float64, f::CastUint64ToFloat64, 42u64);
+    bench_unary!(
+        c,
+        cast_uint64_to_string,
+        f::CastUint64ToString,
+        D::UInt64(42)
+    );
+
+    // Float32 casts
+    bench_unary!(c, cast_float32_to_int16, f::CastFloat32ToInt16, 42.0f32);
+    bench_unary!(c, cast_float32_to_int32, f::CastFloat32ToInt32, 42.0f32);
+    bench_unary!(c, cast_float32_to_int64, f::CastFloat32ToInt64, 42.0f32);
+    bench_unary!(c, cast_float32_to_uint16, f::CastFloat32ToUint16, 42.0f32);
+    bench_unary!(c, cast_float32_to_uint32, f::CastFloat32ToUint32, 42.0f32);
+    bench_unary!(c, cast_float32_to_uint64, f::CastFloat32ToUint64, 42.0f32);
+    bench_unary!(c, cast_float32_to_float64, f::CastFloat32ToFloat64, 42.0f32);
+    bench_unary!(c, cast_float32_to_string, f::CastFloat32ToString, 42.0f32);
+
+    // Float64 casts
+    bench_unary!(c, cast_float64_to_int16, f::CastFloat64ToInt16, 42.0f64);
+    bench_unary!(c, cast_float64_to_int32, f::CastFloat64ToInt32, 42.0f64);
+    bench_unary!(c, cast_float64_to_int64, f::CastFloat64ToInt64, 42.0f64);
+    bench_unary!(c, cast_float64_to_uint16, f::CastFloat64ToUint16, 42.0f64);
+    bench_unary!(c, cast_float64_to_uint32, f::CastFloat64ToUint32, 42.0f64);
+    bench_unary!(c, cast_float64_to_uint64, f::CastFloat64ToUint64, 42.0f64);
+    bench_unary!(c, cast_float64_to_float32, f::CastFloat64ToFloat32, 42.0f64);
+    bench_unary!(c, cast_float64_to_string, f::CastFloat64ToString, 42.0f64);
+
+    // Numeric casts
+    bench_unary!(
+        c,
+        cast_numeric_to_float32,
+        f::CastNumericToFloat32,
+        Numeric::from(42)
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_float64,
+        f::CastNumericToFloat64,
+        Numeric::from(42)
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_int16,
+        f::CastNumericToInt16,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_int32,
+        f::CastNumericToInt32,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_int64,
+        f::CastNumericToInt64,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_uint16,
+        f::CastNumericToUint16,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_uint32,
+        f::CastNumericToUint32,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_uint64,
+        f::CastNumericToUint64,
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_string,
+        f::CastNumericToString,
+        Numeric::from(42),
+    );
+
+    // Parameterized casts (XToNumeric)
+    bench_unary!(c, cast_int16_to_numeric, f::CastInt16ToNumeric(None), 42i16);
+    bench_unary!(c, cast_int32_to_numeric, f::CastInt32ToNumeric(None), 42i32);
+    bench_unary!(c, cast_int64_to_numeric, f::CastInt64ToNumeric(None), 42i64);
+    bench_unary!(
+        c,
+        cast_uint16_to_numeric,
+        f::CastUint16ToNumeric(None),
+        42u16
+    );
+    bench_unary!(
+        c,
+        cast_uint32_to_numeric,
+        f::CastUint32ToNumeric(None),
+        42u32
+    );
+    bench_unary!(
+        c,
+        cast_uint64_to_numeric,
+        f::CastUint64ToNumeric(None),
+        42u64
+    );
+    bench_unary!(
+        c,
+        cast_float32_to_numeric,
+        f::CastFloat32ToNumeric(None),
+        42f32
+    );
+    bench_unary!(
+        c,
+        cast_float64_to_numeric,
+        f::CastFloat64ToNumeric(None),
+        42f64
+    );
+
+    // String parsing casts
+    bench_unary!(c, cast_string_to_bool, f::CastStringToBool, "true");
+    bench_unary!(c, cast_string_to_int16, f::CastStringToInt16, "42");
+    bench_unary!(c, cast_string_to_int32, f::CastStringToInt32, "42");
+    bench_unary!(c, cast_string_to_int64, f::CastStringToInt64, "42");
+    bench_unary!(c, cast_string_to_uint16, f::CastStringToUint16, "42");
+    bench_unary!(c, cast_string_to_uint32, f::CastStringToUint32, "42");
+    bench_unary!(c, cast_string_to_uint64, f::CastStringToUint64, "42");
+    bench_unary!(c, cast_string_to_float32, f::CastStringToFloat32, "42.0");
+    bench_unary!(c, cast_string_to_float64, f::CastStringToFloat64, "42.0");
+    bench_unary!(c, cast_string_to_date, f::CastStringToDate, "2024-01-15");
+    bench_unary!(c, cast_string_to_time, f::CastStringToTime, "12:30:45");
+    bench_unary!(
+        c,
+        cast_string_to_timestamp,
+        f::CastStringToTimestamp(None),
+        "2024-01-15 12:30:45"
+    );
+    bench_unary!(
+        c,
+        cast_string_to_timestamp_tz,
+        f::CastStringToTimestampTz(None),
+        "2024-01-15 12:30:45+00"
+    );
+    bench_unary!(
+        c,
+        cast_string_to_interval,
+        f::CastStringToInterval,
+        "1 day 2 hours"
+    );
+    bench_unary!(
+        c,
+        cast_string_to_uuid,
+        f::CastStringToUuid,
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+    );
+    bench_unary!(c, cast_string_to_jsonb, f::CastStringToJsonb, "42");
+    bench_unary!(c, cast_string_to_bytes, f::CastStringToBytes, "\\xDEADBEEF");
+
+    // Other casts
+    bench_unary!(c, cast_oid_to_int32, f::CastOidToInt32, D::UInt32(42));
+    bench_unary!(c, cast_oid_to_int64, f::CastOidToInt64, D::UInt32(42));
+    bench_unary!(c, cast_oid_to_string, f::CastOidToString, D::UInt32(42));
+    bench_unary!(c, cast_uuid_to_string, f::CastUuidToString, Uuid::nil());
+    bench_unary!(c, cast_bytes_to_string, f::CastBytesToString, b"hello");
+    bench_unary!(c, cast_jsonb_to_string, f::CastJsonbToString, "hello");
+    bench_unary!(c, cast_jsonb_to_int16, f::CastJsonbToInt16, 42f64);
+    bench_unary!(c, cast_jsonb_to_int32, f::CastJsonbToInt32, 42f64);
+    bench_unary!(c, cast_jsonb_to_int64, f::CastJsonbToInt64, 42f64);
+    bench_unary!(c, cast_jsonb_to_float32, f::CastJsonbToFloat32, 42f64);
+    bench_unary!(c, cast_jsonb_to_float64, f::CastJsonbToFloat64, 42f64);
+    bench_unary!(c, cast_jsonb_to_bool, f::CastJsonbToBool, true);
+
+    // --- Timestamp/Date casts ---
+
+    bench_unary!(
+        c,
+        cast_date_to_timestamp,
+        f::CastDateToTimestamp(None),
+        Date::from_pg_epoch(8_415).unwrap(),
+    );
+    bench_unary!(
+        c,
+        cast_date_to_timestamp_tz,
+        f::CastDateToTimestampTz(None),
+        Date::from_pg_epoch(8_415).unwrap(),
+    );
+
+    c.bench_function("cast_timestamp_to_date", |b| {
+        let func = UnaryFunc::from(f::CastTimestampToDate);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-fn cast_timestamp_tz_to_date(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampTzToDate);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn cast_timestamp_tz_to_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampTzToTimestamp {
-        from: None,
-        to: None,
+    c.bench_function("cast_timestamp_to_time", |b| {
+        let func = UnaryFunc::from(f::CastTimestampToTime);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-fn cast_timestamp_tz_to_string(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampTzToString);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn cast_timestamp_tz_to_time(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampTzToTime);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-bench_unary!(to_timestamp, f::ToTimestamp, 1705312245.0f64);
-
-// --- MzTimestamp casts ---
-
-bench_unary!(
-    cast_mz_timestamp_to_string,
-    f::CastMzTimestampToString,
-    D::MzTimestamp(Timestamp::from(1705312245000u64)),
-);
-bench_unary!(
-    cast_mz_timestamp_to_timestamp,
-    f::CastMzTimestampToTimestamp,
-    D::MzTimestamp(Timestamp::from(1705312245000u64)),
-);
-bench_unary!(
-    cast_mz_timestamp_to_timestamp_tz,
-    f::CastMzTimestampToTimestampTz,
-    D::MzTimestamp(Timestamp::from(1705312245000u64)),
-);
-bench_unary!(
-    cast_string_to_mz_timestamp,
-    f::CastStringToMzTimestamp,
-    "1705312245000",
-);
-bench_unary!(
-    cast_uint64_to_mz_timestamp,
-    f::CastUint64ToMzTimestamp,
-    D::UInt64(1705312245000),
-);
-bench_unary!(
-    cast_uint32_to_mz_timestamp,
-    f::CastUint32ToMzTimestamp,
-    D::UInt32(1705312245),
-);
-bench_unary!(
-    cast_int64_to_mz_timestamp,
-    f::CastInt64ToMzTimestamp,
-    D::Int64(1705312245000),
-);
-bench_unary!(
-    cast_int32_to_mz_timestamp,
-    f::CastInt32ToMzTimestamp,
-    D::Int32(1705312245),
-);
-bench_unary!(
-    cast_numeric_to_mz_timestamp,
-    f::CastNumericToMzTimestamp,
-    Numeric::from(1705312245000i64),
-);
-
-fn cast_timestamp_to_mz_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampToMzTimestamp);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn cast_timestamp_tz_to_mz_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastTimestampTzToMzTimestamp);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-bench_unary!(
-    cast_date_to_mz_timestamp,
-    f::CastDateToMzTimestamp,
-    Date::from_pg_epoch(8_415).unwrap(),
-);
-
-bench_unary!(
-    step_mz_timestamp,
-    f::StepMzTimestamp,
-    D::MzTimestamp(Timestamp::from(1705312245000u64)),
-);
-
-// --- PgLegacyChar / Char / VarChar casts ---
-
-bench_unary!(cast_int32_to_pg_legacy_char, f::CastInt32ToPgLegacyChar, D::Int32(65));
-bench_unary!(cast_string_to_pg_legacy_char, f::CastStringToPgLegacyChar, "A");
-bench_unary!(cast_string_to_pg_legacy_name, f::CastStringToPgLegacyName, "my_table");
-bench_unary!(cast_pg_legacy_char_to_string, f::CastPgLegacyCharToString, D::UInt8(65));
-bench_unary!(cast_pg_legacy_char_to_char, f::CastPgLegacyCharToChar, D::UInt8(65));
-bench_unary!(cast_pg_legacy_char_to_var_char, f::CastPgLegacyCharToVarChar, D::UInt8(65));
-bench_unary!(cast_pg_legacy_char_to_int32, f::CastPgLegacyCharToInt32, D::UInt8(65));
-
-bench_unary!(
-    cast_string_to_char,
-    f::CastStringToChar {
-        length: None,
-        fail_on_len: false,
-    },
-    "hello",
-);
-bench_unary!(
-    cast_string_to_var_char,
-    f::CastStringToVarChar {
-        length: None,
-        fail_on_len: false,
-    },
-    "hello",
-);
-bench_unary!(cast_char_to_string, f::CastCharToString, "hello");
-bench_unary!(cast_var_char_to_string, f::CastVarCharToString, "hello");
-bench_unary!(pad_char, f::PadChar { length: None }, "hello");
-
-// --- OID / Reg* casts ---
-
-bench_unary!(cast_oid_to_reg_class, f::CastOidToRegClass, D::UInt32(42));
-bench_unary!(cast_reg_class_to_oid, f::CastRegClassToOid, D::UInt32(42));
-bench_unary!(cast_oid_to_reg_proc, f::CastOidToRegProc, D::UInt32(42));
-bench_unary!(cast_reg_proc_to_oid, f::CastRegProcToOid, D::UInt32(42));
-bench_unary!(cast_oid_to_reg_type, f::CastOidToRegType, D::UInt32(42));
-bench_unary!(cast_reg_type_to_oid, f::CastRegTypeToOid, D::UInt32(42));
-bench_unary!(cast_string_to_oid, f::CastStringToOid, "42");
-
-// --- Jsonb extras ---
-
-fn jsonb_array_length(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::JsonbArrayLength);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let arr = sa.make_datum(|packer| {
-        packer.push_list(&[D::Float64(OrderedFloat(1.0)), D::Float64(OrderedFloat(2.0)), D::Float64(OrderedFloat(3.0))]);
+    c.bench_function("cast_timestamp_to_string", |b| {
+        let func = UnaryFunc::from(f::CastTimestampToString);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let arena = RowArena::new();
-    let datums: &[D] = &[arr];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-fn jsonb_strip_nulls(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::JsonbStripNulls);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let obj = sa.make_datum(|packer| {
-        packer.push_dict_with(|packer| {
-            packer.push(D::String("a"));
-            packer.push(D::Float64(OrderedFloat(1.0)));
-            packer.push(D::String("b"));
-            packer.push(D::Null);
+    c.bench_function("cast_timestamp_to_timestamp_tz", |b| {
+        let func = UnaryFunc::from(f::CastTimestampToTimestampTz {
+            from: None,
+            to: None,
         });
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let arena = RowArena::new();
-    let datums: &[D] = &[obj];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-bench_unary!(cast_jsonbable_to_jsonb, f::CastJsonbableToJsonb, 42f64);
-bench_unary!(
-    cast_jsonb_to_numeric,
-    f::CastJsonbToNumeric(None),
-    42f64,
-);
-
-// --- Numeric extras ---
-
-bench_unary!(
-    adjust_numeric_scale,
-    f::AdjustNumericScale(NumericMaxScale::try_from(2i64).unwrap()),
-    Numeric::from(42),
-);
-bench_unary!(
-    cast_string_to_numeric,
-    f::CastStringToNumeric(None),
-    "42.5",
-);
-
-// --- Extract / DatePart / DateTrunc ---
-
-fn extract_interval(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ExtractInterval(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn extract_time(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ExtractTime(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn extract_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ExtractTimestamp(DateTimeUnits::Year));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn extract_timestamp_tz(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ExtractTimestampTz(DateTimeUnits::Year));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn extract_date(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ExtractDate(DateTimeUnits::Year));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Date(Date::from_pg_epoch(8_415).unwrap())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_part_interval(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DatePartInterval(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_part_time(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DatePartTime(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_part_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DatePartTimestamp(DateTimeUnits::Year));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_part_timestamp_tz(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DatePartTimestampTz(DateTimeUnits::Year));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_trunc_timestamp(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DateTruncTimestamp(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn date_trunc_timestamp_tz(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::DateTruncTimestampTz(DateTimeUnits::Hour));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn adjust_timestamp_precision(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::AdjustTimestampPrecision {
-        from: None,
-        to: None,
+    c.bench_function("cast_timestamp_tz_to_date", |b| {
+        let func = UnaryFunc::from(f::CastTimestampTzToDate);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-fn adjust_timestamp_tz_precision(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::AdjustTimestampTzPrecision {
-        from: None,
-        to: None,
-    });
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Timezone ---
-
-fn timezone_timestamp(b: &mut Bencher) {
-    use mz_pgtz::timezone::Timezone;
-    let func = UnaryFunc::from(f::TimezoneTimestamp(Timezone::Tz(chrono_tz::UTC)));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Timestamp(make_ts())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn timezone_timestamp_tz(b: &mut Bencher) {
-    use mz_pgtz::timezone::Timezone;
-    let func = UnaryFunc::from(f::TimezoneTimestampTz(Timezone::Tz(chrono_tz::UTC)));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::TimestampTz(make_tstz())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn timezone_time(b: &mut Bencher) {
-    use mz_pgtz::timezone::Timezone;
-    let func = UnaryFunc::from(f::TimezoneTime {
-        tz: Timezone::Tz(chrono_tz::UTC),
-        wall_time: NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap(),
-    });
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 0).unwrap())];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Pattern matching ---
-
-fn is_like_match(b: &mut Bencher) {
-    let matcher = like_pattern::compile("%world%", false).unwrap();
-    let func = UnaryFunc::from(f::IsLikeMatch(matcher));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::String("hello world")];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn is_regexp_match(b: &mut Bencher) {
-    let regex = Regex::new("\\d+", false).unwrap();
-    let func = UnaryFunc::from(f::IsRegexpMatch(regex));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::String("hello 42 world")];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn regexp_match_unary(b: &mut Bencher) {
-    let regex = Regex::new("(\\d+)", false).unwrap();
-    let func = UnaryFunc::from(f::RegexpMatch(regex));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::String("hello 42 world")];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn regexp_split_to_array_unary(b: &mut Bencher) {
-    let regex = Regex::new("\\d", false).unwrap();
-    let func = UnaryFunc::from(f::RegexpSplitToArray(regex));
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::String("one1two2three")];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Range functions ---
-
-fn bench_range_empty(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeEmpty);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_lower_inc(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeLowerInc);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_upper_inc(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeUpperInc);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_lower_inf(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeLowerInf);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_upper_inf(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeUpperInf);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_lower(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeLower);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn bench_range_upper(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::RangeUpper);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let range = sa.make_datum(|packer| {
-        packer
-            .push_range(mz_repr::adt::range::Range::new(Some((
-                mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
-                mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
-            ))))
-            .unwrap();
-    });
-    let arena = RowArena::new();
-    let datums: &[D] = &[range];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Collection ops ---
-
-fn list_length(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::ListLength);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let list = sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
-    let arena = RowArena::new();
-    let datums: &[D] = &[list];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn map_length(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::MapLength);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let map = sa.make_datum(|packer| {
-        packer.push_dict_with(|packer| {
-            packer.push(D::String("a"));
-            packer.push(D::Int32(1));
-            packer.push(D::String("b"));
-            packer.push(D::Int32(2));
+    c.bench_function("cast_timestamp_tz_to_timestamp", |b| {
+        let func = UnaryFunc::from(f::CastTimestampTzToTimestamp {
+            from: None,
+            to: None,
         });
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let arena = RowArena::new();
-    let datums: &[D] = &[map];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
 
-// --- ACL / privileges ---
-
-fn mz_acl_item_grantor(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::MzAclItemGrantor);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = MzAclItem {
-        grantee: RoleId::User(1),
-        grantor: RoleId::User(2),
-        acl_mode: AclMode::empty(),
-    };
-    let datums: &[D] = &[D::MzAclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn mz_acl_item_grantee(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::MzAclItemGrantee);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = MzAclItem {
-        grantee: RoleId::User(1),
-        grantor: RoleId::User(2),
-        acl_mode: AclMode::empty(),
-    };
-    let datums: &[D] = &[D::MzAclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn mz_acl_item_privileges(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::MzAclItemPrivileges);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = MzAclItem {
-        grantee: RoleId::User(1),
-        grantor: RoleId::User(2),
-        acl_mode: AclMode::empty(),
-    };
-    let datums: &[D] = &[D::MzAclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-bench_unary!(mz_format_privileges, f::MzFormatPrivileges, "r");
-bench_unary!(mz_validate_privileges, f::MzValidatePrivileges, "r");
-bench_unary!(mz_validate_role_privilege, f::MzValidateRolePrivilege, "USAGE");
-
-fn acl_item_grantor(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::AclItemGrantor);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = AclItem::empty(Oid(1), Oid(2));
-    let datums: &[D] = &[D::AclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn acl_item_grantee(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::AclItemGrantee);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = AclItem::empty(Oid(1), Oid(2));
-    let datums: &[D] = &[D::AclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn acl_item_privileges(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::AclItemPrivileges);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let item = AclItem::empty(Oid(1), Oid(2));
-    let datums: &[D] = &[D::AclItem(item)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Misc ---
-
-bench_unary!(mz_type_name, f::MzTypeName, D::UInt32(25)); // text oid
-bench_unary!(
-    try_parse_monotonic_iso8601_timestamp,
-    f::TryParseMonotonicIso8601Timestamp,
-    "2024-01-15T12:30:45Z",
-);
-
-fn pg_column_size(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::PgColumnSize);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::Int32(42)];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn mz_row_size(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::MzRowSize);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let list = sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
-    let arena = RowArena::new();
-    let datums: &[D] = &[list];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-// --- Int2Vector / String casts ---
-
-fn cast_string_to_int2_vector(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastStringToInt2Vector);
-    let a = MirScalarExpr::column(0);
-    let arena = RowArena::new();
-    let datums: &[D] = &[D::String("1 2 3")];
-    b.iter(|| func.eval(datums, &arena, &a));
-}
-
-fn cast_int2_vector_to_string(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastInt2VectorToString);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let vec = sa.make_datum(|packer| {
-        packer.try_push_array(&[mz_repr::adt::array::ArrayDimension { lower_bound: 1, length: 3 }], &[D::Int16(1), D::Int16(2), D::Int16(3)]).unwrap();
+    c.bench_function("cast_timestamp_tz_to_string", |b| {
+        let func = UnaryFunc::from(f::CastTimestampTzToString);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let arena = RowArena::new();
-    let datums: &[D] = &[vec];
-    b.iter(|| func.eval(datums, &arena, &a));
+
+    c.bench_function("cast_timestamp_tz_to_time", |b| {
+        let func = UnaryFunc::from(f::CastTimestampTzToTime);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    bench_unary!(c, to_timestamp, f::ToTimestamp, 1705312245.0f64);
+
+    // --- MzTimestamp casts ---
+
+    bench_unary!(
+        c,
+        cast_mz_timestamp_to_string,
+        f::CastMzTimestampToString,
+        D::MzTimestamp(Timestamp::from(1705312245000u64)),
+    );
+    bench_unary!(
+        c,
+        cast_mz_timestamp_to_timestamp,
+        f::CastMzTimestampToTimestamp,
+        D::MzTimestamp(Timestamp::from(1705312245000u64)),
+    );
+    bench_unary!(
+        c,
+        cast_mz_timestamp_to_timestamp_tz,
+        f::CastMzTimestampToTimestampTz,
+        D::MzTimestamp(Timestamp::from(1705312245000u64)),
+    );
+    bench_unary!(
+        c,
+        cast_string_to_mz_timestamp,
+        f::CastStringToMzTimestamp,
+        "1705312245000",
+    );
+    bench_unary!(
+        c,
+        cast_uint64_to_mz_timestamp,
+        f::CastUint64ToMzTimestamp,
+        D::UInt64(1705312245000),
+    );
+    bench_unary!(
+        c,
+        cast_uint32_to_mz_timestamp,
+        f::CastUint32ToMzTimestamp,
+        D::UInt32(1705312245),
+    );
+    bench_unary!(
+        c,
+        cast_int64_to_mz_timestamp,
+        f::CastInt64ToMzTimestamp,
+        D::Int64(1705312245000),
+    );
+    bench_unary!(
+        c,
+        cast_int32_to_mz_timestamp,
+        f::CastInt32ToMzTimestamp,
+        D::Int32(1705312245),
+    );
+    bench_unary!(
+        c,
+        cast_numeric_to_mz_timestamp,
+        f::CastNumericToMzTimestamp,
+        Numeric::from(1705312245000i64),
+    );
+
+    c.bench_function("cast_timestamp_to_mz_timestamp", |b| {
+        let func = UnaryFunc::from(f::CastTimestampToMzTimestamp);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("cast_timestamp_tz_to_mz_timestamp", |b| {
+        let func = UnaryFunc::from(f::CastTimestampTzToMzTimestamp);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    bench_unary!(
+        c,
+        cast_date_to_mz_timestamp,
+        f::CastDateToMzTimestamp,
+        Date::from_pg_epoch(8_415).unwrap(),
+    );
+
+    bench_unary!(
+        c,
+        step_mz_timestamp,
+        f::StepMzTimestamp,
+        D::MzTimestamp(Timestamp::from(1705312245000u64)),
+    );
+
+    // --- PgLegacyChar / Char / VarChar casts ---
+
+    bench_unary!(
+        c,
+        cast_int32_to_pg_legacy_char,
+        f::CastInt32ToPgLegacyChar,
+        D::Int32(65)
+    );
+    bench_unary!(
+        c,
+        cast_string_to_pg_legacy_char,
+        f::CastStringToPgLegacyChar,
+        "A"
+    );
+    bench_unary!(
+        c,
+        cast_string_to_pg_legacy_name,
+        f::CastStringToPgLegacyName,
+        "my_table"
+    );
+    bench_unary!(
+        c,
+        cast_pg_legacy_char_to_string,
+        f::CastPgLegacyCharToString,
+        D::UInt8(65)
+    );
+    bench_unary!(
+        c,
+        cast_pg_legacy_char_to_char,
+        f::CastPgLegacyCharToChar,
+        D::UInt8(65)
+    );
+    bench_unary!(
+        c,
+        cast_pg_legacy_char_to_var_char,
+        f::CastPgLegacyCharToVarChar,
+        D::UInt8(65)
+    );
+    bench_unary!(
+        c,
+        cast_pg_legacy_char_to_int32,
+        f::CastPgLegacyCharToInt32,
+        D::UInt8(65)
+    );
+
+    bench_unary!(
+        c,
+        cast_string_to_char,
+        f::CastStringToChar {
+            length: None,
+            fail_on_len: false,
+        },
+        "hello",
+    );
+    bench_unary!(
+        c,
+        cast_string_to_var_char,
+        f::CastStringToVarChar {
+            length: None,
+            fail_on_len: false,
+        },
+        "hello",
+    );
+    bench_unary!(c, cast_char_to_string, f::CastCharToString, "hello");
+    bench_unary!(c, cast_var_char_to_string, f::CastVarCharToString, "hello");
+    bench_unary!(c, pad_char, f::PadChar { length: None }, "hello");
+
+    // --- OID / Reg* casts ---
+
+    bench_unary!(
+        c,
+        cast_oid_to_reg_class,
+        f::CastOidToRegClass,
+        D::UInt32(42)
+    );
+    bench_unary!(
+        c,
+        cast_reg_class_to_oid,
+        f::CastRegClassToOid,
+        D::UInt32(42)
+    );
+    bench_unary!(c, cast_oid_to_reg_proc, f::CastOidToRegProc, D::UInt32(42));
+    bench_unary!(c, cast_reg_proc_to_oid, f::CastRegProcToOid, D::UInt32(42));
+    bench_unary!(c, cast_oid_to_reg_type, f::CastOidToRegType, D::UInt32(42));
+    bench_unary!(c, cast_reg_type_to_oid, f::CastRegTypeToOid, D::UInt32(42));
+    bench_unary!(c, cast_string_to_oid, f::CastStringToOid, "42");
+
+    // --- Jsonb extras ---
+
+    c.bench_function("jsonb_array_length", |b| {
+        let func = UnaryFunc::from(f::JsonbArrayLength);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let arr = sa.make_datum(|packer| {
+            packer.push_list(&[
+                D::Float64(OrderedFloat(1.0)),
+                D::Float64(OrderedFloat(2.0)),
+                D::Float64(OrderedFloat(3.0)),
+            ]);
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[arr];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("jsonb_strip_nulls", |b| {
+        let func = UnaryFunc::from(f::JsonbStripNulls);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let obj = sa.make_datum(|packer| {
+            packer.push_dict_with(|packer| {
+                packer.push(D::String("a"));
+                packer.push(D::Float64(OrderedFloat(1.0)));
+                packer.push(D::String("b"));
+                packer.push(D::Null);
+            });
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[obj];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    bench_unary!(c, cast_jsonbable_to_jsonb, f::CastJsonbableToJsonb, 42f64);
+    bench_unary!(c, cast_jsonb_to_numeric, f::CastJsonbToNumeric(None), 42f64,);
+
+    // --- Numeric extras ---
+
+    bench_unary!(
+        c,
+        adjust_numeric_scale,
+        f::AdjustNumericScale(NumericMaxScale::try_from(2i64).unwrap()),
+        Numeric::from(42),
+    );
+    bench_unary!(
+        c,
+        cast_string_to_numeric,
+        f::CastStringToNumeric(None),
+        "42.5",
+    );
+
+    // --- Int2Vector / String casts ---
+
+    c.bench_function("cast_string_to_int2_vector", |b| {
+        let func = UnaryFunc::from(f::CastStringToInt2Vector);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::String("1 2 3")];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("cast_int2_vector_to_string", |b| {
+        let func = UnaryFunc::from(f::CastInt2VectorToString);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let vec = sa.make_datum(|packer| {
+            packer
+                .try_push_array(
+                    &[mz_repr::adt::array::ArrayDimension {
+                        lower_bound: 1,
+                        length: 3,
+                    }],
+                    &[D::Int16(1), D::Int16(2), D::Int16(3)],
+                )
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[vec];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("cast_int2_vector_to_array", |b| {
+        let func = UnaryFunc::from(f::CastInt2VectorToArray);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let vec = sa.make_datum(|packer| {
+            packer
+                .try_push_array(
+                    &[mz_repr::adt::array::ArrayDimension {
+                        lower_bound: 1,
+                        length: 3,
+                    }],
+                    &[D::Int16(1), D::Int16(2), D::Int16(3)],
+                )
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[vec];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
 }
 
-fn cast_int2_vector_to_array(b: &mut Bencher) {
-    let func = UnaryFunc::from(f::CastInt2VectorToArray);
-    let a = MirScalarExpr::column(0);
-    let sa = RowArena::new();
-    let vec = sa.make_datum(|packer| {
-        packer.try_push_array(&[mz_repr::adt::array::ArrayDimension { lower_bound: 1, length: 3 }], &[D::Int16(1), D::Int16(2), D::Int16(3)]).unwrap();
+// Remaining unary functions
+
+fn remaining_benches(c: &mut Criterion) {
+    // String operations
+    bench_unary!(c, upper, f::Upper, "hello");
+    bench_unary!(c, lower, f::Lower, "HELLO");
+    bench_unary!(c, initcap, f::Initcap, "hello world");
+    bench_unary!(c, trim_whitespace, f::TrimWhitespace, "  hello  ");
+    bench_unary!(
+        c,
+        trim_leading_whitespace,
+        f::TrimLeadingWhitespace,
+        "  hello  "
+    );
+    bench_unary!(
+        c,
+        trim_trailing_whitespace,
+        f::TrimTrailingWhitespace,
+        "  hello  "
+    );
+    bench_unary!(c, ascii, f::Ascii, "hello");
+    bench_unary!(c, char_length, f::CharLength, "hello");
+    bench_unary!(c, bit_length_bytes, f::BitLengthBytes, b"hello");
+    bench_unary!(c, bit_length_string, f::BitLengthString, "hello");
+    bench_unary!(c, byte_length_bytes, f::ByteLengthBytes, b"hello");
+    bench_unary!(c, byte_length_string, f::ByteLengthString, "hello");
+    bench_unary!(c, bit_count_bytes, f::BitCountBytes, b"\xff");
+    bench_unary!(c, chr, f::Chr, D::Int32(65));
+    bench_unary!(c, reverse, f::Reverse, "hello");
+    bench_unary!(c, quote_ident, f::QuoteIdent, "my_table");
+    bench_unary!(c, pg_size_pretty, f::PgSizePretty, Numeric::from(1048576));
+
+    // Jsonb
+    bench_unary!(
+        c,
+        jsonb_typeof,
+        f::JsonbTypeof,
+        D::Float64(OrderedFloat(42.0))
+    );
+    bench_unary!(c, jsonb_pretty, f::JsonbPretty, "hello");
+
+    // Date/time
+    bench_unary!(c, justify_days, f::JustifyDays, Interval::new(0, 35, 0));
+    bench_unary!(
+        c,
+        justify_hours,
+        f::JustifyHours,
+        Interval::new(0, 0, 30 * 3_600_000_000)
+    );
+    bench_unary!(
+        c,
+        justify_interval,
+        f::JustifyInterval,
+        Interval::new(0, 35, 30 * 3_600_000_000)
+    );
+    bench_unary!(
+        c,
+        cast_date_to_string,
+        f::CastDateToString,
+        Date::from_pg_epoch(0).unwrap(),
+    );
+    bench_unary!(
+        c,
+        cast_time_to_string,
+        f::CastTimeToString,
+        NaiveTime::from_hms_opt(12, 30, 45).unwrap(),
+    );
+    bench_unary!(
+        c,
+        cast_interval_to_string,
+        f::CastIntervalToString,
+        Interval::new(1, 2, 3_000_000)
+    );
+    bench_unary!(
+        c,
+        cast_interval_to_time,
+        f::CastIntervalToTime,
+        Interval::new(0, 0, 45_000_000_000)
+    );
+    bench_unary!(
+        c,
+        cast_time_to_interval,
+        f::CastTimeToInterval,
+        NaiveTime::from_hms_opt(12, 30, 45).unwrap()
+    );
+
+    // Hash functions
+    bench_unary!(c, crc32_bytes, f::Crc32Bytes, b"hello");
+    bench_unary!(c, crc32_string, f::Crc32String, "hello");
+    bench_unary!(c, kafka_murmur2_bytes, f::KafkaMurmur2Bytes, b"hello");
+    bench_unary!(c, kafka_murmur2_string, f::KafkaMurmur2String, "hello");
+    bench_unary!(c, seahash_bytes, f::SeahashBytes, b"hello");
+    bench_unary!(c, seahash_string, f::SeahashString, "hello");
+
+    // --- Extract / DatePart / DateTrunc ---
+
+    c.bench_function("extract_interval", |b| {
+        let func = UnaryFunc::from(f::ExtractInterval(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
+        b.iter(|| func.eval(datums, &arena, &a));
     });
-    let arena = RowArena::new();
-    let datums: &[D] = &[vec];
-    b.iter(|| func.eval(datums, &arena, &a));
+
+    c.bench_function("extract_time", |b| {
+        let func = UnaryFunc::from(f::ExtractTime(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("extract_timestamp", |b| {
+        let func = UnaryFunc::from(f::ExtractTimestamp(DateTimeUnits::Year));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("extract_timestamp_tz", |b| {
+        let func = UnaryFunc::from(f::ExtractTimestampTz(DateTimeUnits::Year));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("extract_date", |b| {
+        let func = UnaryFunc::from(f::ExtractDate(DateTimeUnits::Year));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Date(Date::from_pg_epoch(8_415).unwrap())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_part_interval", |b| {
+        let func = UnaryFunc::from(f::DatePartInterval(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Interval(Interval::new(1, 2, 3_600_000_000))];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_part_time", |b| {
+        let func = UnaryFunc::from(f::DatePartTime(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 45).unwrap())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_part_timestamp", |b| {
+        let func = UnaryFunc::from(f::DatePartTimestamp(DateTimeUnits::Year));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_part_timestamp_tz", |b| {
+        let func = UnaryFunc::from(f::DatePartTimestampTz(DateTimeUnits::Year));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_trunc_timestamp", |b| {
+        let func = UnaryFunc::from(f::DateTruncTimestamp(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("date_trunc_timestamp_tz", |b| {
+        let func = UnaryFunc::from(f::DateTruncTimestampTz(DateTimeUnits::Hour));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("adjust_timestamp_precision", |b| {
+        let func = UnaryFunc::from(f::AdjustTimestampPrecision {
+            from: None,
+            to: None,
+        });
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("adjust_timestamp_tz_precision", |b| {
+        let func = UnaryFunc::from(f::AdjustTimestampTzPrecision {
+            from: None,
+            to: None,
+        });
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- Timezone ---
+
+    c.bench_function("timezone_timestamp", |b| {
+        use mz_pgtz::timezone::Timezone;
+        let func = UnaryFunc::from(f::TimezoneTimestamp(Timezone::Tz(chrono_tz::UTC)));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Timestamp(make_ts())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("timezone_timestamp_tz", |b| {
+        use mz_pgtz::timezone::Timezone;
+        let func = UnaryFunc::from(f::TimezoneTimestampTz(Timezone::Tz(chrono_tz::UTC)));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::TimestampTz(make_tstz())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("timezone_time", |b| {
+        use mz_pgtz::timezone::Timezone;
+        let func = UnaryFunc::from(f::TimezoneTime {
+            tz: Timezone::Tz(chrono_tz::UTC),
+            wall_time: NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        });
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Time(NaiveTime::from_hms_opt(12, 30, 0).unwrap())];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- Pattern matching ---
+
+    c.bench_function("is_like_match", |b| {
+        let matcher = like_pattern::compile("%world%", false).unwrap();
+        let func = UnaryFunc::from(f::IsLikeMatch(matcher));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::String("hello world")];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("is_regexp_match", |b| {
+        let regex = Regex::new("\\d+", false).unwrap();
+        let func = UnaryFunc::from(f::IsRegexpMatch(regex));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::String("hello 42 world")];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("regexp_match_unary", |b| {
+        let regex = Regex::new("(\\d+)", false).unwrap();
+        let func = UnaryFunc::from(f::RegexpMatch(regex));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::String("hello 42 world")];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("regexp_split_to_array_unary", |b| {
+        let regex = Regex::new("\\d", false).unwrap();
+        let func = UnaryFunc::from(f::RegexpSplitToArray(regex));
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::String("one1two2three")];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- Range functions ---
+
+    c.bench_function("bench_range_empty", |b| {
+        let func = UnaryFunc::from(f::RangeEmpty);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_lower_inc", |b| {
+        let func = UnaryFunc::from(f::RangeLowerInc);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_upper_inc", |b| {
+        let func = UnaryFunc::from(f::RangeUpperInc);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_lower_inf", |b| {
+        let func = UnaryFunc::from(f::RangeLowerInf);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_upper_inf", |b| {
+        let func = UnaryFunc::from(f::RangeUpperInf);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_lower", |b| {
+        let func = UnaryFunc::from(f::RangeLower);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("bench_range_upper", |b| {
+        let func = UnaryFunc::from(f::RangeUpper);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let range = sa.make_datum(|packer| {
+            packer
+                .push_range(mz_repr::adt::range::Range::new(Some((
+                    mz_repr::adt::range::RangeBound::new(D::Int32(1), true),
+                    mz_repr::adt::range::RangeBound::new(D::Int32(10), false),
+                ))))
+                .unwrap();
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[range];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- Collection ops ---
+
+    c.bench_function("list_length", |b| {
+        let func = UnaryFunc::from(f::ListLength);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let list =
+            sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
+        let arena = RowArena::new();
+        let datums: &[D] = &[list];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("map_length", |b| {
+        let func = UnaryFunc::from(f::MapLength);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let map = sa.make_datum(|packer| {
+            packer.push_dict_with(|packer| {
+                packer.push(D::String("a"));
+                packer.push(D::Int32(1));
+                packer.push(D::String("b"));
+                packer.push(D::Int32(2));
+            });
+        });
+        let arena = RowArena::new();
+        let datums: &[D] = &[map];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- ACL / privileges ---
+
+    c.bench_function("mz_acl_item_grantor", |b| {
+        let func = UnaryFunc::from(f::MzAclItemGrantor);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = MzAclItem {
+            grantee: RoleId::User(1),
+            grantor: RoleId::User(2),
+            acl_mode: AclMode::empty(),
+        };
+        let datums: &[D] = &[D::MzAclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("mz_acl_item_grantee", |b| {
+        let func = UnaryFunc::from(f::MzAclItemGrantee);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = MzAclItem {
+            grantee: RoleId::User(1),
+            grantor: RoleId::User(2),
+            acl_mode: AclMode::empty(),
+        };
+        let datums: &[D] = &[D::MzAclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("mz_acl_item_privileges", |b| {
+        let func = UnaryFunc::from(f::MzAclItemPrivileges);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = MzAclItem {
+            grantee: RoleId::User(1),
+            grantor: RoleId::User(2),
+            acl_mode: AclMode::empty(),
+        };
+        let datums: &[D] = &[D::MzAclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    bench_unary!(c, mz_format_privileges, f::MzFormatPrivileges, "r");
+    bench_unary!(c, mz_validate_privileges, f::MzValidatePrivileges, "r");
+    bench_unary!(
+        c,
+        mz_validate_role_privilege,
+        f::MzValidateRolePrivilege,
+        "USAGE"
+    );
+
+    c.bench_function("acl_item_grantor", |b| {
+        let func = UnaryFunc::from(f::AclItemGrantor);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = AclItem::empty(Oid(1), Oid(2));
+        let datums: &[D] = &[D::AclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("acl_item_grantee", |b| {
+        let func = UnaryFunc::from(f::AclItemGrantee);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = AclItem::empty(Oid(1), Oid(2));
+        let datums: &[D] = &[D::AclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("acl_item_privileges", |b| {
+        let func = UnaryFunc::from(f::AclItemPrivileges);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let item = AclItem::empty(Oid(1), Oid(2));
+        let datums: &[D] = &[D::AclItem(item)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    // --- Misc ---
+
+    bench_unary!(c, mz_type_name, f::MzTypeName, D::UInt32(25)); // text oid
+    bench_unary!(
+        c,
+        try_parse_monotonic_iso8601_timestamp,
+        f::TryParseMonotonicIso8601Timestamp,
+        "2024-01-15T12:30:45Z",
+    );
+
+    c.bench_function("pg_column_size", |b| {
+        let func = UnaryFunc::from(f::PgColumnSize);
+        let a = MirScalarExpr::column(0);
+        let arena = RowArena::new();
+        let datums: &[D] = &[D::Int32(42)];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
+
+    c.bench_function("mz_row_size", |b| {
+        let func = UnaryFunc::from(f::MzRowSize);
+        let a = MirScalarExpr::column(0);
+        let sa = RowArena::new();
+        let list =
+            sa.make_datum(|packer| packer.push_list(&[D::Int32(1), D::Int32(2), D::Int32(3)]));
+        let arena = RowArena::new();
+        let datums: &[D] = &[list];
+        b.iter(|| func.eval(datums, &arena, &a));
+    });
 }
 
 // Benchmark registration
 
-benchmark_group!(
-    arithmetic_benches,
-    // Boolean
-    not,
-    is_null,
-    is_true,
-    is_false,
-    // Neg
-    neg_int16,
-    neg_int16_error,
-    neg_int32,
-    neg_int32_error,
-    neg_int64,
-    neg_int64_error,
-    neg_float32,
-    neg_float64,
-    neg_numeric,
-    neg_interval,
-    // Abs
-    abs_int16,
-    abs_int32,
-    abs_int64,
-    abs_float32,
-    abs_float64,
-    abs_numeric,
-    // BitNot
-    bit_not_int16,
-    bit_not_int32,
-    bit_not_int64,
-    bit_not_uint16,
-    bit_not_uint32,
-    bit_not_uint64 // Sqrt/Cbrt, Ceil/Floor/Round/Trunc, Log/Ln/Exp, Trig, Degrees/Radians
-                   // are in *_group functions via benchmark_main
-);
-
-benchmark_group!(
-    cast_benches,
-    // Bool
-    cast_bool_to_string,
-    cast_bool_to_string_nonstandard,
-    cast_bool_to_int32,
-    cast_bool_to_int64,
-    // Int16
-    cast_int16_to_float32,
-    cast_int16_to_float64,
-    cast_int16_to_int32,
-    cast_int16_to_int64,
-    cast_int16_to_uint16,
-    cast_int16_to_uint32,
-    cast_int16_to_uint64,
-    cast_int16_to_string,
-    cast_int16_to_numeric,
-    // Int32
-    cast_int32_to_bool,
-    cast_int32_to_float32,
-    cast_int32_to_float64,
-    cast_int32_to_int16,
-    cast_int32_to_int64,
-    cast_int32_to_uint16,
-    cast_int32_to_uint32,
-    cast_int32_to_uint64,
-    cast_int32_to_string,
-    cast_int32_to_oid,
-    cast_int32_to_numeric,
-    // Int64
-    cast_int64_to_int16,
-    cast_int64_to_int32,
-    cast_int64_to_uint16,
-    cast_int64_to_uint32,
-    cast_int64_to_uint64,
-    cast_int64_to_bool,
-    cast_int64_to_float32,
-    cast_int64_to_float64,
-    cast_int64_to_string,
-    cast_int64_to_oid,
-    cast_int64_to_numeric,
-    // Uint16
-    cast_uint16_to_uint32,
-    cast_uint16_to_uint64,
-    cast_uint16_to_int16,
-    cast_uint16_to_int32,
-    cast_uint16_to_int64,
-    cast_uint16_to_float32,
-    cast_uint16_to_float64,
-    cast_uint16_to_string,
-    cast_uint16_to_numeric,
-    // Uint32
-    cast_uint32_to_uint16,
-    cast_uint32_to_uint64,
-    cast_uint32_to_int16,
-    cast_uint32_to_int32,
-    cast_uint32_to_int64,
-    cast_uint32_to_float32,
-    cast_uint32_to_float64,
-    cast_uint32_to_string,
-    cast_uint32_to_numeric,
-    // Uint64
-    cast_uint64_to_uint16,
-    cast_uint64_to_uint32,
-    cast_uint64_to_int16,
-    cast_uint64_to_int32,
-    cast_uint64_to_int64,
-    cast_uint64_to_float32,
-    cast_uint64_to_float64,
-    cast_uint64_to_string,
-    cast_uint64_to_numeric,
-    // Float32
-    cast_float32_to_int16,
-    cast_float32_to_int32,
-    cast_float32_to_int64,
-    cast_float32_to_uint16,
-    cast_float32_to_uint32,
-    cast_float32_to_uint64,
-    cast_float32_to_float64,
-    cast_float32_to_string,
-    cast_float32_to_numeric,
-    // Float64
-    cast_float64_to_int16,
-    cast_float64_to_int32,
-    cast_float64_to_int64,
-    cast_float64_to_uint16,
-    cast_float64_to_uint32,
-    cast_float64_to_uint64,
-    cast_float64_to_float32,
-    cast_float64_to_string,
-    cast_float64_to_numeric,
-    // Numeric
-    cast_numeric_to_float32,
-    cast_numeric_to_float64,
-    cast_numeric_to_int16,
-    cast_numeric_to_int32,
-    cast_numeric_to_int64,
-    cast_numeric_to_uint16,
-    cast_numeric_to_uint32,
-    cast_numeric_to_uint64,
-    cast_numeric_to_string,
-    // String parsing
-    cast_string_to_bool,
-    cast_string_to_int16,
-    cast_string_to_int32,
-    cast_string_to_int64,
-    cast_string_to_uint16,
-    cast_string_to_uint32,
-    cast_string_to_uint64,
-    cast_string_to_float32,
-    cast_string_to_float64,
-    cast_string_to_date,
-    cast_string_to_time,
-    cast_string_to_timestamp,
-    cast_string_to_timestamp_tz,
-    cast_string_to_interval,
-    cast_string_to_uuid,
-    cast_string_to_jsonb,
-    cast_string_to_bytes,
-    // Other casts
-    cast_oid_to_int32,
-    cast_oid_to_int64,
-    cast_oid_to_string,
-    cast_uuid_to_string,
-    cast_bytes_to_string,
-    cast_jsonb_to_string,
-    cast_jsonb_to_int16,
-    cast_jsonb_to_int32,
-    cast_jsonb_to_int64,
-    cast_jsonb_to_float32,
-    cast_jsonb_to_float64,
-    cast_jsonb_to_bool,
-    // Timestamp/Date casts
-    cast_date_to_timestamp,
-    cast_date_to_timestamp_tz,
-    cast_timestamp_to_date,
-    cast_timestamp_to_time,
-    cast_timestamp_to_string,
-    cast_timestamp_to_timestamp_tz,
-    cast_timestamp_tz_to_date,
-    cast_timestamp_tz_to_timestamp,
-    cast_timestamp_tz_to_string,
-    cast_timestamp_tz_to_time,
-    to_timestamp,
-    // MzTimestamp casts
-    cast_mz_timestamp_to_string,
-    cast_mz_timestamp_to_timestamp,
-    cast_mz_timestamp_to_timestamp_tz,
-    cast_string_to_mz_timestamp,
-    cast_uint64_to_mz_timestamp,
-    cast_uint32_to_mz_timestamp,
-    cast_int64_to_mz_timestamp,
-    cast_int32_to_mz_timestamp,
-    cast_numeric_to_mz_timestamp,
-    cast_timestamp_to_mz_timestamp,
-    cast_timestamp_tz_to_mz_timestamp,
-    cast_date_to_mz_timestamp,
-    step_mz_timestamp,
-    // PgLegacyChar / Char / VarChar
-    cast_int32_to_pg_legacy_char,
-    cast_string_to_pg_legacy_char,
-    cast_string_to_pg_legacy_name,
-    cast_pg_legacy_char_to_string,
-    cast_pg_legacy_char_to_char,
-    cast_pg_legacy_char_to_var_char,
-    cast_pg_legacy_char_to_int32,
-    cast_string_to_char,
-    cast_string_to_var_char,
-    cast_char_to_string,
-    cast_var_char_to_string,
-    pad_char,
-    // OID / Reg*
-    cast_oid_to_reg_class,
-    cast_reg_class_to_oid,
-    cast_oid_to_reg_proc,
-    cast_reg_proc_to_oid,
-    cast_oid_to_reg_type,
-    cast_reg_type_to_oid,
-    cast_string_to_oid,
-    // Jsonb extras
-    jsonb_array_length,
-    jsonb_strip_nulls,
-    cast_jsonbable_to_jsonb,
-    cast_jsonb_to_numeric,
-    // Numeric extras
-    adjust_numeric_scale,
-    cast_string_to_numeric,
-    // Int2Vector
-    cast_string_to_int2_vector,
-    cast_int2_vector_to_string,
-    cast_int2_vector_to_array
-);
-
-benchmark_group!(
-    remaining_benches,
-    // String operations
-    upper,
-    lower,
-    initcap,
-    trim_whitespace,
-    trim_leading_whitespace,
-    trim_trailing_whitespace,
-    ascii,
-    char_length,
-    bit_length_bytes,
-    bit_length_string,
-    byte_length_bytes,
-    byte_length_string,
-    bit_count_bytes,
-    chr,
-    reverse,
-    quote_ident,
-    pg_size_pretty,
-    // Jsonb
-    jsonb_typeof,
-    jsonb_pretty,
-    // Date/time
-    justify_days,
-    justify_hours,
-    justify_interval,
-    cast_date_to_string,
-    cast_time_to_string,
-    cast_interval_to_string,
-    cast_interval_to_time,
-    cast_time_to_interval,
-    // Hash functions
-    crc32_bytes,
-    crc32_string,
-    kafka_murmur2_bytes,
-    kafka_murmur2_string,
-    seahash_bytes,
-    seahash_string,
-    // Extract / DatePart / DateTrunc
-    extract_interval,
-    extract_time,
-    extract_timestamp,
-    extract_timestamp_tz,
-    extract_date,
-    date_part_interval,
-    date_part_time,
-    date_part_timestamp,
-    date_part_timestamp_tz,
-    date_trunc_timestamp,
-    date_trunc_timestamp_tz,
-    adjust_timestamp_precision,
-    adjust_timestamp_tz_precision,
-    // Timezone
-    timezone_timestamp,
-    timezone_timestamp_tz,
-    timezone_time,
-    // Pattern matching
-    is_like_match,
-    is_regexp_match,
-    regexp_match_unary,
-    regexp_split_to_array_unary,
-    // Range
-    bench_range_empty,
-    bench_range_lower_inc,
-    bench_range_upper_inc,
-    bench_range_lower_inf,
-    bench_range_upper_inf,
-    bench_range_lower,
-    bench_range_upper,
-    // Collection ops
-    list_length,
-    map_length,
-    // ACL / privileges
-    mz_acl_item_grantor,
-    mz_acl_item_grantee,
-    mz_acl_item_privileges,
-    mz_format_privileges,
-    mz_validate_privileges,
-    mz_validate_role_privilege,
-    acl_item_grantor,
-    acl_item_grantee,
-    acl_item_privileges,
-    // Misc
-    mz_type_name,
-    try_parse_monotonic_iso8601_timestamp,
-    pg_column_size,
-    mz_row_size
-);
-
-benchmark_main!(
-    arithmetic_benches,
-    cast_benches,
-    remaining_benches,
-    // Multi-input benchmark groups (each input is a separate benchmark entry)
-    sqrt_float64_group,
-    sqrt_numeric_group,
-    cbrt_float64_group,
-    ceil_float32_group,
-    ceil_float64_group,
-    ceil_numeric_group,
-    floor_float32_group,
-    floor_float64_group,
-    floor_numeric_group,
-    round_float32_group,
-    round_float64_group,
-    round_numeric_group,
-    trunc_float32_group,
-    trunc_float64_group,
-    trunc_numeric_group,
-    log10_group,
-    log10_numeric_group,
-    ln_group,
-    ln_numeric_group,
-    exp_group,
-    exp_numeric_group,
-    cos_group,
-    acos_group,
-    cosh_group,
-    acosh_group,
-    sin_group,
-    asin_group,
-    sinh_group,
-    asinh_group,
-    tan_group,
-    atan_group,
-    tanh_group,
-    atanh_group,
-    cot_group,
-    degrees_group,
-    radians_group
-);
+criterion_group!(benches, arithmetic_benches, cast_benches, remaining_benches);
+criterion_main!(benches);

--- a/src/expr/benches/bench_variadic.rs
+++ b/src/expr/benches/bench_variadic.rs
@@ -7,268 +7,245 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bencher::{Bencher, benchmark_group, benchmark_main};
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use criterion::{Criterion, criterion_group, criterion_main};
+use mz_expr::func::variadic as v;
 use mz_expr::{MirScalarExpr, VariadicFunc};
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, RowArena};
 
-use VariadicFunc::*;
-
 macro_rules! bench_variadic {
-    ($bench_name:ident, $variant:expr, $( $datum:expr ),+ $(,)? ) => {
-        fn $bench_name(b: &mut Bencher) {
-            let func = $variant;
+    ($c:expr, $bench_name:ident, $variant:expr, $( $datum:expr ),+ $(,)? ) => {
+        $c.bench_function(stringify!($bench_name), |b| {
+            let func = VariadicFunc::from($variant);
             let datums: &[Datum] = &[ $( ($datum).into() ),+ ];
             let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
             let arena = RowArena::new();
             b.iter(|| func.eval(datums, &arena, &exprs));
-        }
+        });
     };
 }
 
 // Logic / comparison
 
-bench_variadic!(coalesce, Coalesce, 1i32, 2i32);
-bench_variadic!(greatest, Greatest, 10i32, 20i32, 5i32);
-bench_variadic!(least, Least, 10i32, 20i32, 5i32);
-bench_variadic!(and, And, true, true, true);
-bench_variadic!(or, Or, true, true, true);
-bench_variadic!(error_if_null, ErrorIfNull, 42i32, "value was null");
+fn logic_string_benches(c: &mut Criterion) {
+    bench_variadic!(c, coalesce, v::Coalesce, 1i32, 2i32);
+    bench_variadic!(c, greatest, v::Greatest, 10i32, 20i32, 5i32);
+    bench_variadic!(c, least, v::Least, 10i32, 20i32, 5i32);
+    bench_variadic!(c, and, v::And, true, true, true);
+    bench_variadic!(c, or, v::Or, true, true, true);
+    bench_variadic!(c, error_if_null, v::ErrorIfNull, 42i32, "value was null");
 
-// String functions
+    // String functions
 
-bench_variadic!(concat, Concat, "hello", " ", "world");
-bench_variadic!(concat_ws, ConcatWs, ", ", "one", "two", "three");
-bench_variadic!(substr, Substr, "hello world", 7i32, 5i32);
-bench_variadic!(replace, Replace, "hello world", "world", "rust");
-bench_variadic!(translate, Translate, "hello", "helo", "HELO");
-bench_variadic!(split_part, SplitPart, "one.two.three", ".", 2i32);
-bench_variadic!(pad_leading, PadLeading, "hi", 10i32, "*");
-bench_variadic!(regexp_match, RegexpMatch, "hello world 42", "(\\d+)");
+    bench_variadic!(c, concat, v::Concat, "hello", " ", "world");
+    bench_variadic!(c, concat_ws, v::ConcatWs, ", ", "one", "two", "three");
+    bench_variadic!(c, substr, v::Substr, "hello world", 7i32, 5i32);
+    bench_variadic!(c, replace, v::Replace, "hello world", "world", "rust");
+    bench_variadic!(c, translate, v::Translate, "hello", "helo", "HELO");
+    bench_variadic!(c, split_part, v::SplitPart, "one.two.three", ".", 2i32);
+    bench_variadic!(c, pad_leading, v::PadLeading, "hi", 10i32, "*");
+    bench_variadic!(c, regexp_match, v::RegexpMatch, "hello world 42", "(\\d+)");
 
-bench_variadic!(
-    regexp_split_to_array,
-    RegexpSplitToArray,
-    "one1two2three",
-    "\\d"
-);
+    bench_variadic!(
+        c,
+        regexp_split_to_array,
+        v::RegexpSplitToArray,
+        "one1two2three",
+        "\\d"
+    );
 
-bench_variadic!(
-    regexp_replace,
-    RegexpReplace,
-    "hello world",
-    "wo.ld",
-    "rust"
-);
+    bench_variadic!(
+        c,
+        regexp_replace,
+        v::RegexpReplace,
+        "hello world",
+        "wo.ld",
+        "rust"
+    );
 
-bench_variadic!(string_to_array, StringToArray, "one,two,three", ",");
+    bench_variadic!(c, string_to_array, v::StringToArray, "one,two,three", ",");
+}
 
 // JSON functions
 
-bench_variadic!(jsonb_build_array, JsonbBuildArray, 1i32, "two", true);
+fn json_crypto_benches(c: &mut Criterion) {
+    bench_variadic!(c, jsonb_build_array, v::JsonbBuildArray, 1i32, "two", true);
 
-bench_variadic!(
-    jsonb_build_object,
-    JsonbBuildObject,
-    "key1",
-    1i32,
-    "key2",
-    "value2"
-);
+    bench_variadic!(
+        c,
+        jsonb_build_object,
+        v::JsonbBuildObject,
+        "key1",
+        1i32,
+        "key2",
+        "value2"
+    );
 
-// HMAC / crypto
+    // HMAC / crypto
 
-bench_variadic!(hmac_string, HmacString, "hello", "secret", "sha256");
+    bench_variadic!(c, hmac_string, v::HmacString, "hello", "secret", "sha256");
 
-bench_variadic!(
-    hmac_bytes,
-    HmacBytes,
-    Datum::Bytes(&[1, 2, 3, 4]),
-    Datum::Bytes(&[5, 6, 7, 8]),
-    "sha256"
-);
+    bench_variadic!(
+        c,
+        hmac_bytes,
+        v::HmacBytes,
+        Datum::Bytes(&[1, 2, 3, 4]),
+        Datum::Bytes(&[5, 6, 7, 8]),
+        "sha256"
+    );
+}
 
 // Timestamp / date functions (hand-written due to complex datum construction)
 
-fn bench_make_timestamp(b: &mut Bencher) {
-    let func = MakeTimestamp;
-    let datums: &[Datum] = &[
-        2024i64.into(),
-        1i64.into(),
-        15i64.into(),
-        12i64.into(),
-        30i64.into(),
-        45.0f64.into(),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
+fn timestamp_benches(c: &mut Criterion) {
+    c.bench_function("bench_make_timestamp", |b| {
+        let func = VariadicFunc::from(v::MakeTimestamp);
+        let datums: &[Datum] = &[
+            2024i64.into(),
+            1i64.into(),
+            15i64.into(),
+            12i64.into(),
+            30i64.into(),
+            45.0f64.into(),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_bin_timestamp", |b| {
+        let func = VariadicFunc::from(v::DateBinTimestamp);
+        let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
+        let ts = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap(),
+        )
+        .unwrap();
+        let origin = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        )
+        .unwrap();
+        let datums: &[Datum] = &[
+            Datum::Interval(interval),
+            Datum::Timestamp(ts),
+            Datum::Timestamp(origin),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_bin_timestamp_tz", |b| {
+        let func = VariadicFunc::from(v::DateBinTimestampTz);
+        let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
+        let ts = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+        )
+        .unwrap();
+        let origin = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let datums: &[Datum] = &[
+            Datum::Interval(interval),
+            Datum::TimestampTz(ts),
+            Datum::TimestampTz(origin),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_diff_timestamp", |b| {
+        let func = VariadicFunc::from(v::DateDiffTimestamp);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            NaiveDate::from_ymd_opt(2024, 6, 20)
+                .unwrap()
+                .and_hms_opt(8, 15, 30)
+                .unwrap(),
+        )
+        .unwrap();
+        let datums: &[Datum] = &["day".into(), Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_diff_timestamp_tz", |b| {
+        let func = VariadicFunc::from(v::DateDiffTimestampTz);
+        let ts1 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+        )
+        .unwrap();
+        let ts2 = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 6, 20, 8, 15, 30).unwrap(),
+        )
+        .unwrap();
+        let datums: &[Datum] = &[
+            "day".into(),
+            Datum::TimestampTz(ts1),
+            Datum::TimestampTz(ts2),
+        ];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_diff_date", |b| {
+        let func = VariadicFunc::from(v::DateDiffDate);
+        let d1 = Date::from_pg_epoch(8_415).unwrap(); // ~2024-01-15
+        let d2 = Date::from_pg_epoch(8_572).unwrap(); // ~2024-06-20
+        let datums: &[Datum] = &["day".into(), Datum::Date(d1), Datum::Date(d2)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_date_diff_time", |b| {
+        let func = VariadicFunc::from(v::DateDiffTime);
+        let t1 = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
+        let t2 = NaiveTime::from_hms_opt(18, 45, 30).unwrap();
+        let datums: &[Datum] = &["hour".into(), Datum::Time(t1), Datum::Time(t2)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
+
+    c.bench_function("bench_timezone_time", |b| {
+        let func = VariadicFunc::from(v::TimezoneTime);
+        let t = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
+        let wall = CheckedTimestamp::from_timestamplike(
+            Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+        )
+        .unwrap();
+        let datums: &[Datum] = &["UTC".into(), Datum::Time(t), Datum::TimestampTz(wall)];
+        let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+        let arena = RowArena::new();
+        b.iter(|| func.eval(datums, &arena, &exprs));
+    });
 }
 
-fn bench_date_bin_timestamp(b: &mut Bencher) {
-    let func = DateBinTimestamp;
-    let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
-    let ts = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 30, 45)
-            .unwrap(),
-    )
-    .unwrap();
-    let origin = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 1)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap(),
-    )
-    .unwrap();
-    let datums: &[Datum] = &[
-        Datum::Interval(interval),
-        Datum::Timestamp(ts),
-        Datum::Timestamp(origin),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
+// Benchmark registration
 
-fn bench_date_bin_timestamp_tz(b: &mut Bencher) {
-    let func = DateBinTimestampTz;
-    let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
-    let ts = CheckedTimestamp::from_timestamplike(
-        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
-    )
-    .unwrap();
-    let origin =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
-            .unwrap();
-    let datums: &[Datum] = &[
-        Datum::Interval(interval),
-        Datum::TimestampTz(ts),
-        Datum::TimestampTz(origin),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-fn bench_date_diff_timestamp(b: &mut Bencher) {
-    let func = DateDiffTimestamp;
-    let ts1 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 1, 15)
-            .unwrap()
-            .and_hms_opt(12, 30, 45)
-            .unwrap(),
-    )
-    .unwrap();
-    let ts2 = CheckedTimestamp::from_timestamplike(
-        NaiveDate::from_ymd_opt(2024, 6, 20)
-            .unwrap()
-            .and_hms_opt(8, 15, 30)
-            .unwrap(),
-    )
-    .unwrap();
-    let datums: &[Datum] = &["day".into(), Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-fn bench_date_diff_timestamp_tz(b: &mut Bencher) {
-    let func = DateDiffTimestampTz;
-    let ts1 = CheckedTimestamp::from_timestamplike(
-        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
-    )
-    .unwrap();
-    let ts2 =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 20, 8, 15, 30).unwrap())
-            .unwrap();
-    let datums: &[Datum] = &[
-        "day".into(),
-        Datum::TimestampTz(ts1),
-        Datum::TimestampTz(ts2),
-    ];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-fn bench_date_diff_date(b: &mut Bencher) {
-    let func = DateDiffDate;
-    let d1 = Date::from_pg_epoch(8_415).unwrap(); // ~2024-01-15
-    let d2 = Date::from_pg_epoch(8_572).unwrap(); // ~2024-06-20
-    let datums: &[Datum] = &["day".into(), Datum::Date(d1), Datum::Date(d2)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-fn bench_date_diff_time(b: &mut Bencher) {
-    let func = DateDiffTime;
-    let t1 = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
-    let t2 = NaiveTime::from_hms_opt(18, 45, 30).unwrap();
-    let datums: &[Datum] = &["hour".into(), Datum::Time(t1), Datum::Time(t2)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-fn bench_timezone_time(b: &mut Bencher) {
-    let func = TimezoneTime;
-    let t = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
-    let wall =
-        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
-            .unwrap();
-    let datums: &[Datum] = &["UTC".into(), Datum::Time(t), Datum::TimestampTz(wall)];
-    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
-    let arena = RowArena::new();
-    b.iter(|| func.eval(datums, &arena, &exprs));
-}
-
-// Benchmark groups
-
-benchmark_group!(
+criterion_group!(
+    benches,
     logic_string_benches,
-    coalesce,
-    greatest,
-    least,
-    and,
-    or,
-    error_if_null,
-    concat,
-    concat_ws,
-    substr,
-    replace,
-    translate,
-    split_part,
-    pad_leading,
-    regexp_match,
-    regexp_split_to_array,
-    regexp_replace,
-    string_to_array
-);
-
-benchmark_group!(
     json_crypto_benches,
-    jsonb_build_array,
-    jsonb_build_object,
-    hmac_string,
-    hmac_bytes
+    timestamp_benches
 );
-
-benchmark_group!(
-    timestamp_benches,
-    bench_make_timestamp,
-    bench_date_bin_timestamp,
-    bench_date_bin_timestamp_tz,
-    bench_date_diff_timestamp,
-    bench_date_diff_timestamp_tz,
-    bench_date_diff_date,
-    bench_date_diff_time,
-    bench_timezone_time
-);
-
-benchmark_main!(logic_string_benches, json_crypto_benches, timestamp_benches);
+criterion_main!(benches);

--- a/src/expr/benches/bench_variadic.rs
+++ b/src/expr/benches/bench_variadic.rs
@@ -1,0 +1,274 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bencher::{Bencher, benchmark_group, benchmark_main};
+use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use mz_expr::{MirScalarExpr, VariadicFunc};
+use mz_repr::adt::date::Date;
+use mz_repr::adt::interval::Interval;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, RowArena};
+
+use VariadicFunc::*;
+
+macro_rules! bench_variadic {
+    ($bench_name:ident, $variant:expr, $( $datum:expr ),+ $(,)? ) => {
+        fn $bench_name(b: &mut Bencher) {
+            let func = $variant;
+            let datums: &[Datum] = &[ $( ($datum).into() ),+ ];
+            let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+            let arena = RowArena::new();
+            b.iter(|| func.eval(datums, &arena, &exprs));
+        }
+    };
+}
+
+// Logic / comparison
+
+bench_variadic!(coalesce, Coalesce, 1i32, 2i32);
+bench_variadic!(greatest, Greatest, 10i32, 20i32, 5i32);
+bench_variadic!(least, Least, 10i32, 20i32, 5i32);
+bench_variadic!(and, And, true, true, true);
+bench_variadic!(or, Or, true, true, true);
+bench_variadic!(error_if_null, ErrorIfNull, 42i32, "value was null");
+
+// String functions
+
+bench_variadic!(concat, Concat, "hello", " ", "world");
+bench_variadic!(concat_ws, ConcatWs, ", ", "one", "two", "three");
+bench_variadic!(substr, Substr, "hello world", 7i32, 5i32);
+bench_variadic!(replace, Replace, "hello world", "world", "rust");
+bench_variadic!(translate, Translate, "hello", "helo", "HELO");
+bench_variadic!(split_part, SplitPart, "one.two.three", ".", 2i32);
+bench_variadic!(pad_leading, PadLeading, "hi", 10i32, "*");
+bench_variadic!(regexp_match, RegexpMatch, "hello world 42", "(\\d+)");
+
+bench_variadic!(
+    regexp_split_to_array,
+    RegexpSplitToArray,
+    "one1two2three",
+    "\\d"
+);
+
+bench_variadic!(
+    regexp_replace,
+    RegexpReplace,
+    "hello world",
+    "wo.ld",
+    "rust"
+);
+
+bench_variadic!(string_to_array, StringToArray, "one,two,three", ",");
+
+// JSON functions
+
+bench_variadic!(jsonb_build_array, JsonbBuildArray, 1i32, "two", true);
+
+bench_variadic!(
+    jsonb_build_object,
+    JsonbBuildObject,
+    "key1",
+    1i32,
+    "key2",
+    "value2"
+);
+
+// HMAC / crypto
+
+bench_variadic!(hmac_string, HmacString, "hello", "secret", "sha256");
+
+bench_variadic!(
+    hmac_bytes,
+    HmacBytes,
+    Datum::Bytes(&[1, 2, 3, 4]),
+    Datum::Bytes(&[5, 6, 7, 8]),
+    "sha256"
+);
+
+// Timestamp / date functions (hand-written due to complex datum construction)
+
+fn bench_make_timestamp(b: &mut Bencher) {
+    let func = MakeTimestamp;
+    let datums: &[Datum] = &[
+        2024i64.into(),
+        1i64.into(),
+        15i64.into(),
+        12i64.into(),
+        30i64.into(),
+        45.0f64.into(),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_bin_timestamp(b: &mut Bencher) {
+    let func = DateBinTimestamp;
+    let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
+    let ts = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap();
+    let origin = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+    )
+    .unwrap();
+    let datums: &[Datum] = &[
+        Datum::Interval(interval),
+        Datum::Timestamp(ts),
+        Datum::Timestamp(origin),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_bin_timestamp_tz(b: &mut Bencher) {
+    let func = DateBinTimestampTz;
+    let interval = Interval::new(0, 0, 3_600_000_000); // 1 hour
+    let ts = CheckedTimestamp::from_timestamplike(
+        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+    )
+    .unwrap();
+    let origin =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+            .unwrap();
+    let datums: &[Datum] = &[
+        Datum::Interval(interval),
+        Datum::TimestampTz(ts),
+        Datum::TimestampTz(origin),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_diff_timestamp(b: &mut Bencher) {
+    let func = DateDiffTimestamp;
+    let ts1 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap(),
+    )
+    .unwrap();
+    let ts2 = CheckedTimestamp::from_timestamplike(
+        NaiveDate::from_ymd_opt(2024, 6, 20)
+            .unwrap()
+            .and_hms_opt(8, 15, 30)
+            .unwrap(),
+    )
+    .unwrap();
+    let datums: &[Datum] = &["day".into(), Datum::Timestamp(ts1), Datum::Timestamp(ts2)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_diff_timestamp_tz(b: &mut Bencher) {
+    let func = DateDiffTimestampTz;
+    let ts1 = CheckedTimestamp::from_timestamplike(
+        Utc.with_ymd_and_hms(2024, 1, 15, 12, 30, 45).unwrap(),
+    )
+    .unwrap();
+    let ts2 =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 6, 20, 8, 15, 30).unwrap())
+            .unwrap();
+    let datums: &[Datum] = &[
+        "day".into(),
+        Datum::TimestampTz(ts1),
+        Datum::TimestampTz(ts2),
+    ];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_diff_date(b: &mut Bencher) {
+    let func = DateDiffDate;
+    let d1 = Date::from_pg_epoch(8_415).unwrap(); // ~2024-01-15
+    let d2 = Date::from_pg_epoch(8_572).unwrap(); // ~2024-06-20
+    let datums: &[Datum] = &["day".into(), Datum::Date(d1), Datum::Date(d2)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_date_diff_time(b: &mut Bencher) {
+    let func = DateDiffTime;
+    let t1 = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
+    let t2 = NaiveTime::from_hms_opt(18, 45, 30).unwrap();
+    let datums: &[Datum] = &["hour".into(), Datum::Time(t1), Datum::Time(t2)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+fn bench_timezone_time(b: &mut Bencher) {
+    let func = TimezoneTime;
+    let t = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
+    let wall =
+        CheckedTimestamp::from_timestamplike(Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap())
+            .unwrap();
+    let datums: &[Datum] = &["UTC".into(), Datum::Time(t), Datum::TimestampTz(wall)];
+    let exprs: Vec<MirScalarExpr> = (0..datums.len()).map(MirScalarExpr::column).collect();
+    let arena = RowArena::new();
+    b.iter(|| func.eval(datums, &arena, &exprs));
+}
+
+// Benchmark groups
+
+benchmark_group!(
+    logic_string_benches,
+    coalesce,
+    greatest,
+    least,
+    and,
+    or,
+    error_if_null,
+    concat,
+    concat_ws,
+    substr,
+    replace,
+    translate,
+    split_part,
+    pad_leading,
+    regexp_match,
+    regexp_split_to_array,
+    regexp_replace,
+    string_to_array
+);
+
+benchmark_group!(
+    json_crypto_benches,
+    jsonb_build_array,
+    jsonb_build_object,
+    hmac_string,
+    hmac_bytes
+);
+
+benchmark_group!(
+    timestamp_benches,
+    bench_make_timestamp,
+    bench_date_bin_timestamp,
+    bench_date_bin_timestamp_tz,
+    bench_date_diff_timestamp,
+    bench_date_diff_timestamp_tz,
+    bench_date_diff_date,
+    bench_date_diff_time,
+    bench_timezone_time
+);
+
+benchmark_main!(logic_string_benches, json_crypto_benches, timestamp_benches);


### PR DESCRIPTION
## Summary
- Add comprehensive benchmarks for scalar function evaluation using the `bencher` crate
- Covers ~380 benchmark cases across binary (191), unary (213), and variadic (29) functions
- Multi-input macros (`bench_*_multi!`) evaluate diverse parameter values per iteration for math-sensitive functions (sqrt, trig, log, div, power) to avoid misleading results from "easy" inputs

## Key findings from initial run
- **Eval dispatch floor**: ~20 ns (irreducible cost of literal extraction + enum match + trait dispatch)
- **Numeric arithmetic is dramatically slower**: numeric sqrt is ~280x slower than float64, numeric log is ~1000x slower
- **Regex compilation per call**: variadic `RegexpMatch` ~47 us due to per-call regex compilation
- **ToChar**: ~81 us due to format string parsing per call

## Test plan
- [x] `cargo bench -p mz-expr --bench bench_binary` — 191 benchmarks pass
- [x] `cargo bench -p mz-expr --bench bench_unary` — 213 benchmarks pass
- [x] `cargo bench -p mz-expr --bench bench_variadic` — 29 benchmarks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)