### PR TITLE
crd: add extra volumes and volume mounts to environmentd

### DIFF
--- a/doc/user/data/self_managed/materialize_crd_descriptions.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions.json
@@ -115,6 +115,14 @@
         "deprecated": false
       },
       {
+        "name": "fdbClusterConfigMapName",
+        "type": "String",
+        "description": "The name of a ConfigMap containing a FoundationDB cluster file.\nThe ConfigMap must contain a `cluster-file` key whose value is the\nFoundationDB cluster file contents. When set, orchestratord will\nmount the cluster file and set the `FDB_CLUSTER_FILE` environment\nvariable automatically.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
+      {
         "name": "environmentdResourceRequirements",
         "type": "io.k8s.api.core.v1.ResourceRequirements",
         "description": "Resource requirements for the environmentd pod.",

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -107,6 +107,12 @@ pub mod v1alpha1 {
         pub environmentd_extra_args: Option<Vec<String>>,
         /// Extra environment variables to pass to the environmentd binary.
         pub environmentd_extra_env: Option<Vec<EnvVar>>,
+        /// The name of a ConfigMap containing a FoundationDB cluster file.
+        /// The ConfigMap must contain a `cluster-file` key whose value is
+        /// the FoundationDB cluster file contents. When set, orchestratord
+        /// will mount the cluster file and set the `FDB_CLUSTER_FILE`
+        /// environment variable automatically.
+        pub fdb_cluster_config_map_name: Option<String>,
         /// {{<warning>}}
         /// Deprecated.
         ///

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -974,6 +974,35 @@ fn create_environmentd_statefulset_object(
         args.extend(extra_args.iter().cloned());
     }
 
+    // Mount the FoundationDB cluster file if configured.
+    if let Some(ref name) = mz.spec.fdb_cluster_config_map_name {
+        volumes.push(Volume {
+            name: "fdb-cluster".to_string(),
+            config_map: Some(ConfigMapVolumeSource {
+                default_mode: Some(0o400),
+                name: name.to_owned(),
+                items: Some(vec![KeyToPath {
+                    key: "cluster-file".to_string(),
+                    path: "fdb.cluster".to_string(),
+                    ..Default::default()
+                }]),
+                optional: Some(false),
+            }),
+            ..Default::default()
+        });
+        volume_mounts.push(VolumeMount {
+            name: "fdb-cluster".to_string(),
+            mount_path: "/fdb-cluster".to_string(),
+            read_only: Some(true),
+            ..Default::default()
+        });
+        env.push(EnvVar {
+            name: "FDB_CLUSTER_FILE".to_string(),
+            value: Some("/fdb-cluster/fdb.cluster".to_string()),
+            ..Default::default()
+        });
+    }
+
     let probe = Probe {
         initial_delay_seconds: Some(1),
         failure_threshold: Some(12),


### PR DESCRIPTION
Add a dedicated `fdbClusterConfigMapName` field to the Materialize CRD spec. When set, orchestratord mounts the referenced ConfigMap (expecting a `cluster-file` key) and sets the `FDB_CLUSTER_FILE` environment variable automatically, following the same pattern as `systemParameterConfigmapName` and the license key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)