### PR TITLE
Adapter: unify RBAC for Side Effecting Functions

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1376,6 +1376,7 @@ impl SessionClient {
                 | Command::CopyToPreflight { .. }
                 | Command::ExecuteCopyTo { .. }
                 | Command::ExecuteSideEffectingFunc { .. }
+                | Command::GetConnectionAuthenticatedRole { .. }
                 | Command::RegisterFrontendPeek { .. }
                 | Command::UnregisterFrontendPeek { .. }
                 | Command::ExplainTimestamp { .. }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1376,7 +1376,7 @@ impl SessionClient {
                 | Command::CopyToPreflight { .. }
                 | Command::ExecuteCopyTo { .. }
                 | Command::ExecuteSideEffectingFunc { .. }
-                | Command::GetConnectionAuthenticatedRole { .. }
+                | Command::LookupConnection { .. }
                 | Command::RegisterFrontendPeek { .. }
                 | Command::UnregisterFrontendPeek { .. }
                 | Command::ExplainTimestamp { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -332,8 +332,15 @@ pub enum Command {
         plan: SideEffectingFunc,
         conn_id: ConnectionId,
         /// The current role of the session, used for RBAC checks.
-        current_role: RoleId,
         tx: oneshot::Sender<Result<ExecuteResponse, AdapterError>>,
+    },
+
+    /// Look up the authenticated role for a connection by its raw connection ID.
+    /// Returns `Some(role_id)` if the connection exists, `None` otherwise.
+    /// Used by frontend peek sequencing to provide `active_conns` data to `rbac::check_plan`.
+    GetConnectionAuthenticatedRole {
+        connection_id: u32,
+        tx: oneshot::Sender<Option<RoleId>>,
     },
 
     /// Register a pending peek initiated by frontend sequencing. This is needed for:
@@ -409,6 +416,7 @@ impl Command {
             | Command::CopyToPreflight { .. }
             | Command::ExecuteCopyTo { .. }
             | Command::ExecuteSideEffectingFunc { .. }
+            | Command::GetConnectionAuthenticatedRole { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
             | Command::ExplainTimestamp { .. }
@@ -449,6 +457,7 @@ impl Command {
             | Command::CopyToPreflight { .. }
             | Command::ExecuteCopyTo { .. }
             | Command::ExecuteSideEffectingFunc { .. }
+            | Command::GetConnectionAuthenticatedRole { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
             | Command::ExplainTimestamp { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -335,12 +335,18 @@ pub enum Command {
         tx: oneshot::Sender<Result<ExecuteResponse, AdapterError>>,
     },
 
-    /// Look up the authenticated role for a connection by its raw connection ID.
-    /// Returns `Some(role_id)` if the connection exists, `None` otherwise.
-    /// Used by frontend peek sequencing to provide `active_conns` data to `rbac::check_plan`.
-    GetConnectionAuthenticatedRole {
+    /// Look up an active connection by its raw connection ID, returning its
+    /// `ConnectionId` handle and authenticated role, or `None` if there is no
+    /// such connection.
+    ///
+    /// While the caller holds the returned `ConnectionId` handle, the raw
+    /// connection ID cannot be reused by a new connection. Frontend peek
+    /// sequencing relies on this to ensure that the connection it performs an
+    /// RBAC check against is the same one that a subsequent
+    /// `ExecuteSideEffectingFunc` acts on.
+    LookupConnection {
         connection_id: u32,
-        tx: oneshot::Sender<Option<RoleId>>,
+        tx: oneshot::Sender<Option<(ConnectionId, RoleId)>>,
     },
 
     /// Register a pending peek initiated by frontend sequencing. This is needed for:
@@ -416,7 +422,7 @@ impl Command {
             | Command::CopyToPreflight { .. }
             | Command::ExecuteCopyTo { .. }
             | Command::ExecuteSideEffectingFunc { .. }
-            | Command::GetConnectionAuthenticatedRole { .. }
+            | Command::LookupConnection { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
             | Command::ExplainTimestamp { .. }
@@ -457,7 +463,7 @@ impl Command {
             | Command::CopyToPreflight { .. }
             | Command::ExecuteCopyTo { .. }
             | Command::ExecuteSideEffectingFunc { .. }
-            | Command::GetConnectionAuthenticatedRole { .. }
+            | Command::LookupConnection { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
             | Command::ExplainTimestamp { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -331,7 +331,6 @@ pub enum Command {
     ExecuteSideEffectingFunc {
         plan: SideEffectingFunc,
         conn_id: ConnectionId,
-        /// The current role of the session, used for RBAC checks.
         tx: oneshot::Sender<Result<ExecuteResponse, AdapterError>>,
     },
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -474,9 +474,7 @@ impl Message {
                 Command::CopyToPreflight { .. } => "copy-to-preflight",
                 Command::ExecuteCopyTo { .. } => "execute-copy-to",
                 Command::ExecuteSideEffectingFunc { .. } => "execute-side-effecting-func",
-                Command::GetConnectionAuthenticatedRole { .. } => {
-                    "get-connection-authenticated-role"
-                }
+                Command::LookupConnection { .. } => "lookup-connection",
                 Command::RegisterFrontendPeek { .. } => "register-frontend-peek",
                 Command::UnregisterFrontendPeek { .. } => "unregister-frontend-peek",
                 Command::ExplainTimestamp { .. } => "explain-timestamp",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -474,6 +474,9 @@ impl Message {
                 Command::CopyToPreflight { .. } => "copy-to-preflight",
                 Command::ExecuteCopyTo { .. } => "execute-copy-to",
                 Command::ExecuteSideEffectingFunc { .. } => "execute-side-effecting-func",
+                Command::GetConnectionAuthenticatedRole { .. } => {
+                    "get-connection-authenticated-role"
+                }
                 Command::RegisterFrontendPeek { .. } => "register-frontend-peek",
                 Command::UnregisterFrontendPeek { .. } => "unregister-frontend-peek",
                 Command::ExplainTimestamp { .. } => "explain-timestamp",

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -541,12 +541,14 @@ impl Coordinator {
                     let result = self.execute_side_effecting_func(plan, conn_id).await;
                     let _ = tx.send(result);
                 }
-                Command::GetConnectionAuthenticatedRole { connection_id, tx } => {
-                    let role = self
-                        .active_conns
-                        .get_key_value(&connection_id)
-                        .map(|(_, meta)| *meta.authenticated_role_id());
-                    let _ = tx.send(role);
+                Command::LookupConnection { connection_id, tx } => {
+                    let conn =
+                        self.active_conns
+                            .get_key_value(&connection_id)
+                            .map(|(id_handle, meta)| {
+                                (id_handle.clone(), *meta.authenticated_role_id())
+                            });
+                    let _ = tx.send(conn);
                 }
                 Command::RegisterFrontendPeek {
                     uuid,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -537,16 +537,16 @@ impl Coordinator {
                     .await;
                 }
 
-                Command::ExecuteSideEffectingFunc {
-                    plan,
-                    conn_id,
-                    current_role,
-                    tx,
-                } => {
-                    let result = self
-                        .execute_side_effecting_func(plan, conn_id, current_role)
-                        .await;
+                Command::ExecuteSideEffectingFunc { plan, conn_id, tx } => {
+                    let result = self.execute_side_effecting_func(plan, conn_id).await;
                     let _ = tx.send(result);
+                }
+                Command::GetConnectionAuthenticatedRole { connection_id, tx } => {
+                    let role = self
+                        .active_conns
+                        .get_key_value(&connection_id)
+                        .map(|(_, meta)| *meta.authenticated_role_id());
+                    let _ = tx.send(role);
                 }
                 Command::RegisterFrontendPeek {
                     uuid,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -36,7 +36,7 @@ use mz_sql::catalog::{CatalogError, SessionCatalog};
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
     self, AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, CreateSourcePlanBundle,
-    FetchPlan, HirScalarExpr, MutationKind, Params, Plan, PlanKind, RaisePlan,
+    FetchPlan, HirScalarExpr, MutationKind, Params, Plan, PlanKind, RaisePlan, SideEffectingFunc,
 };
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
@@ -187,16 +187,24 @@ impl Coordinator {
                 }
             }
 
+            // Look up the authenticated role of the connection targeted by
+            // pg_cancel_backend, which check_plan needs for its RBAC check.
+            // Linear search through active connections is fine because this
+            // happens at most once per statement.
+            let target_conn_role = match &plan {
+                Plan::SideEffectingFunc(SideEffectingFunc::PgCancelBackend {
+                    connection_id: Some(connection_id),
+                }) => self
+                    .active_conns()
+                    .into_iter()
+                    .find(|(conn_id, _)| conn_id.unhandled() == *connection_id)
+                    .map(|(_, conn_meta)| *conn_meta.authenticated_role_id()),
+                _ => None,
+            };
+
             if let Err(e) = rbac::check_plan(
                 &session_catalog,
-                Some(|id| {
-                    // We use linear search through active connections if needed, which is fine
-                    // because the RBAC check will call the closure at most once.
-                    self.active_conns()
-                        .into_iter()
-                        .find(|(conn_id, _)| conn_id.unhandled() == id)
-                        .map(|(_, conn_meta)| *conn_meta.authenticated_role_id())
-                }),
+                target_conn_role,
                 ctx.session(),
                 &plan,
                 target_cluster_id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2284,10 +2284,9 @@ impl Coordinator {
     }
 
     /// Execute a side-effecting function from the frontend peek path.
-    /// This is separate from `sequence_side_effecting_func` because
-    /// - It doesn't have an ExecuteContext.
-    /// - It needs to do its own RBAC check, because the `rbac::check_plan` call in the frontend
-    ///   peek sequencing can't look at `active_conns`.
+    /// This is separate from `sequence_side_effecting_func` because it doesn't have an
+    /// ExecuteContext. RBAC is checked by the caller via `rbac::check_plan` before
+    /// sending `Command::ExecuteSideEffectingFunc`.
     ///
     /// TODO(peek-seq): Delete `sequence_side_effecting_func` after we delete the old peek
     /// sequencing.
@@ -2295,7 +2294,6 @@ impl Coordinator {
         &mut self,
         plan: SideEffectingFunc,
         conn_id: ConnectionId,
-        current_role: RoleId,
     ) -> Result<ExecuteResponse, AdapterError> {
         match plan {
             SideEffectingFunc::PgCancelBackend { connection_id } => {
@@ -2312,36 +2310,11 @@ impl Coordinator {
                     return Err(AdapterError::Canceled);
                 }
 
-                // Perform RBAC check: the current user must be a member of the role
-                // that owns the connection being cancelled.
-                if let Some((_id_handle, conn_meta)) =
+                // check_plan already verified role membership.
+                if let Some((id_handle, _conn_meta)) =
                     self.active_conns.get_key_value(&connection_id)
                 {
-                    let target_role = *conn_meta.authenticated_role_id();
-                    let role_membership = self
-                        .catalog()
-                        .state()
-                        .collect_role_membership(&current_role);
-                    if !role_membership.contains(&target_role) {
-                        let target_role_name = self
-                            .catalog()
-                            .try_get_role(&target_role)
-                            .map(|role| role.name().to_string())
-                            .unwrap_or_else(|| target_role.to_string());
-                        return Err(AdapterError::Unauthorized(
-                            rbac::UnauthorizedError::RoleMembership {
-                                role_names: vec![target_role_name],
-                            },
-                        ));
-                    }
-
-                    // RBAC check passed, proceed with cancellation.
-                    let id_handle = self
-                        .active_conns
-                        .get_key_value(&connection_id)
-                        .map(|(id, _)| id.clone())
-                        .expect("checked above");
-                    self.handle_privileged_cancel(id_handle).await;
+                    self.handle_privileged_cancel(id_handle.clone()).await;
                     Ok(Self::send_immediate_rows(Row::pack_slice(&[Datum::True])))
                 } else {
                     // Connection not found, return false.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2286,7 +2286,10 @@ impl Coordinator {
     /// Execute a side-effecting function from the frontend peek path.
     /// This is separate from `sequence_side_effecting_func` because it doesn't have an
     /// ExecuteContext. RBAC is checked by the caller via `rbac::check_plan` before
-    /// sending `Command::ExecuteSideEffectingFunc`.
+    /// sending `Command::ExecuteSideEffectingFunc`. The caller must hold the target
+    /// connection's `ConnectionId` handle from its RBAC check until this command
+    /// completes, so that the connection found in `active_conns` here (if any) is
+    /// the same one the check was performed against.
     ///
     /// TODO(peek-seq): Delete `sequence_side_effecting_func` after we delete the old peek
     /// sequencing.
@@ -2310,7 +2313,10 @@ impl Coordinator {
                     return Err(AdapterError::Canceled);
                 }
 
-                // check_plan already verified role membership.
+                // The caller verified role membership via rbac::check_plan and
+                // still holds the target's `ConnectionId` handle, so this entry
+                // (if present) is the same connection the check was performed
+                // against.
                 if let Some((id_handle, _conn_meta)) =
                     self.active_conns.get_key_value(&connection_id)
                 {

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -24,7 +24,6 @@ use mz_ore::now::EpochMillis;
 use mz_ore::task::JoinHandle;
 use mz_ore::{soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
-use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, GlobalId, IntoRowIterator, Timestamp};
 use mz_sql::ast::Raw;
 use mz_sql::catalog::CatalogCluster;
@@ -436,11 +435,11 @@ impl PeekClient {
                         connection_id: None,
                     } => None,
                 };
-                let active_conns_role = target_conn.as_ref().map(|(_, role)| *role);
+                let target_conn_role = target_conn.as_ref().map(|(_, role)| *role);
 
                 rbac::check_plan(
                     &conn_catalog,
-                    Some(move |_id: u32| active_conns_role),
+                    target_conn_role,
                     session,
                     &plan,
                     None,
@@ -533,8 +532,8 @@ impl PeekClient {
         rbac::check_plan(
             &conn_catalog,
             // SideEffectingFunc is handled above (with its own check_plan call) and returns
-            // early, so active_conns is not needed for the remaining plan types here.
-            None::<fn(u32) -> Option<RoleId>>,
+            // early, so no target connection role is needed for the remaining plan types here.
+            None,
             session,
             &plan,
             Some(target_cluster_id),

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -414,13 +414,19 @@ impl PeekClient {
                 }
             }
             Plan::SideEffectingFunc(sef_plan) => {
-                // Fetch the authenticated role for the target connection so
+                // Look up the target connection's authenticated role, so that
                 // check_plan can perform RBAC for side-effecting functions.
-                let active_conns_role = match sef_plan {
+                //
+                // The RBAC check reflects the state at this point in time. A
+                // concurrent change to the issuer's role membership does not
+                // affect the already in-flight execution, similarly to how
+                // privilege changes don't affect other kinds of in-flight
+                // statements.
+                let target_conn = match sef_plan {
                     SideEffectingFunc::PgCancelBackend {
                         connection_id: Some(connection_id),
                     } => {
-                        self.call_coordinator(|tx| Command::GetConnectionAuthenticatedRole {
+                        self.call_coordinator(|tx| Command::LookupConnection {
                             connection_id: *connection_id,
                             tx,
                         })
@@ -430,6 +436,7 @@ impl PeekClient {
                         connection_id: None,
                     } => None,
                 };
+                let active_conns_role = target_conn.as_ref().map(|(_, role)| *role);
 
                 rbac::check_plan(
                     &conn_catalog,
@@ -449,6 +456,14 @@ impl PeekClient {
                         tx,
                     })
                     .await?;
+
+                // We held the target's `ConnectionId` handle from the RBAC
+                // check until the Coordinator executed the function, which
+                // prevented the raw connection ID from being reused by a new
+                // connection. So the connection the Coordinator acted on (if
+                // it found one) is the one whose role we checked above.
+                drop(target_conn);
+
                 return Ok(Some(response));
             }
             Plan::Subscribe(subscribe) => (QueryPlan::Subscribe(subscribe), ExplainContext::None),

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -30,7 +30,8 @@ use mz_sql::ast::Raw;
 use mz_sql::catalog::CatalogCluster;
 use mz_sql::plan::Params;
 use mz_sql::plan::{
-    self, Explainee, ExplaineeStatement, Plan, QueryWhen, SelectPlan, SubscribePlan,
+    self, Explainee, ExplaineeStatement, Plan, QueryWhen, SelectPlan, SideEffectingFunc,
+    SubscribePlan,
 };
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
@@ -413,14 +414,38 @@ impl PeekClient {
                 }
             }
             Plan::SideEffectingFunc(sef_plan) => {
-                // Side-effecting functions need Coordinator state (e.g., active_conns),
-                // so delegate to the Coordinator via a Command.
-                // The RBAC check is performed in the Coordinator where active_conns is available.
+                // Fetch the authenticated role for the target connection so
+                // check_plan can perform RBAC for side-effecting functions.
+                let active_conns_role = match sef_plan {
+                    SideEffectingFunc::PgCancelBackend {
+                        connection_id: Some(connection_id),
+                    } => {
+                        self.call_coordinator(|tx| Command::GetConnectionAuthenticatedRole {
+                            connection_id: *connection_id,
+                            tx,
+                        })
+                        .await
+                    }
+                    SideEffectingFunc::PgCancelBackend {
+                        connection_id: None,
+                    } => None,
+                };
+
+                rbac::check_plan(
+                    &conn_catalog,
+                    Some(move |_id: u32| active_conns_role),
+                    session,
+                    &plan,
+                    None,
+                    &resolved_ids,
+                    &sql_impl_ids,
+                )?;
+
+                // RBAC passed. Delegate execution to the Coordinator.
                 let response = self
                     .call_coordinator(|tx| Command::ExecuteSideEffectingFunc {
                         plan: sef_plan.clone(),
                         conn_id: session.conn_id().clone(),
-                        current_role: session.role_metadata().current_role,
                         tx,
                     })
                     .await?;
@@ -492,8 +517,8 @@ impl PeekClient {
 
         rbac::check_plan(
             &conn_catalog,
-            // We can't look at `active_conns` here, but that's ok, because this case was handled
-            // above already inside `Command::ExecuteSideEffectingFunc`.
+            // SideEffectingFunc is handled above (with its own check_plan call) and returns
+            // early, so active_conns is not needed for the remaining plan types here.
             None::<fn(u32) -> Option<RoleId>>,
             session,
             &plan,

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -404,9 +404,10 @@ pub fn check_usage(
 /// only checked by the `restrict_to_user_objects` restriction.
 pub fn check_plan(
     catalog: &impl SessionCatalog,
-    // Function mapping a connection ID to an authenticated role. The roles may have been dropped
-    // concurrently. Only required for Plan::SideEffectingFunc; can be None for other plan types.
-    active_conns: Option<impl FnOnce(u32) -> Option<RoleId>>,
+    // The authenticated role of the connection targeted by the plan, if the plan is a
+    // Plan::SideEffectingFunc that targets an existing connection. The role may have been
+    // dropped concurrently. Ignored for other plan types.
+    target_conn_role: Option<RoleId>,
     session: &dyn SessionMetadata,
     plan: &Plan,
     target_cluster_id: Option<ClusterId>,
@@ -423,7 +424,7 @@ pub fn check_plan(
     let rbac_requirements = generate_rbac_requirements(
         catalog,
         plan,
-        active_conns,
+        target_conn_role,
         target_cluster_id,
         session.role_metadata().current_role,
     );
@@ -452,7 +453,7 @@ pub fn is_rbac_enabled_for_session(
 fn generate_rbac_requirements(
     catalog: &impl SessionCatalog,
     plan: &Plan,
-    active_conns: Option<impl FnOnce(u32) -> Option<RoleId>>,
+    target_conn_role: Option<RoleId>,
     target_cluster_id: Option<ClusterId>,
     role_id: RoleId,
 ) -> RbacRequirements {
@@ -840,7 +841,7 @@ fn generate_rbac_requirements(
             for privilege in generate_rbac_requirements(
                 catalog,
                 &Plan::Select(select_plan.clone()),
-                active_conns,
+                target_conn_role,
                 target_cluster_id,
                 role_id,
             )
@@ -1564,12 +1565,8 @@ fn generate_rbac_requirements(
                     connection_id: None,
                 } => BTreeSet::new(),
                 SideEffectingFunc::PgCancelBackend {
-                    connection_id: Some(connection_id),
-                } => active_conns.expect("active_conns is required for Plan::SideEffectingFunc")(
-                    *connection_id,
-                )
-                .map(|x| [x].into())
-                .unwrap_or_default(),
+                    connection_id: Some(_),
+                } => target_conn_role.map(|x| [x].into()).unwrap_or_default(),
             };
             RbacRequirements {
                 role_membership,

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -404,11 +404,8 @@ pub fn check_usage(
 /// only checked by the `restrict_to_user_objects` restriction.
 pub fn check_plan(
     catalog: &impl SessionCatalog,
-    // Function mapping a connection ID to an authenticated role. The roles may have been dropped concurrently.
-    // Only required for Plan::SideEffectingFunc; can be None for other plan types.
-    // TODO(peek-seq): Remove this when deleting the old peek sequencing. The logic here that uses
-    // `active_conns` is mirrored in `execute_side_effecting_func`, which is what the frontend peek
-    // sequencing uses.
+    // Function mapping a connection ID to an authenticated role. The roles may have been dropped
+    // concurrently. Only required for Plan::SideEffectingFunc; can be None for other plan types.
     active_conns: Option<impl FnOnce(u32) -> Option<RoleId>>,
     session: &dyn SessionMetadata,
     plan: &Plan,

--- a/test/testdrive/cancel-subscribe-rbac.td
+++ b/test/testdrive/cancel-subscribe-rbac.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_rbac_checks = true;
+CREATE ROLE cancel_owner_${testdrive.seed} LOGIN PASSWORD 'ownerpass';
+CREATE TABLE pid_store (pid int);
+GRANT INSERT ON TABLE pid_store TO cancel_owner_${testdrive.seed};
+GRANT SELECT ON TABLE pid_store TO materialize;
+
+$ postgres-connect name=owner url=postgres://cancel_owner_${testdrive.seed}:ownerpass@${testdrive.materialize-sql-addr}
+
+# Have the owner store its own backend PID in a table,
+# so the default (materialize) connection can read it.
+$ postgres-execute connection=owner
+INSERT INTO pid_store VALUES (pg_backend_pid());
+
+$ set-from-sql var=owner-backend-pid
+SELECT CAST(pid AS text) FROM pid_store;
+
+! SELECT pg_cancel_backend(CAST(${owner-backend-pid} AS int4));
+contains:must be a member of "cancel_owner_${testdrive.seed}"
+
+$ postgres-execute connection=mz_system
+GRANT cancel_owner_${testdrive.seed} TO materialize;
+
+> SELECT pg_cancel_backend(CAST(${owner-backend-pid} AS int4));
+true
+
+$ postgres-execute connection=mz_system
+REVOKE cancel_owner_${testdrive.seed} FROM materialize;

--- a/test/testdrive/cancel-subscribe-rbac.td
+++ b/test/testdrive/cancel-subscribe-rbac.td
@@ -29,6 +29,11 @@ SELECT CAST(pid AS text) FROM pid_store;
 ! SELECT pg_cancel_backend(CAST(${owner-backend-pid} AS int4));
 contains:must be a member of "cancel_owner_${testdrive.seed}"
 
+# A superuser can cancel another role's backend without being a member of
+# that role. Regression test for SQL-228 (database-issues#11333).
+$ postgres-execute connection=mz_system
+SELECT pg_cancel_backend(CAST(${owner-backend-pid} AS int4));
+
 $ postgres-execute connection=mz_system
 GRANT cancel_owner_${testdrive.seed} TO materialize;
 


### PR DESCRIPTION
During an incident I tried to kill some backends with mz_system and I couldn't. This was because the usually RBAC bypass doesn't work for the special impl in the coord for side effect functions. I'd prefer to unify this where possible and feel it's worth paying an extra coord hop is worth it.

Fixes: https://github.com/MaterializeInc/database-issues/issues/11333