### PR TITLE
compute: move MV sink persist I/O off Timely thread

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -212,6 +212,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_compute_sync_mv_sink",
+            "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_password_auth",
             "true",
             ["true", "false"],

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -213,7 +213,7 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_compute_sync_mv_sink",
-            "false",
+            "true",
             ["true", "false"],
         ),
         VariableSystemParameter(

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1595,6 +1595,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_upsert_v2"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_coalesce_case_transform"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_compute_sync_mv_sink"] = BOOLEAN_FLAG_VALUES
 
         # If you are adding a new config flag in Materialize, consider using it
         # here instead of just marking it as uninteresting to silence the

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -31,6 +31,13 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
      linear joins.",
 );
 
+/// Use sync Timely operators with Tokio tasks for the MV sink.
+pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
+    "enable_compute_sync_mv_sink",
+    false,
+    "Use sync Timely operators with Tokio tasks for the MV sink.",
+);
+
 /// Whether rendering should use the new MV sink correction buffer implementation.
 pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "enable_compute_correction_v2",
@@ -381,6 +388,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&ENABLE_HALF_JOIN2)
         .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&ENABLE_SYNC_MV_SINK)
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -34,7 +34,7 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
 /// Use sync Timely operators with Tokio tasks for the MV sink.
 pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
     "enable_compute_sync_mv_sink",
-    false,
+    true,
     "Use sync Timely operators with Tokio tasks for the MV sink.",
 );
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -281,7 +281,7 @@ pub fn build_compute_dataflow(
                             until.clone(),
                             mfp.as_mut(),
                             compute_state.dataflow_max_inflight_bytes(),
-                            start_signal.clone(),
+                            start_signal.clone().into_send_future(),
                             ErrorHandler::Halt("compute_import"),
                         );
 
