### PR TITLE
orchestratord test: Allow 2 min for initial reconciliation

### DIFF
--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1963,7 +1963,8 @@ def workflow_documentation_defaults(
             ["kubectl", "apply", "-f", os.path.join(dir, "sample-materialize.yaml")]
         )
 
-        for i in range(180):
+        # This should finish quickly, see https://github.com/MaterializeInc/database-issues/issues/10099
+        for i in range(120):
             try:
                 data = json.loads(
                     spawn.capture(


### PR DESCRIPTION
Test run: https://buildkite.com/materialize/nightly/builds/15335 
Should currently fail because of https://github.com/MaterializeInc/database-issues/issues/10099