### PR TITLE
frontegg-mock: add tenant management API endpoints

### DIFF
--- a/src/frontegg-mock/src/handlers.rs
+++ b/src/frontegg-mock/src/handlers.rs
@@ -11,10 +11,12 @@ pub mod auth;
 pub mod group;
 pub mod scim;
 pub mod sso;
+pub mod tenant;
 pub mod user;
 
 pub use auth::*;
 pub use group::*;
 pub use scim::*;
 pub use sso::*;
+pub use tenant::*;
 pub use user::*;

--- a/src/frontegg-mock/src/handlers/auth.rs
+++ b/src/frontegg-mock/src/handlers/auth.rs
@@ -14,6 +14,7 @@ use crate::utils::{
 };
 use axum::{Json, extract::State, http::StatusCode};
 use mz_frontegg_auth::{ApiTokenResponse, ClaimTokenType};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -143,4 +144,48 @@ pub async fn handle_post_token_refresh(
             handle_post_auth_api_token(State(context), Json(request)).await
         }
     }
+}
+
+/// Request body for vendor authentication.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorAuthRequest {
+    pub client_id: String,
+    pub secret: String,
+}
+
+/// Response body for vendor authentication.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorAuthResponse {
+    pub token: String,
+    pub expires_in: i64,
+}
+
+/// Handle POST /auth/vendor
+/// Authenticates a vendor SDK client and returns a JWT token.
+pub async fn handle_post_auth_vendor(
+    State(context): State<Arc<Context>>,
+    Json(_request): Json<VendorAuthRequest>,
+) -> Result<Json<VendorAuthResponse>, StatusCode> {
+    // For the mock, we accept any client_id/secret and return a valid token.
+    // In production, this would validate the credentials.
+    let now_secs = (context.now)() / 1000;
+    let exp_secs = now_secs as i64 + context.expires_in_secs;
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &serde_json::json!({
+            "sub": "vendor",
+            "iss": context.issuer,
+            "iat": now_secs,
+            "exp": exp_secs,
+        }),
+        &context.encoding_key,
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(VendorAuthResponse {
+        token,
+        expires_in: context.expires_in_secs,
+    }))
 }