@@ -1568,6 +1568,15 @@ impl StartSignal {
 
     pub fn has_fired(&self) -> bool {
         self.token_ref.strong_count() == 0
+    }
+
+    /// Returns a Send-safe future that completes when the signal fires.
+    ///
+    /// Unlike `StartSignal` itself, the returned future does not retain a reference to the token,
+    /// so it cannot be used for `drop_on_fire` or `has_fired` checks.
+    pub fn into_send_future(self) -> impl Future<Output = ()> + Send {
+        use futures::FutureExt;
+        self.fut.map(|_| ())
     }
 
     pub fn drop_on_fire(&self, to_drop: Box<dyn Any>) {

--- a/src/compute/src/sink.rs
+++ b/src/compute/src/sink.rs
@@ -11,5 +11,6 @@ mod copy_to_s3_oneshot;
 mod correction;
 mod correction_v2;
 mod materialized_view;
+mod materialized_view_v2;
 mod refresh;
 mod subscribe;

--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -10,11 +10,10 @@
 //! The `Correction` data structure used by `persist_sink::write_batches` to stash updates before
 //! they are written into batches.
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt;
+use std::num::NonZeroIsize;
 use std::ops::{AddAssign, Bound, RangeBounds, SubAssign};
-use std::rc::Rc;
 
 use differential_dataflow::consolidation::{consolidate, consolidate_updates};
 use differential_dataflow::logging::{BatchEvent, DropEvent};
@@ -29,6 +28,7 @@ use mz_persist_client::metrics::{SinkMetrics, SinkWorkerMetrics, UpdateDelta};
 use mz_repr::{Diff, Timestamp};
 use timely::PartialOrder;
 use timely::progress::Antichain;
+use tokio::sync::mpsc;
 
 use crate::logging::compute::{
     ArrangementHeapAllocations, ArrangementHeapCapacity, ArrangementHeapSize,
@@ -53,7 +53,7 @@ impl<D: Data> Correction<D> {
     pub fn new(
         metrics: SinkMetrics,
         worker_metrics: SinkWorkerMetrics,
-        logging: Option<Logging>,
+        logging: Option<ChannelLogging>,
         config: &ConfigSet,
     ) -> Self {
         if ENABLE_CORRECTION_V2.get(config) {
@@ -92,7 +92,7 @@ impl<D: Data> Correction<D> {
     pub fn updates_before(
         &mut self,
         upper: &Antichain<Timestamp>,
-    ) -> Box<dyn Iterator<Item = (D, Timestamp, Diff)> + '_> {
+    ) -> Box<dyn Iterator<Item = (D, Timestamp, Diff)> + Send + '_> {
         match self {
             Self::V1(c) => Box::new(c.updates_before(upper)),
             Self::V2(c) => Box::new(c.updates_before(upper)),
@@ -282,7 +282,7 @@ impl<D: Data> CorrectionV1<D> {
     pub fn updates_before<'a>(
         &'a mut self,
         upper: &Antichain<Timestamp>,
-    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + ExactSizeIterator + use<'a, D> {
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + ExactSizeIterator + Send + use<'a, D> {
         let lower = Antichain::from_elem(Timestamp::MIN);
         self.updates_within(&lower, upper)
     }
@@ -535,76 +535,96 @@ impl AddAssign<Self> for SizeMetrics {
     }
 }
 
-/// Helper for correction buffer logging.
+/// A logging event sent from the Tokio task back to the Timely thread.
+#[derive(Debug)]
+pub(super) enum LoggingEvent {
+    ChainCreated(usize),
+    ChainDropped(usize),
+    SizeDiff(NonZeroIsize),
+    CapacityDiff(NonZeroIsize),
+    AllocationsDiff(NonZeroIsize),
+}
+
+/// Channel-based logging for corrections on a Tokio task. `Send`-safe.
 ///
+/// Sends logging events to the Timely thread, where they are applied to the real `Logging`
+/// instance. This allows corrections on the Tokio task to participate in introspection logging
+/// without holding `Rc<RefCell<..>>`.
+#[derive(Clone, Debug)]
+pub(super) struct ChannelLogging(mpsc::UnboundedSender<LoggingEvent>);
+
+impl ChannelLogging {
+    pub fn new(tx: mpsc::UnboundedSender<LoggingEvent>) -> Self {
+        Self(tx)
+    }
+
+    pub fn chain_created(&self, updates: usize) {
+        let _ = self.0.send(LoggingEvent::ChainCreated(updates));
+    }
+
+    pub fn chain_dropped(&self, updates: usize) {
+        let _ = self.0.send(LoggingEvent::ChainDropped(updates));
+    }
+
+    pub fn report_size_diff(&self, diff: isize) {
+        if let Some(diff) = NonZeroIsize::new(diff) {
+            let _ = self.0.send(LoggingEvent::SizeDiff(diff));
+        }
+    }
+
+    pub fn report_capacity_diff(&self, diff: isize) {
+        if let Some(diff) = NonZeroIsize::new(diff) {
+            let _ = self.0.send(LoggingEvent::CapacityDiff(diff));
+        }
+    }
+
+    pub fn report_allocations_diff(&self, diff: isize) {
+        if let Some(diff) = NonZeroIsize::new(diff) {
+            let _ = self.0.send(LoggingEvent::AllocationsDiff(diff));
+        }
+    }
+}
+
+/// State for correction buffer logging on the Timely thread.
+///
+/// Drains [`LoggingEvent`]s sent by [`ChannelLogging`] from the Tokio task and applies them
+/// to the compute and differential loggers. Emits `ArrangementHeapSizeOperator` on construction
+/// and `ArrangementHeapSizeOperatorDrop` on drop.
 // TODO: Correction buffer logging currently reuses the arrangement batch and size logging. This
 // isn't strictly correct as a correction buffer is not an arrangement. Consider refactoring this
 // to be about "operator sizes" instead.
-#[derive(Clone, Debug)]
-pub(super) struct Logging(Rc<RefCell<LoggingInner>>);
-
-impl Logging {
-    pub fn new(
-        compute_logger: ComputeLogger,
-        differential_logger: differential_dataflow::logging::Logger,
-        operator_id: usize,
-        address: Vec<usize>,
-    ) -> Self {
-        let inner = LoggingInner::new(compute_logger, differential_logger, operator_id, address);
-        Self(Rc::new(RefCell::new(inner)))
-    }
-
-    /// A new chain was created.
-    pub fn chain_created(&self, updates: usize) {
-        self.0.borrow_mut().chain_created(updates);
-    }
-
-    /// A chain was dropped.
-    pub fn chain_dropped(&self, updates: usize) {
-        self.0.borrow_mut().chain_dropped(updates);
-    }
-
-    /// Report a heap size diff.
-    pub fn report_size_diff(&self, diff: isize) {
-        self.0.borrow_mut().report_size_diff(diff);
-    }
-
-    /// Report a heap capacity diff.
-    pub fn report_capacity_diff(&self, diff: isize) {
-        self.0.borrow_mut().report_capacity_diff(diff);
-    }
-
-    /// Report a heap allocations diff.
-    pub fn report_allocations_diff(&self, diff: isize) {
-        self.0.borrow_mut().report_allocations_diff(diff);
-    }
-}
-
-/// Inner state for correction buffer logging.
-///
-/// This is separate from `Logging` and shared via an `Rc`, to ensure we only emit
-/// `ArrangementHeapSizeOperator{Drop}` events once, even though we pass the logger to both the Ok
-/// and the Err correction buffer.
-struct LoggingInner {
+pub(super) struct CorrectionLogger {
     compute_logger: ComputeLogger,
     differential_logger: differential_dataflow::logging::Logger,
     operator_id: usize,
+    rx: mpsc::UnboundedReceiver<LoggingEvent>,
+    /// Net number of batches logged (BatchEvent - DropEvent).
+    net_batches: isize,
+    /// Net number of records logged across all batch/drop/merge events.
+    net_records: isize,
+    /// Cumulative heap size delta, for retraction on drop.
+    net_size: isize,
+    /// Cumulative heap capacity delta, for retraction on drop.
+    net_capacity: isize,
+    /// Cumulative heap allocations delta, for retraction on drop.
+    net_allocations: isize,
 }
 
-impl fmt::Debug for LoggingInner {
+impl fmt::Debug for CorrectionLogger {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LoggingInner")
+        f.debug_struct("CorrectionLogger")
             .field("operator_id", &self.operator_id)
             .finish_non_exhaustive()
     }
 }
 
-impl LoggingInner {
-    fn new(
+impl CorrectionLogger {
+    pub fn new(
         compute_logger: ComputeLogger,
         differential_logger: differential_dataflow::logging::Logger,
         operator_id: usize,
         address: Vec<usize>,
+        rx: mpsc::UnboundedReceiver<LoggingEvent>,
     ) -> Self {
         compute_logger.log(&ComputeEvent::ArrangementHeapSizeOperator(
             ArrangementHeapSizeOperator {
@@ -617,60 +637,123 @@ impl LoggingInner {
             compute_logger,
             differential_logger,
             operator_id,
+            rx,
+            net_batches: 0,
+            net_records: 0,
+            net_size: 0,
+            net_capacity: 0,
+            net_allocations: 0,
         }
     }
 
-    fn chain_created(&self, updates: usize) {
-        self.differential_logger.log(BatchEvent {
-            operator: self.operator_id,
-            length: updates,
-        });
-    }
+    /// Drain logging events from the channel and apply them locally.
+    pub fn apply_events(&mut self) {
+        use LoggingEvent::*;
 
-    fn chain_dropped(&self, updates: usize) {
-        self.differential_logger.log(DropEvent {
-            operator: self.operator_id,
-            length: updates,
-        });
-    }
-
-    fn report_size_diff(&self, diff: isize) {
-        if diff != 0 {
-            self.compute_logger
-                .log(&ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
-                    operator_id: self.operator_id,
-                    delta_size: diff,
-                }));
-        }
-    }
-
-    fn report_capacity_diff(&self, diff: isize) {
-        if diff != 0 {
-            self.compute_logger
-                .log(&ComputeEvent::ArrangementHeapCapacity(
-                    ArrangementHeapCapacity {
-                        operator_id: self.operator_id,
-                        delta_capacity: diff,
-                    },
-                ));
-        }
-    }
-
-    fn report_allocations_diff(&self, diff: isize) {
-        if diff != 0 {
-            self.compute_logger
-                .log(&ComputeEvent::ArrangementHeapAllocations(
-                    ArrangementHeapAllocations {
-                        operator_id: self.operator_id,
-                        delta_allocations: diff,
-                    },
-                ));
+        while let Ok(event) = self.rx.try_recv() {
+            match event {
+                ChainCreated(length) => {
+                    self.net_batches += 1;
+                    self.net_records += isize::try_from(length).expect("must fit");
+                    self.differential_logger.log(BatchEvent {
+                        operator: self.operator_id,
+                        length,
+                    });
+                }
+                ChainDropped(length) => {
+                    self.net_batches -= 1;
+                    self.net_records -= isize::try_from(length).expect("must fit");
+                    self.differential_logger.log(DropEvent {
+                        operator: self.operator_id,
+                        length,
+                    });
+                }
+                SizeDiff(delta_size) => {
+                    self.net_size += delta_size.get();
+                    self.compute_logger.log(&ComputeEvent::ArrangementHeapSize(
+                        ArrangementHeapSize {
+                            operator_id: self.operator_id,
+                            delta_size: delta_size.get(),
+                        },
+                    ));
+                }
+                CapacityDiff(delta_capacity) => {
+                    self.net_capacity += delta_capacity.get();
+                    self.compute_logger
+                        .log(&ComputeEvent::ArrangementHeapCapacity(
+                            ArrangementHeapCapacity {
+                                operator_id: self.operator_id,
+                                delta_capacity: delta_capacity.get(),
+                            },
+                        ));
+                }
+                AllocationsDiff(delta_allocations) => {
+                    self.net_allocations += delta_allocations.get();
+                    self.compute_logger
+                        .log(&ComputeEvent::ArrangementHeapAllocations(
+                            ArrangementHeapAllocations {
+                                operator_id: self.operator_id,
+                                delta_allocations: delta_allocations.get(),
+                            },
+                        ));
+                }
+            }
         }
     }
 }
 
-impl Drop for LoggingInner {
+impl Drop for CorrectionLogger {
     fn drop(&mut self) {
+        // Drain any events that arrived before the drop. Note that the Tokio task
+        // may still be running (abort is async), so some events may not have arrived
+        // yet. We retract any remaining batch/record counts below.
+        self.apply_events();
+
+        // Retract any outstanding batch and record counts that weren't balanced by
+        // ChainDropped events. This handles the case where the Tokio task is aborted
+        // and its Correction destructors haven't run yet (abort is async).
+        //
+        // Each DropEvent retracts one batch and `length` records, so we emit one per
+        // outstanding batch, with the first carrying all outstanding records.
+        for i in 0..self.net_batches {
+            let length = if i == 0 {
+                usize::try_from(self.net_records).unwrap_or(0)
+            } else {
+                0
+            };
+            self.differential_logger.log(DropEvent {
+                operator: self.operator_id,
+                length,
+            });
+        }
+
+        // Retract any outstanding heap size/capacity/allocations deltas.
+        if self.net_size != 0 {
+            self.compute_logger
+                .log(&ComputeEvent::ArrangementHeapSize(ArrangementHeapSize {
+                    operator_id: self.operator_id,
+                    delta_size: -self.net_size,
+                }));
+        }
+        if self.net_capacity != 0 {
+            self.compute_logger
+                .log(&ComputeEvent::ArrangementHeapCapacity(
+                    ArrangementHeapCapacity {
+                        operator_id: self.operator_id,
+                        delta_capacity: -self.net_capacity,
+                    },
+                ));
+        }
+        if self.net_allocations != 0 {
+            self.compute_logger
+                .log(&ComputeEvent::ArrangementHeapAllocations(
+                    ArrangementHeapAllocations {
+                        operator_id: self.operator_id,
+                        delta_allocations: -self.net_allocations,
+                    },
+                ));
+        }
+
         self.compute_logger
             .log(&ComputeEvent::ArrangementHeapSizeOperatorDrop(
                 ArrangementHeapSizeOperatorDrop {

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -138,11 +138,17 @@ use mz_timely_util::columnation::ColumnationStack;
 use timely::PartialOrder;
 use timely::progress::Antichain;
 
-use crate::sink::correction::{Logging, SizeMetrics};
+use crate::sink::correction::{ChannelLogging, SizeMetrics};
 
 /// Convenient alias for use in data trait bounds.
-pub trait Data: differential_dataflow::Data + Columnation {}
-impl<D: differential_dataflow::Data + Columnation> Data for D {}
+pub trait Data:
+    differential_dataflow::Data + Columnation<InnerRegion: Send + Sync> + Send + Sync
+{
+}
+impl<D: differential_dataflow::Data + Columnation<InnerRegion: Send + Sync> + Send + Sync> Data
+    for D
+{
+}
 
 /// A data structure used to store corrections in the MV sink implementation.
 ///
@@ -174,7 +180,7 @@ pub(super) struct CorrectionV2<D: Data> {
     /// Per-worker persist sink metrics.
     worker_metrics: SinkWorkerMetrics,
     /// Introspection logging.
-    logging: Option<Logging>,
+    logging: Option<ChannelLogging>,
 }
 
 impl<D: Data> CorrectionV2<D> {
@@ -182,7 +188,7 @@ impl<D: Data> CorrectionV2<D> {
     pub fn new(
         metrics: SinkMetrics,
         worker_metrics: SinkWorkerMetrics,
-        logging: Option<Logging>,
+        logging: Option<ChannelLogging>,
         chain_proportionality: f64,
         chunk_size: usize,
     ) -> Self {
@@ -274,7 +280,7 @@ impl<D: Data> CorrectionV2<D> {
     pub fn updates_before<'a>(
         &'a mut self,
         upper: &Antichain<Timestamp>,
-    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + 'a {
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + 'a {
         let mut result = None;
 
         if !PartialOrder::less_than(&self.since, upper) {
@@ -1140,11 +1146,11 @@ struct Stage<D> {
     /// We want to report the number of records in the stage. To do so, we pretend that the stage
     /// is a chain, and every time the number of updates inside changes, the chain gets dropped and
     /// re-created.
-    logging: Option<Logging>,
+    logging: Option<ChannelLogging>,
 }
 
 impl<D: Data> Stage<D> {
-    fn new(logging: Option<Logging>, chunk_capacity: usize) -> Self {
+    fn new(logging: Option<ChannelLogging>, chunk_capacity: usize) -> Self {
         // For logging, we pretend the stage consists of a single chain.
         if let Some(logging) = &logging {
             logging.chain_created(0);

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -565,6 +565,16 @@ mod mint {
             // the `persist` stream, because the latter has two annoying glitches:
             //  (a) It starts at the shard's read frontier, not its write frontier.
             //  (b) It can lag behind if there are spikes in ingested data.
+            //
+            // The decoupling from the `persist` stream is load-bearing: that stream can fall
+            // arbitrarily behind the shard upper during snapshot replay or write spikes. Using it
+            // would delay both (1) the controller-visible sink frontier (`shared_frontier`),
+            // which previously caused a CrossJoin feature-bench regression where the controller
+            // held a finished MV dataflow open waiting for the empty frontier, and (2) the
+            // `state.persist_frontier` that gates batch-description minting, stalling mint until
+            // the read-back stream catches up. The goal isn't tick-granular descriptions per
+            // se — it's avoiding the stream-induced stall. See 5eab5ff896 for the original
+            // regression and rationale.
             let mut persist_frontiers = pin!(async_stream::stream! {
                 let mut writer = persist_api.open_writer().await;
                 let mut frontier = Antichain::from_elem(Timestamp::MIN);

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -155,7 +155,8 @@ use crate::compute_state::ComputeState;
 use crate::render::StartSignal;
 use crate::render::errors::DataflowErrorSer;
 use crate::render::sinks::SinkRender;
-use crate::sink::correction::{Correction, Logging};
+use crate::sink::correction::{ChannelLogging, Correction, CorrectionLogger};
+use crate::sink::materialized_view_v2;
 use crate::sink::refresh::apply_refresh;
 
 impl<'scope> SinkRender<'scope> for MaterializedViewSinkConnection<CollectionMetadata> {
@@ -211,25 +212,25 @@ impl<'scope> SinkRender<'scope> for MaterializedViewSinkConnection<CollectionMet
 }
 
 /// Type of the `desired` stream, split into `Ok` and `Err` streams.
-type DesiredStreams<'s> = OkErr<
+pub(super) type DesiredStreams<'s> = OkErr<
     StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
     StreamVec<'s, Timestamp, (DataflowErrorSer, Timestamp, Diff)>,
 >;
 
 /// Type of the `persist` stream, split into `Ok` and `Err` streams.
-type PersistStreams<'s> = OkErr<
+pub(super) type PersistStreams<'s> = OkErr<
     StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
     StreamVec<'s, Timestamp, (DataflowErrorSer, Timestamp, Diff)>,
 >;
 
 /// Type of the `descs` stream.
-type DescsStream<'s> = StreamVec<'s, Timestamp, BatchDescription>;
+pub(super) type DescsStream<'s> = StreamVec<'s, Timestamp, BatchDescription>;
 
 /// Type of the `batches` stream.
-type BatchesStream<'s> = StreamVec<'s, Timestamp, (BatchDescription, ProtoBatch)>;
+pub(super) type BatchesStream<'s> = StreamVec<'s, Timestamp, (BatchDescription, ProtoBatch)>;
 
 /// Type of the shared sink write frontier.
-type SharedSinkFrontier = Rc<RefCell<Antichain<Timestamp>>>;
+pub(super) type SharedSinkFrontier = Rc<RefCell<Antichain<Timestamp>>>;
 
 /// Renders an MV sink writing the given desired collection into the `target` persist collection.
 pub(super) fn persist_sink<'s>(
@@ -244,6 +245,19 @@ pub(super) fn persist_sink<'s>(
 ) -> Rc<dyn Any>
 where
 {
+    if mz_compute_types::dyncfgs::ENABLE_SYNC_MV_SINK.get(&compute_state.worker_config) {
+        return materialized_view_v2::persist_sink(
+            sink_id,
+            target,
+            ok_collection,
+            err_collection,
+            as_of,
+            compute_state,
+            start_signal,
+            read_only_rx,
+        );
+    }
+
     let scope = ok_collection.scope();
     let desired = OkErr::new(ok_collection.inner, err_collection.inner);
 
@@ -287,19 +301,19 @@ where
 
 /// Generic wrapper around ok/err pairs (e.g. streams, frontiers), to simplify code dealing with
 /// such pairs.
-struct OkErr<O, E> {
-    ok: O,
-    err: E,
+pub(super) struct OkErr<O, E> {
+    pub(super) ok: O,
+    pub(super) err: E,
 }
 
 impl<O, E> OkErr<O, E> {
-    fn new(ok: O, err: E) -> Self {
+    pub(super) fn new(ok: O, err: E) -> Self {
         Self { ok, err }
     }
 }
 
 impl OkErr<Antichain<Timestamp>, Antichain<Timestamp>> {
-    fn new_frontiers() -> Self {
+    pub(super) fn new_frontiers() -> Self {
         Self {
             ok: Antichain::from_elem(Timestamp::MIN),
             err: Antichain::from_elem(Timestamp::MIN),
@@ -307,7 +321,7 @@ impl OkErr<Antichain<Timestamp>, Antichain<Timestamp>> {
     }
 
     /// Return the overall frontier, i.e., the minimum of `ok` and `err`.
-    fn frontier(&self) -> &Antichain<Timestamp> {
+    pub(super) fn frontier(&self) -> &Antichain<Timestamp> {
         if PartialOrder::less_equal(&self.ok, &self.err) {
             &self.ok
         } else {
@@ -319,9 +333,13 @@ impl OkErr<Antichain<Timestamp>, Antichain<Timestamp>> {
 /// Advance the given `frontier` to `new`, if the latter one is greater.
 ///
 /// Returns whether `frontier` was advanced.
-fn advance(frontier: &mut Antichain<Timestamp>, new: Antichain<Timestamp>) -> bool {
-    if PartialOrder::less_than(frontier, &new) {
-        *frontier = new;
+pub(super) fn advance(
+    frontier: &mut Antichain<Timestamp>,
+    new: timely::progress::frontier::AntichainRef<'_, Timestamp>,
+) -> bool {
+    if PartialOrder::less_than(&frontier.borrow(), &new) {
+        frontier.clear();
+        frontier.extend(new.iter().cloned());
         true
     } else {
         false
@@ -330,22 +348,22 @@ fn advance(frontier: &mut Antichain<Timestamp>, new: Antichain<Timestamp>) -> bo
 
 /// A persist API specialized to a single collection.
 #[derive(Clone)]
-struct PersistApi {
-    persist_clients: Arc<PersistClientCache>,
-    collection: CollectionMetadata,
-    shard_name: String,
-    purpose: String,
+pub(super) struct PersistApi {
+    pub(super) persist_clients: Arc<PersistClientCache>,
+    pub(super) collection: CollectionMetadata,
+    pub(super) shard_name: String,
+    pub(super) purpose: String,
 }
 
 impl PersistApi {
-    async fn open_client(&self) -> PersistClient {
+    pub(super) async fn open_client(&self) -> PersistClient {
         self.persist_clients
             .open(self.collection.persist_location.clone())
             .await
             .unwrap_or_else(|error| panic!("error opening persist client: {error}"))
     }
 
-    async fn open_writer(&self) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
+    pub(super) async fn open_writer(&self) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
         self.open_client()
             .await
             .open_writer(
@@ -368,7 +386,7 @@ impl PersistApi {
 }
 
 /// Instantiate a persist source reading back the `target` collection.
-fn persist_source<'s>(
+pub(super) fn persist_source<'s>(
     scope: Scope<'s, Timestamp>,
     sink_id: GlobalId,
     target: CollectionMetadata,
@@ -419,14 +437,18 @@ fn persist_source<'s>(
 /// Each batch description also contains the index of its "append worker", i.e. the worker that is
 /// responsible for appending the written batches to the output shard.
 #[derive(Clone, Serialize, Deserialize)]
-struct BatchDescription {
-    lower: Antichain<Timestamp>,
-    upper: Antichain<Timestamp>,
-    append_worker: usize,
+pub(super) struct BatchDescription {
+    pub(super) lower: Antichain<Timestamp>,
+    pub(super) upper: Antichain<Timestamp>,
+    pub(super) append_worker: usize,
 }
 
 impl BatchDescription {
-    fn new(lower: Antichain<Timestamp>, upper: Antichain<Timestamp>, append_worker: usize) -> Self {
+    pub(super) fn new(
+        lower: Antichain<Timestamp>,
+        upper: Antichain<Timestamp>,
+        append_worker: usize,
+    ) -> Self {
         assert!(PartialOrder::less_than(&lower, &upper));
         Self {
             lower,
@@ -449,7 +471,7 @@ impl std::fmt::Debug for BatchDescription {
 }
 
 /// Construct a name for the given sub-operator.
-fn operator_name(sink_id: GlobalId, sub_operator: &str) -> String {
+pub(super) fn operator_name(sink_id: GlobalId, sub_operator: &str) -> String {
     format!("mv_sink({sink_id})::{sub_operator}")
 }
 
@@ -674,19 +696,19 @@ mod mint {
         }
 
         fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.desired_frontiers.ok, frontier) {
+            if advance(&mut self.desired_frontiers.ok, frontier.borrow()) {
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
         fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.desired_frontiers.err, frontier) {
+            if advance(&mut self.desired_frontiers.err, frontier.borrow()) {
                 self.trace("advanced `desired` err frontier");
             }
         }
 
         fn advance_persist_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.persist_frontier, frontier) {
+            if advance(&mut self.persist_frontier, frontier.borrow()) {
                 self.trace("advanced `persist` frontier");
             }
         }
@@ -757,17 +779,21 @@ mod write {
         let name = operator_name(sink_id, "write");
         let mut op = OperatorBuilder::new(name, scope.clone());
 
-        let mut logging = None;
+        let mut channel_logging = None;
+        let mut correction_logger = None;
         if let (Some(compute_logger), Some(differential_logger)) = (
             scope.worker().logger_for("materialize/compute"),
             scope.worker().logger_for("differential/arrange"),
         ) {
             let operator_info = op.operator_info();
-            logging = Some(Logging::new(
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            channel_logging = Some(ChannelLogging::new(tx));
+            correction_logger = Some(CorrectionLogger::new(
                 compute_logger,
                 differential_logger.into(),
                 operator_info.global_id,
                 operator_info.address.to_vec(),
+                rx,
             ));
         }
 
@@ -801,12 +827,18 @@ mod write {
                 worker_id,
                 writer,
                 sink_metrics,
-                logging,
+                channel_logging,
                 as_of,
                 &worker_config,
             );
+            let mut correction_logger = correction_logger;
 
             loop {
+                // Drain correction logging events from the channel.
+                if let Some(logger) = &mut correction_logger {
+                    logger.apply_events();
+                }
+
                 // Read from the inputs, extract `desired` updates as positive contributions to
                 // `correction` and `persist` updates as negative contributions. If either the
                 // `desired` or `persist` frontier advances, or if we receive a new batch description,
@@ -922,7 +954,7 @@ mod write {
             worker_id: usize,
             persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
             metrics: SinkMetrics,
-            logging: Option<Logging>,
+            logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
             worker_config: &ConfigSet,
         ) -> Self {
@@ -979,28 +1011,28 @@ mod write {
         }
 
         fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.desired_frontiers.ok, frontier) {
+            if advance(&mut self.desired_frontiers.ok, frontier.borrow()) {
                 self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
         fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.desired_frontiers.err, frontier) {
+            if advance(&mut self.desired_frontiers.err, frontier.borrow()) {
                 self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` err frontier");
             }
         }
 
         fn advance_persist_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.persist_frontiers.ok, frontier) {
+            if advance(&mut self.persist_frontiers.ok, frontier.borrow()) {
                 self.apply_persist_frontier_advancement();
                 self.trace("advanced `persist` ok frontier");
             }
         }
 
         fn advance_persist_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.persist_frontiers.err, frontier) {
+            if advance(&mut self.persist_frontiers.err, frontier.borrow()) {
                 self.apply_persist_frontier_advancement();
                 self.trace("advanced `persist` err frontier");
             }
@@ -1227,7 +1259,7 @@ mod append {
         }
 
         fn advance_batches_frontier(&mut self, frontier: Antichain<Timestamp>) {
-            if advance(&mut self.batches_frontier, frontier) {
+            if advance(&mut self.batches_frontier, frontier.borrow()) {
                 self.trace("advanced `batches` frontier");
             }
         }

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -403,7 +403,7 @@ fn persist_source<'s>(
             until,
             map_filter_project,
             compute_state.dataflow_max_inflight_bytes(),
-            start_signal,
+            start_signal.into_send_future(),
             ErrorHandler::Halt("compute persist sink"),
         );
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -1,0 +1,1375 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A dataflow sink that writes input records to a persist shard.
+//!
+//! This implementation is both parallel and self-correcting.
+//!
+//!  * parallel: Multiple workers can participate in writing updates for the same times, letting
+//!    sink throughput scale with the number of workers allocated to the replica.
+//!  * self-correcting: The sink continually compares the contents of the persist shard with the
+//!    contents of the input collection and writes down the difference. If the persist shard ends
+//!    up with undesired contents for any reason, this is corrected the next time the sink manages
+//!    to append to the shard.
+//!
+//! ### Operators
+//!
+//! The persist sink consists of a graph of operators.
+//!
+//!    desired                    persist <---------------.
+//!       |                          |                    |
+//!       |                          |                    |
+//!       |---------------------.    |                    |
+//!       |                     |    |                    |
+//!       |                     |    |                    |
+//!       v                     v    v                    |
+//!   +--------+              +--------+              +--------+
+//!   |  mint  | --descs-.--> | write  | --batches--> | append |
+//!   +--------+          \   +--------+          .-> +--------+
+//!                        \_____________________/
+//!
+//!  * `mint` mints batch descriptions, i.e., `(lower, upper)` bounds of batches that should be
+//!    written. The persist API requires that all workers write batches with the same bounds, so
+//!    they can be appended as a single logical batch. To ensure this, the `mint` operator only
+//!    runs on a single worker that broadcasts minted descriptions to all workers. Batch bounds are
+//!    picked based on the frontiers of the `desired` stream and the output persist shard.
+//!  * `write` stages batch data in persist, based on the batch descriptions received from the
+//!    `mint` operator, but without appending it to the persist shard. This is a multi-worker
+//!    operator, with each worker writing batches of the data that arrives at its local inputs. To
+//!    do so it reads from the `desired` and `persist` streams and produces the difference between
+//!    them to write back out, ensuring that the final contents of the persist shard match
+//!    `desired`.
+//!  * `append` appends the batches minted by `mint` and written by `write` to the persist shard.
+//!    This is a multi-worker operator, where workers are responsible for different subsets of
+//!    batch descriptions. If a worker is responsible for a given batch description, it waits for
+//!    all workers to stage their batches for that batch description, then appends all the batches
+//!    together as a single logical batch.
+//!
+//! Note that while the above graph suggests that `mint` and `write` both receive copies of the
+//! `desired` stream, the actual implementation passes that stream through `mint` and lets `write`
+//! read the passed-through stream, to avoid cloning data.
+//!
+//! Also note that the `append` operator's implementation would perhaps be more natural as a
+//! single-worker implementation. The purpose of sharing the work between all workers is to avoid a
+//! work imbalance where one worker is overloaded (doing both appends and the consequent persist
+//! maintenance work) while others are comparatively idle.
+//!
+//! The persist sink is written to be robust to the presence of other conflicting instances (e.g.
+//! from other replicas) writing to the same persist shard. Each of the three operators needs to be
+//! able to handle conflicting writes that unexpectedly change the contents of the output persist
+//! shard.
+//!
+//! ### Frontiers
+//!
+//! The `desired` frontier tracks the progress of the upstream dataflow, but may be rounded up to
+//! the next refresh time for dataflows that follow a refresh schedule other than "on commit".
+//!
+//! The `persist` frontier tracks the `upper` frontier of the target persist shard, with one
+//! exception: When the `persist_source` that reads back the shard is rendered, it will start
+//! reading at its `since` frontier. So if the shard's `since` is initially greater than its
+//! `upper`, the `persist` frontier too will be in advance of the shard `upper`, until the `upper`
+//! has caught up. To avoid getting confused by this edge case, the `mint` operator does not use
+//! the `persist` stream to observe the shard frontier but keeps its own `WriteHandle` instead.
+//!
+//! The `descs` frontier communicates which `lower` bounds may still be emitted in batch
+//! descriptions. All future batch descriptions will have a `lower` that is greater or equal to the
+//! current `descs` frontier.
+//!
+//! The `batches` frontier communicates for which `lower` bounds batches may still be written. All
+//! batches for descriptions with `lower`s less than the current `batches` frontier have already
+//! been written.
+//!
+//! ### Invariants
+//!
+//! The implementation upholds several invariants that can be relied upon to simplify the
+//! implementation:
+//!
+//!  1. `lower`s in minted batch descriptions are unique and strictly increasing. That is, the
+//!     `mint` operator will never mint the same `lower` twice and a minted `lower` is always
+//!     greater than any previously minted ones.
+//!  2. `upper`s in minted batch descriptions are monotonically increasing.
+//!  3. From (1) follows that there is always at most one "valid" batch description in flight in
+//!     the operator graph. "Valid" here means that the described batch can be appended to the
+//!     persist shard.
+//!
+//! The main simplification these invariants allow is that operators only need to keep track of the
+//! most recent batch description and/or `lower`. Previous batch descriptions are not valid
+//! anymore, so there is no reason to hold any state or perform any work in support of them.
+//!
+//! ### Read-only Mode
+//!
+//! The persist sink can optionally be initialized in read-only mode. In this mode it is passive
+//! and avoids any writes to persist. Activating the `read_only_rx` transitions the sink into write
+//! mode, where it commences normal operation.
+//!
+//! Read-only mode is implemented by the `mint` operator. To disable writes, the `mint` operator
+//! simply avoids minting any batch descriptions. Since both the `write` and the `append` operator
+//! require batch descriptions to write/append batches, this suppresses any persist communication.
+//! At the same time, the `write` operator still observes changes to the `desired` and `persist`
+//! collections, allowing it to keep its correction buffer up-to-date.
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::pin::pin;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use differential_dataflow::{AsCollection, Hashable, VecCollection};
+use futures::StreamExt;
+use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
+use mz_compute_types::sinks::{ComputeSinkDesc, MaterializedViewSinkConnection};
+use mz_dyncfg::ConfigSet;
+use mz_ore::cast::CastFrom;
+use mz_persist_client::batch::{Batch, ProtoBatch};
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::metrics::SinkMetrics;
+use mz_persist_client::operators::shard_source::{ErrorHandler, SnapshotMode};
+use mz_persist_client::write::WriteHandle;
+use mz_persist_client::{Diagnostics, PersistClient};
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_types::StorageDiff;
+use mz_storage_types::controller::CollectionMetadata;
+use mz_storage_types::errors::DataflowError;
+use mz_storage_types::sources::SourceData;
+use mz_timely_util::builder_async::PressOnDropButton;
+use mz_timely_util::builder_async::{Event, OperatorBuilder};
+use mz_timely_util::probe::{Handle, ProbeNotify};
+use serde::{Deserialize, Serialize};
+use timely::PartialOrder;
+use timely::container::CapacityContainerBuilder;
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::vec::Broadcast;
+use timely::dataflow::operators::{Capability, CapabilitySet, probe};
+use timely::dataflow::{Scope, StreamVec};
+use timely::progress::Antichain;
+use tokio::sync::watch;
+use tracing::trace;
+
+use crate::compute_state::ComputeState;
+use crate::render::StartSignal;
+use crate::render::sinks::SinkRender;
+use crate::sink::correction::{Correction, Logging};
+use crate::sink::refresh::apply_refresh;
+
+impl<'scope> SinkRender<'scope> for MaterializedViewSinkConnection<CollectionMetadata> {
+    fn render_sink(
+        &self,
+        compute_state: &mut ComputeState,
+        sink: &ComputeSinkDesc<CollectionMetadata>,
+        sink_id: GlobalId,
+        as_of: Antichain<Timestamp>,
+        start_signal: StartSignal,
+        mut ok_collection: VecCollection<'scope, Timestamp, Row, Diff>,
+        mut err_collection: VecCollection<'scope, Timestamp, DataflowError, Diff>,
+        _ct_times: Option<VecCollection<'scope, Timestamp, (), Diff>>,
+        output_probe: &Handle<Timestamp>,
+    ) -> Option<Rc<dyn Any>> {
+        // Attach probes reporting the compute frontier.
+        // The `apply_refresh` operator can round up frontiers, making it impossible to accurately
+        // track the progress of the computation, so we need to attach probes before it.
+        let probe = probe::Handle::default();
+        ok_collection = ok_collection
+            .probe_with(&probe)
+            .inner
+            .probe_notify_with(vec![output_probe.clone()])
+            .as_collection();
+        let collection_state = compute_state.expect_collection_mut(sink_id);
+        collection_state.compute_probe = Some(probe);
+
+        // If a `RefreshSchedule` was specified, round up timestamps.
+        if let Some(refresh_schedule) = &sink.refresh_schedule {
+            ok_collection = apply_refresh(ok_collection, refresh_schedule.clone());
+            err_collection = apply_refresh(err_collection, refresh_schedule.clone());
+        }
+
+        if sink.up_to != Antichain::default() {
+            unimplemented!(
+                "UP TO is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
+            )
+        }
+
+        let read_only_rx = collection_state.read_only_rx.clone();
+
+        let token = persist_sink(
+            sink_id,
+            &self.storage_metadata,
+            ok_collection,
+            err_collection,
+            as_of,
+            compute_state,
+            start_signal,
+            read_only_rx,
+        );
+        Some(token)
+    }
+}
+
+/// Type of the `desired` stream, split into `Ok` and `Err` streams.
+type DesiredStreams<'s> = OkErr<
+    StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
+    StreamVec<'s, Timestamp, (DataflowError, Timestamp, Diff)>,
+>;
+
+/// Type of the `persist` stream, split into `Ok` and `Err` streams.
+type PersistStreams<'s> = OkErr<
+    StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
+    StreamVec<'s, Timestamp, (DataflowError, Timestamp, Diff)>,
+>;
+
+/// Type of the `descs` stream.
+type DescsStream<'s> = StreamVec<'s, Timestamp, BatchDescription>;
+
+/// Type of the `batches` stream.
+type BatchesStream<'s> = StreamVec<'s, Timestamp, (BatchDescription, ProtoBatch)>;
+
+/// Type of the shared sink write frontier.
+type SharedSinkFrontier = Rc<RefCell<Antichain<Timestamp>>>;
+
+/// Renders an MV sink writing the given desired collection into the `target` persist collection.
+pub(super) fn persist_sink<'s>(
+    sink_id: GlobalId,
+    target: &CollectionMetadata,
+    ok_collection: VecCollection<'s, Timestamp, Row, Diff>,
+    err_collection: VecCollection<'s, Timestamp, DataflowError, Diff>,
+    as_of: Antichain<Timestamp>,
+    compute_state: &mut ComputeState,
+    start_signal: StartSignal,
+    read_only_rx: watch::Receiver<bool>,
+) -> Rc<dyn Any>
+where
+{
+    let scope = ok_collection.scope();
+    let desired = OkErr::new(ok_collection.inner, err_collection.inner);
+
+    // Read back the persist shard.
+    let (persist, persist_token) =
+        persist_source(scope, sink_id, target.clone(), compute_state, start_signal);
+
+    let persist_api = PersistApi {
+        persist_clients: Arc::clone(&compute_state.persist_clients),
+        collection: target.clone(),
+        shard_name: sink_id.to_string(),
+        purpose: format!("MV sink {sink_id}"),
+    };
+
+    let (desired, descs, sink_frontier, mint_token) = mint::render(
+        sink_id,
+        persist_api.clone(),
+        as_of.clone(),
+        read_only_rx,
+        desired,
+    );
+
+    let (batches, write_token) = write::render(
+        sink_id,
+        persist_api.clone(),
+        as_of,
+        desired,
+        persist,
+        descs.clone(),
+        Rc::clone(&compute_state.worker_config),
+    );
+
+    let append_token = append::render(sink_id, persist_api, descs, batches);
+
+    // Report sink frontier updates to the `ComputeState`.
+    let collection = compute_state.expect_collection_mut(sink_id);
+    collection.sink_write_frontier = Some(sink_frontier);
+
+    Rc::new((persist_token, mint_token, write_token, append_token))
+}
+
+/// Generic wrapper around ok/err pairs (e.g. streams, frontiers), to simplify code dealing with
+/// such pairs.
+struct OkErr<O, E> {
+    ok: O,
+    err: E,
+}
+
+impl<O, E> OkErr<O, E> {
+    fn new(ok: O, err: E) -> Self {
+        Self { ok, err }
+    }
+}
+
+impl OkErr<Antichain<Timestamp>, Antichain<Timestamp>> {
+    fn new_frontiers() -> Self {
+        Self {
+            ok: Antichain::from_elem(Timestamp::MIN),
+            err: Antichain::from_elem(Timestamp::MIN),
+        }
+    }
+
+    /// Return the overall frontier, i.e., the minimum of `ok` and `err`.
+    fn frontier(&self) -> &Antichain<Timestamp> {
+        if PartialOrder::less_equal(&self.ok, &self.err) {
+            &self.ok
+        } else {
+            &self.err
+        }
+    }
+}
+
+/// Advance the given `frontier` to `new`, if the latter one is greater.
+///
+/// Returns whether `frontier` was advanced.
+fn advance(frontier: &mut Antichain<Timestamp>, new: Antichain<Timestamp>) -> bool {
+    if PartialOrder::less_than(frontier, &new) {
+        *frontier = new;
+        true
+    } else {
+        false
+    }
+}
+
+/// A persist API specialized to a single collection.
+#[derive(Clone)]
+struct PersistApi {
+    persist_clients: Arc<PersistClientCache>,
+    collection: CollectionMetadata,
+    shard_name: String,
+    purpose: String,
+}
+
+impl PersistApi {
+    async fn open_client(&self) -> PersistClient {
+        self.persist_clients
+            .open(self.collection.persist_location.clone())
+            .await
+            .unwrap_or_else(|error| panic!("error opening persist client: {error}"))
+    }
+
+    async fn open_writer(&self) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
+        self.open_client()
+            .await
+            .open_writer(
+                self.collection.data_shard,
+                Arc::new(self.collection.relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics {
+                    shard_name: self.shard_name.clone(),
+                    handle_purpose: self.purpose.clone(),
+                },
+            )
+            .await
+            .unwrap_or_else(|error| panic!("error opening persist writer: {error}"))
+    }
+
+    async fn open_metrics(&self) -> SinkMetrics {
+        let client = self.open_client().await;
+        client.metrics().sink.clone()
+    }
+}
+
+/// Instantiate a persist source reading back the `target` collection.
+fn persist_source<'s>(
+    scope: Scope<'s, Timestamp>,
+    sink_id: GlobalId,
+    target: CollectionMetadata,
+    compute_state: &ComputeState,
+    start_signal: StartSignal,
+) -> (PersistStreams<'s>, Vec<PressOnDropButton>) {
+    // There is no guarantee that the sink as-of is beyond the persist shard's since. If it isn't,
+    // instantiating a `persist_source` with it would panic. So instead we leave it to
+    // `persist_source` to select an appropriate as-of. We only care about times beyond the current
+    // shard upper anyway.
+    //
+    // TODO(teskje): Ideally we would select the as-of as `join(sink_as_of, since, upper)`, to
+    // allow `persist_source` to omit as much historical detail as possible. However, we don't know
+    // the shard frontiers and we cannot get them here as that requires an `async` context. We
+    // should consider extending the `persist_source` API to allow as-of selection based on the
+    // shard's current frontiers.
+    let as_of = None;
+
+    let until = Antichain::new();
+    let map_filter_project = None;
+
+    let (ok_stream, err_stream, token) = mz_storage_operators::persist_source::persist_source(
+        scope,
+        sink_id,
+        Arc::clone(&compute_state.persist_clients),
+        &compute_state.txns_ctx,
+        target,
+        None,
+        as_of,
+        SnapshotMode::Include,
+        until,
+        map_filter_project,
+        compute_state.dataflow_max_inflight_bytes(),
+        start_signal.into_send_future(),
+        ErrorHandler::Halt("compute persist sink"),
+    );
+
+    let streams = OkErr::new(ok_stream, err_stream);
+    (streams, token)
+}
+
+/// A description for a batch of updates to be written.
+///
+/// Batch descriptions are produced by the `mint` operator and consumed by the `write` and `append`
+/// operators, where they inform which batches should be written or appended, respectively.
+///
+/// Each batch description also contains the index of its "append worker", i.e. the worker that is
+/// responsible for appending the written batches to the output shard.
+#[derive(Clone, Serialize, Deserialize)]
+struct BatchDescription {
+    lower: Antichain<Timestamp>,
+    upper: Antichain<Timestamp>,
+    append_worker: usize,
+}
+
+impl BatchDescription {
+    fn new(lower: Antichain<Timestamp>, upper: Antichain<Timestamp>, append_worker: usize) -> Self {
+        assert!(PartialOrder::less_than(&lower, &upper));
+        Self {
+            lower,
+            upper,
+            append_worker,
+        }
+    }
+}
+
+impl std::fmt::Debug for BatchDescription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "({:?}, {:?})@{}",
+            self.lower.elements(),
+            self.upper.elements(),
+            self.append_worker,
+        )
+    }
+}
+
+/// Construct a name for the given sub-operator.
+fn operator_name(sink_id: GlobalId, sub_operator: &str) -> String {
+    format!("mv_sink({sink_id})::{sub_operator}")
+}
+
+/// Implementation of the `mint` operator.
+mod mint {
+    use super::*;
+
+    /// Render the `mint` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `as_of`: The first time for which the sink may produce output.
+    ///  * `read_only_tx`: A receiver that reports the sink is in read-only mode.
+    ///  * `desired`: The ok/err streams that should be sinked to persist.
+    pub fn render<'s>(
+        sink_id: GlobalId,
+        persist_api: PersistApi,
+        as_of: Antichain<Timestamp>,
+        mut read_only_rx: watch::Receiver<bool>,
+        desired: DesiredStreams<'s>,
+    ) -> (
+        DesiredStreams<'s>,
+        DescsStream<'s>,
+        SharedSinkFrontier,
+        PressOnDropButton,
+    ) {
+        let scope = desired.ok.scope();
+        let worker_id = scope.index();
+        let worker_count = scope.peers();
+
+        // Determine the active worker for the mint operator.
+        let active_worker_id = usize::cast_from(sink_id.hashed()) % scope.peers();
+
+        let sink_frontier = Rc::new(RefCell::new(Antichain::from_elem(Timestamp::MIN)));
+        let shared_frontier = Rc::clone(&sink_frontier);
+
+        let name = operator_name(sink_id, "mint");
+        let mut op = OperatorBuilder::new(name, scope);
+
+        let (ok_output, ok_stream) = op.new_output::<CapacityContainerBuilder<_>>();
+        let (err_output, err_stream) = op.new_output::<CapacityContainerBuilder<_>>();
+        let desired_outputs = OkErr::new(ok_output, err_output);
+        let desired_output_streams = OkErr::new(ok_stream, err_stream);
+
+        let (desc_output, desc_output_stream) = op.new_output::<CapacityContainerBuilder<_>>();
+
+        let mut desired_inputs = OkErr {
+            ok: op.new_input_for(desired.ok, Pipeline, &desired_outputs.ok),
+            err: op.new_input_for(desired.err, Pipeline, &desired_outputs.err),
+        };
+
+        let button = op.build(move |capabilities| async move {
+            // Passing through the `desired` streams only requires data capabilities, so we can
+            // immediately drop their initial capabilities here.
+            let [_, _, desc_cap]: [_; 3] =
+                capabilities.try_into().expect("one capability per output");
+
+            // Non-active workers just pass the `desired` and `persist` data through.
+            if worker_id != active_worker_id {
+                drop(desc_cap);
+                shared_frontier.borrow_mut().clear();
+
+                loop {
+                    tokio::select! {
+                        Some(event) = desired_inputs.ok.next() => {
+                            if let Event::Data(cap, mut data) = event {
+                                desired_outputs.ok.give_container(&cap, &mut data);
+                            }
+                        }
+                        Some(event) = desired_inputs.err.next() => {
+                            if let Event::Data(cap, mut data) = event {
+                                desired_outputs.err.give_container(&cap, &mut data);
+                            }
+                        }
+                        // All inputs are exhausted, so we can shut down.
+                        else => return,
+                    }
+                }
+            }
+
+            let mut cap_set = CapabilitySet::from_elem(desc_cap);
+
+            let read_only = *read_only_rx.borrow_and_update();
+            let mut state = State::new(sink_id, worker_count, as_of, read_only);
+
+            // Create a stream that reports advancements of the target shard's frontier and updates
+            // the shared sink frontier.
+            //
+            // We collect the persist frontier from a write handle directly, rather than inspecting
+            // the `persist` stream, because the latter has two annoying glitches:
+            //  (a) It starts at the shard's read frontier, not its write frontier.
+            //  (b) It can lag behind if there are spikes in ingested data.
+            let mut persist_frontiers = pin!(async_stream::stream! {
+                let mut writer = persist_api.open_writer().await;
+                let mut frontier = Antichain::from_elem(Timestamp::MIN);
+                while !frontier.is_empty() {
+                    writer.wait_for_upper_past(&frontier).await;
+                    frontier = writer.upper().clone();
+                    shared_frontier.borrow_mut().clone_from(&frontier);
+                    yield frontier.clone();
+                }
+            });
+
+            loop {
+                // Read from the inputs, pass through all data to the respective outputs, and keep
+                // track of the input frontiers. When a frontier advances we might have to mint a
+                // new batch description.
+                let maybe_desc = tokio::select! {
+                    Some(event) = desired_inputs.ok.next() => {
+                        match event {
+                            Event::Data(cap, mut data) => {
+                                desired_outputs.ok.give_container(&cap, &mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_desired_ok_frontier(frontier);
+                                state.maybe_mint_batch_description()
+                            }
+                        }
+                    }
+                    Some(event) = desired_inputs.err.next() => {
+                        match event {
+                            Event::Data(cap, mut data) => {
+                                desired_outputs.err.give_container(&cap, &mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_desired_err_frontier(frontier);
+                                state.maybe_mint_batch_description()
+                            }
+                        }
+                    }
+                    Some(frontier) = persist_frontiers.next() => {
+                        state.advance_persist_frontier(frontier);
+                        state.maybe_mint_batch_description()
+                    }
+                    Ok(()) = read_only_rx.changed(), if read_only => {
+                        state.allow_writes();
+                        state.maybe_mint_batch_description()
+                    }
+                    // All inputs are exhausted, so we can shut down.
+                    else => return,
+                };
+
+                if let Some(desc) = maybe_desc {
+                    let lower_ts = *desc.lower.as_option().expect("not empty");
+                    let cap = cap_set.delayed(&lower_ts);
+                    desc_output.give(&cap, desc);
+
+                    // We only emit strictly increasing `lower`s, so we can let our output frontier
+                    // advance beyond the current `lower`.
+                    cap_set.downgrade([lower_ts.step_forward()]);
+                } else {
+                    // The next emitted `lower` will be at least the `persist` frontier, so we can
+                    // advance our output frontier as far.
+                    let _ = cap_set.try_downgrade(state.persist_frontier.iter());
+                }
+            }
+        });
+
+        (
+            desired_output_streams,
+            desc_output_stream,
+            sink_frontier,
+            button.press_on_drop(),
+        )
+    }
+
+    /// State maintained by the `mint` operator.
+    struct State {
+        sink_id: GlobalId,
+        /// The number of workers in the Timely cluster.
+        worker_count: usize,
+        /// The frontiers of the `desired` inputs.
+        desired_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
+        /// The frontier of the target persist shard.
+        persist_frontier: Antichain<Timestamp>,
+        /// The append worker for the next batch description, chosen in round-robin fashion.
+        next_append_worker: usize,
+        /// The last `lower` we have emitted in a batch description, if any. Whenever the
+        /// `persist_frontier` moves beyond this frontier, we need to mint a new description.
+        last_lower: Option<Antichain<Timestamp>>,
+        /// Whether we are operating in read-only mode.
+        ///
+        /// In read-only mode, minting of batch descriptions is disabled.
+        read_only: bool,
+    }
+
+    impl State {
+        fn new(
+            sink_id: GlobalId,
+            worker_count: usize,
+            as_of: Antichain<Timestamp>,
+            read_only: bool,
+        ) -> Self {
+            // Initializing `persist_frontier` to the `as_of` ensures that the first minted batch
+            // description will have a `lower` of `as_of` or beyond, and thus that we don't spend
+            // work needlessly writing batches at previous times.
+            let persist_frontier = as_of;
+
+            Self {
+                sink_id,
+                worker_count,
+                desired_frontiers: OkErr::new_frontiers(),
+                persist_frontier,
+                next_append_worker: 0,
+                last_lower: None,
+                read_only,
+            }
+        }
+
+        fn trace<S: AsRef<str>>(&self, message: S) {
+            let message = message.as_ref();
+            trace!(
+                sink_id = %self.sink_id,
+                desired_frontier = ?self.desired_frontiers.frontier().elements(),
+                persist_frontier = ?self.persist_frontier.elements(),
+                last_lower = ?self.last_lower.as_ref().map(|f| f.elements()),
+                message,
+            );
+        }
+
+        fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.desired_frontiers.ok, frontier) {
+                self.trace("advanced `desired` ok frontier");
+            }
+        }
+
+        fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.desired_frontiers.err, frontier) {
+                self.trace("advanced `desired` err frontier");
+            }
+        }
+
+        fn advance_persist_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.persist_frontier, frontier) {
+                self.trace("advanced `persist` frontier");
+            }
+        }
+
+        fn allow_writes(&mut self) {
+            if self.read_only {
+                self.read_only = false;
+                self.trace("disabled read-only mode");
+            }
+        }
+
+        fn maybe_mint_batch_description(&mut self) -> Option<BatchDescription> {
+            let desired_frontier = self.desired_frontiers.frontier();
+            let persist_frontier = &self.persist_frontier;
+
+            // We only mint new batch descriptions when:
+            //  1. We are _not_ in read-only mode.
+            //  2. The `desired` frontier is ahead of the `persist` frontier.
+            //  3. The `persist` frontier advanced since we last emitted a batch description.
+            let desired_ahead = PartialOrder::less_than(persist_frontier, desired_frontier);
+            let persist_advanced = self.last_lower.as_ref().map_or(true, |lower| {
+                PartialOrder::less_than(lower, persist_frontier)
+            });
+
+            if self.read_only || !desired_ahead || !persist_advanced {
+                return None;
+            }
+
+            let lower = persist_frontier.clone();
+            let upper = desired_frontier.clone();
+            let append_worker = self.next_append_worker;
+            let desc = BatchDescription::new(lower, upper, append_worker);
+
+            self.next_append_worker = (append_worker + 1) % self.worker_count;
+            self.last_lower = Some(desc.lower.clone());
+
+            self.trace(format!("minted batch description: {desc:?}"));
+            Some(desc)
+        }
+    }
+}
+
+/// Implementation of the `write` operator.
+mod write {
+    use super::*;
+
+    /// Render the `write` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `as_of`: The first time for which the sink may produce output.
+    ///  * `desired`: The ok/err streams that should be sinked to persist.
+    ///  * `persist`: The ok/err streams read back from the output persist shard.
+    ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
+    pub fn render<'s>(
+        sink_id: GlobalId,
+        persist_api: PersistApi,
+        as_of: Antichain<Timestamp>,
+        desired: DesiredStreams<'s>,
+        persist: PersistStreams<'s>,
+        descs: DescsStream<'s>,
+        worker_config: Rc<ConfigSet>,
+    ) -> (BatchesStream<'s>, PressOnDropButton) {
+        let scope = desired.ok.scope();
+        let worker_id = scope.index();
+
+        let name = operator_name(sink_id, "write");
+        let mut op = OperatorBuilder::new(name, scope.clone());
+
+        let mut logging = None;
+        if let (Some(compute_logger), Some(differential_logger)) = (
+            scope.worker().logger_for("materialize/compute"),
+            scope.worker().logger_for("differential/arrange"),
+        ) {
+            let operator_info = op.operator_info();
+            logging = Some(Logging::new(
+                compute_logger,
+                differential_logger.into(),
+                operator_info.global_id,
+                operator_info.address.to_vec(),
+            ));
+        }
+
+        let (batches_output, batches_output_stream) =
+            op.new_output::<CapacityContainerBuilder<_>>();
+
+        // It is important that we exchange the `desired` and `persist` data the same way, so
+        // updates that cancel each other out end up on the same worker.
+        let exchange_ok = |(d, _, _): &(Row, Timestamp, Diff)| d.hashed();
+        let exchange_err = |(d, _, _): &(DataflowError, Timestamp, Diff)| d.hashed();
+
+        let mut desired_inputs = OkErr::new(
+            op.new_disconnected_input(desired.ok, Exchange::new(exchange_ok)),
+            op.new_disconnected_input(desired.err, Exchange::new(exchange_err)),
+        );
+        let mut persist_inputs = OkErr::new(
+            op.new_disconnected_input(persist.ok, Exchange::new(exchange_ok)),
+            op.new_disconnected_input(persist.err, Exchange::new(exchange_err)),
+        );
+        let mut descs_input = op.new_input_for(descs.broadcast(), Pipeline, &batches_output);
+
+        let button = op.build(move |capabilities| async move {
+            // We will use the data capabilities from the `descs` input to produce output, so no
+            // need to hold onto the initial capabilities.
+            drop(capabilities);
+
+            let writer = persist_api.open_writer().await;
+            let sink_metrics = persist_api.open_metrics().await;
+            let mut state = State::new(
+                sink_id,
+                worker_id,
+                writer,
+                sink_metrics,
+                logging,
+                as_of,
+                &worker_config,
+            );
+
+            loop {
+                // Read from the inputs, extract `desired` updates as positive contributions to
+                // `correction` and `persist` updates as negative contributions. If either the
+                // `desired` or `persist` frontier advances, or if we receive a new batch description,
+                // we might have to write a new batch.
+                let maybe_batch = tokio::select! {
+                    Some(event) = desired_inputs.ok.next() => {
+                        match event {
+                            Event::Data(_cap, mut data) => {
+                                state.corrections.ok.insert(&mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_desired_ok_frontier(frontier);
+                                state.maybe_write_batch().await
+                            }
+                        }
+                    }
+                    Some(event) = desired_inputs.err.next() => {
+                        match event {
+                            Event::Data(_cap, mut data) => {
+                                state.corrections.err.insert(&mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_desired_err_frontier(frontier);
+                                state.maybe_write_batch().await
+                            }
+                        }
+                    }
+                    Some(event) = persist_inputs.ok.next() => {
+                        match event {
+                            Event::Data(_cap, mut data) => {
+                                state.corrections.ok.insert_negated(&mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_persist_ok_frontier(frontier);
+                                state.maybe_write_batch().await
+                            }
+                        }
+                    }
+                    Some(event) = persist_inputs.err.next() => {
+                        match event {
+                            Event::Data(_cap, mut data) => {
+                                state.corrections.err.insert_negated(&mut data);
+                                None
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_persist_err_frontier(frontier);
+                                state.maybe_write_batch().await
+                            }
+                        }
+                    }
+                    Some(event) = descs_input.next() => {
+                        match event {
+                            Event::Data(cap, data) => {
+                                for desc in data {
+                                    state.absorb_batch_description(desc, cap.clone());
+                                }
+                                state.maybe_write_batch().await
+                            }
+                            Event::Progress(_frontier) => None,
+                        }
+                    }
+                    // All inputs are exhausted, so we can shut down.
+                    else => return,
+                };
+
+                if let Some((index, batch, cap)) = maybe_batch {
+                    batches_output.give(&cap, (index, batch));
+                }
+            }
+        });
+
+        (batches_output_stream, button.press_on_drop())
+    }
+
+    /// State maintained by the `write` operator.
+    struct State {
+        sink_id: GlobalId,
+        worker_id: usize,
+        persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        /// Contains `desired - persist`, reflecting the updates we would like to commit to
+        /// `persist` in order to "correct" it to track `desired`. This collection is only modified
+        /// by updates received from either the `desired` or `persist` inputs.
+        corrections: OkErr<Correction<Row>, Correction<DataflowError>>,
+        /// The frontiers of the `desired` inputs.
+        desired_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
+        /// The frontiers of the `persist` inputs.
+        ///
+        /// Note that this is _not_ the same as the write frontier of the output persist shard! It
+        /// usually is, but during snapshot processing, these frontiers will start at the shard's
+        /// read frontier, so they can be beyond its write frontier. This is important as it means
+        /// we must not discard batch descriptions based on these persist frontiers: A batch
+        /// description might still be valid even if its `lower` is before the persist frontiers we
+        /// observe.
+        persist_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
+        /// The current valid batch description and associated output capability, if any.
+        batch_description: Option<(BatchDescription, Capability<Timestamp>)>,
+        /// A request to force a consolidation of `corrections` once both `desired_frontiers` and
+        /// `persist_frontiers` become greater than the given frontier.
+        ///
+        /// Normally we force a consolidation whenever we write a batch, but there are periods
+        /// (like read-only mode) when that doesn't happen, and we need to manually force
+        /// consolidation instead. Currently this is only used to ensure we quickly get rid of the
+        /// snapshot updates.
+        force_consolidation_after: Option<Antichain<Timestamp>>,
+    }
+
+    impl State {
+        fn new(
+            sink_id: GlobalId,
+            worker_id: usize,
+            persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+            metrics: SinkMetrics,
+            logging: Option<Logging>,
+            as_of: Antichain<Timestamp>,
+            worker_config: &ConfigSet,
+        ) -> Self {
+            let worker_metrics = metrics.for_worker(worker_id);
+
+            // Force a consolidation of `corrections` after the snapshot updates have been fully
+            // processed, to ensure we get rid of those as quickly as possible.
+            let force_consolidation_after = Some(as_of.clone());
+
+            let mut state = Self {
+                sink_id,
+                worker_id,
+                persist_writer,
+                corrections: OkErr::new(
+                    Correction::new(
+                        metrics.clone(),
+                        worker_metrics.clone(),
+                        logging.clone(),
+                        worker_config,
+                    ),
+                    Correction::new(metrics, worker_metrics, logging, worker_config),
+                ),
+                desired_frontiers: OkErr::new_frontiers(),
+                persist_frontiers: OkErr::new_frontiers(),
+                batch_description: None,
+                force_consolidation_after,
+            };
+
+            // Immediately advance the persist frontier tracking to the `as_of`.
+            // This is important to ensure the persist sink doesn't get stuck if the output shard's
+            // initial frontier is less than the `as_of`. The `mint` operator first emits a batch
+            // description with `lower = as_of`, and the `write` operator only emits a batch when
+            // its observed persist frontier is >= the batch description's `lower`, which (assuming
+            // no other writers) would be never if we didn't advance the observed persist frontier
+            // to the `as_of`.
+            if MV_SINK_ADVANCE_PERSIST_FRONTIERS.get(worker_config) {
+                state.advance_persist_ok_frontier(as_of.clone());
+                state.advance_persist_err_frontier(as_of);
+            }
+
+            state
+        }
+
+        fn trace<S: AsRef<str>>(&self, message: S) {
+            let message = message.as_ref();
+            trace!(
+                sink_id = %self.sink_id,
+                worker = %self.worker_id,
+                desired_frontier = ?self.desired_frontiers.frontier().elements(),
+                persist_frontier = ?self.persist_frontiers.frontier().elements(),
+                batch_description = ?self.batch_description.as_ref().map(|(d, _)| d),
+                message,
+            );
+        }
+
+        fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.desired_frontiers.ok, frontier) {
+                self.apply_desired_frontier_advancement();
+                self.trace("advanced `desired` ok frontier");
+            }
+        }
+
+        fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.desired_frontiers.err, frontier) {
+                self.apply_desired_frontier_advancement();
+                self.trace("advanced `desired` err frontier");
+            }
+        }
+
+        fn advance_persist_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.persist_frontiers.ok, frontier) {
+                self.apply_persist_frontier_advancement();
+                self.trace("advanced `persist` ok frontier");
+            }
+        }
+
+        fn advance_persist_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.persist_frontiers.err, frontier) {
+                self.apply_persist_frontier_advancement();
+                self.trace("advanced `persist` err frontier");
+            }
+        }
+
+        /// Apply the effects of a previous `desired` frontier advancement.
+        fn apply_desired_frontier_advancement(&mut self) {
+            self.maybe_force_consolidation();
+        }
+
+        /// Apply the effects of a previous `persist` frontier advancement.
+        fn apply_persist_frontier_advancement(&mut self) {
+            let frontier = self.persist_frontiers.frontier();
+
+            // We will only emit times at or after the `persist` frontier, so now is a good time to
+            // advance the times of stashed updates.
+            self.corrections.ok.advance_since(frontier.clone());
+            self.corrections.err.advance_since(frontier.clone());
+
+            self.maybe_force_consolidation();
+        }
+
+        /// If the current consolidation request has become applicable, apply it.
+        fn maybe_force_consolidation(&mut self) {
+            let Some(request) = &self.force_consolidation_after else {
+                return;
+            };
+
+            let desired_frontier = self.desired_frontiers.frontier();
+            let persist_frontier = self.persist_frontiers.frontier();
+            if PartialOrder::less_than(request, desired_frontier)
+                && PartialOrder::less_than(request, persist_frontier)
+            {
+                self.trace("forcing correction consolidation");
+                self.corrections.ok.consolidate_at_since();
+                self.corrections.err.consolidate_at_since();
+
+                // Remove the consolidation request, now that we have fulfilled it.
+                self.force_consolidation_after = None;
+            }
+        }
+
+        fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {
+            // The incoming batch description is outdated if we already have a batch description
+            // with a greater `lower`.
+            //
+            // Note that we cannot assume a description is outdated based on the comparison of its
+            // `lower` with the `persist_frontier`. The persist frontier observed by the `write`
+            // operator is initialized with the shard's read frontier, so it can be greater than
+            // the shard's write frontier.
+            if let Some((prev, _)) = &self.batch_description {
+                if PartialOrder::less_than(&desc.lower, &prev.lower) {
+                    self.trace(format!("skipping outdated batch description: {desc:?}"));
+                    return;
+                }
+            }
+
+            self.batch_description = Some((desc, cap));
+            self.trace("set batch description");
+        }
+
+        async fn maybe_write_batch(
+            &mut self,
+        ) -> Option<(BatchDescription, ProtoBatch, Capability<Timestamp>)> {
+            let (desc, _cap) = self.batch_description.as_ref()?;
+
+            // We can write a new batch if we have seen all `persist` updates before `lower` and
+            // all `desired` updates up to `upper`.
+            let persist_complete =
+                PartialOrder::less_equal(&desc.lower, self.persist_frontiers.frontier());
+            let desired_complete =
+                PartialOrder::less_equal(&desc.upper, self.desired_frontiers.frontier());
+            if !persist_complete || !desired_complete {
+                return None;
+            }
+
+            let (desc, cap) = self.batch_description.take()?;
+
+            let ok_updates = self.corrections.ok.updates_before(&desc.upper);
+            let err_updates = self.corrections.err.updates_before(&desc.upper);
+
+            let oks = ok_updates.map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
+            let errs = err_updates.map(|(d, t, r)| ((SourceData(Err(d)), ()), t, r.into_inner()));
+            let mut updates = oks.chain(errs).peekable();
+
+            // Don't write empty batches.
+            if updates.peek().is_none() {
+                drop(updates);
+                self.trace("skipping empty batch");
+                return None;
+            }
+
+            let batch = self
+                .persist_writer
+                .batch(updates, desc.lower.clone(), desc.upper.clone())
+                .await
+                .expect("valid usage")
+                .into_transmittable_batch();
+
+            self.trace("wrote a batch");
+            Some((desc, batch, cap))
+        }
+    }
+}
+
+/// Implementation of the `append` operator.
+mod append {
+    use super::*;
+
+    /// Render the `append` operator.
+    ///
+    /// The parameters passed in are:
+    ///  * `sink_id`: The `GlobalId` of the sink export.
+    ///  * `persist_api`: An object providing access to the output persist shard.
+    ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
+    ///  * `batches`: The stream of written batches produced by the `write` operator.
+    pub fn render<'s>(
+        sink_id: GlobalId,
+        persist_api: PersistApi,
+        descs: DescsStream<'s>,
+        batches: BatchesStream<'s>,
+    ) -> PressOnDropButton {
+        let scope = descs.scope();
+        let worker_id = scope.index();
+
+        let name = operator_name(sink_id, "append");
+        let mut op = OperatorBuilder::new(name, scope);
+
+        // Broadcast batch descriptions to all workers, regardless of whether or not they are
+        // responsible for the append, to give them a chance to clean up any outdated state they
+        // might still hold.
+        let mut descs_input = op.new_disconnected_input(descs.broadcast(), Pipeline);
+        let mut batches_input = op.new_disconnected_input(
+            batches,
+            Exchange::new(move |(desc, _): &(BatchDescription, _)| {
+                u64::cast_from(desc.append_worker)
+            }),
+        );
+
+        let button = op.build(move |_capabilities| async move {
+            let writer = persist_api.open_writer().await;
+            let mut state = State::new(sink_id, worker_id, writer);
+
+            loop {
+                // Read from the inputs, absorb batch descriptions and batches. If the `batches`
+                // frontier advances, or if we receive a new batch description, we might have to
+                // append a new batch.
+                tokio::select! {
+                    Some(event) = descs_input.next() => {
+                        if let Event::Data(_cap, data) = event {
+                            for desc in data {
+                                state.absorb_batch_description(desc).await;
+                                state.maybe_append_batches().await;
+                            }
+                        }
+                    }
+                    Some(event) = batches_input.next() => {
+                        match event {
+                            Event::Data(_cap, data) => {
+                                // The batch description is only used for routing and we ignore it
+                                // here since we already get one from `descs_input`.
+                                for (_desc, batch) in data {
+                                    state.absorb_batch(batch).await;
+                                }
+                            }
+                            Event::Progress(frontier) => {
+                                state.advance_batches_frontier(frontier);
+                                state.maybe_append_batches().await;
+                            }
+                        }
+                    }
+                    // All inputs are exhausted, so we can shut down.
+                    else => return,
+                }
+            }
+        });
+
+        button.press_on_drop()
+    }
+
+    /// State maintained by the `append` operator.
+    struct State {
+        sink_id: GlobalId,
+        worker_id: usize,
+        persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        /// The current input frontier of `batches`.
+        batches_frontier: Antichain<Timestamp>,
+        /// The greatest observed `lower` from both `descs` and `batches`.
+        lower: Antichain<Timestamp>,
+        /// The batch description for `lower`, if any.
+        batch_description: Option<BatchDescription>,
+        /// Batches received for `lower`.
+        batches: Vec<Batch<SourceData, (), Timestamp, StorageDiff>>,
+    }
+
+    impl State {
+        fn new(
+            sink_id: GlobalId,
+            worker_id: usize,
+            persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        ) -> Self {
+            Self {
+                sink_id,
+                worker_id,
+                persist_writer,
+                batches_frontier: Antichain::from_elem(Timestamp::MIN),
+                lower: Antichain::from_elem(Timestamp::MIN),
+                batch_description: None,
+                batches: Default::default(),
+            }
+        }
+
+        fn trace<S: AsRef<str>>(&self, message: S) {
+            let message = message.as_ref();
+            trace!(
+                sink_id = %self.sink_id,
+                worker = %self.worker_id,
+                batches_frontier = ?self.batches_frontier.elements(),
+                lower = ?self.lower.elements(),
+                batch_description = ?self.batch_description,
+                message,
+            );
+        }
+
+        fn advance_batches_frontier(&mut self, frontier: Antichain<Timestamp>) {
+            if advance(&mut self.batches_frontier, frontier) {
+                self.trace("advanced `batches` frontier");
+            }
+        }
+
+        /// Advance the current `lower`.
+        ///
+        /// Discards all currently stashed batches and batch descriptions, assuming that they are
+        /// now invalid.
+        async fn advance_lower(&mut self, frontier: Antichain<Timestamp>) {
+            assert!(PartialOrder::less_than(&self.lower, &frontier));
+
+            self.lower = frontier;
+            self.batch_description = None;
+
+            // Remove stashed batches, cleaning up those we didn't append.
+            for batch in self.batches.drain(..) {
+                batch.delete().await;
+            }
+
+            self.trace("advanced `lower`");
+        }
+
+        /// Absorb the given batch description into the state, provided it is not outdated.
+        async fn absorb_batch_description(&mut self, desc: BatchDescription) {
+            if PartialOrder::less_than(&self.lower, &desc.lower) {
+                self.advance_lower(desc.lower.clone()).await;
+            } else if &self.lower != &desc.lower {
+                self.trace(format!("skipping outdated batch description: {desc:?}"));
+                return;
+            }
+
+            if desc.append_worker == self.worker_id {
+                self.batch_description = Some(desc);
+                self.trace("set batch description");
+            }
+        }
+
+        /// Absorb the given batch into the state, provided it is not outdated.
+        async fn absorb_batch(&mut self, batch: ProtoBatch) {
+            let batch = self.persist_writer.batch_from_transmittable_batch(batch);
+            if PartialOrder::less_than(&self.lower, batch.lower()) {
+                self.advance_lower(batch.lower().clone()).await;
+            } else if &self.lower != batch.lower() {
+                self.trace(format!(
+                    "skipping outdated batch: ({:?}, {:?})",
+                    batch.lower().elements(),
+                    batch.upper().elements(),
+                ));
+
+                // Ensure the batch's data gets properly cleaned up before dropping it.
+                batch.delete().await;
+                return;
+            }
+
+            self.batches.push(batch);
+            self.trace("absorbed a batch");
+        }
+
+        async fn maybe_append_batches(&mut self) {
+            let batches_complete = PartialOrder::less_than(&self.lower, &self.batches_frontier);
+            if !batches_complete {
+                return;
+            }
+
+            let Some(desc) = self.batch_description.take() else {
+                return;
+            };
+
+            let new_lower = match self.append_batches(desc).await {
+                Ok(shard_upper) => {
+                    self.trace("appended a batch");
+                    shard_upper
+                }
+                Err(shard_upper) => {
+                    // Failing the append is expected in the presence of concurrent replicas. There
+                    // is nothing special to do here: The self-correcting feedback mechanism
+                    // ensures that we observe the concurrent changes, compute their consequences,
+                    // and append them at a future time.
+                    self.trace(format!(
+                        "append failed due to `lower` mismatch: {:?}",
+                        shard_upper.elements(),
+                    ));
+                    shard_upper
+                }
+            };
+
+            self.advance_lower(new_lower).await;
+        }
+
+        /// Append the current `batches` to the output shard.
+        ///
+        /// Returns whether the append was successful or not, and the current shard upper in either
+        /// case.
+        ///
+        /// This method advances the shard upper to the batch `lower` if necessary. This is the
+        /// mechanism that brings the shard upper to the sink as-of when appending the initial
+        /// batch.
+        ///
+        /// An alternative mechanism for bringing the shard upper to the sink as-of would be making
+        /// a single append at operator startup. The reason we are doing it here instead is that it
+        /// simplifies the implementation of read-only mode. In read-only mode we have to defer any
+        /// persist writes, including the initial upper bump. Having only a single place that
+        /// performs writes makes it easy to ensure we are doing that correctly.
+        async fn append_batches(
+            &mut self,
+            desc: BatchDescription,
+        ) -> Result<Antichain<Timestamp>, Antichain<Timestamp>> {
+            let (lower, upper) = (desc.lower, desc.upper);
+            let mut to_append: Vec<_> = self.batches.iter_mut().collect();
+
+            loop {
+                let result = self
+                    .persist_writer
+                    .compare_and_append_batch(&mut to_append, lower.clone(), upper.clone(), true)
+                    .await
+                    .expect("valid usage");
+
+                match result {
+                    Ok(()) => return Ok(upper),
+                    Err(mismatch) if PartialOrder::less_than(&mismatch.current, &lower) => {
+                        advance_shard_upper(&mut self.persist_writer, lower.clone()).await;
+
+                        // At this point the shard's since and upper are likely the same, a state
+                        // that is likely to hit edge-cases in logic reasoning about frontiers.
+                        fail::fail_point!("mv_advanced_upper");
+                    }
+                    Err(mismatch) => return Err(mismatch.current),
+                }
+            }
+        }
+    }
+
+    /// Advance the frontier of the given writer's shard to at least the given `upper`.
+    async fn advance_shard_upper(
+        persist_writer: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        upper: Antichain<Timestamp>,
+    ) {
+        let empty_updates: &[((SourceData, ()), Timestamp, StorageDiff)] = &[];
+        let lower = Antichain::from_elem(Timestamp::MIN);
+        persist_writer
+            .append(empty_updates, lower, upper)
+            .await
+            .expect("valid usage")
+            .expect("should always succeed");
+    }
+}

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -447,17 +447,55 @@ mod write {
 
     /// Commands sent from the Timely operator to the Tokio write task.
     enum WriteCommand {
-        /// Forward desired updates to the corrections buffer.
-        Desired(Result<Vec<(Row, Timestamp, Diff)>, Vec<(DataflowError, Timestamp, Diff)>>),
-        /// Forward persist updates (negated) to the corrections buffer.
-        Persist(Result<Vec<(Row, Timestamp, Diff)>, Vec<(DataflowError, Timestamp, Diff)>>),
-        /// The persist frontier advanced. Used for `advance_since` and consolidation.
-        PersistFrontier(Antichain<Timestamp>),
-        /// Force a consolidation of the corrections buffer.
-        ForceConsolidation,
+        /// A coalesced batch of work gathered during a single operator activation.
+        ///
+        /// The Timely closure accumulates all updates observed across the four data inputs plus
+        /// any frontier advancement and forced-consolidation flag, and sends a single
+        /// `WriteCommand::Batch` per activation. This keeps the channel overhead independent of
+        /// the number of Timely chunks processed per activation.
+        Batch(BatchUpdates),
         /// Write a batch with the given description. The task drains corrections and writes
         /// them to persist.
         WriteBatch(BatchDescription),
+    }
+
+    /// The payload of a coalesced [`WriteCommand::Batch`].
+    struct BatchUpdates {
+        /// Positive contributions from the `desired` ok input.
+        desired_ok: Vec<(Row, Timestamp, Diff)>,
+        /// Positive contributions from the `desired` err input.
+        desired_err: Vec<(DataflowError, Timestamp, Diff)>,
+        /// Negative contributions from the `persist` ok input.
+        persist_ok: Vec<(Row, Timestamp, Diff)>,
+        /// Negative contributions from the `persist` err input.
+        persist_err: Vec<(DataflowError, Timestamp, Diff)>,
+        /// The new persist frontier, if it advanced this activation.
+        persist_frontier: Option<Antichain<Timestamp>>,
+        /// Whether a consolidation of the corrections buffer should be forced.
+        force_consolidation: bool,
+    }
+
+    impl BatchUpdates {
+        fn new() -> Self {
+            Self {
+                desired_ok: Vec::new(),
+                desired_err: Vec::new(),
+                persist_ok: Vec::new(),
+                persist_err: Vec::new(),
+                persist_frontier: None,
+                force_consolidation: false,
+            }
+        }
+
+        /// Returns true if there is no work in this batch.
+        fn is_empty(&self) -> bool {
+            self.desired_ok.is_empty()
+                && self.desired_err.is_empty()
+                && self.persist_ok.is_empty()
+                && self.persist_err.is_empty()
+                && self.persist_frontier.is_none()
+                && !self.force_consolidation
+        }
     }
 
     /// A response from the Tokio write task back to the Timely operator.
@@ -600,26 +638,21 @@ mod write {
                 if let Some(logger) = &mut correction_logger {
                     logger.apply_events();
                 }
-                // Drain all inputs and forward data to the Tokio task.
+                // Coalesce all work from this activation into a single command. This keeps
+                // per-chunk channel overhead low, which matters for hydration when many small
+                // Timely chunks arrive in a single activation sweep.
+                let mut batch = BatchUpdates::new();
                 desired_ok_input.for_each(|_cap, data| {
-                    cmd_tx
-                        .send(WriteCommand::Desired(Ok(std::mem::take(data))))
-                        .expect("write task unexpectedly gone");
+                    batch.desired_ok.append(data);
                 });
                 desired_err_input.for_each(|_cap, data| {
-                    cmd_tx
-                        .send(WriteCommand::Desired(Err(std::mem::take(data))))
-                        .expect("write task unexpectedly gone");
+                    batch.desired_err.append(data);
                 });
                 persist_ok_input.for_each(|_cap, data| {
-                    cmd_tx
-                        .send(WriteCommand::Persist(Ok(std::mem::take(data))))
-                        .expect("write task unexpectedly gone");
+                    batch.persist_ok.append(data);
                 });
                 persist_err_input.for_each(|_cap, data| {
-                    cmd_tx
-                        .send(WriteCommand::Persist(Err(std::mem::take(data))))
-                        .expect("write task unexpectedly gone");
+                    batch.persist_err.append(data);
                 });
 
                 // Accept batch descriptions.
@@ -630,21 +663,22 @@ mod write {
                     }
                 });
 
-                // Track frontiers. Send persist frontier to Tokio task for advance_since.
+                // Track frontiers. Include the new persist frontier in the coalesced batch for
+                // `advance_since`.
                 state.advance_desired_ok_frontier(frontiers[0].frontier());
                 state.advance_desired_err_frontier(frontiers[1].frontier());
                 if state.advance_persist_ok_frontier(frontiers[2].frontier())
                     | state.advance_persist_err_frontier(frontiers[3].frontier())
                 {
-                    cmd_tx
-                        .send(WriteCommand::PersistFrontier(
-                            state.persist_frontiers.frontier().to_owned(),
-                        ))
-                        .expect("write task unexpectedly gone");
+                    batch.persist_frontier = Some(state.persist_frontiers.frontier().to_owned());
                 }
                 if state.should_force_consolidation() {
+                    batch.force_consolidation = true;
+                }
+
+                if !batch.is_empty() {
                     cmd_tx
-                        .send(WriteCommand::ForceConsolidation)
+                        .send(WriteCommand::Batch(batch))
                         .expect("write task unexpectedly gone");
                 }
 
@@ -693,27 +727,32 @@ mod write {
         resp_tx: &mpsc::UnboundedSender<WriteResponse>,
     ) {
         match cmd {
-            WriteCommand::Desired(Ok(mut updates)) => {
-                corrections.ok.insert(&mut updates);
-            }
-            WriteCommand::Desired(Err(mut updates)) => {
-                corrections.err.insert(&mut updates);
-            }
-            WriteCommand::Persist(Ok(mut updates)) => {
-                corrections.ok.insert_negated(&mut updates);
-            }
-            WriteCommand::Persist(Err(mut updates)) => {
-                corrections.err.insert_negated(&mut updates);
-            }
-            WriteCommand::PersistFrontier(frontier) => {
-                // We will only emit times at or after the `persist` frontier, so now is a good
-                // time to advance the times of stashed updates.
-                corrections.ok.advance_since(frontier.clone());
-                corrections.err.advance_since(frontier);
-            }
-            WriteCommand::ForceConsolidation => {
-                corrections.ok.consolidate_at_since();
-                corrections.err.consolidate_at_since();
+            WriteCommand::Batch(mut batch) => {
+                // Apply the same logical sequence of operations that the per-chunk commands
+                // used to: positive desired inserts, negated persist inserts, then optional
+                // frontier advancement and forced consolidation.
+                if !batch.desired_ok.is_empty() {
+                    corrections.ok.insert(&mut batch.desired_ok);
+                }
+                if !batch.desired_err.is_empty() {
+                    corrections.err.insert(&mut batch.desired_err);
+                }
+                if !batch.persist_ok.is_empty() {
+                    corrections.ok.insert_negated(&mut batch.persist_ok);
+                }
+                if !batch.persist_err.is_empty() {
+                    corrections.err.insert_negated(&mut batch.persist_err);
+                }
+                if let Some(frontier) = batch.persist_frontier {
+                    // We will only emit times at or after the `persist` frontier, so now is a
+                    // good time to advance the times of stashed updates.
+                    corrections.ok.advance_since(frontier.clone());
+                    corrections.err.advance_since(frontier);
+                }
+                if batch.force_consolidation {
+                    corrections.ok.consolidate_at_since();
+                    corrections.err.consolidate_at_since();
+                }
             }
             WriteCommand::WriteBatch(desc) => {
                 // Chain ok and err correction iterators directly, avoiding an

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -28,7 +28,6 @@ use mz_persist_client::batch::{Batch, ProtoBatch};
 use mz_persist_client::write::WriteHandle;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::StorageDiff;
-use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
 use timely::PartialOrder;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
@@ -43,6 +42,7 @@ use tracing::trace;
 
 use crate::compute_state::ComputeState;
 use crate::render::StartSignal;
+use crate::render::errors::DataflowErrorSer;
 use crate::sink::correction::{ChannelLogging, Correction, CorrectionLogger};
 use crate::sink::materialized_view::{
     BatchDescription, BatchesStream, DescsStream, DesiredStreams, OkErr, PersistApi,
@@ -56,7 +56,7 @@ pub(super) fn persist_sink<'s>(
     sink_id: GlobalId,
     target: &mz_storage_types::controller::CollectionMetadata,
     ok_collection: VecCollection<'s, Timestamp, Row, Diff>,
-    err_collection: VecCollection<'s, Timestamp, DataflowError, Diff>,
+    err_collection: VecCollection<'s, Timestamp, DataflowErrorSer, Diff>,
     as_of: Antichain<Timestamp>,
     compute_state: &mut ComputeState,
     start_signal: StartSignal,
@@ -464,11 +464,11 @@ mod write {
         /// Positive contributions from the `desired` ok input.
         desired_ok: Vec<(Row, Timestamp, Diff)>,
         /// Positive contributions from the `desired` err input.
-        desired_err: Vec<(DataflowError, Timestamp, Diff)>,
+        desired_err: Vec<(DataflowErrorSer, Timestamp, Diff)>,
         /// Negative contributions from the `persist` ok input.
         persist_ok: Vec<(Row, Timestamp, Diff)>,
         /// Negative contributions from the `persist` err input.
-        persist_err: Vec<(DataflowError, Timestamp, Diff)>,
+        persist_err: Vec<(DataflowErrorSer, Timestamp, Diff)>,
         /// The new persist frontier, if it advanced this activation.
         persist_frontier: Option<Antichain<Timestamp>>,
         /// Whether a consolidation of the corrections buffer should be forced.
@@ -553,7 +553,7 @@ mod write {
         // It is important that we exchange the `desired` and `persist` data the same way, so
         // updates that cancel each other out end up on the same worker.
         let exchange_ok = |(d, _, _): &(Row, Timestamp, Diff)| d.hashed();
-        let exchange_err = |(d, _, _): &(DataflowError, Timestamp, Diff)| d.hashed();
+        let exchange_err = |(d, _, _): &(DataflowErrorSer, Timestamp, Diff)| d.hashed();
 
         // Data inputs are created before the output, so they are not connected to it.
         let mut desired_ok_input = builder.new_input(desired.ok, Exchange::new(exchange_ok));
@@ -574,7 +574,7 @@ mod write {
         // Construct corrections on the Timely thread (reads ConfigSet), then move to the
         // Tokio task. The ChannelLogging sends events back to the Timely thread.
         let worker_metrics = sink_metrics.for_worker(worker_id);
-        let mut corrections: OkErr<Correction<Row>, Correction<DataflowError>> = OkErr::new(
+        let mut corrections: OkErr<Correction<Row>, Correction<DataflowErrorSer>> = OkErr::new(
             Correction::new(
                 sink_metrics.clone(),
                 worker_metrics.clone(),
@@ -721,7 +721,7 @@ mod write {
     /// negative contributions, so the buffer contains `desired - persist`, i.e. the updates that
     /// need to be written to bring the shard in line with `desired`.
     async fn apply_command(
-        corrections: &mut OkErr<Correction<Row>, Correction<DataflowError>>,
+        corrections: &mut OkErr<Correction<Row>, Correction<DataflowErrorSer>>,
         writer: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         cmd: WriteCommand,
         resp_tx: &mpsc::UnboundedSender<WriteResponse>,
@@ -764,7 +764,7 @@ mod write {
                 let errs = corrections
                     .err
                     .updates_before(&desc.upper)
-                    .map(|(d, t, r)| ((SourceData(Err(d)), ()), t, r.into_inner()));
+                    .map(|(d, t, r)| ((SourceData(Err(d.deserialize())), ()), t, r.into_inner()));
                 let mut updates = oks.chain(errs).peekable();
 
                 if updates.peek().is_none() {

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -207,6 +207,16 @@ mod mint {
             //  (a) It starts at the shard's read frontier, not its write frontier.
             //  (b) It can lag behind if there are spikes in ingested data.
             //
+            // The decoupling from the `persist` stream is load-bearing: that stream can fall
+            // arbitrarily behind the shard upper during snapshot replay or write spikes. Using
+            // it would delay both (1) the controller-visible sink frontier (`shared_frontier`),
+            // which previously caused a CrossJoin feature-bench regression where the controller
+            // held a finished MV dataflow open waiting for the empty frontier, and (2) the
+            // `state.persist_frontier` that gates batch-description minting, stalling mint until
+            // the read-back stream catches up. The goal isn't tick-granular descriptions per
+            // se — it's avoiding the stream-induced stall. See 5eab5ff896 for the original
+            // regression and rationale.
+            //
             // The task sends the empty frontier as its final message before exiting. The
             // operator drops `persist_rx` once it receives the empty frontier.
             let (persist_tx, persist_rx) = mpsc::unbounded_channel();
@@ -405,30 +415,41 @@ mod mint {
 
         /// Drain persist frontier updates from the Tokio task.
         ///
+        /// Frontiers from the `persist_watch` task are monotonically increasing, so only the
+        /// most recent one matters. We drain all queued messages and apply just the latest,
+        /// avoiding redundant `advance_persist_frontier`/`trace!` calls when several updates
+        /// arrived between activations.
+        ///
         /// The task sends the empty frontier as its final message before exiting. Once
         /// received, we drop the receiver.
         fn drain_persist_rx(&mut self, shared_frontier: &RefCell<Antichain<Timestamp>>) {
             let Some(mut rx) = self.persist_rx.take() else {
                 return;
             };
+            let mut latest: Option<Antichain<Timestamp>> = None;
+            let mut closed = false;
             loop {
                 match rx.try_recv() {
                     Ok(frontier) => {
-                        shared_frontier.borrow_mut().clone_from(&frontier);
                         let done = frontier.is_empty();
-                        self.advance_persist_frontier(frontier.borrow());
+                        latest = Some(frontier);
                         if done {
-                            return;
+                            closed = true;
+                            break;
                         }
                     }
-                    Err(mpsc::error::TryRecvError::Empty) => {
-                        self.persist_rx = Some(rx);
-                        return;
-                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => {
                         panic!("mint persist_watch task unexpectedly gone");
                     }
                 }
+            }
+            if let Some(frontier) = latest {
+                shared_frontier.borrow_mut().clone_from(&frontier);
+                self.advance_persist_frontier(frontier.borrow());
+            }
+            if !closed {
+                self.persist_rx = Some(rx);
             }
         }
 

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -7,244 +7,61 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! A dataflow sink that writes input records to a persist shard.
+//! Sync Timely operator implementation of the MV sink.
 //!
-//! This implementation is both parallel and self-correcting.
+//! This module provides an alternative implementation of `persist_sink` that uses sync Timely
+//! operators communicating with Tokio tasks via channels, instead of async Timely operators.
+//! Gated behind the `ENABLE_SYNC_MV_SINK` dyncfg.
 //!
-//!  * parallel: Multiple workers can participate in writing updates for the same times, letting
-//!    sink throughput scale with the number of workers allocated to the replica.
-//!  * self-correcting: The sink continually compares the contents of the persist shard with the
-//!    contents of the input collection and writes down the difference. If the persist shard ends
-//!    up with undesired contents for any reason, this is corrected the next time the sink manages
-//!    to append to the shard.
-//!
-//! ### Operators
-//!
-//! The persist sink consists of a graph of operators.
-//!
-//!    desired                    persist <---------------.
-//!       |                          |                    |
-//!       |                          |                    |
-//!       |---------------------.    |                    |
-//!       |                     |    |                    |
-//!       |                     |    |                    |
-//!       v                     v    v                    |
-//!   +--------+              +--------+              +--------+
-//!   |  mint  | --descs-.--> | write  | --batches--> | append |
-//!   +--------+          \   +--------+          .-> +--------+
-//!                        \_____________________/
-//!
-//!  * `mint` mints batch descriptions, i.e., `(lower, upper)` bounds of batches that should be
-//!    written. The persist API requires that all workers write batches with the same bounds, so
-//!    they can be appended as a single logical batch. To ensure this, the `mint` operator only
-//!    runs on a single worker that broadcasts minted descriptions to all workers. Batch bounds are
-//!    picked based on the frontiers of the `desired` stream and the output persist shard.
-//!  * `write` stages batch data in persist, based on the batch descriptions received from the
-//!    `mint` operator, but without appending it to the persist shard. This is a multi-worker
-//!    operator, with each worker writing batches of the data that arrives at its local inputs. To
-//!    do so it reads from the `desired` and `persist` streams and produces the difference between
-//!    them to write back out, ensuring that the final contents of the persist shard match
-//!    `desired`.
-//!  * `append` appends the batches minted by `mint` and written by `write` to the persist shard.
-//!    This is a multi-worker operator, where workers are responsible for different subsets of
-//!    batch descriptions. If a worker is responsible for a given batch description, it waits for
-//!    all workers to stage their batches for that batch description, then appends all the batches
-//!    together as a single logical batch.
-//!
-//! Note that while the above graph suggests that `mint` and `write` both receive copies of the
-//! `desired` stream, the actual implementation passes that stream through `mint` and lets `write`
-//! read the passed-through stream, to avoid cloning data.
-//!
-//! Also note that the `append` operator's implementation would perhaps be more natural as a
-//! single-worker implementation. The purpose of sharing the work between all workers is to avoid a
-//! work imbalance where one worker is overloaded (doing both appends and the consequent persist
-//! maintenance work) while others are comparatively idle.
-//!
-//! The persist sink is written to be robust to the presence of other conflicting instances (e.g.
-//! from other replicas) writing to the same persist shard. Each of the three operators needs to be
-//! able to handle conflicting writes that unexpectedly change the contents of the output persist
-//! shard.
-//!
-//! ### Frontiers
-//!
-//! The `desired` frontier tracks the progress of the upstream dataflow, but may be rounded up to
-//! the next refresh time for dataflows that follow a refresh schedule other than "on commit".
-//!
-//! The `persist` frontier tracks the `upper` frontier of the target persist shard, with one
-//! exception: When the `persist_source` that reads back the shard is rendered, it will start
-//! reading at its `since` frontier. So if the shard's `since` is initially greater than its
-//! `upper`, the `persist` frontier too will be in advance of the shard `upper`, until the `upper`
-//! has caught up. To avoid getting confused by this edge case, the `mint` operator does not use
-//! the `persist` stream to observe the shard frontier but keeps its own `WriteHandle` instead.
-//!
-//! The `descs` frontier communicates which `lower` bounds may still be emitted in batch
-//! descriptions. All future batch descriptions will have a `lower` that is greater or equal to the
-//! current `descs` frontier.
-//!
-//! The `batches` frontier communicates for which `lower` bounds batches may still be written. All
-//! batches for descriptions with `lower`s less than the current `batches` frontier have already
-//! been written.
-//!
-//! ### Invariants
-//!
-//! The implementation upholds several invariants that can be relied upon to simplify the
-//! implementation:
-//!
-//!  1. `lower`s in minted batch descriptions are unique and strictly increasing. That is, the
-//!     `mint` operator will never mint the same `lower` twice and a minted `lower` is always
-//!     greater than any previously minted ones.
-//!  2. `upper`s in minted batch descriptions are monotonically increasing.
-//!  3. From (1) follows that there is always at most one "valid" batch description in flight in
-//!     the operator graph. "Valid" here means that the described batch can be appended to the
-//!     persist shard.
-//!
-//! The main simplification these invariants allow is that operators only need to keep track of the
-//! most recent batch description and/or `lower`. Previous batch descriptions are not valid
-//! anymore, so there is no reason to hold any state or perform any work in support of them.
-//!
-//! ### Read-only Mode
-//!
-//! The persist sink can optionally be initialized in read-only mode. In this mode it is passive
-//! and avoids any writes to persist. Activating the `read_only_rx` transitions the sink into write
-//! mode, where it commences normal operation.
-//!
-//! Read-only mode is implemented by the `mint` operator. To disable writes, the `mint` operator
-//! simply avoids minting any batch descriptions. Since both the `write` and the `append` operator
-//! require batch descriptions to write/append batches, this suppresses any persist communication.
-//! At the same time, the `write` operator still observes changes to the `desired` and `persist`
-//! collections, allowing it to keep its correction buffer up-to-date.
+//! See the [main module](super::materialized_view) for the operator graph and design docs.
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::pin::pin;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use differential_dataflow::{AsCollection, Hashable, VecCollection};
-use futures::StreamExt;
+use differential_dataflow::{Hashable, VecCollection};
 use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
-use mz_compute_types::sinks::{ComputeSinkDesc, MaterializedViewSinkConnection};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, ProtoBatch};
-use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::metrics::SinkMetrics;
-use mz_persist_client::operators::shard_source::{ErrorHandler, SnapshotMode};
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{Diagnostics, PersistClient};
-use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::StorageDiff;
-use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
-use mz_timely_util::builder_async::PressOnDropButton;
-use mz_timely_util::builder_async::{Event, OperatorBuilder};
-use mz_timely_util::probe::{Handle, ProbeNotify};
-use serde::{Deserialize, Serialize};
 use timely::PartialOrder;
-use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::generic::OutputBuilder;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::vec::Broadcast;
-use timely::dataflow::operators::{Capability, CapabilitySet, probe};
-use timely::dataflow::{Scope, StreamVec};
+use timely::dataflow::operators::{Capability, CapabilitySet};
 use timely::progress::Antichain;
-use tokio::sync::watch;
+use timely::progress::frontier::AntichainRef;
+use tokio::sync::{mpsc, watch};
 use tracing::trace;
 
 use crate::compute_state::ComputeState;
 use crate::render::StartSignal;
-use crate::render::sinks::SinkRender;
-use crate::sink::correction::{Correction, Logging};
-use crate::sink::refresh::apply_refresh;
-
-impl<'scope> SinkRender<'scope> for MaterializedViewSinkConnection<CollectionMetadata> {
-    fn render_sink(
-        &self,
-        compute_state: &mut ComputeState,
-        sink: &ComputeSinkDesc<CollectionMetadata>,
-        sink_id: GlobalId,
-        as_of: Antichain<Timestamp>,
-        start_signal: StartSignal,
-        mut ok_collection: VecCollection<'scope, Timestamp, Row, Diff>,
-        mut err_collection: VecCollection<'scope, Timestamp, DataflowError, Diff>,
-        _ct_times: Option<VecCollection<'scope, Timestamp, (), Diff>>,
-        output_probe: &Handle<Timestamp>,
-    ) -> Option<Rc<dyn Any>> {
-        // Attach probes reporting the compute frontier.
-        // The `apply_refresh` operator can round up frontiers, making it impossible to accurately
-        // track the progress of the computation, so we need to attach probes before it.
-        let probe = probe::Handle::default();
-        ok_collection = ok_collection
-            .probe_with(&probe)
-            .inner
-            .probe_notify_with(vec![output_probe.clone()])
-            .as_collection();
-        let collection_state = compute_state.expect_collection_mut(sink_id);
-        collection_state.compute_probe = Some(probe);
-
-        // If a `RefreshSchedule` was specified, round up timestamps.
-        if let Some(refresh_schedule) = &sink.refresh_schedule {
-            ok_collection = apply_refresh(ok_collection, refresh_schedule.clone());
-            err_collection = apply_refresh(err_collection, refresh_schedule.clone());
-        }
-
-        if sink.up_to != Antichain::default() {
-            unimplemented!(
-                "UP TO is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
-            )
-        }
-
-        let read_only_rx = collection_state.read_only_rx.clone();
-
-        let token = persist_sink(
-            sink_id,
-            &self.storage_metadata,
-            ok_collection,
-            err_collection,
-            as_of,
-            compute_state,
-            start_signal,
-            read_only_rx,
-        );
-        Some(token)
-    }
-}
-
-/// Type of the `desired` stream, split into `Ok` and `Err` streams.
-type DesiredStreams<'s> = OkErr<
-    StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
-    StreamVec<'s, Timestamp, (DataflowError, Timestamp, Diff)>,
->;
-
-/// Type of the `persist` stream, split into `Ok` and `Err` streams.
-type PersistStreams<'s> = OkErr<
-    StreamVec<'s, Timestamp, (Row, Timestamp, Diff)>,
-    StreamVec<'s, Timestamp, (DataflowError, Timestamp, Diff)>,
->;
-
-/// Type of the `descs` stream.
-type DescsStream<'s> = StreamVec<'s, Timestamp, BatchDescription>;
-
-/// Type of the `batches` stream.
-type BatchesStream<'s> = StreamVec<'s, Timestamp, (BatchDescription, ProtoBatch)>;
-
-/// Type of the shared sink write frontier.
-type SharedSinkFrontier = Rc<RefCell<Antichain<Timestamp>>>;
+use crate::sink::correction::{ChannelLogging, Correction, CorrectionLogger};
+use crate::sink::materialized_view::{
+    BatchDescription, BatchesStream, DescsStream, DesiredStreams, OkErr, PersistApi,
+    PersistStreams, SharedSinkFrontier, advance, operator_name, persist_source,
+};
 
 /// Renders an MV sink writing the given desired collection into the `target` persist collection.
+///
+/// This is the sync Timely operator implementation, using Tokio tasks for I/O.
 pub(super) fn persist_sink<'s>(
     sink_id: GlobalId,
-    target: &CollectionMetadata,
+    target: &mz_storage_types::controller::CollectionMetadata,
     ok_collection: VecCollection<'s, Timestamp, Row, Diff>,
     err_collection: VecCollection<'s, Timestamp, DataflowError, Diff>,
     as_of: Antichain<Timestamp>,
     compute_state: &mut ComputeState,
     start_signal: StartSignal,
     read_only_rx: watch::Receiver<bool>,
-) -> Rc<dyn Any>
-where
-{
+) -> Rc<dyn Any> {
     let scope = ok_collection.scope();
     let desired = OkErr::new(ok_collection.inner, err_collection.inner);
 
@@ -259,7 +76,7 @@ where
         purpose: format!("MV sink {sink_id}"),
     };
 
-    let (desired, descs, sink_frontier, mint_token) = mint::render(
+    let (desired, descs, sink_frontier) = mint::render(
         sink_id,
         persist_api.clone(),
         as_of.clone(),
@@ -267,7 +84,12 @@ where
         desired,
     );
 
-    let (batches, write_token) = write::render(
+    // Broadcast batch descriptions to all workers, regardless of whether or not they are
+    // responsible for the append, to give them a chance to clean up any outdated state they
+    // might still hold.
+    let descs = descs.broadcast();
+
+    let batches = write::render(
         sink_id,
         persist_api.clone(),
         as_of,
@@ -277,185 +99,19 @@ where
         Rc::clone(&compute_state.worker_config),
     );
 
-    let append_token = append::render(sink_id, persist_api, descs, batches);
+    append::render(sink_id, persist_api, descs, batches);
 
     // Report sink frontier updates to the `ComputeState`.
     let collection = compute_state.expect_collection_mut(sink_id);
     collection.sink_write_frontier = Some(sink_frontier);
 
-    Rc::new((persist_token, mint_token, write_token, append_token))
-}
-
-/// Generic wrapper around ok/err pairs (e.g. streams, frontiers), to simplify code dealing with
-/// such pairs.
-struct OkErr<O, E> {
-    ok: O,
-    err: E,
-}
-
-impl<O, E> OkErr<O, E> {
-    fn new(ok: O, err: E) -> Self {
-        Self { ok, err }
-    }
-}
-
-impl OkErr<Antichain<Timestamp>, Antichain<Timestamp>> {
-    fn new_frontiers() -> Self {
-        Self {
-            ok: Antichain::from_elem(Timestamp::MIN),
-            err: Antichain::from_elem(Timestamp::MIN),
-        }
-    }
-
-    /// Return the overall frontier, i.e., the minimum of `ok` and `err`.
-    fn frontier(&self) -> &Antichain<Timestamp> {
-        if PartialOrder::less_equal(&self.ok, &self.err) {
-            &self.ok
-        } else {
-            &self.err
-        }
-    }
-}
-
-/// Advance the given `frontier` to `new`, if the latter one is greater.
-///
-/// Returns whether `frontier` was advanced.
-fn advance(frontier: &mut Antichain<Timestamp>, new: Antichain<Timestamp>) -> bool {
-    if PartialOrder::less_than(frontier, &new) {
-        *frontier = new;
-        true
-    } else {
-        false
-    }
-}
-
-/// A persist API specialized to a single collection.
-#[derive(Clone)]
-struct PersistApi {
-    persist_clients: Arc<PersistClientCache>,
-    collection: CollectionMetadata,
-    shard_name: String,
-    purpose: String,
-}
-
-impl PersistApi {
-    async fn open_client(&self) -> PersistClient {
-        self.persist_clients
-            .open(self.collection.persist_location.clone())
-            .await
-            .unwrap_or_else(|error| panic!("error opening persist client: {error}"))
-    }
-
-    async fn open_writer(&self) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
-        self.open_client()
-            .await
-            .open_writer(
-                self.collection.data_shard,
-                Arc::new(self.collection.relation_desc.clone()),
-                Arc::new(UnitSchema),
-                Diagnostics {
-                    shard_name: self.shard_name.clone(),
-                    handle_purpose: self.purpose.clone(),
-                },
-            )
-            .await
-            .unwrap_or_else(|error| panic!("error opening persist writer: {error}"))
-    }
-
-    async fn open_metrics(&self) -> SinkMetrics {
-        let client = self.open_client().await;
-        client.metrics().sink.clone()
-    }
-}
-
-/// Instantiate a persist source reading back the `target` collection.
-fn persist_source<'s>(
-    scope: Scope<'s, Timestamp>,
-    sink_id: GlobalId,
-    target: CollectionMetadata,
-    compute_state: &ComputeState,
-    start_signal: StartSignal,
-) -> (PersistStreams<'s>, Vec<PressOnDropButton>) {
-    // There is no guarantee that the sink as-of is beyond the persist shard's since. If it isn't,
-    // instantiating a `persist_source` with it would panic. So instead we leave it to
-    // `persist_source` to select an appropriate as-of. We only care about times beyond the current
-    // shard upper anyway.
-    //
-    // TODO(teskje): Ideally we would select the as-of as `join(sink_as_of, since, upper)`, to
-    // allow `persist_source` to omit as much historical detail as possible. However, we don't know
-    // the shard frontiers and we cannot get them here as that requires an `async` context. We
-    // should consider extending the `persist_source` API to allow as-of selection based on the
-    // shard's current frontiers.
-    let as_of = None;
-
-    let until = Antichain::new();
-    let map_filter_project = None;
-
-    let (ok_stream, err_stream, token) = mz_storage_operators::persist_source::persist_source(
-        scope,
-        sink_id,
-        Arc::clone(&compute_state.persist_clients),
-        &compute_state.txns_ctx,
-        target,
-        None,
-        as_of,
-        SnapshotMode::Include,
-        until,
-        map_filter_project,
-        compute_state.dataflow_max_inflight_bytes(),
-        start_signal.into_send_future(),
-        ErrorHandler::Halt("compute persist sink"),
-    );
-
-    let streams = OkErr::new(ok_stream, err_stream);
-    (streams, token)
-}
-
-/// A description for a batch of updates to be written.
-///
-/// Batch descriptions are produced by the `mint` operator and consumed by the `write` and `append`
-/// operators, where they inform which batches should be written or appended, respectively.
-///
-/// Each batch description also contains the index of its "append worker", i.e. the worker that is
-/// responsible for appending the written batches to the output shard.
-#[derive(Clone, Serialize, Deserialize)]
-struct BatchDescription {
-    lower: Antichain<Timestamp>,
-    upper: Antichain<Timestamp>,
-    append_worker: usize,
-}
-
-impl BatchDescription {
-    fn new(lower: Antichain<Timestamp>, upper: Antichain<Timestamp>, append_worker: usize) -> Self {
-        assert!(PartialOrder::less_than(&lower, &upper));
-        Self {
-            lower,
-            upper,
-            append_worker,
-        }
-    }
-}
-
-impl std::fmt::Debug for BatchDescription {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "({:?}, {:?})@{}",
-            self.lower.elements(),
-            self.upper.elements(),
-            self.append_worker,
-        )
-    }
-}
-
-/// Construct a name for the given sub-operator.
-fn operator_name(sink_id: GlobalId, sub_operator: &str) -> String {
-    format!("mv_sink({sink_id})::{sub_operator}")
+    Rc::new(persist_token)
 }
 
 /// Implementation of the `mint` operator.
 mod mint {
     use super::*;
+    use timely::progress::frontier::AntichainRef;
 
     /// Render the `mint` operator.
     ///
@@ -463,7 +119,7 @@ mod mint {
     ///  * `sink_id`: The `GlobalId` of the sink export.
     ///  * `persist_api`: An object providing access to the output persist shard.
     ///  * `as_of`: The first time for which the sink may produce output.
-    ///  * `read_only_tx`: A receiver that reports the sink is in read-only mode.
+    ///  * `read_only_rx`: A receiver that reports the sink is in read-only mode.
     ///  * `desired`: The ok/err streams that should be sinked to persist.
     pub fn render<'s>(
         sink_id: GlobalId,
@@ -471,12 +127,7 @@ mod mint {
         as_of: Antichain<Timestamp>,
         mut read_only_rx: watch::Receiver<bool>,
         desired: DesiredStreams<'s>,
-    ) -> (
-        DesiredStreams<'s>,
-        DescsStream<'s>,
-        SharedSinkFrontier,
-        PressOnDropButton,
-    ) {
+    ) -> (DesiredStreams<'s>, DescsStream<'s>, SharedSinkFrontier) {
         let scope = desired.ok.scope();
         let worker_id = scope.index();
         let worker_count = scope.peers();
@@ -488,117 +139,145 @@ mod mint {
         let shared_frontier = Rc::clone(&sink_frontier);
 
         let name = operator_name(sink_id, "mint");
-        let mut op = OperatorBuilder::new(name, scope);
+        let mut builder = OperatorBuilderRc::new(name, scope.clone());
+        let info = builder.operator_info();
 
-        let (ok_output, ok_stream) = op.new_output::<CapacityContainerBuilder<_>>();
-        let (err_output, err_stream) = op.new_output::<CapacityContainerBuilder<_>>();
-        let desired_outputs = OkErr::new(ok_output, err_output);
-        let desired_output_streams = OkErr::new(ok_stream, err_stream);
+        // Create outputs (before inputs, so no input connections yet).
+        let (ok_output, ok_stream) = builder.new_output();
+        let (err_output, err_stream) = builder.new_output();
+        let (desc_output, desc_stream) = builder.new_output();
 
-        let (desc_output, desc_output_stream) = op.new_output::<CapacityContainerBuilder<_>>();
+        let mut ok_output = OutputBuilder::from(ok_output);
+        let mut err_output = OutputBuilder::from(err_output);
+        let mut desc_output = OutputBuilder::from(desc_output);
 
-        let mut desired_inputs = OkErr {
-            ok: op.new_input_for(desired.ok, Pipeline, &desired_outputs.ok),
-            err: op.new_input_for(desired.err, Pipeline, &desired_outputs.err),
-        };
+        // desired_ok -> output 0 (ok passthrough)
+        let mut desired_ok_input = builder.new_input_connection(
+            desired.ok,
+            Pipeline,
+            [(0, Antichain::from_elem(Default::default()))],
+        );
+        // desired_err -> output 1 (err passthrough)
+        let mut desired_err_input = builder.new_input_connection(
+            desired.err,
+            Pipeline,
+            [(1, Antichain::from_elem(Default::default()))],
+        );
 
-        let button = op.build(move |capabilities| async move {
+        // Set up background tasks and state for the active worker only.
+        let mut task_handles = Vec::new();
+        let read_only = *read_only_rx.borrow_and_update();
+        let mut state = None;
+        if worker_id == active_worker_id {
+            // Spawn a Tokio task to watch the persist shard's upper frontier.
+            //
+            // We collect the persist frontier from a write handle directly, rather than
+            // inspecting the `persist` stream, because the latter has two annoying glitches:
+            //  (a) It starts at the shard's read frontier, not its write frontier.
+            //  (b) It can lag behind if there are spikes in ingested data.
+            //
+            // The task sends the empty frontier as its final message before exiting. The
+            // operator drops `persist_rx` once it receives the empty frontier.
+            let (persist_tx, persist_rx) = mpsc::unbounded_channel();
+            let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+            let handle = mz_ore::task::spawn(
+                || operator_name(sink_id, "mint::persist_watch"),
+                async move {
+                    let mut writer = persist_api.open_writer().await;
+                    let mut frontier = Antichain::from_elem(Timestamp::MIN);
+                    loop {
+                        writer.wait_for_upper_past(&frontier).await;
+                        frontier = writer.upper().clone();
+                        if persist_tx.send(frontier.clone()).is_err() {
+                            return;
+                        }
+                        if sync_activator.activate().is_err() {
+                            return;
+                        }
+                        if frontier.is_empty() {
+                            return;
+                        }
+                    }
+                },
+            );
+            task_handles.push(handle.abort_on_drop());
+
+            // Spawn a Tokio task to wake the operator when read-only mode changes.
+            if read_only {
+                let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+                let mut rx = read_only_rx.clone();
+                let handle = mz_ore::task::spawn(
+                    || format!("mv_sink({sink_id})::mint::read_only_watch"),
+                    async move {
+                        let _ = rx.changed().await;
+                        let _ = sync_activator.activate();
+                    },
+                );
+                task_handles.push(handle.abort_on_drop());
+            }
+
+            state = Some(State::new(
+                sink_id,
+                worker_count,
+                as_of,
+                read_only,
+                persist_rx,
+            ));
+        }
+
+        builder.build(move |capabilities| {
             // Passing through the `desired` streams only requires data capabilities, so we can
             // immediately drop their initial capabilities here.
             let [_, _, desc_cap]: [_; 3] =
                 capabilities.try_into().expect("one capability per output");
 
-            // Non-active workers just pass the `desired` and `persist` data through.
-            if worker_id != active_worker_id {
+            let mut cap_set = if state.is_some() {
+                Some(CapabilitySet::from_elem(desc_cap))
+            } else {
                 drop(desc_cap);
                 shared_frontier.borrow_mut().clear();
+                None
+            };
 
-                loop {
-                    tokio::select! {
-                        Some(event) = desired_inputs.ok.next() => {
-                            if let Event::Data(cap, mut data) = event {
-                                desired_outputs.ok.give_container(&cap, &mut data);
-                            }
-                        }
-                        Some(event) = desired_inputs.err.next() => {
-                            if let Event::Data(cap, mut data) = event {
-                                desired_outputs.err.give_container(&cap, &mut data);
-                            }
-                        }
-                        // All inputs are exhausted, so we can shut down.
-                        else => return,
-                    }
-                }
-            }
+            move |frontiers| {
+                // Keep task handles alive so they are aborted when the operator is dropped.
+                let _ = &task_handles;
 
-            let mut cap_set = CapabilitySet::from_elem(desc_cap);
+                // Pass through desired data.
+                let mut ok_out = ok_output.activate();
+                desired_ok_input.for_each(|cap, data| {
+                    ok_out.session(&cap).give_container(data);
+                });
+                let mut err_out = err_output.activate();
+                desired_err_input.for_each(|cap, data| {
+                    err_out.session(&cap).give_container(data);
+                });
 
-            let read_only = *read_only_rx.borrow_and_update();
-            let mut state = State::new(sink_id, worker_count, as_of, read_only);
-
-            // Create a stream that reports advancements of the target shard's frontier and updates
-            // the shared sink frontier.
-            //
-            // We collect the persist frontier from a write handle directly, rather than inspecting
-            // the `persist` stream, because the latter has two annoying glitches:
-            //  (a) It starts at the shard's read frontier, not its write frontier.
-            //  (b) It can lag behind if there are spikes in ingested data.
-            let mut persist_frontiers = pin!(async_stream::stream! {
-                let mut writer = persist_api.open_writer().await;
-                let mut frontier = Antichain::from_elem(Timestamp::MIN);
-                while !frontier.is_empty() {
-                    writer.wait_for_upper_past(&frontier).await;
-                    frontier = writer.upper().clone();
-                    shared_frontier.borrow_mut().clone_from(&frontier);
-                    yield frontier.clone();
-                }
-            });
-
-            loop {
-                // Read from the inputs, pass through all data to the respective outputs, and keep
-                // track of the input frontiers. When a frontier advances we might have to mint a
-                // new batch description.
-                let maybe_desc = tokio::select! {
-                    Some(event) = desired_inputs.ok.next() => {
-                        match event {
-                            Event::Data(cap, mut data) => {
-                                desired_outputs.ok.give_container(&cap, &mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_desired_ok_frontier(frontier);
-                                state.maybe_mint_batch_description()
-                            }
-                        }
-                    }
-                    Some(event) = desired_inputs.err.next() => {
-                        match event {
-                            Event::Data(cap, mut data) => {
-                                desired_outputs.err.give_container(&cap, &mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_desired_err_frontier(frontier);
-                                state.maybe_mint_batch_description()
-                            }
-                        }
-                    }
-                    Some(frontier) = persist_frontiers.next() => {
-                        state.advance_persist_frontier(frontier);
-                        state.maybe_mint_batch_description()
-                    }
-                    Ok(()) = read_only_rx.changed(), if read_only => {
-                        state.allow_writes();
-                        state.maybe_mint_batch_description()
-                    }
-                    // All inputs are exhausted, so we can shut down.
-                    else => return,
+                let Some(state) = &mut state else {
+                    // Non-active worker: just pass through data.
+                    return;
                 };
+                let cap_set = cap_set.as_mut().unwrap();
 
-                if let Some(desc) = maybe_desc {
+                // Track desired frontiers.
+                state.advance_desired_ok_frontier(frontiers[0].frontier());
+                state.advance_desired_err_frontier(frontiers[1].frontier());
+
+                state.drain_persist_rx(&shared_frontier);
+
+                // Check read-only mode.
+                if state.read_only && read_only_rx.has_changed().unwrap_or(false) {
+                    if !*read_only_rx.borrow_and_update() {
+                        state.allow_writes();
+                    }
+                }
+
+                // Try to mint a batch description.
+                let mut desc_out = desc_output.activate();
+                if let Some(desc) = state.maybe_mint_batch_description() {
                     let lower_ts = *desc.lower.as_option().expect("not empty");
                     let cap = cap_set.delayed(&lower_ts);
-                    desc_output.give(&cap, desc);
+                    desc_out.session(&cap).give(desc);
 
                     // We only emit strictly increasing `lower`s, so we can let our output frontier
                     // advance beyond the current `lower`.
@@ -611,12 +290,8 @@ mod mint {
             }
         });
 
-        (
-            desired_output_streams,
-            desc_output_stream,
-            sink_frontier,
-            button.press_on_drop(),
-        )
+        let desired_output_streams = OkErr::new(ok_stream, err_stream);
+        (desired_output_streams, desc_stream, sink_frontier)
     }
 
     /// State maintained by the `mint` operator.
@@ -628,6 +303,10 @@ mod mint {
         desired_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
         /// The frontier of the target persist shard.
         persist_frontier: Antichain<Timestamp>,
+        /// Receiver for persist frontier updates from the Tokio persist_watch task.
+        ///
+        /// Dropped once the empty frontier is received (the task's shutdown signal).
+        persist_rx: Option<mpsc::UnboundedReceiver<Antichain<Timestamp>>>,
         /// The append worker for the next batch description, chosen in round-robin fashion.
         next_append_worker: usize,
         /// The last `lower` we have emitted in a batch description, if any. Whenever the
@@ -645,10 +324,11 @@ mod mint {
             worker_count: usize,
             as_of: Antichain<Timestamp>,
             read_only: bool,
+            persist_rx: mpsc::UnboundedReceiver<Antichain<Timestamp>>,
         ) -> Self {
             // Initializing `persist_frontier` to the `as_of` ensures that the first minted batch
             // description will have a `lower` of `as_of` or beyond, and thus that we don't spend
-            // work needlessly writing batches at previous times.
+            // effort writing out snapshots of data that is already in the shard.
             let persist_frontier = as_of;
 
             Self {
@@ -656,6 +336,7 @@ mod mint {
                 worker_count,
                 desired_frontiers: OkErr::new_frontiers(),
                 persist_frontier,
+                persist_rx: Some(persist_rx),
                 next_append_worker: 0,
                 last_lower: None,
                 read_only,
@@ -668,33 +349,62 @@ mod mint {
                 sink_id = %self.sink_id,
                 desired_frontier = ?self.desired_frontiers.frontier().elements(),
                 persist_frontier = ?self.persist_frontier.elements(),
-                last_lower = ?self.last_lower.as_ref().map(|f| f.elements()),
+                last_lower = ?self.last_lower,
                 message,
             );
         }
 
-        fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_desired_ok_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.ok, frontier) {
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
-        fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_desired_err_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.err, frontier) {
                 self.trace("advanced `desired` err frontier");
             }
         }
 
-        fn advance_persist_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_persist_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.persist_frontier, frontier) {
                 self.trace("advanced `persist` frontier");
+            }
+        }
+
+        /// Drain persist frontier updates from the Tokio task.
+        ///
+        /// The task sends the empty frontier as its final message before exiting. Once
+        /// received, we drop the receiver.
+        fn drain_persist_rx(&mut self, shared_frontier: &RefCell<Antichain<Timestamp>>) {
+            let Some(mut rx) = self.persist_rx.take() else {
+                return;
+            };
+            loop {
+                match rx.try_recv() {
+                    Ok(frontier) => {
+                        shared_frontier.borrow_mut().clone_from(&frontier);
+                        let done = frontier.is_empty();
+                        self.advance_persist_frontier(frontier.borrow());
+                        if done {
+                            return;
+                        }
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => {
+                        self.persist_rx = Some(rx);
+                        return;
+                    }
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        panic!("mint persist_watch task unexpectedly gone");
+                    }
+                }
             }
         }
 
         fn allow_writes(&mut self) {
             if self.read_only {
                 self.read_only = false;
-                self.trace("disabled read-only mode");
+                self.trace("switched to write mode");
             }
         }
 
@@ -733,6 +443,29 @@ mod mint {
 mod write {
     use super::*;
 
+    use mz_timely_util::activator::ArcActivator;
+
+    /// Commands sent from the Timely operator to the Tokio write task.
+    enum WriteCommand {
+        /// Forward desired updates to the corrections buffer.
+        Desired(Result<Vec<(Row, Timestamp, Diff)>, Vec<(DataflowError, Timestamp, Diff)>>),
+        /// Forward persist updates (negated) to the corrections buffer.
+        Persist(Result<Vec<(Row, Timestamp, Diff)>, Vec<(DataflowError, Timestamp, Diff)>>),
+        /// The persist frontier advanced. Used for `advance_since` and consolidation.
+        PersistFrontier(Antichain<Timestamp>),
+        /// Force a consolidation of the corrections buffer.
+        ForceConsolidation,
+        /// Write a batch with the given description. The task drains corrections and writes
+        /// them to persist.
+        WriteBatch(BatchDescription),
+    }
+
+    /// A response from the Tokio write task back to the Timely operator.
+    struct WriteResponse {
+        /// The written batch, or `None` if the corrections buffer had no updates.
+        batch: Option<ProtoBatch>,
+    }
+
     /// Render the `write` operator.
     ///
     /// The parameters passed in are:
@@ -750,149 +483,277 @@ mod write {
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
         worker_config: Rc<ConfigSet>,
-    ) -> (BatchesStream<'s>, PressOnDropButton) {
+    ) -> BatchesStream<'s> {
         let scope = desired.ok.scope();
         let worker_id = scope.index();
 
         let name = operator_name(sink_id, "write");
-        let mut op = OperatorBuilder::new(name, scope.clone());
+        let mut builder = OperatorBuilderRc::new(name, scope.clone());
+        let info = builder.operator_info();
 
-        let mut logging = None;
+        // Set up correction buffer logging. CorrectionLogger is not Send (uses timely
+        // loggers), so the Tokio task uses ChannelLogging to send events back to the
+        // Timely thread for application by the CorrectionLogger.
+        let mut channel_logging = None;
+        let mut correction_logger = None;
         if let (Some(compute_logger), Some(differential_logger)) = (
             scope.worker().logger_for("materialize/compute"),
             scope.worker().logger_for("differential/arrange"),
         ) {
-            let operator_info = op.operator_info();
-            logging = Some(Logging::new(
+            let operator_info = builder.operator_info();
+            let (tx, rx) = mpsc::unbounded_channel();
+            channel_logging = Some(ChannelLogging::new(tx));
+            correction_logger = Some(CorrectionLogger::new(
                 compute_logger,
                 differential_logger.into(),
                 operator_info.global_id,
                 operator_info.address.to_vec(),
+                rx,
             ));
         }
-
-        let (batches_output, batches_output_stream) =
-            op.new_output::<CapacityContainerBuilder<_>>();
 
         // It is important that we exchange the `desired` and `persist` data the same way, so
         // updates that cancel each other out end up on the same worker.
         let exchange_ok = |(d, _, _): &(Row, Timestamp, Diff)| d.hashed();
         let exchange_err = |(d, _, _): &(DataflowError, Timestamp, Diff)| d.hashed();
 
-        let mut desired_inputs = OkErr::new(
-            op.new_disconnected_input(desired.ok, Exchange::new(exchange_ok)),
-            op.new_disconnected_input(desired.err, Exchange::new(exchange_err)),
-        );
-        let mut persist_inputs = OkErr::new(
-            op.new_disconnected_input(persist.ok, Exchange::new(exchange_ok)),
-            op.new_disconnected_input(persist.err, Exchange::new(exchange_err)),
-        );
-        let mut descs_input = op.new_input_for(descs.broadcast(), Pipeline, &batches_output);
+        // Data inputs are created before the output, so they are not connected to it.
+        let mut desired_ok_input = builder.new_input(desired.ok, Exchange::new(exchange_ok));
+        let mut desired_err_input = builder.new_input(desired.err, Exchange::new(exchange_err));
+        let mut persist_ok_input = builder.new_input(persist.ok, Exchange::new(exchange_ok));
+        let mut persist_err_input = builder.new_input(persist.err, Exchange::new(exchange_err));
+        let mut descs_input = builder.new_input(descs, Pipeline);
 
-        let button = op.build(move |capabilities| async move {
+        // Only descs (input 4) is connected to the batches output.
+        let (batches_output, batches_output_stream) =
+            builder.new_output_connection([(4, Antichain::from_elem(Default::default()))]);
+        let mut batches_output = OutputBuilder::from(batches_output);
+
+        // Obtain SinkMetrics synchronously from the persist client cache, rather than through
+        // a WriteHandle, to avoid async I/O on the Timely thread.
+        let sink_metrics = persist_api.persist_clients.metrics().sink.clone();
+
+        // Construct corrections on the Timely thread (reads ConfigSet), then move to the
+        // Tokio task. The ChannelLogging sends events back to the Timely thread.
+        let worker_metrics = sink_metrics.for_worker(worker_id);
+        let mut corrections: OkErr<Correction<Row>, Correction<DataflowError>> = OkErr::new(
+            Correction::new(
+                sink_metrics.clone(),
+                worker_metrics.clone(),
+                channel_logging.clone(),
+                &worker_config,
+            ),
+            Correction::new(
+                sink_metrics.clone(),
+                worker_metrics,
+                channel_logging,
+                &worker_config,
+            ),
+        );
+
+        // Channels for commands and responses.
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<WriteCommand>();
+        let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<WriteResponse>();
+
+        // Spawn Tokio task that owns the WriteHandle and corrections buffer.
+        let (activator, activation_ack) = ArcActivator::new(scope, &info);
+        let write_task_handle = {
+            mz_ore::task::spawn(
+                || operator_name(sink_id, "write::batch_writer"),
+                async move {
+                    let mut writer = persist_api.open_writer().await;
+
+                    while let Some(cmd) = cmd_rx.recv().await {
+                        apply_command(&mut corrections, &mut writer, cmd, &resp_tx).await;
+                        // Activate the operator to drain logging events and process batch responses.
+                        // ArcActivator suppresses redundant activations, so this is cheap.
+                        activator.activate();
+                    }
+                },
+            )
+            .abort_on_drop()
+        };
+
+        builder.build(move |capabilities| {
             // We will use the data capabilities from the `descs` input to produce output, so no
             // need to hold onto the initial capabilities.
             drop(capabilities);
 
-            let writer = persist_api.open_writer().await;
-            let sink_metrics = persist_api.open_metrics().await;
-            let mut state = State::new(
-                sink_id,
-                worker_id,
-                writer,
-                sink_metrics,
-                logging,
-                as_of,
-                &worker_config,
-            );
+            let mut state = State::new(sink_id, worker_id, as_of, &worker_config);
 
-            loop {
-                // Read from the inputs, extract `desired` updates as positive contributions to
-                // `correction` and `persist` updates as negative contributions. If either the
-                // `desired` or `persist` frontier advances, or if we receive a new batch description,
-                // we might have to write a new batch.
-                let maybe_batch = tokio::select! {
-                    Some(event) = desired_inputs.ok.next() => {
-                        match event {
-                            Event::Data(_cap, mut data) => {
-                                state.corrections.ok.insert(&mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_desired_ok_frontier(frontier);
-                                state.maybe_write_batch().await
-                            }
-                        }
+            // Whether a batch write is currently in flight in the Tokio task.
+            let mut batch_in_flight: Option<(BatchDescription, Capability<Timestamp>)> = None;
+
+            // CorrectionLogger lives on the Timely thread and drains events from
+            // the channel each activation. On drop, it drains remaining events and
+            // retracts all logged state.
+            let mut correction_logger = correction_logger;
+
+            move |frontiers| {
+                // Keep task handle alive so it is aborted when the operator is dropped.
+                let _ = &write_task_handle;
+
+                // Acknowledge activation so the Tokio task can activate us again.
+                activation_ack.ack();
+
+                // Drain logging events from the Tokio task's ChannelLogging.
+                if let Some(logger) = &mut correction_logger {
+                    logger.apply_events();
+                }
+                // Drain all inputs and forward data to the Tokio task.
+                desired_ok_input.for_each(|_cap, data| {
+                    cmd_tx
+                        .send(WriteCommand::Desired(Ok(std::mem::take(data))))
+                        .expect("write task unexpectedly gone");
+                });
+                desired_err_input.for_each(|_cap, data| {
+                    cmd_tx
+                        .send(WriteCommand::Desired(Err(std::mem::take(data))))
+                        .expect("write task unexpectedly gone");
+                });
+                persist_ok_input.for_each(|_cap, data| {
+                    cmd_tx
+                        .send(WriteCommand::Persist(Ok(std::mem::take(data))))
+                        .expect("write task unexpectedly gone");
+                });
+                persist_err_input.for_each(|_cap, data| {
+                    cmd_tx
+                        .send(WriteCommand::Persist(Err(std::mem::take(data))))
+                        .expect("write task unexpectedly gone");
+                });
+
+                // Accept batch descriptions.
+                descs_input.for_each(|cap, data| {
+                    let cap = cap.retain(0);
+                    for desc in data.drain(..) {
+                        state.absorb_batch_description(desc, cap.clone());
                     }
-                    Some(event) = desired_inputs.err.next() => {
-                        match event {
-                            Event::Data(_cap, mut data) => {
-                                state.corrections.err.insert(&mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_desired_err_frontier(frontier);
-                                state.maybe_write_batch().await
-                            }
-                        }
-                    }
-                    Some(event) = persist_inputs.ok.next() => {
-                        match event {
-                            Event::Data(_cap, mut data) => {
-                                state.corrections.ok.insert_negated(&mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_persist_ok_frontier(frontier);
-                                state.maybe_write_batch().await
-                            }
-                        }
-                    }
-                    Some(event) = persist_inputs.err.next() => {
-                        match event {
-                            Event::Data(_cap, mut data) => {
-                                state.corrections.err.insert_negated(&mut data);
-                                None
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_persist_err_frontier(frontier);
-                                state.maybe_write_batch().await
-                            }
-                        }
-                    }
-                    Some(event) = descs_input.next() => {
-                        match event {
-                            Event::Data(cap, data) => {
-                                for desc in data {
-                                    state.absorb_batch_description(desc, cap.clone());
+                });
+
+                // Track frontiers. Send persist frontier to Tokio task for advance_since.
+                state.advance_desired_ok_frontier(frontiers[0].frontier());
+                state.advance_desired_err_frontier(frontiers[1].frontier());
+                if state.advance_persist_ok_frontier(frontiers[2].frontier())
+                    | state.advance_persist_err_frontier(frontiers[3].frontier())
+                {
+                    cmd_tx
+                        .send(WriteCommand::PersistFrontier(
+                            state.persist_frontiers.frontier().to_owned(),
+                        ))
+                        .expect("write task unexpectedly gone");
+                }
+                if state.should_force_consolidation() {
+                    cmd_tx
+                        .send(WriteCommand::ForceConsolidation)
+                        .expect("write task unexpectedly gone");
+                }
+
+                // Try to receive batch results from the Tokio task.
+                loop {
+                    match resp_rx.try_recv() {
+                        Ok(resp) => {
+                            if let Some((desc, cap)) = batch_in_flight.take() {
+                                if let Some(batch) = resp.batch {
+                                    let mut out = batches_output.activate();
+                                    out.session(&cap).give((desc, batch));
+                                    state.trace("wrote a batch");
+                                } else {
+                                    state.trace("skipping empty batch");
                                 }
-                                state.maybe_write_batch().await
                             }
-                            Event::Progress(_frontier) => None,
+                        }
+                        Err(mpsc::error::TryRecvError::Empty) => break,
+                        Err(mpsc::error::TryRecvError::Disconnected) => {
+                            panic!("write task unexpectedly gone");
                         }
                     }
-                    // All inputs are exhausted, so we can shut down.
-                    else => return,
-                };
+                }
 
-                if let Some((index, batch, cap)) = maybe_batch {
-                    batches_output.give(&cap, (index, batch));
+                // If no batch in flight, try to write a new batch.
+                if batch_in_flight.is_none() {
+                    if let Some((desc, cap)) = state.maybe_start_batch(&cmd_tx) {
+                        batch_in_flight = Some((desc, cap));
+                    }
                 }
             }
         });
 
-        (batches_output_stream, button.press_on_drop())
+        batches_output_stream
     }
 
-    /// State maintained by the `write` operator.
+    /// Apply a single command to the task state.
+    ///
+    /// `desired` updates enter `corrections` as positive contributions and `persist` updates as
+    /// negative contributions, so the buffer contains `desired - persist`, i.e. the updates that
+    /// need to be written to bring the shard in line with `desired`.
+    async fn apply_command(
+        corrections: &mut OkErr<Correction<Row>, Correction<DataflowError>>,
+        writer: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        cmd: WriteCommand,
+        resp_tx: &mpsc::UnboundedSender<WriteResponse>,
+    ) {
+        match cmd {
+            WriteCommand::Desired(Ok(mut updates)) => {
+                corrections.ok.insert(&mut updates);
+            }
+            WriteCommand::Desired(Err(mut updates)) => {
+                corrections.err.insert(&mut updates);
+            }
+            WriteCommand::Persist(Ok(mut updates)) => {
+                corrections.ok.insert_negated(&mut updates);
+            }
+            WriteCommand::Persist(Err(mut updates)) => {
+                corrections.err.insert_negated(&mut updates);
+            }
+            WriteCommand::PersistFrontier(frontier) => {
+                // We will only emit times at or after the `persist` frontier, so now is a good
+                // time to advance the times of stashed updates.
+                corrections.ok.advance_since(frontier.clone());
+                corrections.err.advance_since(frontier);
+            }
+            WriteCommand::ForceConsolidation => {
+                corrections.ok.consolidate_at_since();
+                corrections.err.consolidate_at_since();
+            }
+            WriteCommand::WriteBatch(desc) => {
+                // Chain ok and err correction iterators directly, avoiding an
+                // intermediate Vec allocation.
+                let oks = corrections
+                    .ok
+                    .updates_before(&desc.upper)
+                    .map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
+                let errs = corrections
+                    .err
+                    .updates_before(&desc.upper)
+                    .map(|(d, t, r)| ((SourceData(Err(d)), ()), t, r.into_inner()));
+                let mut updates = oks.chain(errs).peekable();
+
+                if updates.peek().is_none() {
+                    // No corrections to write.
+                    let _ = resp_tx.send(WriteResponse { batch: None });
+                    return;
+                }
+
+                let batch = writer
+                    .batch(updates, desc.lower, desc.upper)
+                    .await
+                    .expect("valid usage");
+                let proto_batch = batch.into_transmittable_batch();
+                if let Err(err) = resp_tx.send(WriteResponse {
+                    batch: Some(proto_batch),
+                }) {
+                    let batch =
+                        writer.batch_from_transmittable_batch(err.0.batch.expect("just sent"));
+                    batch.delete().await;
+                }
+            }
+        }
+    }
+
+    /// State maintained by the `write` operator on the Timely thread.
     struct State {
         sink_id: GlobalId,
         worker_id: usize,
-        persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-        /// Contains `desired - persist`, reflecting the updates we would like to commit to
-        /// `persist` in order to "correct" it to track `desired`. This collection is only modified
-        /// by updates received from either the `desired` or `persist` inputs.
-        corrections: OkErr<Correction<Row>, Correction<DataflowError>>,
         /// The frontiers of the `desired` inputs.
         desired_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
         /// The frontiers of the `persist` inputs.
@@ -906,7 +767,7 @@ mod write {
         persist_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
         /// The current valid batch description and associated output capability, if any.
         batch_description: Option<(BatchDescription, Capability<Timestamp>)>,
-        /// A request to force a consolidation of `corrections` once both `desired_frontiers` and
+        /// A request to force a consolidation of corrections once both `desired_frontiers` and
         /// `persist_frontiers` become greater than the given frontier.
         ///
         /// Normally we force a consolidation whenever we write a batch, but there are periods
@@ -920,31 +781,16 @@ mod write {
         fn new(
             sink_id: GlobalId,
             worker_id: usize,
-            persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
-            metrics: SinkMetrics,
-            logging: Option<Logging>,
             as_of: Antichain<Timestamp>,
             worker_config: &ConfigSet,
         ) -> Self {
-            let worker_metrics = metrics.for_worker(worker_id);
-
-            // Force a consolidation of `corrections` after the snapshot updates have been fully
+            // Force a consolidation of corrections after the snapshot updates have been fully
             // processed, to ensure we get rid of those as quickly as possible.
             let force_consolidation_after = Some(as_of.clone());
 
             let mut state = Self {
                 sink_id,
                 worker_id,
-                persist_writer,
-                corrections: OkErr::new(
-                    Correction::new(
-                        metrics.clone(),
-                        worker_metrics.clone(),
-                        logging.clone(),
-                        worker_config,
-                    ),
-                    Correction::new(metrics, worker_metrics, logging, worker_config),
-                ),
                 desired_frontiers: OkErr::new_frontiers(),
                 persist_frontiers: OkErr::new_frontiers(),
                 batch_description: None,
@@ -959,8 +805,8 @@ mod write {
             // no other writers) would be never if we didn't advance the observed persist frontier
             // to the `as_of`.
             if MV_SINK_ADVANCE_PERSIST_FRONTIERS.get(worker_config) {
-                state.advance_persist_ok_frontier(as_of.clone());
-                state.advance_persist_err_frontier(as_of);
+                state.advance_persist_ok_frontier(as_of.borrow());
+                state.advance_persist_err_frontier(as_of.borrow());
             }
 
             state
@@ -978,55 +824,42 @@ mod write {
             );
         }
 
-        fn advance_desired_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_desired_ok_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.ok, frontier) {
-                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
-        fn advance_desired_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_desired_err_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.err, frontier) {
-                self.apply_desired_frontier_advancement();
                 self.trace("advanced `desired` err frontier");
             }
         }
 
-        fn advance_persist_ok_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        /// Returns true if the persist frontier advanced.
+        fn advance_persist_ok_frontier(&mut self, frontier: AntichainRef<Timestamp>) -> bool {
             if advance(&mut self.persist_frontiers.ok, frontier) {
-                self.apply_persist_frontier_advancement();
                 self.trace("advanced `persist` ok frontier");
+                true
+            } else {
+                false
             }
         }
 
-        fn advance_persist_err_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        /// Returns true if the persist frontier advanced.
+        fn advance_persist_err_frontier(&mut self, frontier: AntichainRef<Timestamp>) -> bool {
             if advance(&mut self.persist_frontiers.err, frontier) {
-                self.apply_persist_frontier_advancement();
                 self.trace("advanced `persist` err frontier");
+                true
+            } else {
+                false
             }
         }
 
-        /// Apply the effects of a previous `desired` frontier advancement.
-        fn apply_desired_frontier_advancement(&mut self) {
-            self.maybe_force_consolidation();
-        }
-
-        /// Apply the effects of a previous `persist` frontier advancement.
-        fn apply_persist_frontier_advancement(&mut self) {
-            let frontier = self.persist_frontiers.frontier();
-
-            // We will only emit times at or after the `persist` frontier, so now is a good time to
-            // advance the times of stashed updates.
-            self.corrections.ok.advance_since(frontier.clone());
-            self.corrections.err.advance_since(frontier.clone());
-
-            self.maybe_force_consolidation();
-        }
-
-        /// If the current consolidation request has become applicable, apply it.
-        fn maybe_force_consolidation(&mut self) {
+        /// Check if a forced consolidation should be triggered.
+        fn should_force_consolidation(&mut self) -> bool {
             let Some(request) = &self.force_consolidation_after else {
-                return;
+                return false;
             };
 
             let desired_frontier = self.desired_frontiers.frontier();
@@ -1034,74 +867,42 @@ mod write {
             if PartialOrder::less_than(request, desired_frontier)
                 && PartialOrder::less_than(request, persist_frontier)
             {
-                self.trace("forcing correction consolidation");
-                self.corrections.ok.consolidate_at_since();
-                self.corrections.err.consolidate_at_since();
-
-                // Remove the consolidation request, now that we have fulfilled it.
+                self.trace("requesting correction consolidation");
                 self.force_consolidation_after = None;
+                true
+            } else {
+                false
             }
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {
-            // The incoming batch description is outdated if we already have a batch description
-            // with a greater `lower`.
-            //
-            // Note that we cannot assume a description is outdated based on the comparison of its
-            // `lower` with the `persist_frontier`. The persist frontier observed by the `write`
-            // operator is initialized with the shard's read frontier, so it can be greater than
-            // the shard's write frontier.
-            if let Some((prev, _)) = &self.batch_description {
-                if PartialOrder::less_than(&desc.lower, &prev.lower) {
-                    self.trace(format!("skipping outdated batch description: {desc:?}"));
-                    return;
-                }
-            }
-
             self.batch_description = Some((desc, cap));
             self.trace("set batch description");
         }
 
-        async fn maybe_write_batch(
+        /// Check if a batch can be written and send a write command to the Tokio task if so.
+        fn maybe_start_batch(
             &mut self,
-        ) -> Option<(BatchDescription, ProtoBatch, Capability<Timestamp>)> {
+            cmd_tx: &mpsc::UnboundedSender<WriteCommand>,
+        ) -> Option<(BatchDescription, Capability<Timestamp>)> {
             let (desc, _cap) = self.batch_description.as_ref()?;
 
             // We can write a new batch if we have seen all `persist` updates before `lower` and
-            // all `desired` updates up to `upper`.
-            let persist_complete =
+            // all `desired` updates before `upper`.
+            let persist_ready =
                 PartialOrder::less_equal(&desc.lower, self.persist_frontiers.frontier());
-            let desired_complete =
+            let desired_ready =
                 PartialOrder::less_equal(&desc.upper, self.desired_frontiers.frontier());
-            if !persist_complete || !desired_complete {
+            if !persist_ready || !desired_ready {
                 return None;
             }
 
+            self.trace("write batch description");
             let (desc, cap) = self.batch_description.take()?;
-
-            let ok_updates = self.corrections.ok.updates_before(&desc.upper);
-            let err_updates = self.corrections.err.updates_before(&desc.upper);
-
-            let oks = ok_updates.map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
-            let errs = err_updates.map(|(d, t, r)| ((SourceData(Err(d)), ()), t, r.into_inner()));
-            let mut updates = oks.chain(errs).peekable();
-
-            // Don't write empty batches.
-            if updates.peek().is_none() {
-                drop(updates);
-                self.trace("skipping empty batch");
-                return None;
-            }
-
-            let batch = self
-                .persist_writer
-                .batch(updates, desc.lower.clone(), desc.upper.clone())
-                .await
-                .expect("valid usage")
-                .into_transmittable_batch();
-
-            self.trace("wrote a batch");
-            Some((desc, batch, cap))
+            cmd_tx
+                .send(WriteCommand::WriteBatch(desc.clone()))
+                .expect("write task unexpectedly gone");
+            Some((desc, cap))
         }
     }
 }
@@ -1109,6 +910,16 @@ mod write {
 /// Implementation of the `append` operator.
 mod append {
     use super::*;
+
+    /// Commands sent from the Timely operator to the Tokio append task.
+    enum AppendCommand {
+        /// A new batch description has been received.
+        Description(BatchDescription),
+        /// A written batch has been received.
+        Batch(ProtoBatch),
+        /// The batches frontier has advanced.
+        BatchesFrontier(Antichain<Timestamp>),
+    }
 
     /// Render the `append` operator.
     ///
@@ -1122,66 +933,87 @@ mod append {
         persist_api: PersistApi,
         descs: DescsStream<'s>,
         batches: BatchesStream<'s>,
-    ) -> PressOnDropButton {
+    ) {
         let scope = descs.scope();
         let worker_id = scope.index();
 
         let name = operator_name(sink_id, "append");
-        let mut op = OperatorBuilder::new(name, scope);
+        let mut builder = OperatorBuilderRc::new(name, scope.clone());
+        let mut descs_input = builder.new_input(descs, Pipeline);
+        let batch_exchange =
+            Exchange::new(|(desc, _): &(BatchDescription, _)| u64::cast_from(desc.append_worker));
+        let mut batches_input = builder.new_input(batches, batch_exchange);
 
-        // Broadcast batch descriptions to all workers, regardless of whether or not they are
-        // responsible for the append, to give them a chance to clean up any outdated state they
-        // might still hold.
-        let mut descs_input = op.new_disconnected_input(descs.broadcast(), Pipeline);
-        let mut batches_input = op.new_disconnected_input(
-            batches,
-            Exchange::new(move |(desc, _): &(BatchDescription, _)| {
-                u64::cast_from(desc.append_worker)
-            }),
-        );
+        // Channel for commands to the Tokio append task.
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<AppendCommand>();
 
-        let button = op.build(move |_capabilities| async move {
-            let writer = persist_api.open_writer().await;
-            let mut state = State::new(sink_id, worker_id, writer);
+        // Spawn Tokio task that owns the append state machine.
+        let append_task_handle =
+            mz_ore::task::spawn(|| operator_name(sink_id, "append"), async move {
+                let writer = persist_api.open_writer().await;
+                let mut state = State::new(sink_id, worker_id, writer);
 
-            loop {
-                // Read from the inputs, absorb batch descriptions and batches. If the `batches`
-                // frontier advances, or if we receive a new batch description, we might have to
-                // append a new batch.
-                tokio::select! {
-                    Some(event) = descs_input.next() => {
-                        if let Event::Data(_cap, data) = event {
-                            for desc in data {
-                                state.absorb_batch_description(desc).await;
-                                state.maybe_append_batches().await;
-                            }
+                while let Some(cmd) = cmd_rx.recv().await {
+                    match cmd {
+                        AppendCommand::Description(desc) => {
+                            state.absorb_batch_description(desc).await;
+                            state.maybe_append_batches().await;
+                        }
+                        AppendCommand::Batch(batch) => {
+                            state.absorb_batch(batch).await;
+                        }
+                        AppendCommand::BatchesFrontier(frontier) => {
+                            state.advance_batches_frontier(frontier.borrow());
+                            state.maybe_append_batches().await;
                         }
                     }
-                    Some(event) = batches_input.next() => {
-                        match event {
-                            Event::Data(_cap, data) => {
-                                // The batch description is only used for routing and we ignore it
-                                // here since we already get one from `descs_input`.
-                                for (_desc, batch) in data {
-                                    state.absorb_batch(batch).await;
-                                }
-                            }
-                            Event::Progress(frontier) => {
-                                state.advance_batches_frontier(frontier);
-                                state.maybe_append_batches().await;
-                            }
-                        }
+                }
+            })
+            .abort_on_drop();
+
+        builder.build(move |_capabilities| {
+            let mut prev_batches_frontier = Antichain::from_elem(Timestamp::MIN);
+
+            move |frontiers| {
+                // Keep task handle alive so it is aborted when the operator is dropped.
+                let _ = &append_task_handle;
+
+                // Forward batch descriptions to the Tokio task.
+                descs_input.for_each(|_cap, data| {
+                    for desc in data.drain(..) {
+                        cmd_tx
+                            .send(AppendCommand::Description(desc))
+                            .expect("append task unexpectedly gone");
                     }
-                    // All inputs are exhausted, so we can shut down.
-                    else => return,
+                });
+
+                // Forward batches to the Tokio task.
+                batches_input.for_each(|_cap, data| {
+                    for (_desc, batch) in data.drain(..) {
+                        // The batch description is only used for routing and we ignore it
+                        // here since we already get one from `descs_input`.
+                        cmd_tx
+                            .send(AppendCommand::Batch(batch))
+                            .expect("append task unexpectedly gone");
+                    }
+                });
+
+                // Forward batches frontier advancements.
+                let new_batches_frontier = frontiers[1].frontier();
+                if PartialOrder::less_than(&prev_batches_frontier.borrow(), &new_batches_frontier) {
+                    prev_batches_frontier.clear();
+                    prev_batches_frontier.extend(new_batches_frontier.iter().cloned());
+                    cmd_tx
+                        .send(AppendCommand::BatchesFrontier(
+                            new_batches_frontier.to_owned(),
+                        ))
+                        .expect("append task unexpectedly gone");
                 }
             }
         });
-
-        button.press_on_drop()
     }
 
-    /// State maintained by the `append` operator.
+    /// State maintained by the `append` Tokio task.
     struct State {
         sink_id: GlobalId,
         worker_id: usize,
@@ -1225,7 +1057,7 @@ mod append {
             );
         }
 
-        fn advance_batches_frontier(&mut self, frontier: Antichain<Timestamp>) {
+        fn advance_batches_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.batches_frontier, frontier) {
                 self.trace("advanced `batches` frontier");
             }

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -14,6 +14,37 @@
 //! Gated behind the `ENABLE_SYNC_MV_SINK` dyncfg.
 //!
 //! See the [main module](super::materialized_view) for the operator graph and design docs.
+//!
+//! ### Channel ordering requirements
+//!
+//! Each operator splits state across a Timely thread (which observes inputs and frontiers) and a
+//! Tokio task (which owns persist I/O state). They communicate via `mpsc` command channels, which
+//! preserve send order on a single sender. Each operator instance constructs its own
+//! `(tx, rx)` pair inside `render` and never clones the sender, so there is exactly one producer
+//! per channel — sends are totally ordered. Different worker instances of the same operator
+//! never share a channel, so cross-worker ordering is not a concern. The correctness of the
+//! operators relies on a few ordering invariants between the messages sent within a single Timely
+//! activation:
+//!
+//!  * **`mint`**: the `persist_watch` Tokio task is the sole producer of persist-frontier updates
+//!    and emits them in monotonically increasing order, terminated by the empty frontier. The
+//!    Timely closure drains the receiver each activation; processing in receive order is therefore
+//!    sufficient. No cross-channel ordering is needed because `mint` only has the one channel.
+//!
+//!  * **`write`**: per-activation, the Timely closure first appends all observed input data into
+//!    a single `WriteCommand::Batch` and only then sends a `WriteCommand::WriteBatch` (issued from
+//!    `maybe_start_batch` after frontier checks). The Tokio task processes commands FIFO, so a
+//!    `WriteBatch` is guaranteed to see every `Batch` from the same activation already applied to
+//!    the corrections buffer. Reversing this order would let the task write a batch that is
+//!    missing updates the Timely closure already observed.
+//!
+//!  * **`append`**: per-activation, the Timely closure forwards messages in the order
+//!    `Description` → `Batch` → `BatchesFrontier`. The first two carry the data the task needs
+//!    to absorb; `BatchesFrontier` is the trigger that allows `maybe_append_batches` to fire.
+//!    Sending `BatchesFrontier` *after* its corresponding `Batch` messages ensures the task does
+//!    not append a batch description before all batches contributing to it have been absorbed.
+//!    If the order were reversed, `maybe_append_batches` could fire on an incomplete `batches`
+//!    set and miss writes.
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -915,6 +946,19 @@ mod write {
         }
 
         fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {
+            // Enforce monotonicity: drop descriptions whose `lower` regresses below the one we
+            // already hold. The `mint` operator only emits strictly increasing `lower`s
+            // (invariant 1), so a regression means this description is outdated. We cannot use
+            // `persist_frontiers` for the same check, because during snapshot processing those
+            // frontiers can be ahead of the shard's write frontier and a still-valid description
+            // may have a `lower` below them.
+            if let Some((prev, _)) = &self.batch_description {
+                if PartialOrder::less_than(&desc.lower, &prev.lower) {
+                    self.trace(format!("skipping outdated batch description: {desc:?}"));
+                    return;
+                }
+            }
+
             self.batch_description = Some((desc, cap));
             self.trace("set batch description");
         }
@@ -1037,7 +1081,11 @@ mod append {
                     }
                 });
 
-                // Forward batches frontier advancements.
+                // Forward batches frontier advancements *after* the per-activation
+                // `Description`/`Batch` sends above. The Tokio task drains commands FIFO and only
+                // calls `maybe_append_batches` on `Description`/`BatchesFrontier`; if a frontier
+                // advance arrived before its batches, the task could append an incomplete set.
+                // See module-level docs for the full ordering invariant.
                 let new_batches_frontier = frontiers[1].frontier();
                 if PartialOrder::less_than(&prev_batches_frontier.borrow(), &new_batches_frontier) {
                     prev_batches_frontier.clear();

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -170,7 +170,7 @@ pub fn persist_source<'scope, E>(
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
     max_inflight_bytes: Option<usize>,
-    start_signal: impl Future<Output = ()> + 'static,
+    start_signal: impl Future<Output = ()> + Send + 'static,
     error_handler: ErrorHandler,
 ) -> (
     StreamVec<'scope, mz_repr::Timestamp, (Row, Timestamp, Diff)>,
@@ -308,8 +308,8 @@ pub fn persist_source_core<'g, 'outer, E>(
     map_filter_project: Option<&mut MfpPlan>,
     flow_control: Option<FlowControl<'g, (mz_repr::Timestamp, Subtime)>>,
     // If Some, an override for the default listen sleep retry parameters.
-    listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
-    start_signal: impl Future<Output = ()> + 'static,
+    listen_sleep: Option<impl Fn() -> RetryParameters + Send + 'static>,
+    start_signal: impl Future<Output = ()> + Send + 'static,
     error_handler: ErrorHandler,
 ) -> (
     Stream<

--- a/src/timely-util/src/activator.rs
+++ b/src/timely-util/src/activator.rs
@@ -17,8 +17,11 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use timely::dataflow::Scope;
+use timely::dataflow::operators::generic::OperatorInfo;
 use timely::progress::Timestamp;
 use timely::scheduling::Activator;
 
@@ -136,5 +139,60 @@ impl ActivatorInner {
 
     fn ack(&mut self) {
         self.activated = 0;
+    }
+}
+
+/// A [`timely::scheduling::SyncActivator`] wrapper that coalesces multiple activations.
+///
+/// Tasks can call [`ArcActivator::activate`] liberally. The actual
+/// `SyncActivator::activate` call is suppressed if the operator has not yet run since the
+/// last activation. The Timely operator holds the corresponding [`ActivationAck`] and calls
+/// [`ActivationAck::ack`] each time it is scheduled, resetting the flag so the next
+/// `activate` call goes through.
+pub struct ArcActivator {
+    inner: timely::scheduling::SyncActivator,
+    /// `true` if the operator has been activated but not yet scheduled.
+    pending: Arc<AtomicBool>,
+}
+
+/// Handle held by the Timely operator to acknowledge activations from a [`ArcActivator`].
+///
+/// Call [`ActivationAck::ack`] at the start of each operator scheduling to allow the
+/// [`ArcActivator`] to send new activations.
+pub struct ActivationAck(Arc<AtomicBool>);
+
+impl ArcActivator {
+    /// Create a new [`ArcActivator`] and its corresponding [`ActivationAck`].
+    pub fn new<'scope, T: Timestamp>(
+        scope: Scope<'scope, T>,
+        info: &OperatorInfo,
+    ) -> (Self, ActivationAck) {
+        let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
+        let pending = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                inner: sync_activator,
+                pending: Arc::clone(&pending),
+            },
+            ActivationAck(pending),
+        )
+    }
+
+    /// Activate the Timely operator, unless an activation is already pending.
+    pub fn activate(&self) {
+        // Acquire ensures we see the latest `ack` store before deciding to skip.
+        if !self.pending.swap(true, Ordering::AcqRel) {
+            let _ = self.inner.activate();
+        }
+    }
+}
+
+impl ActivationAck {
+    /// Acknowledge the activation, allowing the [`ArcActivator`] to activate again.
+    ///
+    /// Call this at the start of each operator scheduling.
+    pub fn ack(&self) {
+        // Release ensures the `false` is visible to the Tokio task's `activate`.
+        self.0.store(false, Ordering::Release);
     }
 }


### PR DESCRIPTION
Convert the MV sink's mint, write, and append operators from `AsyncOperatorBuilder` to `OperatorBuilderRc` (sync) with dedicated Tokio tasks for persist I/O.
This removes async overhead from the Timely scheduling loop while keeping persist latency isolated from dataflow scheduling.

Key changes:
* mint: Tokio task watches persist upper via `SyncActivator`; operator manages capabilities and batch description minting
* write: Tokio task owns `WriteHandle` and `CorrectionBuffer`; operator sends commands via channel; `ArcActivator` coalesces redundant cross-thread activations
* append: Tokio task performs `compare_and_append`; operator forwards descriptions, batches, and frontier updates
* `CorrectionLogger` tracks net batch/record/size counts and retracts outstanding logging state on drop, fixing stale introspection rows after dataflow cancellation
* `ChannelLogging` bridges `Correction` events from Tokio task to Timely thread for introspection logging
* All tasks use `abort_on_drop` for prompt cleanup on dataflow shutdown

Shares the infra commit (`compute/storage: add Send-safe infrastructure for sync Timely operators`) with #35450.
Rebase before merging to deduplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)