### PR TITLE
expr: unify scalar function traits under LazyScalarFunc/EagerScalarFunc

### DIFF
--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__add_int16.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__add_int16.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = i16,
     mz_lowertest::MzReflect,
 )]
 pub struct AddInt16;
-impl crate::func::binary::EagerBinaryFunc for AddInt16 {
+impl crate::EagerScalarFunc for AddInt16 {
     type Input<'a> = (Datum<'a>, Datum<'a>);
     type Output<'a> = Result<Datum<'a>, EvalError>;
     fn call<'a>(
@@ -32,15 +32,47 @@ impl crate::func::binary::EagerBinaryFunc for AddInt16 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = <i16>::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false;
         let inputs_nullable = input_types.iter().any(|it| it.nullable);
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+    fn introduces_nulls(&self) -> bool {
+        <i16 as ::mz_repr::OutputDatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn arg_is_monotone(&self, index: usize) -> bool {
+        let monotone: (bool, bool) = (true, true);
+        match index {
+            0 => monotone.0,
+            1 => monotone.1,
+            _ => false,
+        }
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl crate::func::EagerBinaryFunc for AddInt16 {
+    type Input<'a> = (Datum<'a>, Datum<'a>);
+    type Output<'a> = Result<Datum<'a>, EvalError>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        add_int16(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn introduces_nulls(&self) -> bool {
         <i16 as ::mz_repr::OutputDatumType<'_, ()>>::nullable()

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__binary_arena_fn.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__binary_arena_fn.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\nfn unary_fn<'a>(a: Datum<'a>, b: u16, temp
     mz_lowertest::MzReflect,
 )]
 pub struct UnaryFn;
-impl crate::func::binary::EagerBinaryFunc for UnaryFn {
+impl crate::EagerScalarFunc for UnaryFn {
     type Input<'a> = (Datum<'a>, u16);
     type Output<'a> = bool;
     fn call<'a>(
@@ -32,9 +32,7 @@ impl crate::func::binary::EagerBinaryFunc for UnaryFn {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false
             || input_types.get(1usize).map_or(false, |t| t.nullable);
@@ -42,6 +40,23 @@ impl crate::func::binary::EagerBinaryFunc for UnaryFn {
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for UnaryFn {
+    type Input<'a> = (Datum<'a>, u16);
+    type Output<'a> = bool;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        unary_fn(a, b, temp_storage)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for UnaryFn {

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__complex_type.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__complex_type.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(\n    is_monotone = (true, true),\n    output_type = \"Op
     mz_lowertest::MzReflect,
 )]
 pub struct ComplexOutputTypeFn;
-impl crate::func::binary::EagerBinaryFunc for ComplexOutputTypeFn {
+impl crate::EagerScalarFunc for ComplexOutputTypeFn {
     type Input<'a> = (Datum<'a>, Datum<'a>);
     type Output<'a> = Result<Datum<'a>, EvalError>;
     fn call<'a>(
@@ -32,15 +32,47 @@ impl crate::func::binary::EagerBinaryFunc for ComplexOutputTypeFn {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = <Option<bool>>::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false;
         let inputs_nullable = input_types.iter().any(|it| it.nullable);
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+    fn introduces_nulls(&self) -> bool {
+        <Option<bool> as ::mz_repr::OutputDatumType<'_, ()>>::nullable()
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+    fn arg_is_monotone(&self, index: usize) -> bool {
+        let monotone: (bool, bool) = (true, true);
+        match index {
+            0 => monotone.0,
+            1 => monotone.1,
+            _ => false,
+        }
+    }
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+}
+impl crate::func::EagerBinaryFunc for ComplexOutputTypeFn {
+    type Input<'a> = (Datum<'a>, Datum<'a>);
+    type Output<'a> = Result<Datum<'a>, EvalError>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        complex_output_type_fn(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn introduces_nulls(&self) -> bool {
         <Option<bool> as ::mz_repr::OutputDatumType<'_, ()>>::nullable()

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_fn.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_fn.snap
@@ -16,6 +16,28 @@ expression: "#[sqlfunc(test = true)]\nfn unary_fn<'a>(a: Datum<'a>) -> bool {\n 
     mz_lowertest::MzReflect,
 )]
 pub struct UnaryFn;
+impl crate::EagerScalarFunc for UnaryFn {
+    type Input<'a> = Datum<'a>;
+    type Output<'a> = bool;
+    fn call<'a>(
+        &self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        unary_fn(a)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let input_type = &input_types[0];
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+}
 impl crate::func::EagerUnaryFunc for UnaryFn {
     type Input<'a> = Datum<'a>;
     type Output<'a> = bool;
@@ -26,11 +48,7 @@ impl crate::func::EagerUnaryFunc for UnaryFn {
         &self,
         input_type: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
-        let nullable = output.nullable;
-        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+        crate::EagerScalarFunc::output_sql_type(self, &[input_type])
     }
 }
 impl std::fmt::Display for UnaryFn {

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_ref.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__unary_ref.snap
@@ -16,6 +16,28 @@ expression: "#[sqlfunc(test = true)]\nfn unary_fn<'a>(a: &i16) -> bool {\n    un
     mz_lowertest::MzReflect,
 )]
 pub struct UnaryFn;
+impl crate::EagerScalarFunc for UnaryFn {
+    type Input<'a> = &'a i16;
+    type Output<'a> = bool;
+    fn call<'a>(
+        &self,
+        a: Self::Input<'a>,
+        _temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        unary_fn(a)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let input_type = &input_types[0];
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+    }
+}
 impl crate::func::EagerUnaryFunc for UnaryFn {
     type Input<'a> = &'a i16;
     type Output<'a> = bool;
@@ -26,11 +48,7 @@ impl crate::func::EagerUnaryFunc for UnaryFn {
         &self,
         input_type: mz_repr::SqlColumnType,
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
-        let nullable = output.nullable;
-        output.nullable(nullable || (propagates_nulls && input_type.nullable))
+        crate::EagerScalarFunc::output_sql_type(self, &[input_type])
     }
 }
 impl std::fmt::Display for UnaryFn {

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_arena.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_arena.snap
@@ -13,7 +13,37 @@ impl ArrayFill {
         unimplemented!()
     }
 }
-impl crate::func::variadic::EagerVariadicFunc for ArrayFill {
+impl crate::EagerScalarFunc for ArrayFill {
+    type Input<'a> = (Datum<'a>, Datum<'a>, OptionalArg<Datum<'a>>);
+    type Output<'a> = Result<Datum<'a>, EvalError>;
+    fn call<'a>(
+        &self,
+        (fill, dims, lb): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        self.array_fill(fill, dims, lb, temp_storage)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        let non_nullable_input_is_nullable = false;
+        let inputs_nullable = input_types.iter().any(|it| it.nullable);
+        output
+            .nullable(
+                nullable || non_nullable_input_is_nullable
+                    || (propagates_nulls && inputs_nullable),
+            )
+    }
+    fn introduces_nulls(&self) -> bool {
+        false
+    }
+}
+impl crate::func::EagerVariadicFunc for ArrayFill {
     type Input<'a> = (Datum<'a>, Datum<'a>, OptionalArg<Datum<'a>>);
     type Output<'a> = Result<Datum<'a>, EvalError>;
     fn call<'a>(
@@ -27,19 +57,7 @@ impl crate::func::variadic::EagerVariadicFunc for ArrayFill {
         &self,
         input_types: &[mz_repr::SqlColumnType],
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::variadic::EagerVariadicFunc::propagates_nulls(
-            self,
-        );
-        let nullable = output.nullable;
-        let non_nullable_input_is_nullable = false;
-        let inputs_nullable = input_types.iter().any(|it| it.nullable);
-        output
-            .nullable(
-                nullable || non_nullable_input_is_nullable
-                    || (propagates_nulls && inputs_nullable),
-            )
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn introduces_nulls(&self) -> bool {
         false

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_modifiers.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_modifiers.snap
@@ -16,7 +16,40 @@ expression: "#[sqlfunc(Greatest, sqlname = \"greatest\", could_error = false, is
     mz_lowertest::MzReflect,
 )]
 pub struct Greatest;
-impl crate::func::variadic::EagerVariadicFunc for Greatest {
+impl crate::EagerScalarFunc for Greatest {
+    type Input<'a> = Variadic<Datum<'a>>;
+    type Output<'a> = Datum<'a>;
+    fn call<'a>(
+        &self,
+        datums: Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        greatest(datums)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        let non_nullable_input_is_nullable = false;
+        let inputs_nullable = input_types.iter().any(|it| it.nullable);
+        output
+            .nullable(
+                nullable || non_nullable_input_is_nullable
+                    || (propagates_nulls && inputs_nullable),
+            )
+    }
+    fn could_error(&self) -> bool {
+        false
+    }
+    fn arg_is_monotone(&self, _index: usize) -> bool {
+        true
+    }
+}
+impl crate::func::EagerVariadicFunc for Greatest {
     type Input<'a> = Variadic<Datum<'a>>;
     type Output<'a> = Datum<'a>;
     fn call<'a>(
@@ -30,19 +63,7 @@ impl crate::func::variadic::EagerVariadicFunc for Greatest {
         &self,
         input_types: &[mz_repr::SqlColumnType],
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::variadic::EagerVariadicFunc::propagates_nulls(
-            self,
-        );
-        let nullable = output.nullable;
-        let non_nullable_input_is_nullable = false;
-        let inputs_nullable = input_types.iter().any(|it| it.nullable);
-        output
-            .nullable(
-                nullable || non_nullable_input_is_nullable
-                    || (propagates_nulls && inputs_nullable),
-            )
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn could_error(&self) -> bool {
         false

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_tuple.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_tuple.snap
@@ -16,7 +16,37 @@ expression: "#[sqlfunc(Replace, sqlname = \"replace\")]\nfn replace(text: &str, 
     mz_lowertest::MzReflect,
 )]
 pub struct Replace;
-impl crate::func::variadic::EagerVariadicFunc for Replace {
+impl crate::EagerScalarFunc for Replace {
+    type Input<'a> = (&'a str, &'a str, &'a str);
+    type Output<'a> = Result<String, EvalError>;
+    fn call<'a>(
+        &self,
+        (text, from, to): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        replace(text, from, to)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        let non_nullable_input_is_nullable = false
+            || input_types.get(0usize).map_or(false, |t| t.nullable)
+            || input_types.get(1usize).map_or(false, |t| t.nullable)
+            || input_types.get(2usize).map_or(false, |t| t.nullable);
+        let inputs_nullable = input_types.iter().any(|it| it.nullable);
+        output
+            .nullable(
+                nullable || non_nullable_input_is_nullable
+                    || (propagates_nulls && inputs_nullable),
+            )
+    }
+}
+impl crate::func::EagerVariadicFunc for Replace {
     type Input<'a> = (&'a str, &'a str, &'a str);
     type Output<'a> = Result<String, EvalError>;
     fn call<'a>(
@@ -30,22 +60,7 @@ impl crate::func::variadic::EagerVariadicFunc for Replace {
         &self,
         input_types: &[mz_repr::SqlColumnType],
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::variadic::EagerVariadicFunc::propagates_nulls(
-            self,
-        );
-        let nullable = output.nullable;
-        let non_nullable_input_is_nullable = false
-            || input_types.get(0usize).map_or(false, |t| t.nullable)
-            || input_types.get(1usize).map_or(false, |t| t.nullable)
-            || input_types.get(2usize).map_or(false, |t| t.nullable);
-        let inputs_nullable = input_types.iter().any(|it| it.nullable);
-        output
-            .nullable(
-                nullable || non_nullable_input_is_nullable
-                    || (propagates_nulls && inputs_nullable),
-            )
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Replace {

--- a/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_variadic_type.snap
+++ b/src/expr-derive-impl/src/snapshots/mz_expr_derive_impl__test__variadic_variadic_type.snap
@@ -16,7 +16,37 @@ expression: "#[sqlfunc(Concat, sqlname = \"concat\", is_associative = true)]\nfn
     mz_lowertest::MzReflect,
 )]
 pub struct Concat;
-impl crate::func::variadic::EagerVariadicFunc for Concat {
+impl crate::EagerScalarFunc for Concat {
+    type Input<'a> = Variadic<Option<&'a str>>;
+    type Output<'a> = Result<String, EvalError>;
+    fn call<'a>(
+        &self,
+        strs: Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        concat(strs)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        use mz_repr::AsColumnType;
+        let output = Self::Output::as_column_type();
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+        let nullable = output.nullable;
+        let non_nullable_input_is_nullable = false;
+        let inputs_nullable = input_types.iter().any(|it| it.nullable);
+        output
+            .nullable(
+                nullable || non_nullable_input_is_nullable
+                    || (propagates_nulls && inputs_nullable),
+            )
+    }
+    fn is_associative(&self) -> bool {
+        true
+    }
+}
+impl crate::func::EagerVariadicFunc for Concat {
     type Input<'a> = Variadic<Option<&'a str>>;
     type Output<'a> = Result<String, EvalError>;
     fn call<'a>(
@@ -30,19 +60,7 @@ impl crate::func::variadic::EagerVariadicFunc for Concat {
         &self,
         input_types: &[mz_repr::SqlColumnType],
     ) -> mz_repr::SqlColumnType {
-        use mz_repr::AsColumnType;
-        let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::variadic::EagerVariadicFunc::propagates_nulls(
-            self,
-        );
-        let nullable = output.nullable;
-        let non_nullable_input_is_nullable = false;
-        let inputs_nullable = input_types.iter().any(|it| it.nullable);
-        output
-            .nullable(
-                nullable || non_nullable_input_is_nullable
-                    || (propagates_nulls && inputs_nullable),
-            )
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn is_associative(&self) -> bool {
         true

--- a/src/expr-derive-impl/src/sqlfunc.rs
+++ b/src/expr-derive-impl/src/sqlfunc.rs
@@ -397,7 +397,7 @@ fn output_type(arg: &syn::ItemFn) -> Result<&syn::Type, syn::Error> {
     }
 }
 
-/// Produce a `EagerUnaryFunc` implementation.
+/// Produce an `EagerScalarFunc` implementation for a unary function.
 fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<TokenStream> {
     let fn_name = &func.sig.ident;
     let struct_name = camel_case(&func.sig.ident);
@@ -466,7 +466,15 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
         }
     });
 
-    let is_monotone_fn = is_monotone.map(|is_monotone| {
+    let is_monotone_fn = is_monotone.as_ref().map(|is_monotone| {
+        quote! {
+            fn arg_is_monotone(&self, _index: usize) -> bool {
+                #is_monotone
+            }
+        }
+    });
+
+    let compat_is_monotone_fn = is_monotone.map(|is_monotone| {
         quote! {
             fn is_monotone(&self) -> bool {
                 #is_monotone
@@ -518,6 +526,40 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
         )]
         pub struct #struct_name;
 
+        impl crate::EagerScalarFunc for #struct_name {
+            type Input<'a> = #input_ty;
+            type Output<'a> = #output_ty;
+
+            fn call<'a>(
+                &self,
+                a: Self::Input<'a>,
+                _temp_storage: &'a mz_repr::RowArena,
+            ) -> Self::Output<'a> {
+                #fn_name(a)
+            }
+
+            fn output_sql_type(
+                &self,
+                input_types: &[mz_repr::SqlColumnType]
+            ) -> mz_repr::SqlColumnType {
+                use mz_repr::AsColumnType;
+                let input_type = &input_types[0];
+                let output = #output_type;
+                let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
+                let nullable = output.nullable;
+                // The output is nullable if it is nullable by itself or the input is nullable
+                // and this function propagates nulls
+                output.nullable(nullable || (propagates_nulls && input_type.nullable))
+            }
+
+            #could_error_fn
+            #introduces_nulls_fn
+            #inverse_fn
+            #is_monotone_fn
+            #preserves_uniqueness_fn
+        }
+
+        // Compat shim: EagerUnaryFunc for derive_unary! dispatch
         impl crate::func::EagerUnaryFunc for #struct_name {
             type Input<'a> = #input_ty;
             type Output<'a> = #output_ty;
@@ -530,19 +572,13 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
                 &self,
                 input_type: mz_repr::SqlColumnType
             ) -> mz_repr::SqlColumnType {
-                use mz_repr::AsColumnType;
-                let output = #output_type;
-                let propagates_nulls = crate::func::EagerUnaryFunc::propagates_nulls(self);
-                let nullable = output.nullable;
-                // The output is nullable if it is nullable by itself or the input is nullable
-                // and this function propagates nulls
-                output.nullable(nullable || (propagates_nulls && input_type.nullable))
+                crate::EagerScalarFunc::output_sql_type(self, &[input_type])
             }
 
             #could_error_fn
             #introduces_nulls_fn
             #inverse_fn
-            #is_monotone_fn
+            #compat_is_monotone_fn
             #preserves_uniqueness_fn
         }
 
@@ -557,7 +593,7 @@ fn unary_func(func: &syn::ItemFn, modifiers: Modifiers) -> darling::Result<Token
     Ok(result)
 }
 
-/// Produce a `EagerBinaryFunc` implementation.
+/// Produce an `EagerScalarFunc` implementation for a binary function.
 fn binary_func(
     func: &syn::ItemFn,
     modifiers: Modifiers,
@@ -619,7 +655,20 @@ fn binary_func(
         }
     });
 
-    let is_monotone_fn = is_monotone.map(|is_monotone| {
+    let is_monotone_fn = is_monotone.as_ref().map(|is_monotone| {
+        quote! {
+            fn arg_is_monotone(&self, index: usize) -> bool {
+                let monotone: (bool, bool) = #is_monotone;
+                match index {
+                    0 => monotone.0,
+                    1 => monotone.1,
+                    _ => false,
+                }
+            }
+        }
+    });
+
+    let compat_is_monotone_fn = is_monotone.map(|is_monotone| {
         quote! {
             fn is_monotone(&self) -> (bool, bool) {
                 #is_monotone
@@ -698,7 +747,7 @@ fn binary_func(
         )]
         pub struct #struct_name;
 
-        impl crate::func::binary::EagerBinaryFunc for #struct_name {
+        impl crate::EagerScalarFunc for #struct_name {
             type Input<'a> = (#input1_ty, #input2_ty);
             type Output<'a> = #output_ty;
 
@@ -717,7 +766,7 @@ fn binary_func(
                 use mz_repr::AsColumnType;
                 let output = #output_type;
                 let propagates_nulls =
-                    crate::func::binary::EagerBinaryFunc::propagates_nulls(self);
+                    crate::EagerScalarFunc::propagates_nulls(self);
                 let nullable = output.nullable;
                 // The output is nullable if:
                 // 1. The function introduces nulls (output.nullable), or
@@ -742,6 +791,34 @@ fn binary_func(
             #propagates_nulls_fn
         }
 
+        // Compat shim: EagerBinaryFunc for derive_binary! dispatch
+        impl crate::func::EagerBinaryFunc for #struct_name {
+            type Input<'a> = (#input1_ty, #input2_ty);
+            type Output<'a> = #output_ty;
+
+            fn call<'a>(
+                &self,
+                (a, b): Self::Input<'a>,
+                temp_storage: &'a mz_repr::RowArena
+            ) -> Self::Output<'a> {
+                #fn_name(a, b #arena)
+            }
+
+            fn output_sql_type(
+                &self,
+                input_types: &[mz_repr::SqlColumnType],
+            ) -> mz_repr::SqlColumnType {
+                crate::EagerScalarFunc::output_sql_type(self, input_types)
+            }
+
+            #could_error_fn
+            #introduces_nulls_fn
+            #is_infix_op_fn
+            #compat_is_monotone_fn
+            #negate_fn
+            #propagates_nulls_fn
+        }
+
         impl std::fmt::Display for #struct_name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.write_str(#name)
@@ -754,7 +831,7 @@ fn binary_func(
     Ok(result)
 }
 
-/// Produce an `EagerVariadicFunc` implementation.
+/// Produce an `EagerScalarFunc` implementation for a variadic function.
 ///
 /// Two modes based on whether the function has a `&self` receiver:
 /// * `&self` present: struct defined externally, generates method impl + trait impl + Display
@@ -922,7 +999,15 @@ fn variadic_func(
         }
     });
 
-    let is_monotone_fn = is_monotone.map(|is_monotone| {
+    let is_monotone_fn = is_monotone.as_ref().map(|is_monotone| {
+        quote! {
+            fn arg_is_monotone(&self, _index: usize) -> bool {
+                #is_monotone
+            }
+        }
+    });
+
+    let compat_is_monotone_fn = is_monotone.map(|is_monotone| {
         quote! {
             fn is_monotone(&self) -> bool {
                 #is_monotone
@@ -959,7 +1044,7 @@ fn variadic_func(
     let non_nullable_checks = non_nullable_position_checks(&param_types);
 
     let trait_impl = quote! {
-        impl crate::func::variadic::EagerVariadicFunc for #struct_name {
+        impl crate::EagerScalarFunc for #struct_name {
             type Input<'a> = #input_type;
             type Output<'a> = #output_ty;
 
@@ -971,14 +1056,14 @@ fn variadic_func(
                 #call_expr
             }
 
-            fn output_type(
+            fn output_sql_type(
                 &self,
                 input_types: &[mz_repr::SqlColumnType],
             ) -> mz_repr::SqlColumnType {
                 use mz_repr::AsColumnType;
                 let output = #output_type_code;
                 let propagates_nulls =
-                    crate::func::variadic::EagerVariadicFunc::propagates_nulls(self);
+                    crate::EagerScalarFunc::propagates_nulls(self);
                 let nullable = output.nullable;
                 // The output is nullable if:
                 // 1. The function introduces nulls (output.nullable), or
@@ -1005,6 +1090,36 @@ fn variadic_func(
         }
     };
 
+    // Compat shim: EagerVariadicFunc for derive_variadic! dispatch
+    let compat_trait_impl = quote! {
+        impl crate::func::EagerVariadicFunc for #struct_name {
+            type Input<'a> = #input_type;
+            type Output<'a> = #output_ty;
+
+            fn call<'a>(
+                &self,
+                #destructure: Self::Input<'a>,
+                temp_storage: &'a mz_repr::RowArena,
+            ) -> Self::Output<'a> {
+                #call_expr
+            }
+
+            fn output_type(
+                &self,
+                input_types: &[mz_repr::SqlColumnType],
+            ) -> mz_repr::SqlColumnType {
+                crate::EagerScalarFunc::output_sql_type(self, input_types)
+            }
+
+            #could_error_fn
+            #introduces_nulls_fn
+            #is_infix_op_fn
+            #compat_is_monotone_fn
+            #is_associative_fn
+            #propagates_nulls_fn
+        }
+    };
+
     let display_impl = quote! {
         impl std::fmt::Display for #struct_name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -1020,6 +1135,7 @@ fn variadic_func(
                 #func
             }
             #trait_impl
+            #compat_trait_impl
             #display_impl
         }
     } else {
@@ -1033,6 +1149,7 @@ fn variadic_func(
             pub struct #struct_name;
 
             #trait_impl
+            #compat_trait_impl
             #display_impl
 
             #func

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -46,6 +46,7 @@ pub use relation::{
     compare_columns, non_nullable_columns,
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
+pub use scalar::{EagerScalarFunc, LazyScalarFunc};
 pub use scalar::{
     EvalError, FilterCharacteristics, MirScalarExpr, ProtoDomainLimit, ProtoEvalError, like_pattern,
 };

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -51,6 +51,9 @@ use crate::visit::{Visit, VisitChildren};
 
 pub mod func;
 pub mod like_pattern;
+mod scalar_func;
+
+pub use scalar_func::{EagerScalarFunc, LazyScalarFunc};
 
 include!(concat!(env!("OUT_DIR"), "/mz_expr.scalar.rs"));
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -65,10 +65,12 @@ mod unmaterializable;
 pub mod variadic;
 
 pub use binary::BinaryFunc;
+pub(crate) use binary::EagerBinaryFunc;
 pub use impls::*;
 pub use unary::{EagerUnaryFunc, LazyUnaryFunc, UnaryFunc};
 pub use unmaterializable::UnmaterializableFunc;
 pub use variadic::VariadicFunc;
+pub(crate) use variadic::EagerVariadicFunc;
 
 /// The maximum size of the result strings of certain string functions, such as `repeat` and `lpad`.
 /// Chosen to be the smallest number to keep our tests passing without changing. 100MiB is probably

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible1.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible1.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\n#[allow(dead_code)]\nfn fallible1(a: f32, 
     mz_lowertest::MzReflect,
 )]
 pub struct Fallible1;
-impl crate::func::binary::EagerBinaryFunc for Fallible1 {
+impl crate::EagerScalarFunc for Fallible1 {
     type Input<'a> = (f32, f32);
     type Output<'a> = Result<f32, EvalError>;
     fn call<'a>(
@@ -32,9 +32,7 @@ impl crate::func::binary::EagerBinaryFunc for Fallible1 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false
             || input_types.get(0usize).map_or(false, |t| t.nullable)
@@ -43,6 +41,23 @@ impl crate::func::binary::EagerBinaryFunc for Fallible1 {
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for Fallible1 {
+    type Input<'a> = (f32, f32);
+    type Output<'a> = Result<f32, EvalError>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        fallible1(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Fallible1 {

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible2.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible2.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\n#[allow(dead_code)]\nfn fallible2(a: Optio
     mz_lowertest::MzReflect,
 )]
 pub struct Fallible2;
-impl crate::func::binary::EagerBinaryFunc for Fallible2 {
+impl crate::EagerScalarFunc for Fallible2 {
     type Input<'a> = (Option<f32>, Option<f32>);
     type Output<'a> = Result<f32, EvalError>;
     fn call<'a>(
@@ -32,15 +32,30 @@ impl crate::func::binary::EagerBinaryFunc for Fallible2 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false;
         let inputs_nullable = input_types.iter().any(|it| it.nullable);
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for Fallible2 {
+    type Input<'a> = (Option<f32>, Option<f32>);
+    type Output<'a> = Result<f32, EvalError>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        fallible2(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Fallible2 {

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible3.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__fallible3.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\n#[allow(dead_code)]\nfn fallible3(a: f32, 
     mz_lowertest::MzReflect,
 )]
 pub struct Fallible3;
-impl crate::func::binary::EagerBinaryFunc for Fallible3 {
+impl crate::EagerScalarFunc for Fallible3 {
     type Input<'a> = (f32, f32);
     type Output<'a> = Result<Option<f32>, EvalError>;
     fn call<'a>(
@@ -32,9 +32,7 @@ impl crate::func::binary::EagerBinaryFunc for Fallible3 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false
             || input_types.get(0usize).map_or(false, |t| t.nullable)
@@ -43,6 +41,23 @@ impl crate::func::binary::EagerBinaryFunc for Fallible3 {
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for Fallible3 {
+    type Input<'a> = (f32, f32);
+    type Output<'a> = Result<Option<f32>, EvalError>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        fallible3(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Fallible3 {

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible1.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible1.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(sqlname = \"INFALLIBLE\", is_infix_op = true, test = true
     mz_lowertest::MzReflect,
 )]
 pub struct Infallible1;
-impl crate::func::binary::EagerBinaryFunc for Infallible1 {
+impl crate::EagerScalarFunc for Infallible1 {
     type Input<'a> = (f32, f32);
     type Output<'a> = f32;
     fn call<'a>(
@@ -32,9 +32,7 @@ impl crate::func::binary::EagerBinaryFunc for Infallible1 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false
             || input_types.get(0usize).map_or(false, |t| t.nullable)
@@ -43,6 +41,26 @@ impl crate::func::binary::EagerBinaryFunc for Infallible1 {
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+    fn is_infix_op(&self) -> bool {
+        true
+    }
+}
+impl crate::func::EagerBinaryFunc for Infallible1 {
+    type Input<'a> = (f32, f32);
+    type Output<'a> = f32;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        infallible1(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
     fn is_infix_op(&self) -> bool {
         true

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible2.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible2.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\n#[allow(dead_code)]\nfn infallible2(a: Opt
     mz_lowertest::MzReflect,
 )]
 pub struct Infallible2;
-impl crate::func::binary::EagerBinaryFunc for Infallible2 {
+impl crate::EagerScalarFunc for Infallible2 {
     type Input<'a> = (Option<f32>, Option<f32>);
     type Output<'a> = f32;
     fn call<'a>(
@@ -32,15 +32,30 @@ impl crate::func::binary::EagerBinaryFunc for Infallible2 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false;
         let inputs_nullable = input_types.iter().any(|it| it.nullable);
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for Infallible2 {
+    type Input<'a> = (Option<f32>, Option<f32>);
+    type Output<'a> = f32;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        infallible2(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Infallible2 {

--- a/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible3.snap
+++ b/src/expr/src/scalar/func/snapshots/mz_expr__scalar__func__binary__test__infallible3.snap
@@ -16,7 +16,7 @@ expression: "#[sqlfunc(test = true)]\n#[allow(dead_code)]\nfn infallible3(a: f32
     mz_lowertest::MzReflect,
 )]
 pub struct Infallible3;
-impl crate::func::binary::EagerBinaryFunc for Infallible3 {
+impl crate::EagerScalarFunc for Infallible3 {
     type Input<'a> = (f32, f32);
     type Output<'a> = Option<f32>;
     fn call<'a>(
@@ -32,9 +32,7 @@ impl crate::func::binary::EagerBinaryFunc for Infallible3 {
     ) -> mz_repr::SqlColumnType {
         use mz_repr::AsColumnType;
         let output = Self::Output::as_column_type();
-        let propagates_nulls = crate::func::binary::EagerBinaryFunc::propagates_nulls(
-            self,
-        );
+        let propagates_nulls = crate::EagerScalarFunc::propagates_nulls(self);
         let nullable = output.nullable;
         let non_nullable_input_is_nullable = false
             || input_types.get(0usize).map_or(false, |t| t.nullable)
@@ -43,6 +41,23 @@ impl crate::func::binary::EagerBinaryFunc for Infallible3 {
         let is_null = nullable || non_nullable_input_is_nullable
             || (propagates_nulls && inputs_nullable);
         output.nullable(is_null)
+    }
+}
+impl crate::func::EagerBinaryFunc for Infallible3 {
+    type Input<'a> = (f32, f32);
+    type Output<'a> = Option<f32>;
+    fn call<'a>(
+        &self,
+        (a, b): Self::Input<'a>,
+        temp_storage: &'a mz_repr::RowArena,
+    ) -> Self::Output<'a> {
+        infallible3(a, b)
+    }
+    fn output_sql_type(
+        &self,
+        input_types: &[mz_repr::SqlColumnType],
+    ) -> mz_repr::SqlColumnType {
+        crate::EagerScalarFunc::output_sql_type(self, input_types)
     }
 }
 impl std::fmt::Display for Infallible3 {

--- a/src/expr/src/scalar/scalar_func.rs
+++ b/src/expr/src/scalar/scalar_func.rs
@@ -1,0 +1,239 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Unified scalar function traits.
+//!
+//! [`LazyScalarFunc`] and [`EagerScalarFunc`] provide a single trait interface
+//! for all scalar functions, regardless of arity. Functions that previously
+//! implemented `EagerUnaryFunc`, `EagerBinaryFunc`, or `EagerVariadicFunc`
+//! can be migrated to implement [`EagerScalarFunc`] instead.
+//!
+//! A blanket implementation bridges [`EagerScalarFunc`] to [`LazyScalarFunc`],
+//! handling expression evaluation and null propagation automatically.
+
+use std::fmt;
+
+use mz_repr::{
+    Datum, InputDatumType, OutputDatumType, ReprColumnType, RowArena, SqlColumnType,
+};
+
+use crate::{EvalError, MirScalarExpr};
+
+/// A scalar SQL function that lazily evaluates its arguments.
+///
+/// This is the unified replacement for `LazyUnaryFunc`, `LazyBinaryFunc`, and
+/// `LazyVariadicFunc`. All scalar functions should eventually implement this
+/// trait (either directly for lazy functions, or indirectly via
+/// [`EagerScalarFunc`]).
+pub trait LazyScalarFunc: fmt::Display {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        exprs: &'a [MirScalarExpr],
+    ) -> Result<Datum<'a>, EvalError>;
+
+    /// The output [`SqlColumnType`] of this function given the input types.
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType;
+
+    /// The output [`ReprColumnType`] of this function given the input types.
+    fn output_type(&self, input_types: &[ReprColumnType]) -> ReprColumnType {
+        ReprColumnType::from(
+            &self.output_sql_type(
+                &input_types
+                    .iter()
+                    .map(SqlColumnType::from_repr)
+                    .collect::<Vec<_>>(),
+            ),
+        )
+    }
+
+    /// Whether this function will produce NULL on NULL input.
+    fn propagates_nulls(&self) -> bool;
+
+    /// Whether this function will produce NULL on non-NULL input.
+    fn introduces_nulls(&self) -> bool;
+
+    /// Whether this function might error on non-error input.
+    fn could_error(&self) -> bool {
+        true
+    }
+
+    /// Whether the function is monotone with respect to the argument at the
+    /// given index.
+    ///
+    /// Monotone functions map ranges to ranges: given a range of possible
+    /// inputs, we can determine the range of possible outputs just by mapping
+    /// the endpoints.
+    ///
+    /// For multi-argument functions, this describes *pointwise* behaviour:
+    /// the behaviour of any specific argument as the others are held constant.
+    fn arg_is_monotone(&self, _index: usize) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness.
+    ///
+    /// Uniqueness is preserved when `if f(x) = f(y) then x = y` is true.
+    /// Only meaningful for unary functions.
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+
+    /// The inverse of this function, if it exists. Only meaningful for unary
+    /// functions.
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+
+    /// The negation of this function, if it exists. Only meaningful for binary
+    /// functions.
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        None
+    }
+
+    /// Whether this function is an infix operator.
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+
+    /// Whether this function is associative. Only meaningful for variadic
+    /// functions.
+    fn is_associative(&self) -> bool {
+        false
+    }
+}
+
+/// A scalar SQL function that eagerly evaluates its arguments.
+///
+/// This is the unified replacement for `EagerUnaryFunc`, `EagerBinaryFunc`, and
+/// `EagerVariadicFunc`. The `Input` and `Output` associated types drive
+/// automatic null propagation and error handling through [`InputDatumType`] and
+/// [`OutputDatumType`].
+///
+/// A blanket implementation of [`LazyScalarFunc`] is provided for all types
+/// that implement this trait.
+pub trait EagerScalarFunc: fmt::Display {
+    type Input<'a>: InputDatumType<'a, EvalError>;
+    type Output<'a>: OutputDatumType<'a, EvalError>;
+
+    fn call<'a>(&self, input: Self::Input<'a>, temp_storage: &'a RowArena) -> Self::Output<'a>;
+
+    /// The output [`SqlColumnType`] of this function given the input types.
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType;
+
+    /// Whether this function will produce NULL on NULL input.
+    fn propagates_nulls(&self) -> bool {
+        !Self::Input::<'_>::nullable()
+    }
+
+    /// Whether this function will produce NULL on non-NULL input.
+    fn introduces_nulls(&self) -> bool {
+        Self::Output::<'_>::nullable()
+    }
+
+    /// Whether this function might error on non-error input.
+    fn could_error(&self) -> bool {
+        Self::Output::<'_>::fallible()
+    }
+
+    /// Whether the function is monotone with respect to the argument at the
+    /// given index.
+    fn arg_is_monotone(&self, _index: usize) -> bool {
+        false
+    }
+
+    /// Whether this function preserves uniqueness (unary only).
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+
+    /// The inverse of this function (unary only).
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+
+    /// The negation of this function (binary only).
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        None
+    }
+
+    /// Whether this function is an infix operator.
+    fn is_infix_op(&self) -> bool {
+        false
+    }
+
+    /// Whether this function is associative (variadic only).
+    fn is_associative(&self) -> bool {
+        false
+    }
+}
+
+/// Blanket [`LazyScalarFunc`] implementation for all [`EagerScalarFunc`] types.
+///
+/// Evaluates argument expressions, converts them to the expected input type
+/// via [`InputDatumType::try_from_iter`], calls the function, and converts
+/// the output via [`OutputDatumType::into_result`].
+impl<T: EagerScalarFunc> LazyScalarFunc for T {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        exprs: &'a [MirScalarExpr],
+    ) -> Result<Datum<'a>, EvalError> {
+        let mut results = exprs.iter().map(|e| e.eval(datums, temp_storage));
+        match T::Input::try_from_iter(&mut results) {
+            Ok(input) => self.call(input, temp_storage).into_result(temp_storage),
+            Err(Ok(None)) => Err(EvalError::Internal("missing parameter".into())),
+            Err(Ok(Some(datum))) if datum.is_null() => Ok(datum),
+            Err(Ok(Some(_))) => Err(EvalError::Internal("invalid input type".into())),
+            Err(Err(err)) => Err(err),
+        }
+    }
+
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType {
+        EagerScalarFunc::output_sql_type(self, input_types)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        EagerScalarFunc::propagates_nulls(self)
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        EagerScalarFunc::introduces_nulls(self)
+    }
+
+    fn could_error(&self) -> bool {
+        EagerScalarFunc::could_error(self)
+    }
+
+    fn arg_is_monotone(&self, index: usize) -> bool {
+        EagerScalarFunc::arg_is_monotone(self, index)
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        EagerScalarFunc::preserves_uniqueness(self)
+    }
+
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        EagerScalarFunc::inverse(self)
+    }
+
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        EagerScalarFunc::negate(self)
+    }
+
+    fn is_infix_op(&self) -> bool {
+        EagerScalarFunc::is_infix_op(self)
+    }
+
+    fn is_associative(&self) -> bool {
+        EagerScalarFunc::is_associative(self)
+    }
+}

--- a/src/expr/src/scalar/scalar_func.rs
+++ b/src/expr/src/scalar/scalar_func.rs
@@ -175,6 +175,144 @@ pub trait EagerScalarFunc: fmt::Display {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Adapter impls: bridge the existing arity-specific enums to LazyScalarFunc
+// ---------------------------------------------------------------------------
+
+impl LazyScalarFunc for crate::UnaryFunc {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        exprs: &'a [MirScalarExpr],
+    ) -> Result<Datum<'a>, EvalError> {
+        self.eval(datums, temp_storage, &exprs[0])
+    }
+
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType {
+        self.output_sql_type(input_types[0].clone())
+    }
+
+    fn output_type(&self, input_types: &[ReprColumnType]) -> ReprColumnType {
+        self.output_type(input_types[0].clone())
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        self.propagates_nulls()
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        self.introduces_nulls()
+    }
+
+    fn could_error(&self) -> bool {
+        self.could_error()
+    }
+
+    fn arg_is_monotone(&self, _index: usize) -> bool {
+        self.is_monotone()
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        self.preserves_uniqueness()
+    }
+
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        self.inverse()
+    }
+}
+
+impl LazyScalarFunc for crate::BinaryFunc {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        exprs: &'a [MirScalarExpr],
+    ) -> Result<Datum<'a>, EvalError> {
+        self.eval(datums, temp_storage, &[&exprs[0], &exprs[1]])
+    }
+
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType {
+        self.output_sql_type(input_types)
+    }
+
+    fn output_type(&self, input_types: &[ReprColumnType]) -> ReprColumnType {
+        self.output_type(input_types)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        self.propagates_nulls()
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        self.introduces_nulls()
+    }
+
+    fn could_error(&self) -> bool {
+        self.could_error()
+    }
+
+    fn arg_is_monotone(&self, index: usize) -> bool {
+        let (a, b) = self.is_monotone();
+        match index {
+            0 => a,
+            1 => b,
+            _ => false,
+        }
+    }
+
+    fn negate(&self) -> Option<crate::BinaryFunc> {
+        self.negate()
+    }
+
+    fn is_infix_op(&self) -> bool {
+        self.is_infix_op()
+    }
+}
+
+impl LazyScalarFunc for crate::VariadicFunc {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        exprs: &'a [MirScalarExpr],
+    ) -> Result<Datum<'a>, EvalError> {
+        self.eval(datums, temp_storage, exprs)
+    }
+
+    fn output_sql_type(&self, input_types: &[SqlColumnType]) -> SqlColumnType {
+        self.output_sql_type(input_types.to_vec())
+    }
+
+    fn output_type(&self, input_types: &[ReprColumnType]) -> ReprColumnType {
+        self.output_type(input_types.to_vec())
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        self.propagates_nulls()
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        self.introduces_nulls()
+    }
+
+    fn could_error(&self) -> bool {
+        self.could_error()
+    }
+
+    fn arg_is_monotone(&self, _index: usize) -> bool {
+        self.is_monotone()
+    }
+
+    fn is_infix_op(&self) -> bool {
+        self.is_infix_op()
+    }
+
+    fn is_associative(&self) -> bool {
+        self.is_associative()
+    }
+}
+
 /// Blanket [`LazyScalarFunc`] implementation for all [`EagerScalarFunc`] types.
 ///
 /// Evaluates argument expressions, converts them to the expected input type


### PR DESCRIPTION
## Summary

- Introduce unified `LazyScalarFunc` and `EagerScalarFunc` traits that replace the arity-specific `LazyUnaryFunc`/`EagerUnaryFunc`, `LazyBinaryFunc`/`EagerBinaryFunc`, `LazyVariadicFunc`/`EagerVariadicFunc` trait pairs.
- Add adapter implementations of `LazyScalarFunc` for the `UnaryFunc`, `BinaryFunc`, and `VariadicFunc` enums, bridging existing dispatch to the unified interface.
- Update `#[sqlfunc]` to generate both the new `EagerScalarFunc` impl and a backward-compatible compat shim for the old arity-specific trait, allowing incremental migration without breaking existing `derive_unary!`/`derive_binary!`/`derive_variadic!` macros.

## Motivation

The current codebase has three parallel pairs of traits for scalar functions, differing only in arity. This leads to duplicated logic (e.g., triple-dispatch in `MirScalarExpr::eval`, `typ`, `could_error`) and makes it harder to write code that operates on scalar functions generically. The unified traits provide a single interface that all scalar functions can implement, enabling future simplification of `MirScalarExpr` and removal of the old traits.

## Test plan

- [x] `cargo check -p mz-expr` compiles cleanly
- [x] `cargo test -p mz-expr --lib` — all 48 tests pass
- [x] `cargo test -p mz-expr-derive-impl --lib` — all 10 snapshot tests pass
- [x] No behavioral changes — purely additive refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)