--- a/src/frontegg-mock/src/handlers/tenant.rs
+++ b/src/frontegg-mock/src/handlers/tenant.rs
@@ -1,0 +1,198 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::models::{TenantConfig, TenantResponse};
+use crate::server::Context;
+
+/// Handle GET /tenants/resources/tenants/v1
+/// Lists all tenants.
+///
+/// If no explicit tenants are configured, derives tenants from the users' tenant_ids.
+pub async fn handle_list_tenants(
+    State(context): State<Arc<Context>>,
+) -> Result<Json<Vec<TenantResponse>>, StatusCode> {
+    let tenants = context.tenants.lock().unwrap();
+
+    // If explicit tenants are configured, return those
+    if !tenants.is_empty() {
+        let responses: Vec<TenantResponse> = tenants.values().map(TenantResponse::from).collect();
+        return Ok(Json(responses));
+    }
+    drop(tenants);
+
+    // Otherwise, derive tenants from users
+    let users = context.users.lock().unwrap();
+    let tenant_ids: BTreeSet<_> = users.values().map(|u| u.tenant_id).collect();
+
+    let now = Utc::now();
+    let responses: Vec<TenantResponse> = tenant_ids
+        .into_iter()
+        .map(|id| TenantResponse {
+            id,
+            name: format!("Tenant {}", &id.to_string()[..8]),
+            metadata: serde_json::json!({}),
+            creator_name: None,
+            creator_email: None,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        })
+        .collect();
+
+    Ok(Json(responses))
+}
+
+/// Handle GET /tenants/resources/tenants/v1/:id
+/// Gets a single tenant by ID.
+///
+/// Note: The frontegg client expects a Vec<Tenant> response (and pops the first element).
+pub async fn handle_get_tenant(
+    State(context): State<Arc<Context>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Vec<TenantResponse>>, StatusCode> {
+    let tenants = context.tenants.lock().unwrap();
+
+    // If the tenant exists in the explicit tenants map, return it
+    if let Some(tenant) = tenants.get(&id) {
+        return Ok(Json(vec![TenantResponse::from(tenant)]));
+    }
+    drop(tenants);
+
+    // Check if the tenant exists in users
+    let users = context.users.lock().unwrap();
+    let tenant_exists = users.values().any(|u| u.tenant_id == id);
+    drop(users);
+
+    if !tenant_exists {
+        return Ok(Json(vec![])); // Empty vec will cause client to return NOT_FOUND
+    }
+
+    // Return a derived tenant
+    let now = Utc::now();
+    let response = TenantResponse {
+        id,
+        name: format!("Tenant {}", &id.to_string()[..8]),
+        metadata: serde_json::json!({}),
+        creator_name: None,
+        creator_email: None,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+
+    Ok(Json(vec![response]))
+}
+
+/// Request body for creating a tenant.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTenantRequest {
+    #[serde(default = "Uuid::new_v4")]
+    pub tenant_id: Uuid,
+    pub name: String,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    pub creator_name: Option<String>,
+    pub creator_email: Option<String>,
+}
+
+/// Handle POST /tenants/resources/tenants/v1
+/// Creates a new tenant.
+pub async fn handle_create_tenant(
+    State(context): State<Arc<Context>>,
+    Json(body): Json<CreateTenantRequest>,
+) -> Result<Json<TenantResponse>, StatusCode> {
+    let now = Utc::now();
+    let tenant = TenantConfig {
+        id: body.tenant_id,
+        name: body.name,
+        metadata: body.metadata,
+        creator_name: body.creator_name,
+        creator_email: body.creator_email,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+
+    let response = TenantResponse::from(&tenant);
+    let mut tenants = context.tenants.lock().unwrap();
+    tenants.insert(tenant.id, tenant);
+
+    Ok(Json(response))
+}
+
+/// Request body for setting tenant metadata.
+#[derive(Debug, Deserialize)]
+pub struct SetTenantMetadataRequest {
+    pub metadata: serde_json::Value,
+}
+
+/// Handle POST /tenants/resources/tenants/v1/:id/metadata
+/// Sets/updates tenant metadata.
+pub async fn handle_set_tenant_metadata(
+    State(context): State<Arc<Context>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<SetTenantMetadataRequest>,
+) -> Result<Json<TenantResponse>, StatusCode> {
+    let mut tenants = context.tenants.lock().unwrap();
+
+    // If the tenant exists in the explicit tenants map, update it
+    if let Some(tenant) = tenants.get_mut(&id) {
+        // Merge the new metadata with existing metadata
+        if let Some(existing) = tenant.metadata.as_object_mut() {
+            if let Some(new_obj) = body.metadata.as_object() {
+                for (k, v) in new_obj {
+                    existing.insert(k.clone(), v.clone());
+                }
+            }
+        } else {
+            tenant.metadata = body.metadata;
+        }
+        tenant.updated_at = Utc::now();
+        return Ok(Json(TenantResponse::from(&*tenant)));
+    }
+    drop(tenants);
+
+    // Check if the tenant exists in users
+    let users = context.users.lock().unwrap();
+    let tenant_exists = users.values().any(|u| u.tenant_id == id);
+    drop(users);
+
+    if !tenant_exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Create a new tenant entry with the metadata
+    let now = Utc::now();
+    let tenant = TenantConfig {
+        id,
+        name: format!("Tenant {}", &id.to_string()[..8]),
+        metadata: body.metadata,
+        creator_name: None,
+        creator_email: None,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+    let response = TenantResponse::from(&tenant);
+    let mut tenants = context.tenants.lock().unwrap();
+    tenants.insert(id, tenant);
+
+    Ok(Json(response))
+}

--- a/src/frontegg-mock/src/models.rs
+++ b/src/frontegg-mock/src/models.rs
@@ -10,6 +10,7 @@
 pub mod group;
 pub mod scim;
 pub mod sso;
+pub mod tenant;
 pub mod token;
 pub mod user;
 pub mod utils;
@@ -17,6 +18,7 @@ pub mod utils;
 pub use group::*;
 pub use scim::*;
 pub use sso::*;
+pub use tenant::*;
 pub use token::*;
 pub use user::*;
 pub use utils::*;

--- a/src/frontegg-mock/src/models/tenant.rs
+++ b/src/frontegg-mock/src/models/tenant.rs
@@ -1,0 +1,84 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Configuration for a tenant in the mock.
+#[derive(Debug, Clone)]
+pub struct TenantConfig {
+    pub id: Uuid,
+    pub name: String,
+    pub metadata: serde_json::Value,
+    pub creator_name: Option<String>,
+    pub creator_email: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl TenantConfig {
+    pub fn new(id: Uuid, name: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id,
+            name: name.into(),
+            metadata: serde_json::json!({}),
+            creator_name: None,
+            creator_email: None,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        }
+    }
+}
+
+/// Tenant response matching the Frontegg API format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TenantResponse {
+    #[serde(rename = "tenantId")]
+    pub id: Uuid,
+    pub name: String,
+    /// Metadata serialized as a nested JSON string (what Frontegg API returns)
+    #[serde(serialize_with = "serialize_nested_json")]
+    pub metadata: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_email: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+fn serialize_nested_json<S>(value: &serde_json::Value, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    // Serialize the value as a JSON string
+    let json_string = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&json_string)
+}
+
+impl From<&TenantConfig> for TenantResponse {
+    fn from(config: &TenantConfig) -> Self {
+        Self {
+            id: config.id,
+            name: config.name.clone(),
+            metadata: config.metadata.clone(),
+            creator_name: config.creator_name.clone(),
+            creator_email: config.creator_email.clone(),
+            created_at: config.created_at,
+            updated_at: config.updated_at,
+            deleted_at: config.deleted_at,
+        }
+    }
+}

--- a/src/frontegg-mock/src/server.rs
+++ b/src/frontegg-mock/src/server.rs
@@ -31,6 +31,7 @@ use crate::models::*;
 const AUTH_API_TOKEN_PATH: &str = "/identity/resources/auth/v1/api-token";
 const AUTH_USER_PATH: &str = "/identity/resources/auth/v1/user";
 const AUTH_API_TOKEN_REFRESH_PATH: &str = "/identity/resources/auth/v1/api-token/token/refresh";
+const AUTH_VENDOR_PATH: &str = "/auth/vendor";
 const GROUPS_PATH: &str = "/frontegg/identity/resources/groups/v1";
 const GROUP_PATH: &str = "/frontegg/identity/resources/groups/v1/{:id}";
 const GROUP_ROLES_PATH: &str = "/frontegg/identity/resources/groups/v1/{:id}/roles";
@@ -48,6 +49,9 @@ const USERS_V3_PATH: &str = "/identity/resources/users/v3";
 const ROLES_PATH: &str = "/identity/resources/roles/v2";
 const SCIM_CONFIGURATIONS_PATH: &str = "/frontegg/directory/resources/v1/configurations/scim2";
 const SCIM_CONFIGURATION_PATH: &str = "/frontegg/directory/resources/v1/configurations/scim2/{:id}";
+const TENANTS_PATH: &str = "/tenants/resources/tenants/v1";
+const TENANT_PATH: &str = "/tenants/resources/tenants/v1/{:id}";
+const TENANT_METADATA_PATH: &str = "/tenants/resources/tenants/v1/{:id}/metadata";
 const SSO_CONFIGS_PATH: &str = "/frontegg/team/resources/sso/v1/configurations";
 const SSO_CONFIG_PATH: &str = "/frontegg/team/resources/sso/v1/configurations/{:id}";
 const SSO_CONFIG_DOMAINS_PATH: &str =
@@ -153,12 +157,14 @@ impl FronteggMockServer {
             sso_configs: Mutex::new(BTreeMap::new()),
             groups: Mutex::new(BTreeMap::new()),
             scim_configurations: Mutex::new(BTreeMap::new()),
+            tenants: Mutex::new(BTreeMap::new()),
         });
 
         let router = Router::new()
             .route(AUTH_API_TOKEN_PATH, post(handle_post_auth_api_token))
             .route(AUTH_USER_PATH, post(handle_post_auth_user))
             .route(AUTH_API_TOKEN_REFRESH_PATH, post(handle_post_token_refresh))
+            .route(AUTH_VENDOR_PATH, post(handle_post_auth_vendor))
             .route(USERS_ME_PATH, get(handle_get_user_profile))
             .route(
                 USERS_API_TOKENS_PATH,
@@ -239,6 +245,12 @@ impl FronteggMockServer {
                 SCIM_CONFIGURATION_PATH,
                 delete(handle_delete_scim_configuration),
             )
+            .route(
+                TENANTS_PATH,
+                get(handle_list_tenants).post(handle_create_tenant),
+            )
+            .route(TENANT_PATH, get(handle_get_tenant))
+            .route(TENANT_METADATA_PATH, post(handle_set_tenant_metadata))
             .route(
                 INTERNAL_USER_PASSWORD_PATH,
                 post(internal_handle_get_user_password),
@@ -322,4 +334,5 @@ pub struct Context {
     pub sso_configs: Mutex<BTreeMap<String, SSOConfigStorage>>,
     pub groups: Mutex<BTreeMap<String, Group>>,
     pub scim_configurations: Mutex<BTreeMap<String, SCIM2ConfigurationStorage>>,
+    pub tenants: Mutex<BTreeMap<uuid::Uuid, TenantConfig>>,
 }


### PR DESCRIPTION
Adds mock implementations for Frontegg tenant API:
- GET /tenants - list all tenants
- GET /tenants/:id - get tenant by ID
- POST /tenants - create tenant
- PATCH /tenants/:id/metadata - update tenant metadata
- POST /identity/resources/auth/v1/api-token - vendor API token auth

These endpoints are being added to assist with local development of internal services in the cloud repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Remove these sections if your commit already has a good description!

### Motivation
APIs needed for
https://github.com/MaterializeInc/cloud/pull/12242
