### PR TITLE
Introduce v1 of the Materialize CRD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "hyper-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1341,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "hyper-util",
+ "openssl",
+ "openssl-sys",
+ "pin-project-lite",
+ "tokio",
+ "tokio-openssl",
+ "tower-service",
 ]
 
 [[package]]
@@ -3690,6 +3721,16 @@ checksum = "a8cd42c159de9b90a91efc0ce350e3142099571ef498e7fa1a1dcc1d1eeccd9d"
 dependencies = [
  "memchr",
  "uuid",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -6267,6 +6308,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tracing",
  "uuid",
 ]
@@ -7341,6 +7383,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-server",
  "clap",
  "futures",
  "http 1.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,11 +1357,11 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.9.0",
  "hyper-util",
- "openssl",
- "openssl-sys",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-openssl",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -7406,6 +7406,7 @@ dependencies = [
  "prometheus",
  "rand 0.9.4",
  "reqwest 0.12.28",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -11278,6 +11279,8 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -11313,6 +11316,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,6 +297,7 @@ aws-smithy-types = { version = "1.1.8", features = ["byte-stream-poll-next"] }
 aws-types = "1.3.9"
 axum = { version = "0.8.8", features = ["ws"] }
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
+axum-server = { version = "0.8.0", features = ["tls-openssl"] }
 azure_core = "0.21.0"
 azure_identity = "0.21.0"
 azure_storage = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ aws-smithy-types = { version = "1.1.8", features = ["byte-stream-poll-next"] }
 aws-types = "1.3.9"
 axum = { version = "0.8.8", features = ["ws"] }
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
-axum-server = { version = "0.8.0", features = ["tls-openssl"] }
+axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 azure_core = "0.21.0"
 azure_identity = "0.21.0"
 azure_storage = "0.21.0"
@@ -473,6 +473,7 @@ reqwest-retry = "0.8.0"
 rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"
+rustls = "0.23.38"
 rpassword = "7.5.1"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 ryu = "1.0.23"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2465,6 +2465,32 @@ steps:
         agents:
           queue: hetzner-aarch64-16cpu-32gb
 
+      - id: orchestratord-v1alpha2-opt-in
+        label: "Orchestratord v1alpha2 opt-in tests"
+        artifact_paths: ["mz_debug_*.zip"]
+        depends_on: devel-docker-tags
+        timeout_in_minutes: 120
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: orchestratord
+              run: v1alpha2-opt-in
+              ci-builder: stable
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+
+      - id: orchestratord-manually-promote
+        label: "Orchestratord ManuallyPromote tests"
+        artifact_paths: ["mz_debug_*.zip"]
+        depends_on: devel-docker-tags
+        timeout_in_minutes: 120
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: orchestratord
+              run: manually-promote
+              ci-builder: stable
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+
   - id: emulator
     label: Materialize Emulator
     depends_on: build-aarch64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2465,15 +2465,15 @@ steps:
         agents:
           queue: hetzner-aarch64-16cpu-32gb
 
-      - id: orchestratord-v1alpha2-opt-in
-        label: "Orchestratord v1alpha2 opt-in tests"
+      - id: orchestratord-v1-opt-in
+        label: "Orchestratord v1 opt-in tests"
         artifact_paths: ["mz_debug_*.zip"]
         depends_on: devel-docker-tags
         timeout_in_minutes: 120
         plugins:
           - ./ci/plugins/mzcompose:
               composition: orchestratord
-              run: v1alpha2-opt-in
+              run: v1-opt-in
               ci-builder: stable
         agents:
           queue: hetzner-aarch64-16cpu-32gb

--- a/deny.toml
+++ b/deny.toml
@@ -216,6 +216,7 @@ wrappers = [
     "rdkafka",
     "reqsign",
     "reqwest",
+    "rustls",
     "sqlparser",
     "tokio-postgres",
     "tokio-tungstenite",
@@ -225,13 +226,6 @@ wrappers = [
     "want",
     "zopfli",
 ]
-
-# We prefer the system's native TLS or OpenSSL to Rustls, since they are more
-# mature and more widely used. `gcp_auth` only ships with rustls-based TLS,
-# so allow it through.
-[[bans.deny]]
-name = "rustls"
-wrappers = ["hyper-rustls", "tokio-rustls"]
 
 # once_cell is going to be added to std, and doesn't use macros
 # Unfortunately, its heavily used, so we have lots of exceptions.

--- a/doc/developer/design/20260209_simplified_rollout_triggers_and_crd.md
+++ b/doc/developer/design/20260209_simplified_rollout_triggers_and_crd.md
@@ -19,7 +19,7 @@ Additionally, the current system is difficult to automate when faced with evicti
 
 1. **Automatic rollout detection**: The system should automatically detect when a rollout is needed based on spec changes, without requiring users to manually set a UUID.
 
-2. **Seamless version migration**: Existing v1alpha1 resources should continue to work, with automatic conversion to v1alpha2 as needed.
+2. **Seamless version migration**: Existing v1alpha1 resources should continue to work, with automatic conversion to v1 as needed.
 
 3. **Terraform compatibility**: Configuration must not fight with infrastructure as code tools such as Terraform.
 
@@ -34,9 +34,9 @@ Additionally, the current system is difficult to automate when faced with evicti
 
 ## Solution Proposal
 
-### 1. New CRD Version: v1alpha2
+### 1. New CRD Version: v1
 
-Introduce a new `v1alpha2` version of the Materialize CRD with the following changes:
+Introduce a new `v1` version of the Materialize CRD with the following changes:
 
 **Spec changes:**
 - Remove `requestRollout` (`Uuid`) - Rollouts are now triggered automatically when the spec hash changes.
@@ -122,14 +122,14 @@ A new HTTPS webhook server handles CRD version conversion:
 **Endpoint:** `POST /convert`
 
 **Supported conversions:**
-- v1alpha1 -> v1alpha2
-- v1alpha2 -> v1alpha1\*
+- v1alpha1 -> v1
+- v1 -> v1alpha1\*
 
 \*The API server seemed to want this, I don't know why. We can't reconcile these, so going back never makes sense.
 
 **Key conversion logic:**
 
-###### v1alpha1 to v1alpha2:
+###### v1alpha1 to v1:
 - Spec fields:
     - `forcePromote: Uuid` becomes `forcePromote: Option<String>` (nil UUID becomes None)
     - `requestRollout` is removed.
@@ -144,52 +144,52 @@ A new HTTPS webhook server handles CRD version conversion:
         - If we are already in "promoting" status, we should unconditionally complete the promotion for the current rollout rather than destroying and replacing it.
             This may trigger an additional rollout this one time, but I don't know any way around that. I think this is acceptable given the user is doing something very weird by updating orchestratord mid-rollout.
 
-###### v1alpha2 to v1alpha1:
+###### v1 to v1alpha1:
 
-We need to include the `lastCompletedRolloutHash` from v1alpha2 in v1alpha1 as well. This is required for round tripping from v1alpha2 -> v1alpha1 -> v1alpha2,
-which may happen if a user applies a v1alpha1 change over a v1alpha2 object.
+We need to include the `lastCompletedRolloutHash` from v1 in v1alpha1 as well. This is required for round tripping from v1 -> v1alpha1 -> v1,
+which may happen if a user applies a v1alpha1 change over a v1 object.
 
-In the case there is an existing `lastCompletedRolloutHash`, it should be kept as-is through the round trip. As we never reconcile with v1alpha1, it should only change at v1alpha2, so this should be safe.
+In the case there is an existing `lastCompletedRolloutHash`, it should be kept as-is through the round trip. As we never reconcile with v1alpha1, it should only change at v1, so this should be safe.
 
-No attempt is made to support v1alpha1 beyond giving a valid v1alpha1 structure and supporting round tripping to v1alpha2. Fields that do not exist in v1alpha2 may have their nil value.
+No attempt is made to support v1alpha1 beyond giving a valid v1alpha1 structure and supporting round tripping to v1. Fields that do not exist in v1 may have their nil value.
 
 ##### Example round trips
 
-In these examples, we assume that orchestratord's attempt to update the stored version succeeds and that reconciliation is triggered after this update. This is only to simplify this document, and is not necessary for correctness. If orchestratord's attempt to update the stored version fails, or the reconciliation is triggered first, the conversion webhook is simply called at that time and we will reconcile the same v1alpha2 object.
+In these examples, we assume that orchestratord's attempt to update the stored version succeeds and that reconciliation is triggered after this update. This is only to simplify this document, and is not necessary for correctness. If orchestratord's attempt to update the stored version fails, or the reconciliation is triggered first, the conversion webhook is simply called at that time and we will reconcile the same v1 object.
 
 ###### Simplest case
 1. There is a stored v1alpha1 Materialize resource, not actively rolling out, with both `status.lastCompletedRolloutRequest` and `spec.requestRollout` matching.
-1. Orchestratord gets updated to a version with v1alpha2 support.
-1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1alpha2.
-    1. The API server calls the conversion webhook, which returns a v1alpha2 resource. In this case, it would have `status.lastCompletedRolloutHash` and `status.requestedRolloutHash` set to the same calculated hash after conversion.
-1. Orchestratord calls `replace` to store the resource as v1alpha2.
-1. Orchestratord gets notified of the new v1alpha2 resource, but determines there is nothing to do.
+1. Orchestratord gets updated to a version with v1 support.
+1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1.
+    1. The API server calls the conversion webhook, which returns a v1 resource. In this case, it would have `status.lastCompletedRolloutHash` and `status.requestedRolloutHash` set to the same calculated hash after conversion.
+1. Orchestratord calls `replace` to store the resource as v1.
+1. Orchestratord gets notified of the new v1 resource, but determines there is nothing to do.
 
-At this point, the stored version is v1alpha2, and no rollout is triggered.
+At this point, the stored version is v1, and no rollout is triggered.
 
 1. The user then applies a v1alpha1 resource. It contains some change that affects the hash (ie: `spec.environmentd_image_ref`). It may or may not include `spec.requestRollout`, that doesn't matter.
-1. Before storing this change, the API server calls the conversion webhook, which returns a v1alpha2 resource. In this case, it should not contain a status, as the user applied v1alpha1 resource did not contain a status (TODO verify this).
-1. Orchestratord gets notified of the new v1alpha2 resource, which contains the old status not yet updated after the applied v1alpha1 resource. This means the `status.lastCompletedRolloutHash` and `status.requestedRolloutHash` still match each other, but do not match the calculated hash.
+1. Before storing this change, the API server calls the conversion webhook, which returns a v1 resource. In this case, it should not contain a status, as the user applied v1alpha1 resource did not contain a status (TODO verify this).
+1. Orchestratord gets notified of the new v1 resource, which contains the old status not yet updated after the applied v1alpha1 resource. This means the `status.lastCompletedRolloutHash` and `status.requestedRolloutHash` still match each other, but do not match the calculated hash.
 1. Orchestratord reconciles like normal, calculating a new `status.requestedRolloutHash` and triggering a rollout since it is different.
 
-If the user had instead applied a v1alpha2 resource instead, no conversion would be needed and orchestratord would reconcile it directly.
+If the user had instead applied a v1 resource instead, no conversion would be needed and orchestratord would reconcile it directly.
 
 ###### Existing v1alpha1 resource is mid-upgrade, but not promoting
 1. There is a stored v1alpha1 Materialize resource, actively rolling out, with `status.lastCompletedRolloutRequest` and `spec.requestRollout` not matching. It is not in "promoting" status.
-1. Orchestratord gets updated to a version with v1alpha2 support.
-1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1alpha2.
-    1. The API server calls the conversion webhook, which returns a v1alpha2 resource. In this case, it would have `status.lastCompletedRolloutHash` set to `None` and `status.requestedRolloutHash` set to the calculated hash after conversion.
-1. Orchestratord calls `replace` to store the resource as v1alpha2.
-1. Orchestratord gets notified of the new v1alpha2 resource.
+1. Orchestratord gets updated to a version with v1 support.
+1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1.
+    1. The API server calls the conversion webhook, which returns a v1 resource. In this case, it would have `status.lastCompletedRolloutHash` set to `None` and `status.requestedRolloutHash` set to the calculated hash after conversion.
+1. Orchestratord calls `replace` to store the resource as v1.
+1. Orchestratord gets notified of the new v1 resource.
 1. Orchestratord reconciles like normal, continuing the existing rollout and overwriting any objects that are different. This is the same behavior it would have with current orchestratord and v1alpha1.
 
 ###### Existing v1alpha1 resource is mid-upgrade and already promoting
 1. There is a stored v1alpha1 Materialize resource, actively rolling out, with `status.lastCompletedRolloutRequest` and `spec.requestRollout` not matching. It is in "promoting" status.
-1. Orchestratord gets updated to a version with v1alpha2 support.
-1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1alpha2.
-    1. The API server calls the conversion webhook, which returns a v1alpha2 resource. In this case, it would have `status.lastCompletedRolloutHash` set to `None` and `status.requestedRolloutHash` set to the calculated hash after conversion.
-1. Orchestratord calls `replace` to store the resource as v1alpha2.
-1. Orchestratord gets notified of the new v1alpha2 resource.
+1. Orchestratord gets updated to a version with v1 support.
+1. Orchestratord lists existing v1alpha1 resources on startup, in order to upgrade them to v1.
+    1. The API server calls the conversion webhook, which returns a v1 resource. In this case, it would have `status.lastCompletedRolloutHash` set to `None` and `status.requestedRolloutHash` set to the calculated hash after conversion.
+1. Orchestratord calls `replace` to store the resource as v1.
+1. Orchestratord gets notified of the new v1 resource.
 1. Orchestratord reconciles like normal. Critically, it unconditionally continues with promotion rather than overwriting any objects.
 1. After promotion is successful, the updated status triggers a new rollout. (TODO verify that this works if we have a `status.requestedRolloutHash` set in the initial conversion)
 
@@ -216,8 +216,8 @@ Orchestratord will also get readiness probes so nothing tries to call this webho
 ### 5. CRD Registration
 
 The CRD is registered with:
-- Both v1alpha1 and v1alpha2 versions
-- v1alpha2 as the stored version
+- Both v1alpha1 and v1 versions
+- v1 as the stored version
 - Webhook conversion configuration pointing to the operator service
 
 ```rust
@@ -241,7 +241,7 @@ mz_crd.spec.conversion = Some(CustomResourceConversion {
 
 ### 6. Replace all Materialize resources to update their stored versions
 
-We have set v1alpha2 as the stored version, but that doesn't update existing resources. Those are only updated when they are reapplied.
+We have set v1 as the stored version, but that doesn't update existing resources. Those are only updated when they are reapplied.
 
 During orchestratord startup, after waiting for the CRD to be established, we need to loop through all Materialize resources and `replace` them.
 
@@ -250,22 +250,22 @@ If it is possible to determine the stored version of these resources, we should 
 I think it is OK for this to be best-effort, and only warn in case of failure.
 For backward compatibility reasons, we're going to have to support the old version for some time.
 Orchestratord is likely to get restarted/upgraded multiple times in that period, so it can try again.
-If the user ever writes an updated CR, it will also be stored in v1alpha2, so it isn't critical that this work immediately.
+If the user ever writes an updated CR, it will also be stored in v1, so it isn't critical that this work immediately.
 
 ## Known testing required
 
 Our existing nightly orchestratord tests cover a lot, but we'll need to extend them to work with multiple CRD versions.
 
-- Upgrades from existing v1alpha1 environments by applying v1alpha1 CR. (this is basically what we have now, but we need to not break it with the orchestratord changes to reconcile v1alpha2 after conversion)
-- Upgrades from existing v1alpha1 environments by applying v1alpha2 CR.
-- Upgrades from existing v1alpha2 environments by applying v1alpha1 CR.
-- Upgrades from existing v1alpha2 environments by applying v1alpha2 CR.
+- Upgrades from existing v1alpha1 environments by applying v1alpha1 CR. (this is basically what we have now, but we need to not break it with the orchestratord changes to reconcile v1 after conversion)
+- Upgrades from existing v1alpha1 environments by applying v1 CR.
+- Upgrades from existing v1 environments by applying v1alpha1 CR.
+- Upgrades from existing v1 environments by applying v1 CR.
 - Upgrade from existing v1alpha1 environment that is mid-rollout not in "promoting" status.
 - Upgrade from existing v1alpha1 environment that is mid-rollout in "promoting" status.
 - Upgrades with a previous rollout already in progress.
 - Upgrades triggered by annotation.
-- Deploy of latest Materialize image versions using v1alpha2 CR.
-- Deploy of older Materialize image versions using v1alpha2 CR.
+- Deploy of latest Materialize image versions using v1 CR.
+- Deploy of older Materialize image versions using v1 CR.
 
 ## Minimal Viable Prototype
 

--- a/doc/user/content/self-managed-deployments/installation/install-on-local-kind.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-local-kind.md
@@ -107,6 +107,19 @@ Starting in v26.0, Self-Managed Materialize requires a license key.
    kubectl get nodes --show-labels
    ```
 
+1. Install cert-manager
+
+   Cert-manager is used for generating TLS certificates needed by the materialize operator
+   for CRD conversion webhooks.
+
+   ```shell
+   helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+       --version v1.19.2 \
+       --namespace cert-manager \
+       --create-namespace \
+       --set crds.enabled=true
+   ```
+
 1. To help you get started for local evaluation/testing, Materialize provides
    some sample configuration files. Download the sample configuration files from
    the Materialize repo:

--- a/doc/user/content/self-managed-deployments/installation/install-on-local-kind.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-local-kind.md
@@ -107,10 +107,13 @@ Starting in v26.0, Self-Managed Materialize requires a license key.
    kubectl get nodes --show-labels
    ```
 
-1. Install cert-manager
+1. Recommended: Install cert-manager
 
    Cert-manager is used for generating TLS certificates needed by the materialize operator
-   for CRD conversion webhooks.
+   for CRD conversion webhooks. It is currently only required if you enable the v1
+   version of the Materialize CRD by setting `operator.args.installV1CRD=true`
+   when installing the operator, but certificates will become required in a
+   future version of Materialize.
 
    ```shell
    helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -144,6 +144,8 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.args.enableInternalStatementLogging` |  | ``true`` |
 | `operator.args.enableLicenseKeyChecks` |  | ``false`` |
 | `operator.args.startupLogFilter` | Log filtering settings for startup logs | ``"INFO,mz_orchestratord=TRACE"`` |
+| `operator.certificate.secretName` | Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret". | ``nil`` |
+| `operator.certificate.source` | Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'. | ``"cert-manager"`` |
 | `operator.cloudProvider.providers.aws.accountID` | When using AWS, accountID is required | ``""`` |
 | `operator.cloudProvider.providers.aws.enabled` |  | ``false`` |
 | `operator.cloudProvider.providers.aws.iam.roles.connection` | ARN for CREATE CONNECTION feature | ``""`` |

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -143,12 +143,13 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.affinity` | Affinity to use for the operator pod | ``{}`` |
 | `operator.args.enableInternalStatementLogging` |  | ``true`` |
 | `operator.args.enableLicenseKeyChecks` |  | ``false`` |
+| `operator.args.installV1CRD` | Whether to install the v1 version of the Materialize CRD and the conversion webhook that converts between v1 and v1alpha1. When false, only the v1alpha1 CRD version is installed and no webhook serving certificate or service is created. | ``false`` |
 | `operator.args.startupLogFilter` | Log filtering settings for startup logs | ``"INFO,mz_orchestratord=TRACE"`` |
-| `operator.args.webhookCertReloadInterval` | How often orchestratord reloads its webhook TLS certificate from disk and, when the CA changes, refreshes the conversion webhook's CA bundle. Must be shorter than the certificate's lifetime. Accepts a humantime duration (e.g. "1h", "30m"). Leave null to use the binary default. | ``nil`` |
+| `operator.args.webhookCertReloadInterval` | How often orchestratord reloads its webhook TLS certificate from disk and, when the CA changes, refreshes the conversion webhook's CA bundle. Must be shorter than the certificate's lifetime. Accepts a humantime duration (e.g. "1h", "30m"). Leave null to use the binary default. Only used if `installV1CRD` is true. | ``nil`` |
 | `operator.certificate.caDuration` | Lifetime of the root CA that signs the webhook serving certificate, when `source` is "cert-manager". The serving certificate is signed by this CA, so the CA outlives individual serving-certificate rotations. | ``"87600h"`` |
 | `operator.certificate.caRenewBefore` | How long before the root CA expires to renew it. Must be less than `caDuration`. | ``"8760h"`` |
 | `operator.certificate.secretName` | Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret". | ``nil`` |
-| `operator.certificate.source` | Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'. | ``"cert-manager"`` |
+| `operator.certificate.source` | Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'. Only used if `operator.args.installV1CRD` is true. | ``"cert-manager"`` |
 | `operator.cloudProvider.providers.aws.accountID` | When using AWS, accountID is required | ``""`` |
 | `operator.cloudProvider.providers.aws.enabled` |  | ``false`` |
 | `operator.cloudProvider.providers.aws.iam.roles.connection` | ARN for CREATE CONNECTION feature | ``""`` |

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -144,6 +144,9 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.args.enableInternalStatementLogging` |  | ``true`` |
 | `operator.args.enableLicenseKeyChecks` |  | ``false`` |
 | `operator.args.startupLogFilter` | Log filtering settings for startup logs | ``"INFO,mz_orchestratord=TRACE"`` |
+| `operator.args.webhookCertReloadInterval` | How often orchestratord reloads its webhook TLS certificate from disk and, when the CA changes, refreshes the conversion webhook's CA bundle. Must be shorter than the certificate's lifetime. Accepts a humantime duration (e.g. "1h", "30m"). Leave null to use the binary default. | ``nil`` |
+| `operator.certificate.caDuration` | Lifetime of the root CA that signs the webhook serving certificate, when `source` is "cert-manager". The serving certificate is signed by this CA, so the CA outlives individual serving-certificate rotations. | ``"87600h"`` |
+| `operator.certificate.caRenewBefore` | How long before the root CA expires to renew it. Must be less than `caDuration`. | ``"8760h"`` |
 | `operator.certificate.secretName` | Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret". | ``nil`` |
 | `operator.certificate.source` | Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'. | ``"cert-manager"`` |
 | `operator.cloudProvider.providers.aws.accountID` | When using AWS, accountID is required | ``""`` |

--- a/misc/helm-charts/operator/templates/certificate.yaml
+++ b/misc/helm-charts/operator/templates/certificate.yaml
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+{{- if eq .Values.operator.certificate.source "cert-manager" -}}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "materialize-operator.fullname" . }}-self-signed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "materialize-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "materialize-operator.fullname" . }}-self-signed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "materialize-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "materialize-operator.fullname" . }}.{{ .Release.Namespace }}.svc
+  secretName: {{ include "materialize-operator.fullname" . }}-cert
+  privateKey:
+    algorithm: ECDSA
+    rotationPolicy: Always
+  issuerRef:
+    name: {{ include "materialize-operator.fullname" . }}-self-signed
+    kind: Issuer
+    group: cert-manager.io
+{{- end -}}

--- a/misc/helm-charts/operator/templates/certificate.yaml
+++ b/misc/helm-charts/operator/templates/certificate.yaml
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-{{- if eq .Values.operator.certificate.source "cert-manager" -}}
+{{- if and .Values.operator.args.installV1CRD (eq .Values.operator.certificate.source "cert-manager") -}}
 # We provision the webhook serving certificate from a stable root CA rather
 # than as a bare self-signed certificate. The serving certificate rotates
 # frequently, but it is always signed by the same long-lived CA, so the

--- a/misc/helm-charts/operator/templates/certificate.yaml
+++ b/misc/helm-charts/operator/templates/certificate.yaml
@@ -8,7 +8,15 @@
 # by the Apache License, Version 2.0.
 
 {{- if eq .Values.operator.certificate.source "cert-manager" -}}
+# We provision the webhook serving certificate from a stable root CA rather
+# than as a bare self-signed certificate. The serving certificate rotates
+# frequently, but it is always signed by the same long-lived CA, so the
+# `ca.crt` that orchestratord registers as the conversion webhook's caBundle
+# stays valid across serving-certificate rotations. orchestratord refreshes the
+# caBundle if the CA itself ever changes, e.g. on the rare root CA renewal, so a
+# routine serving-certificate rotation leaves the webhook undisturbed.
 ---
+# Bootstrap issuer used only to sign the root CA below.
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -20,10 +28,49 @@ spec:
   selfSigned: {}
 
 ---
+# Long-lived root CA. Stays stable across serving-certificate rotations so the
+# conversion webhook's caBundle remains valid without changing every rotation.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "materialize-operator.fullname" . }}-self-signed
+  name: {{ include "materialize-operator.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "materialize-operator.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  commonName: {{ include "materialize-operator.fullname" . }}-ca
+  secretName: {{ include "materialize-operator.fullname" . }}-ca
+  duration: {{ .Values.operator.certificate.caDuration }}
+  renewBefore: {{ .Values.operator.certificate.caRenewBefore }}
+  privateKey:
+    algorithm: ECDSA
+    rotationPolicy: Always
+  issuerRef:
+    name: {{ include "materialize-operator.fullname" . }}-self-signed
+    kind: Issuer
+    group: cert-manager.io
+
+---
+# CA issuer that signs the serving certificate using the stable root CA.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "materialize-operator.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "materialize-operator.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "materialize-operator.fullname" . }}-ca
+
+---
+# Webhook serving certificate. Rotates frequently; its `ca.crt` is the stable
+# root CA above.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "materialize-operator.fullname" . }}-cert
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "materialize-operator.labels" . | nindent 4 }}
@@ -35,7 +82,7 @@ spec:
     algorithm: ECDSA
     rotationPolicy: Always
   issuerRef:
-    name: {{ include "materialize-operator.fullname" . }}-self-signed
+    name: {{ include "materialize-operator.fullname" . }}-ca
     kind: Issuer
     group: cert-manager.io
 {{- end -}}

--- a/misc/helm-charts/operator/templates/clusterrole.yaml
+++ b/misc/helm-charts/operator/templates/clusterrole.yaml
@@ -76,6 +76,7 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
   - create
   - update

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -242,9 +242,15 @@ spec:
         - >
           --additional-crd-columns={{ toJson .Values.operator.additionalMaterializeCRDColumns }}
         {{- end }}
+        - "--webhook-service-name"
+        - {{ include "materialize-operator.fullname" . }}
+        - "--webhook-service-namespace"
+        - {{ .Release.Namespace }}
         ports:
         - containerPort: 3100
           name: metrics
+        - containerPort: 8001
+          name: webhook
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}
         securityContext:
@@ -256,3 +262,27 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
+          failureThreshold: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
+          failureThreshold: 1
+          periodSeconds: 10
+        volumeMounts:
+          - mountPath: /etc/tls
+            name: certificate
+            readOnly: true
+      volumes:
+        - name: certificate
+          secret:
+            defaultMode: 256
+            optional: false
+            secretName: {{ if eq .Values.operator.certificate.source "cert-manager" }}{{ include "materialize-operator.fullname" . }}-cert{{ else }}{{ .Values.operator.certificate.secretName }}{{ end }}

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
         {{- if not .Values.operator.args.enableLicenseKeyChecks }}
         - "--disable-license-key-checks"
         {{- end }}
+        {{- if .Values.operator.args.webhookCertReloadInterval }}
+        - "--webhook-cert-reload-interval={{ .Values.operator.args.webhookCertReloadInterval }}"
+        {{- end }}
 
         {{/* AWS Configuration */}}
         {{- if eq .Values.operator.cloudProvider.type "aws" }}

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -66,8 +66,11 @@ spec:
         {{- if not .Values.operator.args.enableLicenseKeyChecks }}
         - "--disable-license-key-checks"
         {{- end }}
+        {{- if .Values.operator.args.installV1CRD }}
+        - "--install-v1-crd"
         {{- if .Values.operator.args.webhookCertReloadInterval }}
         - "--webhook-cert-reload-interval={{ .Values.operator.args.webhookCertReloadInterval }}"
+        {{- end }}
         {{- end }}
 
         {{/* AWS Configuration */}}
@@ -245,15 +248,19 @@ spec:
         - >
           --additional-crd-columns={{ toJson .Values.operator.additionalMaterializeCRDColumns }}
         {{- end }}
+        {{- if .Values.operator.args.installV1CRD }}
         - "--webhook-service-name"
         - {{ include "materialize-operator.fullname" . }}
         - "--webhook-service-namespace"
         - {{ .Release.Namespace }}
+        {{- end }}
         ports:
         - containerPort: 3100
           name: metrics
+        {{- if .Values.operator.args.installV1CRD }}
         - containerPort: 8001
           name: webhook
+        {{- end }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}
         securityContext:
@@ -265,6 +272,7 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+        {{- if .Values.operator.args.installV1CRD }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -289,3 +297,4 @@ spec:
             defaultMode: 256
             optional: false
             secretName: {{ if eq .Values.operator.certificate.source "cert-manager" }}{{ include "materialize-operator.fullname" . }}-cert{{ else }}{{ .Values.operator.certificate.secretName }}{{ end }}
+        {{- end }}

--- a/misc/helm-charts/operator/templates/service.yaml
+++ b/misc/helm-charts/operator/templates/service.yaml
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "materialize-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "materialize-operator.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "materialize-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: webhook
+      protocol: TCP
+      port: 8001
+      targetPort: 8001

--- a/misc/helm-charts/operator/templates/service.yaml
+++ b/misc/helm-charts/operator/templates/service.yaml
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+{{- if .Values.operator.args.installV1CRD -}}
 ---
 apiVersion: v1
 kind: Service
@@ -23,3 +24,4 @@ spec:
       protocol: TCP
       port: 8001
       targetPort: 8001
+{{- end -}}

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -34,6 +34,13 @@ operator:
     #  priority: 2
     #  type: "string"
 
+  certificate:
+    # -- (string) Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'.
+    source: cert-manager
+    # -- (string) Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret".
+    secretName: null
+
+
   # Cloud provider configuration
   cloudProvider:
     # -- Specifies cloud provider. Valid values are 'aws', 'gcp', 'azure' , 'generic', or 'local'

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -24,11 +24,16 @@ operator:
     enableInternalStatementLogging: true
     # Newer versions ignore this setting and always enforce license key checks.
     enableLicenseKeyChecks: false
+    # -- Whether to install the v1 version of the Materialize CRD and the
+    # conversion webhook that converts between v1 and v1alpha1. When false,
+    # only the v1alpha1 CRD version is installed and no webhook serving
+    # certificate or service is created.
+    installV1CRD: false
     # -- (string) How often orchestratord reloads its webhook TLS certificate
     # from disk and, when the CA changes, refreshes the conversion webhook's CA
     # bundle. Must be shorter than the certificate's lifetime. Accepts a
     # humantime duration (e.g. "1h", "30m"). Leave null to use the binary
-    # default.
+    # default. Only used if `installV1CRD` is true.
     webhookCertReloadInterval: null
 
   # -- Additional columns to display when printing the Materialize CRD in table format.
@@ -40,8 +45,10 @@ operator:
     #  priority: 2
     #  type: "string"
 
+  # Webhook serving certificate configuration. Only used if
+  # `operator.args.installV1CRD` is true.
   certificate:
-    # -- (string) Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'.
+    # -- (string) Where to obtain the certificate for orchestratord. Valid values are 'cert-manager' and 'secret'. Only used if `operator.args.installV1CRD` is true.
     source: cert-manager
     # -- (string) Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret".
     secretName: null

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -24,6 +24,12 @@ operator:
     enableInternalStatementLogging: true
     # Newer versions ignore this setting and always enforce license key checks.
     enableLicenseKeyChecks: false
+    # -- (string) How often orchestratord reloads its webhook TLS certificate
+    # from disk and, when the CA changes, refreshes the conversion webhook's CA
+    # bundle. Must be shorter than the certificate's lifetime. Accepts a
+    # humantime duration (e.g. "1h", "30m"). Leave null to use the binary
+    # default.
+    webhookCertReloadInterval: null
 
   # -- Additional columns to display when printing the Materialize CRD in table format.
   additionalMaterializeCRDColumns: {}
@@ -39,6 +45,14 @@ operator:
     source: cert-manager
     # -- (string) Name of a secret in the operator's namespace containing ca.crt, tls.crt, and tls.key entries. Only used if `source` is "secret".
     secretName: null
+    # -- (string) Lifetime of the root CA that signs the webhook serving
+    # certificate, when `source` is "cert-manager". The serving certificate is
+    # signed by this CA, so the CA outlives individual serving-certificate
+    # rotations.
+    caDuration: 87600h
+    # -- (string) How long before the root CA expires to renew it. Must be less
+    # than `caDuration`.
+    caRenewBefore: 8760h
 
 
   # Cloud provider configuration

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -28,8 +28,9 @@ schemars.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tracing.workspace = true
-uuid = { workspace = true, features = ["serde", "v4"] }
+uuid = { workspace = true, features = ["serde", "v4", "v5"] }
 
 async-trait = { workspace = true, optional = true }
 mz-repr = { path = "../repr", default-features = false, optional = true }

--- a/src/cloud-resources/src/crd.rs
+++ b/src/cloud-resources/src/crd.rs
@@ -13,7 +13,9 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use futures::future::join_all;
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
+    CustomResourceConversion, CustomResourceDefinition,
+};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::{
     Api, Client, Resource, ResourceExt,
@@ -105,6 +107,9 @@ fn owner_reference<T: Resource<DynamicType = ()>>(t: &T) -> OwnerReference {
 pub struct VersionedCrd {
     pub crds: Vec<CustomResourceDefinition>,
     pub stored_version: String,
+    /// Conversion configuration to apply after merging CRDs.
+    /// `merge_crds` drops the conversion field, so we must set it after merging.
+    pub conversion: Option<CustomResourceConversion>,
 }
 
 pub async fn register_versioned_crds(
@@ -158,7 +163,10 @@ async fn register_custom_resource(
     let crd_name = format!("{}.{}", &crds[0].spec.names.plural, &crds[0].spec.group);
     info!("Registering {} crd", &crd_name);
     let crd_api = Api::<CustomResourceDefinition>::all(kube_client);
-    let crd = merge_crds(crds, &versioned_crds.stored_version).unwrap();
+    let mut crd = merge_crds(crds, &versioned_crds.stored_version).unwrap();
+    if let Some(conversion) = versioned_crds.conversion {
+        crd.spec.conversion = Some(conversion);
+    }
     let crd_json = serde_json::to_string(&serde_json::json!(&crd))?;
     info!(crd_json = %crd_json);
     crd_api

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -22,6 +22,7 @@ use kube::{CustomResource, Resource, ResourceExt};
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::crd::{ManagedResource, MaterializeCertSpec, new_resource_id};
@@ -29,83 +30,84 @@ use mz_server_core::listeners::AuthenticatorKind;
 
 pub const LAST_KNOWN_ACTIVE_GENERATION_ANNOTATION: &str =
     "materialize.cloud/last-known-active-generation";
+pub const FORCE_ROLLOUT_ANNOTATION: &str = "materialize.cloud/force-rollout";
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum MaterializeRolloutStrategy {
+    /// Create a new generation of pods, leaving the old generation around until the
+    /// new ones are ready to take over.
+    /// This minimizes downtime, and is what almost everyone should use.
+    #[default]
+    WaitUntilReady,
+
+    /// Create a new generation of pods, leaving the old generation as the serving generation
+    /// until the user manually promotes the new generation.
+    ///
+    /// When using `ManuallyPromote`, the new generation can be promoted at any
+    /// time, even if it has dataflows that are not fully caught up, by setting
+    /// `forcePromote` to the same value as `requestRollout` in the Materialize spec.
+    ///
+    /// To minimize downtime, promotion should occur when the new generation
+    /// has caught up to the prior generation. To determine if the new
+    /// generation has caught up, consult the `UpToDate` condition in the
+    /// status of the Materialize Resource. If the condition's reason is
+    /// `ReadyToPromote` the new generation is ready to promote.
+    ///
+    /// {{<warning>}}
+    /// Do not leave new generations unpromoted indefinitely.
+    ///
+    /// The new generation keeps open read holds which prevent compaction. Once promoted or
+    /// cancelled, those read holds are released. If left unpromoted for an extended time, this
+    /// data can build up, and can cause extreme deletion load on the metadata backend database
+    /// when finally promoted or cancelled.
+    ///
+    /// To guard against this, a rollout that remains in progress longer
+    /// than `rolloutRequestTimeout` (default 24h) is automatically
+    /// cancelled.
+    /// {{</warning>}}
+    ManuallyPromote,
+
+    /// {{<warning>}}
+    /// THIS WILL CAUSE YOUR MATERIALIZE INSTANCE TO BE UNAVAILABLE FOR SOME TIME!!!
+    ///
+    /// This strategy should ONLY be used by customers with physical hardware who do not have
+    /// enough hardware for the `WaitUntilReady` strategy. If you think you want this, please
+    /// consult with Materialize engineering to discuss your situation.
+    /// {{</warning>}}
+    ///
+    /// Tear down the old generation of pods and promote the new generation of pods immediately,
+    /// without waiting for the new generation of pods to be ready.
+    ImmediatelyPromoteCausingDowntime,
+}
+
+/// Default for [`RolloutRequestTimeout`]. A new generation that sits
+/// un-promoted holds back compaction via read holds, and promoting it
+/// after a long delay can cause incident-inducing load; 24h is a
+/// conservative upper bound on how long any rollout should take.
+pub const DEFAULT_ROLLOUT_REQUEST_TIMEOUT: &str = "24h";
+
+/// The maximum time [`v1alpha1::MaterializeSpec::rollout_request_timeout`] allows a
+/// rollout to remain in progress.
+///
+/// A transparent wrapper around the duration string whose [`Default`] is
+/// [`DEFAULT_ROLLOUT_REQUEST_TIMEOUT`]. Routing the default through `Default`
+/// keeps a single source of truth: the derived `Default` for
+/// [`v1alpha1::MaterializeSpec`], serde's `#[serde(default)]` (applied when the field
+/// is omitted on deserialize), and the schema default surfaced in the
+/// generated CRD (so the API server fills it in and `kubectl explain` shows
+/// it) all resolve to the same value.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(transparent)]
+pub struct RolloutRequestTimeout(pub String);
+
+impl Default for RolloutRequestTimeout {
+    fn default() -> Self {
+        RolloutRequestTimeout(DEFAULT_ROLLOUT_REQUEST_TIMEOUT.to_owned())
+    }
+}
 
 pub mod v1alpha1 {
     use super::*;
-
-    #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema)]
-    pub enum MaterializeRolloutStrategy {
-        /// Create a new generation of pods, leaving the old generation around until the
-        /// new ones are ready to take over.
-        /// This minimizes downtime, and is what almost everyone should use.
-        #[default]
-        WaitUntilReady,
-
-        /// Create a new generation of pods, leaving the old generation as the serving generation
-        /// until the user manually promotes the new generation.
-        ///
-        /// When using `ManuallyPromote`, the new generation can be promoted at any
-        /// time, even if it has dataflows that are not fully caught up, by setting
-        /// `forcePromote` to the same value as `requestRollout` in the Materialize spec.
-        ///
-        /// To minimize downtime, promotion should occur when the new generation
-        /// has caught up to the prior generation. To determine if the new
-        /// generation has caught up, consult the `UpToDate` condition in the
-        /// status of the Materialize Resource. If the condition's reason is
-        /// `ReadyToPromote` the new generation is ready to promote.
-        ///
-        /// {{<warning>}}
-        /// Do not leave new generations unpromoted indefinitely.
-        ///
-        /// The new generation keeps open read holds which prevent compaction. Once promoted or
-        /// cancelled, those read holds are released. If left unpromoted for an extended time, this
-        /// data can build up, and can cause extreme deletion load on the metadata backend database
-        /// when finally promoted or cancelled.
-        ///
-        /// To guard against this, a rollout that remains in progress longer
-        /// than `rolloutRequestTimeout` (default 24h) is automatically
-        /// cancelled.
-        /// {{</warning>}}
-        ManuallyPromote,
-
-        /// {{<warning>}}
-        /// THIS WILL CAUSE YOUR MATERIALIZE INSTANCE TO BE UNAVAILABLE FOR SOME TIME!!!
-        ///
-        /// This strategy should ONLY be used by customers with physical hardware who do not have
-        /// enough hardware for the `WaitUntilReady` strategy. If you think you want this, please
-        /// consult with Materialize engineering to discuss your situation.
-        /// {{</warning>}}
-        ///
-        /// Tear down the old generation of pods and promote the new generation of pods immediately,
-        /// without waiting for the new generation of pods to be ready.
-        ImmediatelyPromoteCausingDowntime,
-    }
-
-    /// Default for [`RolloutRequestTimeout`]. A new generation that sits
-    /// un-promoted holds back compaction via read holds, and promoting it
-    /// after a long delay can cause incident-inducing load; 24h is a
-    /// conservative upper bound on how long any rollout should take.
-    pub const DEFAULT_ROLLOUT_REQUEST_TIMEOUT: &str = "24h";
-
-    /// The maximum time [`MaterializeSpec::rollout_request_timeout`] allows a
-    /// rollout to remain in progress.
-    ///
-    /// A transparent wrapper around the duration string whose [`Default`] is
-    /// [`DEFAULT_ROLLOUT_REQUEST_TIMEOUT`]. Routing the default through `Default`
-    /// keeps a single source of truth: the derived `Default` for
-    /// [`MaterializeSpec`], serde's `#[serde(default)]` (applied when the field
-    /// is omitted on deserialize), and the schema default surfaced in the
-    /// generated CRD (so the API server fills it in and `kubectl explain` shows
-    /// it) all resolve to the same value.
-    #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
-    #[serde(transparent)]
-    pub struct RolloutRequestTimeout(pub String);
-
-    impl Default for RolloutRequestTimeout {
-        fn default() -> Self {
-            RolloutRequestTimeout(DEFAULT_ROLLOUT_REQUEST_TIMEOUT.to_owned())
-        }
-    }
 
     #[derive(
         CustomResource,
@@ -199,7 +201,7 @@ pub mod v1alpha1 {
         /// generation to rehydrate before promoting the new environmentd to
         /// leader.
         #[serde(default)]
-        pub force_promote: Uuid,
+        pub force_promote: String,
         /// This value will be written to an annotation in the generated
         /// environmentd statefulset, in order to force the controller to
         /// detect the generated resources as changed even if no other changes
@@ -556,11 +558,13 @@ pub mod v1alpha1 {
         }
 
         pub fn set_force_promote(&mut self) {
-            self.spec.force_promote = self.spec.request_rollout;
+            self.spec.force_promote = self.spec.request_rollout.hyphenated().to_string();
         }
 
         pub fn should_force_promote(&self) -> bool {
-            self.spec.force_promote == self.spec.request_rollout
+            self.spec.force_promote == self.spec.request_rollout.hyphenated().to_string()
+                || self.spec.force_promote
+                    == super::v1alpha2::Materialize::from(self.clone()).generate_rollout_hash()
                 || self.spec.rollout_strategy
                     == MaterializeRolloutStrategy::ImmediatelyPromoteCausingDowntime
         }
@@ -592,6 +596,713 @@ pub mod v1alpha1 {
                 .iter()
                 .any(|condition| condition.reason == "ReadyToPromote")
                 && &status.resources_hash == resources_hash
+        }
+
+        pub fn is_promoting(&self) -> bool {
+            let Some(status) = self.status.as_ref() else {
+                return false;
+            };
+            if status.conditions.is_empty() {
+                return false;
+            }
+            status
+                .conditions
+                .iter()
+                .any(|condition| condition.reason == "Promoting")
+        }
+
+        pub fn update_in_progress(&self) -> bool {
+            let Some(status) = self.status.as_ref() else {
+                return false;
+            };
+            if status.conditions.is_empty() {
+                return false;
+            }
+            for condition in &status.conditions {
+                if condition.type_ == "UpToDate" && condition.status == "Unknown" {
+                    return true;
+                }
+            }
+            false
+        }
+
+        /// Checks that the given version is greater than or equal
+        /// to the existing version, if the existing version
+        /// can be parsed.
+        pub fn meets_minimum_version(&self, minimum: &Version) -> bool {
+            let version = parse_image_ref(&self.spec.environmentd_image_ref);
+            match version {
+                // Use cmp_precedence() to ignore build metadata per SemVer 2.0.0 spec
+                Some(version) => version.cmp_precedence(minimum).is_ge(),
+                // In the rare case that we see an image reference
+                // that we can't parse, we assume that it satisfies all
+                // version checks. Usually these are custom images that have
+                // been by a developer on a branch forked from a recent copy
+                // of main, and so this works out reasonably well in practice.
+                None => {
+                    tracing::warn!(
+                        image_ref = %self.spec.environmentd_image_ref,
+                        "failed to parse image ref",
+                    );
+                    true
+                }
+            }
+        }
+
+        /// This check isn't strictly required since environmentd will still be able to determine
+        /// if the upgrade is allowed or not. However, doing this check allows us to provide
+        /// the error as soon as possible and in a more user friendly way.
+        pub fn is_valid_upgrade_version(active_version: &Version, next_version: &Version) -> bool {
+            // Don't allow rolling back
+            // Note: semver comparison handles RC versions correctly:
+            // v26.0.0-rc.1 < v26.0.0-rc.2 < v26.0.0
+            // Use cmp_precedence() to ignore build metadata
+            if next_version.cmp_precedence(active_version) == std::cmp::Ordering::Less {
+                return false;
+            }
+
+            if active_version.major == 0 {
+                if next_version.major != active_version.major {
+                    if next_version.major == 26 {
+                        // We require customers to upgrade from 0.147.20 (Self Managed 25.2) or v0.164.X (Cloud)
+                        // before upgrading to 26.0.0
+                        return (active_version.minor == 147 && active_version.patch >= 20)
+                            || active_version.minor >= 164;
+                    } else {
+                        return false;
+                    }
+                }
+                // Self managed 25.1 to 25.2
+                if next_version.minor == 147 && active_version.minor == 130 {
+                    return true;
+                }
+                // only allow upgrading a single minor version at a time
+                return next_version.minor <= active_version.minor + 1;
+            } else if active_version.major >= 26 {
+                // For versions 26.X.X and onwards, we deny upgrades past 1 major version of the active version
+                return next_version.major <= active_version.major + 1;
+            }
+
+            true
+        }
+
+        /// Checks if the current environmentd image ref is within the upgrade window of the last
+        /// successful rollout.
+        pub fn within_upgrade_window(&self) -> bool {
+            let active_environmentd_version = self
+                .status
+                .as_ref()
+                .and_then(|status| {
+                    status
+                        .last_completed_rollout_environmentd_image_ref
+                        .as_ref()
+                })
+                .and_then(|image_ref| parse_image_ref(image_ref));
+
+            if let (Some(next_environmentd_version), Some(active_environmentd_version)) = (
+                parse_image_ref(&self.spec.environmentd_image_ref),
+                active_environmentd_version,
+            ) {
+                Self::is_valid_upgrade_version(
+                    &active_environmentd_version,
+                    &next_environmentd_version,
+                )
+            } else {
+                // If we fail to parse either version,
+                // we still allow the upgrade since environmentd will still error if the upgrade is not allowed.
+                true
+            }
+        }
+
+        pub fn status(&self) -> MaterializeStatus {
+            self.status.clone().unwrap_or_else(|| {
+                let mut status = MaterializeStatus::default();
+
+                status.resource_id = new_resource_id();
+
+                // If we're creating the initial status on an un-soft-deleted
+                // Environment we need to ensure that the last active generation
+                // is restored, otherwise the env will crash loop indefinitely
+                // as its catalog would have durably recorded a greater generation
+                if let Some(last_active_generation) = self
+                    .annotations()
+                    .get(LAST_KNOWN_ACTIVE_GENERATION_ANNOTATION)
+                {
+                    status.active_generation = last_active_generation
+                        .parse()
+                        .expect("valid int generation");
+                }
+
+                // Initialize the last completed rollout environmentd image ref to
+                // the current image ref if not already set.
+                status.last_completed_rollout_environmentd_image_ref =
+                    Some(self.spec.environmentd_image_ref.clone());
+
+                status
+            })
+        }
+    }
+
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct MaterializeStatus {
+        /// Resource identifier used as a name prefix to avoid pod name collisions.
+        pub resource_id: String,
+        /// The generation of Materialize pods actively capable of servicing requests.
+        pub active_generation: u64,
+        /// The UUID of the last successfully completed rollout.
+        pub last_completed_rollout_request: Uuid,
+        /// The image ref of the environmentd image that was last successfully rolled out.
+        /// Used to deny upgrades past 1 major version from the last successful rollout.
+        /// When None, we upgrade anyways.
+        pub last_completed_rollout_environmentd_image_ref: Option<String>,
+        /// A hash calculated from the spec of resources to be created based on this Materialize
+        /// spec. This is used for detecting when the existing resources are up to date.
+        /// If you want to trigger a rollout without making other changes that would cause this
+        /// hash to change, you must set forceRollout to the same UUID as requestRollout.
+        pub resources_hash: String,
+        /// The last completed rollout hash from v1alpha2.
+        /// This exists on this older version only for round-trip conversion support.
+        pub last_completed_rollout_hash: Option<String>,
+        pub conditions: Vec<Condition>,
+    }
+
+    impl MaterializeStatus {
+        pub fn needs_update(&self, other: &Self) -> bool {
+            let now = Timestamp::now();
+            let mut a = self.clone();
+            for condition in &mut a.conditions {
+                condition.last_transition_time = Time(now);
+            }
+            let mut b = other.clone();
+            for condition in &mut b.conditions {
+                condition.last_transition_time = Time(now);
+            }
+            a != b
+        }
+    }
+
+    impl ManagedResource for Materialize {
+        fn default_labels(&self) -> BTreeMap<String, String> {
+            BTreeMap::from_iter([
+                (
+                    "materialize.cloud/organization-name".to_owned(),
+                    self.name_unchecked(),
+                ),
+                (
+                    "materialize.cloud/organization-namespace".to_owned(),
+                    self.namespace(),
+                ),
+                (
+                    "materialize.cloud/mz-resource-id".to_owned(),
+                    self.resource_id().to_owned(),
+                ),
+            ])
+        }
+    }
+
+    impl From<v1alpha2::Materialize> for Materialize {
+        fn from(value: v1alpha2::Materialize) -> Self {
+            let rollout_hash = value.generate_rollout_hash();
+            // Derive a deterministic UUID from the rollout hash so that the
+            // same v1alpha2 spec always produces the same requestRollout,
+            // making re-applies of an unchanged spec idempotent.
+            let request_rollout = Uuid::new_v5(&Uuid::NAMESPACE_OID, rollout_hash.as_bytes());
+            Materialize {
+                metadata: value.metadata,
+                spec: MaterializeSpec {
+                    environmentd_image_ref: value.spec.environmentd_image_ref,
+                    environmentd_extra_args: value.spec.environmentd_extra_args,
+                    environmentd_extra_env: value.spec.environmentd_extra_env,
+                    environmentd_iam_role_arn: None,
+                    environmentd_connection_role_arn: value.spec.environmentd_connection_role_arn,
+                    environmentd_resource_requirements: value
+                        .spec
+                        .environmentd_resource_requirements,
+                    environmentd_scratch_volume_storage_requirement: value
+                        .spec
+                        .environmentd_scratch_volume_storage_requirement,
+                    balancerd_resource_requirements: value.spec.balancerd_resource_requirements,
+                    console_resource_requirements: value.spec.console_resource_requirements,
+                    balancerd_replicas: value.spec.balancerd_replicas,
+                    console_replicas: value.spec.console_replicas,
+                    service_account_name: value.spec.service_account_name,
+                    service_account_annotations: value.spec.service_account_annotations,
+                    service_account_labels: value.spec.service_account_labels,
+                    pod_annotations: value.spec.pod_annotations,
+                    pod_labels: value.spec.pod_labels,
+                    force_promote: value.spec.force_promote.unwrap_or_default(),
+                    force_rollout: value.spec.force_rollout,
+                    rollout_strategy: value.spec.rollout_strategy,
+                    rollout_request_timeout: value.spec.rollout_request_timeout,
+                    backend_secret_name: value.spec.backend_secret_name,
+                    authenticator_kind: value.spec.authenticator_kind,
+                    enable_rbac: value.spec.enable_rbac,
+                    environment_id: value.spec.environment_id,
+                    system_parameter_configmap_name: value.spec.system_parameter_configmap_name,
+                    balancerd_external_certificate_spec: value
+                        .spec
+                        .balancerd_external_certificate_spec,
+                    console_external_certificate_spec: value.spec.console_external_certificate_spec,
+                    internal_certificate_spec: value.spec.internal_certificate_spec,
+                    request_rollout,
+                    in_place_rollout: false,
+                },
+                status: value.status.map(|status| MaterializeStatus {
+                    resource_id: status.resource_id,
+                    active_generation: status.active_generation,
+                    last_completed_rollout_environmentd_image_ref: status
+                        .last_completed_rollout_environmentd_image_ref,
+                    conditions: status.conditions,
+                    // Derive the same deterministic UUID from the last
+                    // completed hash so that request_rollout == this value
+                    // when the spec hasn't changed (no rollout needed).
+                    last_completed_rollout_request: status
+                        .last_completed_rollout_hash
+                        .as_ref()
+                        .map(|hash| Uuid::new_v5(&Uuid::NAMESPACE_OID, hash.as_bytes()))
+                        .unwrap_or(Uuid::nil()),
+                    last_completed_rollout_hash: status.last_completed_rollout_hash,
+                    resources_hash: "".to_owned(),
+                }),
+            }
+        }
+    }
+}
+
+pub mod v1alpha2 {
+    use super::*;
+
+    #[derive(
+        CustomResource,
+        Clone,
+        Debug,
+        Default,
+        PartialEq,
+        Deserialize,
+        Serialize,
+        JsonSchema
+    )]
+    #[serde(rename_all = "camelCase")]
+    #[kube(
+        namespaced,
+        group = "materialize.cloud",
+        version = "v1alpha2",
+        kind = "Materialize",
+        singular = "materialize",
+        plural = "materializes",
+        shortname = "mzs",
+        status = "MaterializeStatus",
+        printcolumn = r#"{"name": "ImageRefRunning", "type": "string", "description": "Reference to the Docker image that is currently in use.", "jsonPath": ".status.lastCompletedRolloutEnvironmentdImageRef", "priority": 1}"#,
+        printcolumn = r#"{"name": "ImageRefToDeploy", "type": "string", "description": "Reference to the Docker image which will be deployed on the next rollout.", "jsonPath": ".spec.environmentdImageRef", "priority": 1}"#,
+        printcolumn = r#"{"name": "UpToDate", "type": "string", "description": "Whether the spec has been applied", "jsonPath": ".status.conditions[?(@.type==\"UpToDate\")].status", "priority": 1}"#
+    )]
+    pub struct MaterializeSpec {
+        /// The environmentd image to run.
+        pub environmentd_image_ref: String,
+        /// Extra args to pass to the environmentd binary.
+        pub environmentd_extra_args: Option<Vec<String>>,
+        /// Extra environment variables to pass to the environmentd binary.
+        pub environmentd_extra_env: Option<Vec<EnvVar>>,
+        /// If running in AWS, override the IAM role to use to support
+        /// the CREATE CONNECTION feature.
+        pub environmentd_connection_role_arn: Option<String>,
+        /// Resource requirements for the environmentd pod.
+        pub environmentd_resource_requirements: Option<ResourceRequirements>,
+        /// Amount of disk to allocate, if a storage class is provided.
+        pub environmentd_scratch_volume_storage_requirement: Option<Quantity>,
+        /// Resource requirements for the balancerd pod.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub balancerd_resource_requirements: Option<ResourceRequirements>,
+        /// Resource requirements for the console pod.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub console_resource_requirements: Option<ResourceRequirements>,
+        /// Number of balancerd pods to create.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub balancerd_replicas: Option<i32>,
+        /// Number of console pods to create.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub console_replicas: Option<i32>,
+
+        /// Name of the kubernetes service account to use.
+        /// If not set, we will create one with the same name as this Materialize object.
+        pub service_account_name: Option<String>,
+        /// Annotations to apply to the service account.
+        ///
+        /// Annotations on service accounts are commonly used by cloud providers for IAM.
+        /// AWS uses "eks.amazonaws.com/role-arn".
+        /// Azure uses "azure.workload.identity/client-id", but
+        /// additionally requires "azure.workload.identity/use": "true" on the pods.
+        pub service_account_annotations: Option<BTreeMap<String, String>>,
+        /// Labels to apply to the service account.
+        pub service_account_labels: Option<BTreeMap<String, String>>,
+        /// Annotations to apply to the pods.
+        pub pod_annotations: Option<BTreeMap<String, String>>,
+        /// Labels to apply to the pods.
+        pub pod_labels: Option<BTreeMap<String, String>>,
+
+        /// If `forcePromote` is set to the same value as the `status.requestedRolloutHash`,
+        /// current rollout will skip waiting for clusters in the new
+        /// generation to rehydrate before promoting the new environmentd to
+        /// leader.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub force_promote: Option<String>,
+        /// This value will force the controller to detect the spec as changed
+        /// even if no other changes happened. This can be used to force a rollout
+        /// to a new generation even without making any meaningful changes.
+        #[serde(default)]
+        pub force_rollout: Uuid,
+        /// Rollout strategy to use when upgrading this Materialize instance.
+        #[serde(default)]
+        pub rollout_strategy: MaterializeRolloutStrategy,
+        /// The maximum amount of time a rollout may remain in progress before
+        /// it is automatically cancelled.
+        ///
+        /// While a rollout is in progress, the new generation of `environmentd`
+        /// runs in a read-only, un-promoted state and holds back compaction via
+        /// read holds. Leaving it in this state for too long can cause
+        /// incident-inducing load when it is eventually promoted, so the
+        /// operator cancels the rollout once this timeout is exceeded: the new
+        /// generation is torn down and the previously-active generation
+        /// continues serving. A new rollout can then be triggered by setting
+        /// `requestRollout` to a new value.
+        ///
+        /// This does not apply to the `ImmediatelyPromoteCausingDowntime`
+        /// rollout strategy or to force-promoted rollouts, since by the time
+        /// those are in progress the old generation may already be gone.
+        ///
+        /// The value is parsed as a human-readable duration, e.g. `24h`,
+        /// `90m`, or `1h 30m`. Defaults to [`DEFAULT_ROLLOUT_REQUEST_TIMEOUT`]
+        /// when omitted (the API server fills it in); an unparseable value also
+        /// falls back to that default.
+        #[serde(default)]
+        pub rollout_request_timeout: RolloutRequestTimeout,
+        /// The name of a secret containing `metadata_backend_url` and `persist_backend_url`.
+        /// It may also contain `external_login_password_mz_system`, which will be used as
+        /// the password for the `mz_system` user if `authenticatorKind` is `Password`.
+        pub backend_secret_name: String,
+        /// How to authenticate with Materialize.
+        #[serde(default)]
+        pub authenticator_kind: AuthenticatorKind,
+        /// Whether to enable role based access control. Defaults to false.
+        #[serde(default)]
+        pub enable_rbac: bool,
+
+        /// The value used by environmentd (via the --environment-id flag) to
+        /// uniquely identify this instance. Must be globally unique, and
+        /// is required if a license key is not provided.
+        /// NOTE: This value MUST NOT be changed in an existing instance,
+        /// since it affects things like the way data is stored in the persist
+        /// backend.
+        #[serde(default)]
+        pub environment_id: Uuid,
+
+        /// The name of a ConfigMap containing system parameters in JSON format.
+        /// The ConfigMap must contain a `system-params.json` key whose value
+        /// is a valid JSON object containing valid system parameters.
+        ///
+        /// Run `SHOW ALL` in SQL to see a subset of configurable system parameters.
+        ///
+        /// Example ConfigMap:
+        /// ```yaml
+        /// data:
+        ///   system-params.json: |
+        ///     {
+        ///       "max_connections": 1000
+        ///     }
+        /// ```
+        pub system_parameter_configmap_name: Option<String>,
+
+        /// The configuration for generating an x509 certificate using cert-manager for balancerd
+        /// to present to incoming connections.
+        /// The `dnsNames` and `issuerRef` fields are required.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub balancerd_external_certificate_spec: Option<MaterializeCertSpec>,
+        /// The configuration for generating an x509 certificate using cert-manager for the console
+        /// to present to incoming connections.
+        /// The `dnsNames` and `issuerRef` fields are required.
+        /// Not yet implemented.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        pub console_external_certificate_spec: Option<MaterializeCertSpec>,
+        /// The cert-manager Issuer or ClusterIssuer to use for database internal communication.
+        /// The `issuerRef` field is required.
+        /// This currently is only used for environmentd, but will eventually support clusterd.
+        /// Not yet implemented.
+        pub internal_certificate_spec: Option<MaterializeCertSpec>,
+    }
+
+    impl Materialize {
+        pub fn generate_rollout_hash(&self) -> String {
+            let mut hasher = Sha256::new();
+            // Remove fields that don't affect the resources generated per generation,
+            // and we don't want to trigger a rollout from.
+            let spec = MaterializeSpec {
+                environmentd_image_ref: self.spec.environmentd_image_ref.clone(),
+                environmentd_extra_args: self.spec.environmentd_extra_args.clone(),
+                environmentd_extra_env: self.spec.environmentd_extra_env.clone(),
+                environmentd_connection_role_arn: self
+                    .spec
+                    .environmentd_connection_role_arn
+                    .clone(),
+                environmentd_resource_requirements: self
+                    .spec
+                    .environmentd_resource_requirements
+                    .clone(),
+                environmentd_scratch_volume_storage_requirement: self
+                    .spec
+                    .environmentd_scratch_volume_storage_requirement
+                    .clone(),
+                balancerd_resource_requirements: None,
+                console_resource_requirements: None,
+                balancerd_replicas: None,
+                console_replicas: None,
+                service_account_name: self.spec.service_account_name.clone(),
+                service_account_annotations: self.spec.service_account_annotations.clone(),
+                service_account_labels: self.spec.service_account_labels.clone(),
+                pod_annotations: self.spec.pod_annotations.clone(),
+                pod_labels: self.spec.pod_labels.clone(),
+                force_promote: None,
+                force_rollout: self.spec.force_rollout,
+                rollout_strategy: self.spec.rollout_strategy.clone(),
+                rollout_request_timeout: self.spec.rollout_request_timeout.clone(),
+                backend_secret_name: self.spec.backend_secret_name.clone(),
+                authenticator_kind: self.spec.authenticator_kind,
+                enable_rbac: self.spec.enable_rbac,
+                environment_id: self.spec.environment_id,
+                system_parameter_configmap_name: self.spec.system_parameter_configmap_name.clone(),
+                balancerd_external_certificate_spec: None,
+                console_external_certificate_spec: None,
+                internal_certificate_spec: self.spec.internal_certificate_spec.clone(),
+            };
+            hasher.update(&serde_json::to_vec(&spec).unwrap());
+            if let Some(annotation) = self
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(FORCE_ROLLOUT_ANNOTATION))
+            {
+                hasher.update(annotation);
+            }
+            format!("{:x}", hasher.finalize())
+        }
+
+        pub fn backend_secret_name(&self) -> String {
+            self.spec.backend_secret_name.clone()
+        }
+
+        pub fn namespace(&self) -> String {
+            self.meta().namespace.clone().unwrap()
+        }
+
+        pub fn create_service_account(&self) -> bool {
+            self.spec.service_account_name.is_none()
+        }
+
+        pub fn service_account_name(&self) -> String {
+            self.spec
+                .service_account_name
+                .clone()
+                .unwrap_or_else(|| self.name_unchecked())
+        }
+
+        pub fn role_name(&self) -> String {
+            self.name_unchecked()
+        }
+
+        pub fn role_binding_name(&self) -> String {
+            self.name_unchecked()
+        }
+
+        pub fn environmentd_statefulset_name(&self, generation: u64) -> String {
+            self.name_prefixed(&format!("environmentd-{generation}"))
+        }
+
+        pub fn environmentd_app_name(&self) -> String {
+            "environmentd".to_owned()
+        }
+
+        pub fn environmentd_service_name(&self) -> String {
+            self.name_prefixed("environmentd")
+        }
+
+        pub fn environmentd_service_internal_fqdn(&self) -> String {
+            format!(
+                "{}.{}.svc.cluster.local",
+                self.environmentd_service_name(),
+                self.meta().namespace.as_ref().unwrap()
+            )
+        }
+
+        pub fn environmentd_generation_service_name(&self, generation: u64) -> String {
+            self.name_prefixed(&format!("environmentd-{generation}"))
+        }
+
+        pub fn balancerd_app_name(&self) -> String {
+            "balancerd".to_owned()
+        }
+
+        pub fn environmentd_certificate_name(&self) -> String {
+            self.name_prefixed("environmentd-external")
+        }
+
+        pub fn environmentd_certificate_secret_name(&self) -> String {
+            self.name_prefixed("environmentd-tls")
+        }
+
+        pub fn balancerd_deployment_name(&self) -> String {
+            self.name_prefixed("balancerd")
+        }
+
+        pub fn balancerd_service_name(&self) -> String {
+            self.name_prefixed("balancerd")
+        }
+
+        pub fn console_app_name(&self) -> String {
+            "console".to_owned()
+        }
+
+        pub fn balancerd_external_certificate_name(&self) -> String {
+            self.name_prefixed("balancerd-external")
+        }
+
+        pub fn balancerd_external_certificate_secret_name(&self) -> String {
+            self.name_prefixed("balancerd-external-tls")
+        }
+
+        pub fn balancerd_replicas(&self) -> i32 {
+            self.spec.balancerd_replicas.unwrap_or(2)
+        }
+
+        pub fn console_replicas(&self) -> i32 {
+            self.spec.console_replicas.unwrap_or(2)
+        }
+
+        pub fn console_configmap_name(&self) -> String {
+            self.name_prefixed("console")
+        }
+
+        pub fn console_deployment_name(&self) -> String {
+            self.name_prefixed("console")
+        }
+
+        pub fn console_service_name(&self) -> String {
+            self.name_prefixed("console")
+        }
+
+        pub fn console_external_certificate_name(&self) -> String {
+            self.name_prefixed("console-external")
+        }
+
+        pub fn console_external_certificate_secret_name(&self) -> String {
+            self.name_prefixed("console-external-tls")
+        }
+
+        pub fn persist_pubsub_service_name(&self, generation: u64) -> String {
+            self.name_prefixed(&format!("persist-pubsub-{generation}"))
+        }
+
+        pub fn listeners_configmap_name(&self, generation: u64) -> String {
+            self.name_prefixed(&format!("listeners-{generation}"))
+        }
+
+        pub fn name_prefixed(&self, suffix: &str) -> String {
+            format!("mz{}-{}", self.resource_id(), suffix)
+        }
+
+        pub fn resource_id(&self) -> &str {
+            &self.status.as_ref().unwrap().resource_id
+        }
+
+        pub fn system_parameter_configmap_name(&self) -> Option<String> {
+            self.spec.system_parameter_configmap_name.clone()
+        }
+
+        pub fn environmentd_scratch_volume_storage_requirement(&self) -> Quantity {
+            self.spec
+                .environmentd_scratch_volume_storage_requirement
+                .clone()
+                .unwrap_or_else(|| {
+                    self.spec
+                        .environmentd_resource_requirements
+                        .as_ref()
+                        .and_then(|requirements| {
+                            requirements
+                                .requests
+                                .as_ref()
+                                .or(requirements.limits.as_ref())
+                        })
+                        // TODO: in cloud, we've been defaulting to twice the
+                        // memory limit, but k8s-openapi doesn't seem to
+                        // provide any way to parse Quantity values, so there
+                        // isn't an easy way to do arithmetic on it
+                        .and_then(|requirements| requirements.get("memory").cloned())
+                        // TODO: is there a better default to use here?
+                        .unwrap_or_else(|| Quantity("4096Mi".to_string()))
+                })
+        }
+
+        pub fn environment_id(&self, cloud_provider: &str, region: &str) -> String {
+            format!(
+                "{}-{}-{}-0",
+                cloud_provider, region, self.spec.environment_id,
+            )
+        }
+
+        pub fn rollout_requested(&self) -> bool {
+            self.status
+                .as_ref()
+                .map(|status| status.last_completed_rollout_hash != status.requested_rollout_hash)
+                .unwrap_or(false)
+        }
+
+        pub fn set_force_promote(&mut self) {
+            self.spec.force_promote = Some(self.generate_rollout_hash());
+        }
+
+        pub fn should_force_promote(&self) -> bool {
+            self.spec.force_promote.as_ref()
+                == self
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.requested_rollout_hash.as_ref())
+                || self.spec.rollout_strategy
+                    == MaterializeRolloutStrategy::ImmediatelyPromoteCausingDowntime
+        }
+
+        pub fn conditions_need_update(&self) -> bool {
+            let Some(status) = self.status.as_ref() else {
+                return true;
+            };
+            if status.conditions.is_empty() {
+                return true;
+            }
+            for condition in &status.conditions {
+                if condition.observed_generation != self.meta().generation {
+                    return true;
+                }
+            }
+            false
+        }
+
+        pub fn is_ready_to_promote(&self, rollout_hash: &str) -> bool {
+            let Some(status) = self.status.as_ref() else {
+                return false;
+            };
+            if status.conditions.is_empty() {
+                return false;
+            }
+            status
+                .conditions
+                .iter()
+                .any(|condition| condition.reason == "ReadyToPromote")
+                && status.requested_rollout_hash.as_deref() == Some(rollout_hash)
         }
 
         pub fn is_promoting(&self) -> bool {
@@ -747,17 +1458,15 @@ pub mod v1alpha1 {
         pub resource_id: String,
         /// The generation of Materialize pods actively capable of servicing requests.
         pub active_generation: u64,
-        /// The UUID of the last successfully completed rollout.
-        pub last_completed_rollout_request: Uuid,
         /// The image ref of the environmentd image that was last successfully rolled out.
         /// Used to deny upgrades past 1 major version from the last successful rollout.
         /// When None, we upgrade anyways.
         pub last_completed_rollout_environmentd_image_ref: Option<String>,
-        /// A hash calculated from the spec of resources to be created based on this Materialize
-        /// spec. This is used for detecting when the existing resources are up to date.
-        /// If you want to trigger a rollout without making other changes that would cause this
-        /// hash to change, you must set forceRollout to the same UUID as requestRollout.
-        pub resources_hash: String,
+        /// The last completed rollout's requestedRolloutHash.
+        pub last_completed_rollout_hash: Option<String>,
+        /// Hash of a subset of the Materialize spec and other fields.
+        /// This is used to determine when the spec has changed and we need to rollout.
+        pub requested_rollout_hash: Option<String>,
         pub conditions: Vec<Condition>,
     }
 
@@ -798,6 +1507,109 @@ pub mod v1alpha1 {
             Some("environmentd")
         }
     }
+
+    impl From<v1alpha1::Materialize> for Materialize {
+        fn from(value: v1alpha1::Materialize) -> Self {
+            let is_promoting = value.is_promoting();
+            let service_account_annotations = if let Some(environmentd_iam_role_arn) =
+                value.spec.environmentd_iam_role_arn
+            {
+                let mut annotations = value.spec.service_account_annotations.unwrap_or_default();
+                annotations
+                    .entry("eks.amazonaws.com/role-arn".to_owned())
+                    .or_insert(environmentd_iam_role_arn);
+                Some(annotations)
+            } else {
+                value.spec.service_account_annotations
+            };
+            let mut mz = Materialize {
+                metadata: value.metadata,
+                spec: MaterializeSpec {
+                    environmentd_image_ref: value.spec.environmentd_image_ref,
+                    environmentd_extra_args: value.spec.environmentd_extra_args,
+                    environmentd_extra_env: value.spec.environmentd_extra_env,
+                    environmentd_connection_role_arn: value.spec.environmentd_connection_role_arn,
+                    environmentd_resource_requirements: value
+                        .spec
+                        .environmentd_resource_requirements,
+                    environmentd_scratch_volume_storage_requirement: value
+                        .spec
+                        .environmentd_scratch_volume_storage_requirement,
+                    balancerd_resource_requirements: value.spec.balancerd_resource_requirements,
+                    console_resource_requirements: value.spec.console_resource_requirements,
+                    balancerd_replicas: value.spec.balancerd_replicas,
+                    console_replicas: value.spec.console_replicas,
+                    service_account_name: value.spec.service_account_name,
+                    service_account_annotations,
+                    service_account_labels: value.spec.service_account_labels,
+                    pod_annotations: value.spec.pod_annotations,
+                    pod_labels: value.spec.pod_labels,
+                    force_promote: if value.spec.force_promote.is_empty()
+                        || &value.spec.force_promote == "00000000-0000-0000-0000-000000000000"
+                    {
+                        None
+                    } else {
+                        Some(value.spec.force_promote.to_string())
+                    },
+                    force_rollout: value.spec.force_rollout,
+                    rollout_strategy: value.spec.rollout_strategy,
+                    rollout_request_timeout: value.spec.rollout_request_timeout,
+                    backend_secret_name: value.spec.backend_secret_name,
+                    authenticator_kind: value.spec.authenticator_kind,
+                    enable_rbac: value.spec.enable_rbac,
+                    environment_id: value.spec.environment_id,
+                    system_parameter_configmap_name: value.spec.system_parameter_configmap_name,
+                    balancerd_external_certificate_spec: value
+                        .spec
+                        .balancerd_external_certificate_spec,
+                    console_external_certificate_spec: value.spec.console_external_certificate_spec,
+                    internal_certificate_spec: value.spec.internal_certificate_spec,
+                },
+                status: None,
+            };
+            let calculated_rollout_hash = mz.generate_rollout_hash();
+            let last_completed_rollout_hash = match value
+                .status
+                .as_ref()
+                .and_then(|status| status.last_completed_rollout_hash.to_owned())
+            {
+                Some(last_completed_rollout_hash) => Some(last_completed_rollout_hash),
+                None => {
+                    let currently_rolling_out = value
+                        .status
+                        .as_ref()
+                        .map(|status| {
+                            status.last_completed_rollout_request != value.spec.request_rollout
+                                // If this is the first apply,
+                                // these could both be nil and we still need to do a rollout.
+                                || status.last_completed_rollout_request.is_nil()
+                        })
+                        .unwrap_or(true);
+                    if currently_rolling_out {
+                        // If they store a change, we're going to start over on a new rollout.
+                        None
+                    } else {
+                        Some(calculated_rollout_hash.clone())
+                    }
+                }
+            };
+            let requested_rollout_hash = if is_promoting {
+                None
+            } else {
+                Some(calculated_rollout_hash)
+            };
+            mz.status = value.status.map(|status| MaterializeStatus {
+                resource_id: status.resource_id,
+                active_generation: status.active_generation,
+                last_completed_rollout_environmentd_image_ref: status
+                    .last_completed_rollout_environmentd_image_ref,
+                last_completed_rollout_hash,
+                requested_rollout_hash,
+                conditions: status.conditions,
+            });
+            mz
+        }
+    }
 }
 
 fn parse_image_ref(image_ref: &str) -> Option<Version> {
@@ -823,10 +1635,8 @@ mod tests {
     use kube::core::ObjectMeta;
     use semver::Version;
 
-    use super::v1alpha1::{
-        DEFAULT_ROLLOUT_REQUEST_TIMEOUT, Materialize, MaterializeSpec, MaterializeStatus,
-        RolloutRequestTimeout,
-    };
+    use super::v1alpha1::{Materialize, MaterializeSpec, MaterializeStatus};
+    use super::{DEFAULT_ROLLOUT_REQUEST_TIMEOUT, RolloutRequestTimeout};
 
     #[mz_ore::test]
     fn meets_minimum_version() {
@@ -875,8 +1685,6 @@ mod tests {
 
     #[mz_ore::test]
     fn within_upgrade_window() {
-        use super::v1alpha1::MaterializeStatus;
-
         let mut mz = Materialize {
             spec: MaterializeSpec {
                 environmentd_image_ref: "materialize/environmentd:v26.0.0".to_owned(),
@@ -1144,8 +1952,6 @@ mod tests {
 
     #[mz_ore::test]
     fn active_environmentd_image_ref() {
-        use super::v1alpha1::MaterializeStatus;
-
         const OLD: &str = "materialize/environmentd:v26.0.0";
         const NEW: &str = "materialize/environmentd:v27.0.0";
 

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -564,7 +564,7 @@ pub mod v1alpha1 {
         pub fn should_force_promote(&self) -> bool {
             self.spec.force_promote == self.spec.request_rollout.hyphenated().to_string()
                 || self.spec.force_promote
-                    == super::v1alpha2::Materialize::from(self.clone()).generate_rollout_hash()
+                    == super::v1::Materialize::from(self.clone()).generate_rollout_hash()
                 || self.spec.rollout_strategy
                     == MaterializeRolloutStrategy::ImmediatelyPromoteCausingDowntime
         }
@@ -761,7 +761,7 @@ pub mod v1alpha1 {
         /// If you want to trigger a rollout without making other changes that would cause this
         /// hash to change, you must set forceRollout to the same UUID as requestRollout.
         pub resources_hash: String,
-        /// The last completed rollout hash from v1alpha2.
+        /// The last completed rollout hash from v1.
         /// This exists on this older version only for round-trip conversion support.
         pub last_completed_rollout_hash: Option<String>,
         pub conditions: Vec<Condition>,
@@ -801,11 +801,11 @@ pub mod v1alpha1 {
         }
     }
 
-    impl From<v1alpha2::Materialize> for Materialize {
-        fn from(value: v1alpha2::Materialize) -> Self {
+    impl From<v1::Materialize> for Materialize {
+        fn from(value: v1::Materialize) -> Self {
             let rollout_hash = value.generate_rollout_hash();
             // Derive a deterministic UUID from the rollout hash so that the
-            // same v1alpha2 spec always produces the same requestRollout,
+            // same v1 spec always produces the same requestRollout,
             // making re-applies of an unchanged spec idempotent.
             let request_rollout = Uuid::new_v5(&Uuid::NAMESPACE_OID, rollout_hash.as_bytes());
             Materialize {
@@ -870,7 +870,7 @@ pub mod v1alpha1 {
     }
 }
 
-pub mod v1alpha2 {
+pub mod v1 {
     use super::*;
 
     #[derive(
@@ -887,7 +887,7 @@ pub mod v1alpha2 {
     #[kube(
         namespaced,
         group = "materialize.cloud",
-        version = "v1alpha2",
+        version = "v1",
         kind = "Materialize",
         singular = "materialize",
         plural = "materializes",

--- a/src/mz-debug/src/k8s_dumper.rs
+++ b/src/mz-debug/src/k8s_dumper.rs
@@ -38,7 +38,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomRe
 use kube::api::{ListParams, LogParams};
 use kube::{Api, Client};
 use mz_cloud_resources::crd::generated::cert_manager::certificates::Certificate;
-use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
+use mz_cloud_resources::crd::materialize::v1alpha2::Materialize;
 
 use serde::{Serialize, de::DeserializeOwned};
 use tracing::{info, warn};

--- a/src/mz-debug/src/k8s_dumper.rs
+++ b/src/mz-debug/src/k8s_dumper.rs
@@ -38,7 +38,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomRe
 use kube::api::{ListParams, LogParams};
 use kube::{Api, Client};
 use mz_cloud_resources::crd::generated::cert_manager::certificates::Certificate;
-use mz_cloud_resources::crd::materialize::v1alpha2::Materialize;
+use mz_cloud_resources::crd::materialize::v1::Materialize;
 
 use serde::{Serialize, de::DeserializeOwned};
 use tracing::{info, warn};

--- a/src/mz-debug/src/utils.rs
+++ b/src/mz-debug/src/utils.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use kube::{Api, Client};
-use mz_cloud_resources::crd::materialize::v1alpha1::Materialize;
+use mz_cloud_resources::crd::materialize::v1alpha2::Materialize;
 use mz_server_core::listeners::AuthenticatorKind;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;

--- a/src/mz-debug/src/utils.rs
+++ b/src/mz-debug/src/utils.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use kube::{Api, Client};
-use mz_cloud_resources::crd::materialize::v1alpha2::Materialize;
+use mz_cloud_resources::crd::materialize::v1::Materialize;
 use mz_server_core::listeners::AuthenticatorKind;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 axum.workspace = true
+axum-server.workspace = true
 clap.workspace = true
 futures.workspace = true
 http.workspace = true

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -36,6 +36,7 @@ mz-server-core = { path = "../server-core", default-features = false }
 prometheus.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -11,8 +11,10 @@ use std::{
     future,
     net::SocketAddr,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
+use axum_server::tls_openssl::OpenSSLConfig;
 use http::HeaderValue;
 use k8s_openapi::{
     api::{
@@ -40,6 +42,7 @@ use mz_orchestratord::{
     k8s::register_crds,
     metrics::{self, Metrics},
     tls::DefaultCertificateSpecs,
+    webhook,
 };
 use mz_ore::{
     cli::{self, CliConfig, KeyValueArg},
@@ -60,6 +63,21 @@ pub struct Args {
     profiling_listen_address: SocketAddr,
     #[clap(long, default_value = "[::]:3100")]
     metrics_listen_address: SocketAddr,
+    #[clap(long, default_value = "[::]:8001")]
+    webhook_listen_address: SocketAddr,
+
+    #[clap(long)]
+    webhook_service_name: String,
+    #[clap(long)]
+    webhook_service_namespace: String,
+    #[clap(long, default_value = "8001")]
+    webhook_service_port: u16,
+    #[clap(long, default_value = "/etc/tls/ca.crt")]
+    tls_ca: String,
+    #[clap(long, default_value = "/etc/tls/tls.crt")]
+    tls_cert: String,
+    #[clap(long, default_value = "/etc/tls/tls.key")]
+    tls_key: String,
 
     #[clap(long)]
     cloud_provider: CloudProvider,
@@ -265,10 +283,41 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let metrics = Arc::new(Metrics::register_into(&metrics_registry));
 
+    {
+        let tls_cert = args.tls_cert;
+        let tls_key = args.tls_key;
+        let config = OpenSSLConfig::from_pem_file(&tls_cert, &tls_key).unwrap();
+        let reload_config = config.clone();
+        let webhook_listen_address = args.webhook_listen_address;
+
+        mz_ore::task::spawn(|| "webhook server", async move {
+            if let Err(e) = axum_server::bind_openssl(webhook_listen_address, config)
+                .serve(webhook::router().into_make_service())
+                .await
+            {
+                panic!("webhook server failed: {}", e.display_with_causes());
+            }
+        });
+
+        mz_ore::task::spawn(|| "webhook certificate reload", async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60 * 60));
+            loop {
+                interval.tick().await;
+                if let Err(err) = reload_config.reload_from_pem_file(&tls_cert, &tls_key) {
+                    tracing::error!("failed to reload webhook TLS certificate: {err}");
+                }
+            }
+        });
+    }
+
     let (client, namespace) = create_client(args.kubernetes_context.clone()).await?;
     register_crds(
         client.clone(),
         args.additional_crd_columns.unwrap_or_default(),
+        args.webhook_service_name,
+        args.webhook_service_namespace,
+        args.webhook_service_port,
+        args.tls_ca,
     )
     .await?;
 

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -39,7 +39,7 @@ use mz_orchestrator_kubernetes::{KubernetesImagePullPolicy, util::create_client}
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_orchestratord::{
     controller,
-    k8s::register_crds,
+    k8s::{ConversionWebhookConfig, register_crds},
     metrics::{self, Metrics},
     tls::DefaultCertificateSpecs,
     webhook,
@@ -66,10 +66,17 @@ pub struct Args {
     #[clap(long, default_value = "[::]:8001")]
     webhook_listen_address: SocketAddr,
 
+    /// Whether to install the v1 version of the Materialize CRD and the
+    /// conversion webhook between v1 and v1alpha1. When false, only the
+    /// v1alpha1 version is installed and the webhook server is not started.
     #[clap(long)]
-    webhook_service_name: String,
-    #[clap(long)]
-    webhook_service_namespace: String,
+    install_v1_crd: bool,
+    /// Required when --install-v1-crd is set.
+    #[clap(long, required_if_eq("install_v1_crd", "true"))]
+    webhook_service_name: Option<String>,
+    /// Required when --install-v1-crd is set.
+    #[clap(long, required_if_eq("install_v1_crd", "true"))]
+    webhook_service_namespace: Option<String>,
     #[clap(long, default_value = "8001")]
     webhook_service_port: u16,
     #[clap(long, default_value = "/etc/tls/ca.crt")]
@@ -293,7 +300,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let tls_cert = args.tls_cert;
     let tls_key = args.tls_key;
     let tls_ca = args.tls_ca;
-    let reload_config = {
+    let reload_config = if args.install_v1_crd {
         let config = OpenSSLConfig::from_pem_file(&tls_cert, &tls_key).unwrap();
         let reload_config = config.clone();
         let webhook_listen_address = args.webhook_listen_address;
@@ -307,21 +314,27 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             }
         });
 
-        reload_config
+        Some(reload_config)
+    } else {
+        None
     };
 
     let (client, namespace) = create_client(args.kubernetes_context.clone()).await?;
     let additional_crd_columns = args.additional_crd_columns.unwrap_or_default();
-    let webhook_service_name = args.webhook_service_name;
-    let webhook_service_namespace = args.webhook_service_namespace;
-    let webhook_service_port = args.webhook_service_port;
+    let conversion_webhook = args.install_v1_crd.then(|| ConversionWebhookConfig {
+        service_name: args
+            .webhook_service_name
+            .expect("clap requires --webhook-service-name with --install-v1-crd"),
+        service_namespace: args
+            .webhook_service_namespace
+            .expect("clap requires --webhook-service-namespace with --install-v1-crd"),
+        service_port: args.webhook_service_port,
+        ca_cert_path: tls_ca.clone(),
+    });
     register_crds(
         client.clone(),
         additional_crd_columns.clone(),
-        webhook_service_name.clone(),
-        webhook_service_namespace.clone(),
-        webhook_service_port,
-        tls_ca.clone(),
+        conversion_webhook.clone(),
     )
     .await?;
 
@@ -336,9 +349,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     // Kubernetes API server would reject every conversion request. Refreshing
     // the CA bundle when the CA changes keeps the webhook working across CA
     // rotations.
-    {
+    if let Some(reload_config) = reload_config {
+        let conversion_webhook = conversion_webhook
+            .expect("conversion webhook config is set whenever the webhook server is started");
         let reload_interval = args.webhook_cert_reload_interval;
         let client = client.clone();
+        let additional_crd_columns = additional_crd_columns.clone();
         mz_ore::task::spawn(|| "webhook certificate reload", async move {
             let mut last_ca = tokio::fs::read(&tls_ca).await.ok();
             let mut interval = tokio::time::interval(reload_interval);
@@ -367,10 +383,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                 match register_crds(
                     client.clone(),
                     additional_crd_columns.clone(),
-                    webhook_service_name.clone(),
-                    webhook_service_namespace.clone(),
-                    webhook_service_port,
-                    tls_ca.clone(),
+                    Some(conversion_webhook.clone()),
                 )
                 .await
                 {
@@ -663,4 +676,43 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     info!("All tasks started successfully.");
 
     future::pending().await
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    const REQUIRED_ARGS: &[&str] = &[
+        "orchestratord",
+        "--cloud-provider=local",
+        "--region=kind",
+        "--console-image-tag-default=latest",
+    ];
+
+    #[mz_ore::test]
+    fn webhook_service_args_required_with_install_v1_crd() {
+        let args = Args::try_parse_from(REQUIRED_ARGS).expect("parses without webhook args");
+        assert!(!args.install_v1_crd);
+
+        assert!(
+            Args::try_parse_from(REQUIRED_ARGS.iter().copied().chain(["--install-v1-crd"]))
+                .is_err(),
+            "--install-v1-crd should require the webhook service args"
+        );
+
+        let args = Args::try_parse_from(REQUIRED_ARGS.iter().copied().chain([
+            "--install-v1-crd",
+            "--webhook-service-name=orchestratord",
+            "--webhook-service-namespace=materialize",
+        ]))
+        .expect("parses with webhook args");
+        assert!(args.install_v1_crd);
+        assert_eq!(args.webhook_service_name.as_deref(), Some("orchestratord"));
+        assert_eq!(
+            args.webhook_service_namespace.as_deref(),
+            Some("materialize")
+        );
+    }
 }

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -78,6 +78,13 @@ pub struct Args {
     tls_cert: String,
     #[clap(long, default_value = "/etc/tls/tls.key")]
     tls_key: String,
+    /// How often to reload the webhook TLS serving certificate from disk and,
+    /// when the CA changes, refresh the conversion webhook's CA bundle. The
+    /// certificate is rotated out-of-band (e.g. by cert-manager), so this must
+    /// be short enough that rotations are picked up before the old certificate
+    /// expires.
+    #[clap(long, default_value = "1h", value_parser = humantime::parse_duration)]
+    webhook_cert_reload_interval: Duration,
 
     #[clap(long)]
     cloud_provider: CloudProvider,
@@ -283,9 +290,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let metrics = Arc::new(Metrics::register_into(&metrics_registry));
 
-    {
-        let tls_cert = args.tls_cert;
-        let tls_key = args.tls_key;
+    let tls_cert = args.tls_cert;
+    let tls_key = args.tls_key;
+    let tls_ca = args.tls_ca;
+    let reload_config = {
         let config = OpenSSLConfig::from_pem_file(&tls_cert, &tls_key).unwrap();
         let reload_config = config.clone();
         let webhook_listen_address = args.webhook_listen_address;
@@ -299,27 +307,88 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             }
         });
 
+        reload_config
+    };
+
+    let (client, namespace) = create_client(args.kubernetes_context.clone()).await?;
+    let additional_crd_columns = args.additional_crd_columns.unwrap_or_default();
+    let webhook_service_name = args.webhook_service_name;
+    let webhook_service_namespace = args.webhook_service_namespace;
+    let webhook_service_port = args.webhook_service_port;
+    register_crds(
+        client.clone(),
+        additional_crd_columns.clone(),
+        webhook_service_name.clone(),
+        webhook_service_namespace.clone(),
+        webhook_service_port,
+        tls_ca.clone(),
+    )
+    .await?;
+
+    // Periodically reload the webhook serving certificate from disk, and
+    // refresh the conversion webhook's CA bundle whenever the CA changes.
+    //
+    // The certificate is rotated out-of-band (e.g. by cert-manager). The
+    // serving certificate is signed by a stable root CA, so routine rotations
+    // reuse the same CA and the CA bundle registered into the CRD at startup
+    // keeps working. But if the CA itself rotates (e.g. on root CA renewal),
+    // that startup CA bundle would not trust the served certificate, and the
+    // Kubernetes API server would reject every conversion request. Refreshing
+    // the CA bundle when the CA changes keeps the webhook working across CA
+    // rotations.
+    {
+        let reload_interval = args.webhook_cert_reload_interval;
+        let client = client.clone();
         mz_ore::task::spawn(|| "webhook certificate reload", async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60 * 60));
+            let mut last_ca = tokio::fs::read(&tls_ca).await.ok();
+            let mut interval = tokio::time::interval(reload_interval);
+            // The first tick completes immediately; skip it so we don't
+            // re-register the CRDs we just registered above.
+            interval.tick().await;
             loop {
                 interval.tick().await;
                 if let Err(err) = reload_config.reload_from_pem_file(&tls_cert, &tls_key) {
                     tracing::error!("failed to reload webhook TLS certificate: {err}");
+                    continue;
+                }
+                let current_ca = match tokio::fs::read(&tls_ca).await {
+                    Ok(ca) => ca,
+                    Err(err) => {
+                        tracing::error!("failed to read webhook CA certificate: {err}");
+                        continue;
+                    }
+                };
+                if last_ca.as_deref() == Some(current_ca.as_slice()) {
+                    continue;
+                }
+                // The CA changed, meaning the certificate was rotated. Re-register
+                // the CRDs so the conversion webhook's caBundle matches the
+                // newly-served certificate.
+                match register_crds(
+                    client.clone(),
+                    additional_crd_columns.clone(),
+                    webhook_service_name.clone(),
+                    webhook_service_namespace.clone(),
+                    webhook_service_port,
+                    tls_ca.clone(),
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!(
+                            "refreshed conversion webhook CA bundle after certificate rotation"
+                        );
+                        last_ca = Some(current_ca);
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            "failed to refresh conversion webhook CA bundle after rotation: {err}"
+                        );
+                    }
                 }
             }
         });
     }
-
-    let (client, namespace) = create_client(args.kubernetes_context.clone()).await?;
-    register_crds(
-        client.clone(),
-        args.additional_crd_columns.unwrap_or_default(),
-        args.webhook_service_name,
-        args.webhook_service_namespace,
-        args.webhook_service_port,
-        args.tls_ca,
-    )
-    .await?;
 
     let crd_api: Api<CustomResourceDefinition> = Api::all(client.clone());
     let crds = crd_api.list(&ListParams::default()).await?;

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use axum_server::tls_openssl::OpenSSLConfig;
+use axum_server::tls_rustls::RustlsConfig;
 use http::HeaderValue;
 use k8s_openapi::{
     api::{
@@ -301,12 +301,23 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let tls_key = args.tls_key;
     let tls_ca = args.tls_ca;
     let reload_config = if args.install_v1_crd {
-        let config = OpenSSLConfig::from_pem_file(&tls_cert, &tls_key).unwrap();
+        // Pin the rustls crypto provider to aws-lc-rs. `RustlsConfig` builds its
+        // `ServerConfig` via `ServerConfig::builder()`, which resolves the
+        // process-default provider. Installing it explicitly keeps the choice
+        // deterministic even in workspace builds where rustls' `ring` feature is
+        // also enabled by another crate (with both features on, rustls cannot
+        // pick a default on its own and would otherwise panic).
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("installing the aws-lc-rs crypto provider should not fail");
+        let config = RustlsConfig::from_pem_file(&tls_cert, &tls_key)
+            .await
+            .unwrap();
         let reload_config = config.clone();
         let webhook_listen_address = args.webhook_listen_address;
 
         mz_ore::task::spawn(|| "webhook server", async move {
-            if let Err(e) = axum_server::bind_openssl(webhook_listen_address, config)
+            if let Err(e) = axum_server::bind_rustls(webhook_listen_address, config)
                 .serve(webhook::router().into_make_service())
                 .await
             {
@@ -363,7 +374,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             interval.tick().await;
             loop {
                 interval.tick().await;
-                if let Err(err) = reload_config.reload_from_pem_file(&tls_cert, &tls_key) {
+                if let Err(err) = reload_config
+                    .reload_from_pem_file(&tls_cert, &tls_key)
+                    .await
+                {
                     tracing::error!("failed to reload webhook TLS certificate: {err}");
                     continue;
                 }

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -42,7 +42,8 @@ use mz_cloud_resources::crd::{
     ManagedResource,
     balancer::v1alpha1::{Balancer, BalancerSpec},
     console::v1alpha1::{BalancerdRef, Console, ConsoleSpec, HttpConnectionScheme},
-    materialize::v1alpha1::{Materialize, MaterializeRolloutStrategy, MaterializeStatus},
+    materialize::MaterializeRolloutStrategy,
+    materialize::v1alpha1::{Materialize, MaterializeStatus},
 };
 use mz_license_keys::validate;
 use mz_orchestrator_kubernetes::KubernetesImagePullPolicy;
@@ -209,6 +210,7 @@ impl Context {
                 ),
                 resource_id: mz.status().resource_id,
                 resources_hash,
+                last_completed_rollout_hash: None,
                 conditions: vec![Condition {
                     type_: "UpToDate".into(),
                     status: "True".into(),
@@ -450,6 +452,7 @@ impl k8s_controller::Context for Context {
                                         .clone(),
                                     resource_id: status.resource_id.clone(),
                                     resources_hash: status.resources_hash.clone(),
+                                    last_completed_rollout_hash: None,
                                     conditions: vec![Condition {
                                         type_: "UpToDate".into(),
                                         status: "False".into(),
@@ -486,6 +489,7 @@ impl k8s_controller::Context for Context {
                                 last_completed_rollout_environmentd_image_ref.clone(),
                             resource_id: status.resource_id,
                             resources_hash: status.resources_hash,
+                            last_completed_rollout_hash: None,
                             conditions: vec![Condition {
                                 type_: "UpToDate".into(),
                                 status: "False".into(),
@@ -541,6 +545,7 @@ impl k8s_controller::Context for Context {
                                     .last_completed_rollout_environmentd_image_ref,
                                 resource_id: status.resource_id.clone(),
                                 resources_hash: String::new(),
+                                last_completed_rollout_hash: None,
                                 conditions: vec![Condition {
                                     type_: "UpToDate".into(),
                                     status: "Unknown".into(),
@@ -596,6 +601,7 @@ impl k8s_controller::Context for Context {
                                         .last_completed_rollout_environmentd_image_ref,
                                     resource_id: status.resource_id,
                                     resources_hash,
+                                    last_completed_rollout_hash: None,
                                     conditions: vec![Condition {
                                         type_: "UpToDate".into(),
                                         status: "Unknown".into(),
@@ -642,6 +648,7 @@ impl k8s_controller::Context for Context {
                                     .last_completed_rollout_environmentd_image_ref,
                                 resource_id: status.resource_id,
                                 resources_hash: resources_hash.clone(),
+                                last_completed_rollout_hash: None,
                                 conditions: vec![Condition {
                                     type_: "UpToDate".into(),
                                     status: "Unknown".into(),
@@ -682,6 +689,7 @@ impl k8s_controller::Context for Context {
                                     .last_completed_rollout_environmentd_image_ref,
                                 resource_id: status.resource_id,
                                 resources_hash: status.resources_hash,
+                                last_completed_rollout_hash: None,
                                 conditions: vec![Condition {
                                     type_: "UpToDate".into(),
                                     status: "False".into(),
@@ -721,6 +729,7 @@ impl k8s_controller::Context for Context {
                                 .last_completed_rollout_environmentd_image_ref,
                             resource_id: status.resource_id.clone(),
                             resources_hash: status.resources_hash,
+                            last_completed_rollout_hash: None,
                             conditions: vec![Condition {
                                 type_: "UpToDate".into(),
                                 status: "False".into(),
@@ -763,6 +772,7 @@ impl k8s_controller::Context for Context {
                                 .last_completed_rollout_environmentd_image_ref,
                             resource_id: status.resource_id.clone(),
                             resources_hash: status.resources_hash,
+                            last_completed_rollout_hash: None,
                             conditions: vec![Condition {
                                 type_: "UpToDate".into(),
                                 status: "True".into(),

--- a/src/orchestratord/src/k8s.rs
+++ b/src/orchestratord/src/k8s.rs
@@ -9,8 +9,13 @@
 
 use std::time::Duration;
 
-use apiextensions::v1::CustomResourceColumnDefinition;
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions;
+use k8s_openapi::{
+    ByteString,
+    apiextensions_apiserver::pkg::apis::apiextensions::v1::{
+        CustomResourceColumnDefinition, CustomResourceConversion, ServiceReference,
+        WebhookClientConfig, WebhookConversion,
+    },
+};
 use kube::{
     Api, Client, CustomResourceExt, Resource, ResourceExt,
     api::{DeleteParams, Patch, PatchParams, PostParams},
@@ -97,8 +102,13 @@ where
 pub async fn register_crds(
     client: Client,
     additional_crd_columns: Vec<CustomResourceColumnDefinition>,
+    webhook_service_name: String,
+    webhook_service_namespace: String,
+    webhook_service_port: u16,
+    ca_cert_path: String,
 ) -> Result<(), anyhow::Error> {
-    let mut mz_crd = crd::materialize::v1alpha1::Materialize::crd();
+    let ca_bytes = tokio::fs::read(ca_cert_path).await?;
+    let mut mz_crd = crd::materialize::v1alpha2::Materialize::crd();
     let default_columns = mz_crd.spec.versions[0]
         .additional_printer_columns
         .take()
@@ -109,26 +119,46 @@ pub async fn register_crds(
             .chain(default_columns)
             .collect(),
     );
+    let mz_conversion = CustomResourceConversion {
+        strategy: "Webhook".to_owned(),
+        webhook: Some(WebhookConversion {
+            client_config: Some(WebhookClientConfig {
+                ca_bundle: Some(ByteString(ca_bytes)),
+                service: Some(ServiceReference {
+                    name: webhook_service_name,
+                    namespace: webhook_service_namespace,
+                    path: Some("/convert".to_owned()),
+                    port: Some(webhook_service_port.into()),
+                }),
+                url: None,
+            }),
+            conversion_review_versions: vec!["v1".to_owned()],
+        }),
+    };
     tokio::time::timeout(
         Duration::from_secs(120),
         register_versioned_crds(
             client.clone(),
             vec![
                 VersionedCrd {
-                    crds: vec![mz_crd],
+                    crds: vec![mz_crd, crd::materialize::v1alpha1::Materialize::crd()],
                     stored_version: String::from("v1alpha1"),
+                    conversion: Some(mz_conversion),
                 },
                 VersionedCrd {
                     crds: vec![crd::balancer::v1alpha1::Balancer::crd()],
                     stored_version: String::from("v1alpha1"),
+                    conversion: None,
                 },
                 VersionedCrd {
                     crds: vec![crd::console::v1alpha1::Console::crd()],
                     stored_version: String::from("v1alpha1"),
+                    conversion: None,
                 },
                 VersionedCrd {
                     crds: vec![crd::vpc_endpoint::v1::VpcEndpoint::crd()],
                     stored_version: String::from("v1"),
+                    conversion: None,
                 },
             ],
             FIELD_MANAGER,

--- a/src/orchestratord/src/k8s.rs
+++ b/src/orchestratord/src/k8s.rs
@@ -108,7 +108,7 @@ pub async fn register_crds(
     ca_cert_path: String,
 ) -> Result<(), anyhow::Error> {
     let ca_bytes = tokio::fs::read(ca_cert_path).await?;
-    let mut mz_crd = crd::materialize::v1alpha2::Materialize::crd();
+    let mut mz_crd = crd::materialize::v1::Materialize::crd();
     let default_columns = mz_crd.spec.versions[0]
         .additional_printer_columns
         .take()

--- a/src/orchestratord/src/k8s.rs
+++ b/src/orchestratord/src/k8s.rs
@@ -99,51 +99,71 @@ where
     }
 }
 
+/// Configuration for the conversion webhook that serves the v1 version of the
+/// Materialize CRD. When present, the v1 version is registered alongside
+/// v1alpha1 with webhook conversion between them; when absent, only v1alpha1
+/// is registered.
+#[derive(Debug, Clone)]
+pub struct ConversionWebhookConfig {
+    pub service_name: String,
+    pub service_namespace: String,
+    pub service_port: u16,
+    pub ca_cert_path: String,
+}
+
 pub async fn register_crds(
     client: Client,
     additional_crd_columns: Vec<CustomResourceColumnDefinition>,
-    webhook_service_name: String,
-    webhook_service_namespace: String,
-    webhook_service_port: u16,
-    ca_cert_path: String,
+    conversion_webhook: Option<ConversionWebhookConfig>,
 ) -> Result<(), anyhow::Error> {
-    let ca_bytes = tokio::fs::read(ca_cert_path).await?;
-    let mut mz_crd = crd::materialize::v1::Materialize::crd();
-    let default_columns = mz_crd.spec.versions[0]
+    let (mut mz_crds, mz_conversion) = match conversion_webhook {
+        Some(config) => {
+            let ca_bytes = tokio::fs::read(config.ca_cert_path).await?;
+            let conversion = CustomResourceConversion {
+                strategy: "Webhook".to_owned(),
+                webhook: Some(WebhookConversion {
+                    client_config: Some(WebhookClientConfig {
+                        ca_bundle: Some(ByteString(ca_bytes)),
+                        service: Some(ServiceReference {
+                            name: config.service_name,
+                            namespace: config.service_namespace,
+                            path: Some("/convert".to_owned()),
+                            port: Some(config.service_port.into()),
+                        }),
+                        url: None,
+                    }),
+                    conversion_review_versions: vec!["v1".to_owned()],
+                }),
+            };
+            (
+                vec![
+                    crd::materialize::v1::Materialize::crd(),
+                    crd::materialize::v1alpha1::Materialize::crd(),
+                ],
+                Some(conversion),
+            )
+        }
+        None => (vec![crd::materialize::v1alpha1::Materialize::crd()], None),
+    };
+    let default_columns = mz_crds[0].spec.versions[0]
         .additional_printer_columns
         .take()
         .expect("should contain ImageRef and UpToDate columns");
-    mz_crd.spec.versions[0].additional_printer_columns = Some(
+    mz_crds[0].spec.versions[0].additional_printer_columns = Some(
         additional_crd_columns
             .into_iter()
             .chain(default_columns)
             .collect(),
     );
-    let mz_conversion = CustomResourceConversion {
-        strategy: "Webhook".to_owned(),
-        webhook: Some(WebhookConversion {
-            client_config: Some(WebhookClientConfig {
-                ca_bundle: Some(ByteString(ca_bytes)),
-                service: Some(ServiceReference {
-                    name: webhook_service_name,
-                    namespace: webhook_service_namespace,
-                    path: Some("/convert".to_owned()),
-                    port: Some(webhook_service_port.into()),
-                }),
-                url: None,
-            }),
-            conversion_review_versions: vec!["v1".to_owned()],
-        }),
-    };
     tokio::time::timeout(
         Duration::from_secs(120),
         register_versioned_crds(
             client.clone(),
             vec![
                 VersionedCrd {
-                    crds: vec![mz_crd, crd::materialize::v1alpha1::Materialize::crd()],
+                    crds: mz_crds,
                     stored_version: String::from("v1alpha1"),
-                    conversion: Some(mz_conversion),
+                    conversion: mz_conversion,
                 },
                 VersionedCrd {
                     crds: vec![crd::balancer::v1alpha1::Balancer::crd()],

--- a/src/orchestratord/src/lib.rs
+++ b/src/orchestratord/src/lib.rs
@@ -13,6 +13,7 @@ pub mod controller;
 pub mod k8s;
 pub mod metrics;
 pub mod tls;
+pub mod webhook;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/src/orchestratord/src/webhook.rs
+++ b/src/orchestratord/src/webhook.rs
@@ -1,0 +1,164 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::anyhow;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use http::StatusCode;
+use kube::core::Status;
+use kube::core::conversion::{ConversionRequest, ConversionResponse, ConversionReview};
+use kube::core::response::reason;
+
+use mz_cloud_resources::crd::materialize::{v1alpha1, v1alpha2};
+use tracing::{debug, warn};
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/convert", post(post_convert))
+        .route("/healthz", get(get_health))
+}
+
+#[derive(Clone, Copy)]
+enum SupportedVersion {
+    V1alpha1,
+    V1alpha2,
+}
+
+impl TryFrom<&str> for SupportedVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "materialize.cloud/v1alpha1" => Ok(SupportedVersion::V1alpha1),
+            "materialize.cloud/v1alpha2" => Ok(SupportedVersion::V1alpha2),
+            _ => Err(anyhow!("unexpected version: {}", value)),
+        }
+    }
+}
+
+fn version_label(v: SupportedVersion) -> &'static str {
+    match v {
+        SupportedVersion::V1alpha1 => "v1alpha1",
+        SupportedVersion::V1alpha2 => "v1alpha2",
+    }
+}
+
+fn convert(
+    desired_version: SupportedVersion,
+    value: serde_json::Value,
+) -> Result<serde_json::Value, anyhow::Error> {
+    let from_version = SupportedVersion::try_from(
+        value
+            .get("apiVersion")
+            .and_then(|version| version.as_str())
+            .ok_or_else(|| anyhow!("missing version"))?,
+    )?;
+    debug!(
+        from = version_label(from_version),
+        to = version_label(desired_version),
+        input_spec = ?value.get("spec"),
+        input_status = ?value.get("status"),
+        "conversion webhook called",
+    );
+    let result = match (from_version, desired_version) {
+        (SupportedVersion::V1alpha1, SupportedVersion::V1alpha1) => Ok(value),
+        (SupportedVersion::V1alpha1, SupportedVersion::V1alpha2) => serde_json::from_value::<
+            v1alpha1::Materialize,
+        >(value)
+        .and_then(|mz_v1alpha1| serde_json::to_value(v1alpha2::Materialize::from(mz_v1alpha1)))
+        .map_err(|e| e.into()),
+        (SupportedVersion::V1alpha2, SupportedVersion::V1alpha1) => serde_json::from_value::<
+            v1alpha2::Materialize,
+        >(value)
+        .and_then(|mz_v1alpha2| serde_json::to_value(v1alpha1::Materialize::from(mz_v1alpha2)))
+        .map_err(|e| e.into()),
+        (SupportedVersion::V1alpha2, SupportedVersion::V1alpha2) => Ok(value),
+    };
+    match &result {
+        Ok(converted) => {
+            debug!(
+                from = version_label(from_version),
+                to = version_label(desired_version),
+                output_spec = ?converted.get("spec"),
+                output_status = ?converted.get("status"),
+                "conversion webhook succeeded",
+            );
+        }
+        Err(e) => {
+            warn!(
+                from = version_label(from_version),
+                to = version_label(desired_version),
+                error = ?e,
+                "conversion webhook failed",
+            );
+        }
+    }
+    result
+}
+
+async fn post_convert(
+    Json(conversion_review): Json<ConversionReview>,
+) -> (StatusCode, Json<ConversionReview>) {
+    let Ok(request) = ConversionRequest::from_review(conversion_review) else {
+        warn!("missing request");
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(
+                ConversionResponse::invalid(Status::failure("missing request", reason::INVALID))
+                    .into_review(),
+            ),
+        );
+    };
+
+    let desired_version = match SupportedVersion::try_from(request.desired_api_version.as_str()) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    ConversionResponse::for_request(request)
+                        .failure(Status::failure(&e.to_string(), reason::BAD_REQUEST))
+                        .into_review(),
+                ),
+            );
+        }
+    };
+
+    let converted_objects: Result<Vec<serde_json::Value>, anyhow::Error> = request
+        .objects
+        .iter()
+        .cloned()
+        .map(|value| convert(desired_version, value))
+        .collect();
+    match converted_objects {
+        Ok(converted_objects) => (
+            StatusCode::OK,
+            Json(
+                ConversionResponse::for_request(request)
+                    .success(converted_objects)
+                    .into_review(),
+            ),
+        ),
+        Err(e) => {
+            warn!("error when converting: {:?}\n{:?}", &e, request.objects);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    ConversionResponse::for_request(request)
+                        .failure(Status::failure(&e.to_string(), reason::UNKNOWN))
+                        .into_review(),
+                ),
+            )
+        }
+    }
+}
+
+async fn get_health() -> StatusCode {
+    StatusCode::OK
+}

--- a/src/orchestratord/src/webhook.rs
+++ b/src/orchestratord/src/webhook.rs
@@ -15,7 +15,7 @@ use kube::core::Status;
 use kube::core::conversion::{ConversionRequest, ConversionResponse, ConversionReview};
 use kube::core::response::reason;
 
-use mz_cloud_resources::crd::materialize::{v1alpha1, v1alpha2};
+use mz_cloud_resources::crd::materialize::{v1, v1alpha1};
 use tracing::{debug, warn};
 
 pub fn router() -> Router {
@@ -27,7 +27,7 @@ pub fn router() -> Router {
 #[derive(Clone, Copy)]
 enum SupportedVersion {
     V1alpha1,
-    V1alpha2,
+    V1,
 }
 
 impl TryFrom<&str> for SupportedVersion {
@@ -36,7 +36,7 @@ impl TryFrom<&str> for SupportedVersion {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "materialize.cloud/v1alpha1" => Ok(SupportedVersion::V1alpha1),
-            "materialize.cloud/v1alpha2" => Ok(SupportedVersion::V1alpha2),
+            "materialize.cloud/v1" => Ok(SupportedVersion::V1),
             _ => Err(anyhow!("unexpected version: {}", value)),
         }
     }
@@ -45,7 +45,7 @@ impl TryFrom<&str> for SupportedVersion {
 fn version_label(v: SupportedVersion) -> &'static str {
     match v {
         SupportedVersion::V1alpha1 => "v1alpha1",
-        SupportedVersion::V1alpha2 => "v1alpha2",
+        SupportedVersion::V1 => "v1",
     }
 }
 
@@ -68,17 +68,17 @@ fn convert(
     );
     let result = match (from_version, desired_version) {
         (SupportedVersion::V1alpha1, SupportedVersion::V1alpha1) => Ok(value),
-        (SupportedVersion::V1alpha1, SupportedVersion::V1alpha2) => serde_json::from_value::<
-            v1alpha1::Materialize,
-        >(value)
-        .and_then(|mz_v1alpha1| serde_json::to_value(v1alpha2::Materialize::from(mz_v1alpha1)))
-        .map_err(|e| e.into()),
-        (SupportedVersion::V1alpha2, SupportedVersion::V1alpha1) => serde_json::from_value::<
-            v1alpha2::Materialize,
-        >(value)
-        .and_then(|mz_v1alpha2| serde_json::to_value(v1alpha1::Materialize::from(mz_v1alpha2)))
-        .map_err(|e| e.into()),
-        (SupportedVersion::V1alpha2, SupportedVersion::V1alpha2) => Ok(value),
+        (SupportedVersion::V1alpha1, SupportedVersion::V1) => {
+            serde_json::from_value::<v1alpha1::Materialize>(value)
+                .and_then(|mz_v1alpha1| serde_json::to_value(v1::Materialize::from(mz_v1alpha1)))
+                .map_err(|e| e.into())
+        }
+        (SupportedVersion::V1, SupportedVersion::V1alpha1) => {
+            serde_json::from_value::<v1::Materialize>(value)
+                .and_then(|mz_v1| serde_json::to_value(v1alpha1::Materialize::from(mz_v1)))
+                .map_err(|e| e.into())
+        }
+        (SupportedVersion::V1, SupportedVersion::V1) => Ok(value),
     };
     match &result {
         Ok(converted) => {

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -2641,6 +2641,230 @@ def workflow_v1alpha2_opt_in(
     print("v1alpha2 opt-in test PASSED")
 
 
+OPERATOR_CERT_SECRET = "operator-materialize-operator-cert"
+OPERATOR_CA_SECRET = "operator-materialize-operator-ca"
+MATERIALIZE_CRD = "materializes.materialize.cloud"
+
+
+def conversion_webhook_works() -> bool:
+    """Returns whether the conversion webhook is currently functional.
+
+    Reading the Materialize resource at v1alpha2 forces the Kubernetes API
+    server to call the conversion webhook to convert the stored v1alpha1
+    object. If the webhook's serving certificate isn't trusted by the
+    caBundle registered in the CRD, the API server rejects the call and this
+    returns False.
+    """
+    result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "materializes.v1alpha2.materialize.cloud",
+            "-n",
+            "materialize-environment",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"conversion webhook probe failed: {result.stderr.decode(errors='replace')}"
+        )
+        return False
+    items = json.loads(result.stdout).get("items", [])
+    return len(items) > 0
+
+
+def get_crd_ca_bundle() -> str:
+    """The caBundle the API server uses to trust the conversion webhook."""
+    return spawn.capture(
+        [
+            "kubectl",
+            "get",
+            "crd",
+            MATERIALIZE_CRD,
+            "-o",
+            "jsonpath={.spec.conversion.webhook.clientConfig.caBundle}",
+        ]
+    ).strip()
+
+
+def get_secret_field(secret: str, field: str) -> str:
+    """A base64-encoded field from a secret in the materialize namespace."""
+    return spawn.capture(
+        [
+            "kubectl",
+            "get",
+            "secret",
+            secret,
+            "-n",
+            "materialize",
+            "-o",
+            rf"jsonpath={{.data.{field}}}",
+        ]
+    ).strip()
+
+
+def get_serving_cert_ca() -> str:
+    """The ca.crt in the mounted serving-certificate secret (the root CA)."""
+    return get_secret_field(OPERATOR_CERT_SECRET, r"ca\.crt")
+
+
+def get_serving_cert_leaf() -> str:
+    """The tls.crt (leaf) in the mounted serving-certificate secret."""
+    return get_secret_field(OPERATOR_CERT_SECRET, r"tls\.crt")
+
+
+def workflow_webhook_cert_rotation(
+    c: Composition,
+    parser: WorkflowArgumentParser,
+) -> None:
+    """Test that the conversion webhook keeps working as its TLS certificate is
+    rotated, i.e. once the original certificate would have expired.
+
+    The webhook is served by orchestratord using a certificate that
+    cert-manager rotates out-of-band, and orchestratord reloads the serving
+    certificate from disk periodically. The serving certificate is signed by a
+    stable root CA, so there are two distinct rotation cases, both tested here
+    without restarting orchestratord:
+
+      1. Serving-certificate rotation (the common case): the leaf rotates but
+         the CA -- and therefore the caBundle registered on the CRD -- stays the
+         same. The webhook must keep working with no caBundle change.
+
+      2. Root CA rotation (rare): ca.crt changes, so orchestratord must
+         re-register the CRD's caBundle to match the newly-served certificate,
+         otherwise the API server would reject every conversion request.
+
+    Rather than wait out real certificate lifetimes, this test deploys with a
+    very short reload interval and forces cert-manager to reissue certificates
+    by deleting their secrets.
+    """
+    parser.add_argument(
+        "--recreate-cluster",
+        action=argparse.BooleanOptionalAction,
+        help="Recreate cluster if it exists already",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help="Custom version tag to use",
+    )
+    parser.add_argument(
+        "--orchestratord-override",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Override orchestratord tag",
+    )
+    args = parser.parse_args()
+
+    definition = setup(c, args)
+
+    # Use cert-manager (the default) so we exercise the real rotation path,
+    # and reload the certificate aggressively so a rotation is picked up in
+    # seconds rather than the default hour.
+    assert definition["operator"]["operator"]["certificate"]["source"] == "cert-manager"
+    definition["operator"]["operator"]["args"]["webhookCertReloadInterval"] = "5s"
+
+    # Deploy a v1alpha2 resource. The initial apply already goes through the
+    # conversion webhook (v1alpha2 -> stored v1alpha1), so this confirms the
+    # webhook works before any rotation.
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    init(definition)
+    apply_materialize(definition)
+
+    def webhook_works() -> None:
+        assert conversion_webhook_works(), "conversion webhook is not working"
+
+    retry(webhook_works, 120)
+    print("Conversion webhook works before rotation")
+
+    initial_ca_bundle = get_crd_ca_bundle()
+    assert initial_ca_bundle, "expected a caBundle to be registered on the CRD"
+
+    # --- Case 1: serving-certificate rotation, CA unchanged ------------------
+    #
+    # Deleting the serving-certificate secret makes cert-manager reissue the
+    # leaf (new key + new tls.crt) signed by the same stable root CA, so ca.crt
+    # is unchanged. The webhook must keep working and the caBundle must NOT
+    # change.
+    leaf_before = get_serving_cert_leaf()
+    ca_before = get_serving_cert_ca()
+    print("Rotating the serving certificate (deleting the serving cert secret)...")
+    spawn.runv(
+        ["kubectl", "delete", "secret", OPERATOR_CERT_SECRET, "-n", "materialize"]
+    )
+
+    def leaf_rotated() -> None:
+        leaf = get_serving_cert_leaf()
+        assert (
+            leaf and leaf != leaf_before
+        ), "cert-manager has not reissued the leaf yet"
+
+    retry(leaf_rotated, 120)
+    assert (
+        get_serving_cert_ca() == ca_before
+    ), "root CA changed during a serving-certificate rotation; expected it to be stable"
+    print("Serving certificate rotated; root CA is unchanged")
+
+    # Give orchestratord time to reload the new leaf (interval is 5s), then
+    # confirm the webhook still works and the caBundle was left untouched.
+    retry(webhook_works, 120)
+    assert (
+        get_crd_ca_bundle() == initial_ca_bundle
+    ), "caBundle changed even though the CA did not"
+    apply_materialize(definition)
+    print("Conversion webhook still works after serving-certificate rotation")
+
+    # --- Case 2: root CA rotation --------------------------------------------
+    #
+    # Rotate the root CA, then reissue the leaf so its ca.crt reflects the new
+    # CA. orchestratord must notice ca.crt changed and re-register the CRD's
+    # caBundle, otherwise the API server would reject conversions.
+    print("Rotating the root CA (deleting the CA secret)...")
+    spawn.runv(["kubectl", "delete", "secret", OPERATOR_CA_SECRET, "-n", "materialize"])
+
+    def ca_secret_rotated() -> None:
+        ca = get_secret_field(OPERATOR_CA_SECRET, r"tls\.crt")
+        assert ca, "cert-manager has not reissued the root CA yet"
+
+    retry(ca_secret_rotated, 120)
+
+    # Force the leaf to be re-signed by the new CA so the mounted ca.crt updates.
+    spawn.runv(
+        ["kubectl", "delete", "secret", OPERATOR_CERT_SECRET, "-n", "materialize"]
+    )
+
+    def serving_ca_changed() -> None:
+        assert (
+            get_serving_cert_ca() != ca_before
+        ), "serving cert's ca.crt has not picked up the new root CA yet"
+
+    retry(serving_ca_changed, 180)
+    print("Root CA rotated and serving certificate re-signed by the new CA")
+
+    # orchestratord must refresh the CRD's caBundle to match the new CA. Waiting
+    # for the caBundle to change proves the re-registration happened.
+    def ca_bundle_refreshed() -> None:
+        current = get_crd_ca_bundle()
+        assert (
+            current and current != initial_ca_bundle
+        ), "orchestratord has not refreshed the conversion webhook caBundle yet"
+
+    retry(ca_bundle_refreshed, 300)
+    print("orchestratord refreshed the conversion webhook caBundle after CA rotation")
+
+    # Decisive check: the old CA is gone, so the webhook can only work if the
+    # newly-served certificate is trusted via the refreshed caBundle. We never
+    # restarted orchestratord, so this exercises the in-process reload +
+    # re-registration path that runs in production.
+    retry(webhook_works, 120)
+    apply_materialize(definition)
+    print("Conversion webhook still works after root CA rotation")
+    print("webhook cert rotation test PASSED")
+
+
 def workflow_manually_promote(
     c: Composition,
     parser: WorkflowArgumentParser,

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1834,18 +1834,18 @@ class MaterializeCRDVersion(Modification):
     def values(cls, version: MzVersion) -> list[Any]:
         return [
             "materialize.cloud/v1alpha1",
-            "materialize.cloud/v1alpha2",
+            "materialize.cloud/v1",
         ]
 
     @classmethod
     def default(cls) -> Any:
-        return "materialize.cloud/v1alpha2"
+        return "materialize.cloud/v1"
 
     def modify(self, definition: dict[str, Any]) -> None:
-        if operator_supports_v1alpha2(definition):
+        if operator_supports_v1(definition):
             definition["materialize"]["apiVersion"] = self.value
         else:
-            # Older versions do not support v1alpha2
+            # Older versions do not support v1
             definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
 
     def validate(self, mods: dict[type[Modification], Any]) -> None:
@@ -2014,13 +2014,13 @@ class CertificateSource(Modification):
         retry(check, 120)
 
 
-def operator_supports_v1alpha2(definition: dict[str, Any]):
+def operator_supports_v1(definition: dict[str, Any]):
     operator_version = MzVersion.parse(
         definition["operator"]["operator"]["image"]["tag"]
     )
-    # v1alpha2 first ships in v26.29; no released self-managed operator serves
-    # the v1alpha2 CRD, so anything older must use v1alpha1. Keep this in sync
-    # with the release that actually introduces the v1alpha2 CRD.
+    # v1 first ships in v26.29; no released self-managed operator serves
+    # the v1 CRD, so anything older must use v1alpha1. Keep this in sync
+    # with the release that actually introduces the v1 CRD.
     return operator_version >= MzVersion.parse("v26.29.0-dev.0")
 
 
@@ -2521,14 +2521,14 @@ def get_materialize_status_at_stored_version() -> dict[str, Any] | None:
     return get_materialize_at_stored_version().get("status")
 
 
-def get_materialize_v1alpha2() -> dict[str, Any]:
-    """Get the first Materialize resource at v1alpha2."""
+def get_materialize_v1() -> dict[str, Any]:
+    """Get the first Materialize resource at v1."""
     data = json.loads(
         spawn.capture(
             [
                 "kubectl",
                 "get",
-                "materializes.v1alpha2.materialize.cloud",
+                "materializes.v1.materialize.cloud",
                 "-n",
                 "materialize-environment",
                 "-o",
@@ -2540,14 +2540,14 @@ def get_materialize_v1alpha2() -> dict[str, Any]:
     return data["items"][0]
 
 
-def workflow_v1alpha2_opt_in(
+def workflow_v1_opt_in(
     c: Composition,
     parser: WorkflowArgumentParser,
 ) -> None:
-    """Test that applying a v1alpha2 resource triggers reconciliation only
+    """Test that applying a v1 resource triggers reconciliation only
     when the spec has changed, and not when it is unchanged.
 
-    The conversion webhook computes a rollout hash from the v1alpha2 spec.
+    The conversion webhook computes a rollout hash from the v1 spec.
     When converting to v1alpha1 for storage, it derives a deterministic
     requestRollout UUID from the hash. When the spec is unchanged, the
     derived UUID matches lastCompletedRolloutRequest, so no rollout occurs.
@@ -2573,11 +2573,11 @@ def workflow_v1alpha2_opt_in(
 
     definition = setup(c, args)
 
-    # Step 1: Deploy with v1alpha2, complete initial rollout.
-    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    # Step 1: Deploy with v1, complete initial rollout.
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
     init(definition)
     run(definition, False)
-    print("Initial v1alpha2 deployment completed")
+    print("Initial v1 deployment completed")
 
     # Record the initial v1alpha1 status.
     mz_v1 = get_materialize_v1alpha1()
@@ -2590,10 +2590,10 @@ def workflow_v1alpha2_opt_in(
     ), f"Expected completed rollout: requestRollout={initial_request_rollout} != lastCompletedRolloutRequest={initial_last_completed_rollout_request}"
     print(f"Initial requestRollout: {initial_request_rollout}")
 
-    # Step 2: Re-apply the same spec at v1alpha2 (no changes).
+    # Step 2: Re-apply the same spec at v1 (no changes).
     # The conversion webhook should compute the same hash, deriving the
     # same requestRollout UUID, so no new rollout should occur.
-    print("Re-applying same spec at v1alpha2 (expecting no rollout)...")
+    print("Re-applying same spec at v1 (expecting no rollout)...")
     apply_materialize(definition)
 
     # Wait a bit and verify that no new rollout was triggered.
@@ -2607,14 +2607,14 @@ def workflow_v1alpha2_opt_in(
     assert (
         noop_last_completed_rollout_request == initial_last_completed_rollout_request
     ), f"Expected lastCompletedRolloutRequest unchanged, but changed from {initial_last_completed_rollout_request} to {noop_last_completed_rollout_request}"
-    print("Confirmed: no rollout triggered by v1alpha2 apply with no changes")
+    print("Confirmed: no rollout triggered by v1 apply with no changes")
 
-    # Step 3: Apply at v1alpha2 with a spec change (extra env var).
+    # Step 3: Apply at v1 with a spec change (extra env var).
     # The conversion webhook should compute a different hash, deriving a
     # different requestRollout UUID, triggering a rollout.
-    print("Applying v1alpha2 with changed environmentdExtraEnv (expecting rollout)...")
+    print("Applying v1 with changed environmentdExtraEnv (expecting rollout)...")
     definition["materialize"]["spec"]["environmentdExtraEnv"] = [
-        {"name": "V1ALPHA2_OPT_IN_TEST", "value": "true"},
+        {"name": "V1_OPT_IN_TEST", "value": "true"},
     ]
     run(definition, False)
 
@@ -2635,10 +2635,10 @@ def workflow_v1alpha2_opt_in(
 
     retry(check_rollout_complete, 120)
     print(
-        f"Confirmed: rollout triggered by v1alpha2 spec change. "
+        f"Confirmed: rollout triggered by v1 spec change. "
         f"requestRollout changed from {initial_request_rollout} to {changed_request_rollout}"
     )
-    print("v1alpha2 opt-in test PASSED")
+    print("v1 opt-in test PASSED")
 
 
 OPERATOR_CERT_SECRET = "operator-materialize-operator-cert"
@@ -2649,7 +2649,7 @@ MATERIALIZE_CRD = "materializes.materialize.cloud"
 def conversion_webhook_works() -> bool:
     """Returns whether the conversion webhook is currently functional.
 
-    Reading the Materialize resource at v1alpha2 forces the Kubernetes API
+    Reading the Materialize resource at v1 forces the Kubernetes API
     server to call the conversion webhook to convert the stored v1alpha1
     object. If the webhook's serving certificate isn't trusted by the
     caBundle registered in the CRD, the API server rejects the call and this
@@ -2659,7 +2659,7 @@ def conversion_webhook_works() -> bool:
         [
             "kubectl",
             "get",
-            "materializes.v1alpha2.materialize.cloud",
+            "materializes.v1.materialize.cloud",
             "-n",
             "materialize-environment",
             "-o",
@@ -2767,10 +2767,10 @@ def workflow_webhook_cert_rotation(
     assert definition["operator"]["operator"]["certificate"]["source"] == "cert-manager"
     definition["operator"]["operator"]["args"]["webhookCertReloadInterval"] = "5s"
 
-    # Deploy a v1alpha2 resource. The initial apply already goes through the
-    # conversion webhook (v1alpha2 -> stored v1alpha1), so this confirms the
+    # Deploy a v1 resource. The initial apply already goes through the
+    # conversion webhook (v1 -> stored v1alpha1), so this confirms the
     # webhook works before any rotation.
-    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
     init(definition)
     apply_materialize(definition)
 
@@ -2869,12 +2869,12 @@ def workflow_manually_promote(
     c: Composition,
     parser: WorkflowArgumentParser,
 ) -> None:
-    """Test ManuallyPromote rollout strategy with both v1alpha1 and v1alpha2
+    """Test ManuallyPromote rollout strategy with both v1alpha1 and v1
     force-promote mechanisms.
 
     Verifies that promotion can be triggered by setting forcePromote to either:
     - The v1alpha1 requestRollout UUID
-    - The v1alpha2 requestedRolloutHash
+    - The v1 requestedRolloutHash
     """
     parser.add_argument(
         "--recreate-cluster",
@@ -2896,8 +2896,8 @@ def workflow_manually_promote(
 
     definition = setup(c, args)
 
-    # Deploy with v1alpha2 and ManuallyPromote strategy.
-    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    # Deploy with v1 and ManuallyPromote strategy.
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
     definition["materialize"]["spec"]["rolloutStrategy"] = "ManuallyPromote"
     init(definition)
     run(definition, False)
@@ -2935,8 +2935,8 @@ def workflow_manually_promote(
     wait_for_rollout_complete()
     print("Test 1 PASSED: Promotion via v1alpha1 requestRollout succeeded")
 
-    # --- Test 2: Promote using v1alpha2 requestedRolloutHash ---
-    print("Test 2: Promote using v1alpha2 requestedRolloutHash")
+    # --- Test 2: Promote using v1 requestedRolloutHash ---
+    print("Test 2: Promote using v1 requestedRolloutHash")
 
     # Make another spec change to trigger a new rollout.
     definition["materialize"]["spec"]["environmentdExtraEnv"] = [
@@ -2946,18 +2946,18 @@ def workflow_manually_promote(
 
     wait_for_ready_to_promote()
 
-    # Read the v1alpha2 status to get the requestedRolloutHash.
-    mz_v2 = get_materialize_v1alpha2()
+    # Read the v1 status to get the requestedRolloutHash.
+    mz_v2 = get_materialize_v1()
     requested_rollout_hash = mz_v2["status"]["requestedRolloutHash"]
     mz_name = mz_v2["metadata"]["name"]
-    print(f"Promoting via v1alpha2 requestedRolloutHash: {requested_rollout_hash}")
+    print(f"Promoting via v1 requestedRolloutHash: {requested_rollout_hash}")
 
-    # Patch at v1alpha2 using the hash as forcePromote.
+    # Patch at v1 using the hash as forcePromote.
     spawn.runv(
         [
             "kubectl",
             "patch",
-            "materializes.v1alpha2.materialize.cloud",
+            "materializes.v1.materialize.cloud",
             mz_name,
             "-n",
             "materialize-environment",
@@ -2967,7 +2967,7 @@ def workflow_manually_promote(
         ],
     )
     wait_for_rollout_complete()
-    print("Test 2 PASSED: Promotion via v1alpha2 requestedRolloutHash succeeded")
+    print("Test 2 PASSED: Promotion via v1 requestedRolloutHash succeeded")
 
     print("workflow_manually_promote PASSED")
 
@@ -3145,8 +3145,8 @@ def workflow_orchestratord_upgrade(
     versions.append(get_version(args.tag))
 
     def set_latest_supported_crd_version(definition: dict[str, Any]):
-        if operator_supports_v1alpha2(definition):
-            definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+        if operator_supports_v1(definition):
+            definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
         else:
             definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
 
@@ -3276,7 +3276,7 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
         #
         # Use this only for the Balancer/Console CRs. The Materialize CR must
         # be read via `get_materialize_at_stored_version`, since a bare
-        # `materializes` resolves to the default-served v1alpha2 version, which
+        # `materializes` resolves to the default-served v1 version, which
         # lacks `requestRollout`/`lastCompletedRolloutRequest`.
         result: dict[str, Any] = {}
 
@@ -4035,7 +4035,7 @@ def run(definition: dict[str, Any], expect_fail: bool) -> None:
 
         # Manually promote it by reading the v1alpha1 resource to get the
         # requestRollout UUID, then patching forcePromote to match it.
-        # Alternatively, forcePromote can be set to the v1alpha2
+        # Alternatively, forcePromote can be set to the v1
         # requestedRolloutHash (tested in workflow_manually_promote).
         mz = get_materialize_v1alpha1()
         request_rollout = mz["spec"]["requestRollout"]

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -20,6 +20,7 @@ import random
 import shutil
 import signal
 import subprocess
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Iterator
@@ -1828,6 +1829,201 @@ class RolloutStrategy(Modification):
         return
 
 
+class MaterializeCRDVersion(Modification):
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return [
+            "materialize.cloud/v1alpha1",
+            "materialize.cloud/v1alpha2",
+        ]
+
+    @classmethod
+    def default(cls) -> Any:
+        return "materialize.cloud/v1alpha2"
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        if operator_supports_v1alpha2(definition):
+            definition["materialize"]["apiVersion"] = self.value
+        else:
+            # Older versions do not support v1alpha2
+            definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        # This should be OK without additional validation,
+        # as we check we deployed in post_run_check.
+        return
+
+
+class CertificateSource(Modification):
+    SECRET_NAME = "orchestratord-custom-cert"
+
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return ["cert-manager", "secret"]
+
+    @classmethod
+    def default(cls) -> Any:
+        return "cert-manager"
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        definition["operator"]["operator"]["certificate"]["source"] = self.value
+        if self.value == "secret":
+            definition["operator"]["operator"]["certificate"][
+                "secretName"
+            ] = self.SECRET_NAME
+            self._create_cert_secret()
+
+    @classmethod
+    def _create_cert_secret(cls) -> None:
+        dns_name = "operator-materialize-operator.materialize.svc"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ca_key = os.path.join(tmpdir, "ca.key")
+            ca_crt = os.path.join(tmpdir, "ca.crt")
+            tls_key = os.path.join(tmpdir, "tls.key")
+            tls_crt = os.path.join(tmpdir, "tls.crt")
+            csr_path = os.path.join(tmpdir, "server.csr")
+            ext_path = os.path.join(tmpdir, "ext.cnf")
+
+            # Generate CA key and self-signed cert
+            spawn.runv(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-keyout",
+                    ca_key,
+                    "-out",
+                    ca_crt,
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-subj",
+                    "/CN=Test CA",
+                ]
+            )
+
+            # Generate server key
+            spawn.runv(
+                [
+                    "openssl",
+                    "genpkey",
+                    "-algorithm",
+                    "rsa",
+                    "-pkeyopt",
+                    "rsa_keygen_bits:2048",
+                    "-out",
+                    tls_key,
+                ]
+            )
+
+            # Generate CSR
+            spawn.runv(
+                [
+                    "openssl",
+                    "req",
+                    "-new",
+                    "-key",
+                    tls_key,
+                    "-out",
+                    csr_path,
+                    "-subj",
+                    f"/CN={dns_name}",
+                ]
+            )
+
+            # Write extension file for SAN
+            with open(ext_path, "w") as f:
+                f.write(f"subjectAltName=DNS:{dns_name}\n")
+
+            # Sign CSR with CA
+            spawn.runv(
+                [
+                    "openssl",
+                    "x509",
+                    "-req",
+                    "-in",
+                    csr_path,
+                    "-CA",
+                    ca_crt,
+                    "-CAkey",
+                    ca_key,
+                    "-CAcreateserial",
+                    "-out",
+                    tls_crt,
+                    "-days",
+                    "1",
+                    "-extfile",
+                    ext_path,
+                ]
+            )
+
+            # Delete existing secret if present
+            try:
+                spawn.capture(
+                    [
+                        "kubectl",
+                        "delete",
+                        "secret",
+                        cls.SECRET_NAME,
+                        "-n",
+                        "materialize",
+                    ],
+                    stderr=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError:
+                pass
+
+            # Create the secret with ca.crt, tls.crt, and tls.key
+            spawn.runv(
+                [
+                    "kubectl",
+                    "create",
+                    "secret",
+                    "generic",
+                    cls.SECRET_NAME,
+                    f"--from-file=ca.crt={ca_crt}",
+                    f"--from-file=tls.crt={tls_crt}",
+                    f"--from-file=tls.key={tls_key}",
+                    "-n",
+                    "materialize",
+                ]
+            )
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        def check() -> None:
+            orchestratord = get_orchestratord_data()
+            volumes = orchestratord["items"][0]["spec"]["volumes"]
+            cert_volume = next(
+                (v for v in volumes if v.get("name") == "certificate"),
+                None,
+            )
+            assert cert_volume is not None, f"Expected certificate volume in {volumes}"
+
+            secret_name = cert_volume["secret"]["secretName"]
+            if self.value == "cert-manager":
+                expected = "operator-materialize-operator-cert"
+            else:
+                expected = self.SECRET_NAME
+            assert (
+                secret_name == expected
+            ), f"Expected certificate secret name '{expected}', got '{secret_name}'"
+
+        retry(check, 120)
+
+
+def operator_supports_v1alpha2(definition: dict[str, Any]):
+    operator_version = MzVersion.parse(
+        definition["operator"]["operator"]["image"]["tag"]
+    )
+    # v1alpha2 first ships in v26.29; no released self-managed operator serves
+    # the v1alpha2 CRD, so anything older must use v1alpha1. Keep this in sync
+    # with the release that actually introduces the v1alpha2 CRD.
+    return operator_version >= MzVersion.parse("v26.29.0-dev.0")
+
+
 class Properties(Enum):
     Defaults = "defaults"
     Individual = "individual"
@@ -1879,6 +2075,8 @@ def workflow_documentation_defaults(
             shutil.rmtree(dir)
         os.mkdir(dir)
         recreate_kind_cluster()
+
+        helm_install_cert_manager()
 
         shutil.copyfile(
             "misc/helm-charts/operator/values.yaml",
@@ -2245,7 +2443,8 @@ def workflow_upgrade_downtime(c: Composition, parser: WorkflowArgumentParser) ->
     thread.start()
     time.sleep(10)  # some time to make sure the thread runs fine
     request = str(uuid.uuid4())
-    definition["materialize"]["spec"]["requestRollout"] = request
+    if definition["materialize"]["apiVersion"] == "materialize.cloud/v1alpha1":
+        definition["materialize"]["spec"]["requestRollout"] = request
     definition["materialize"]["spec"]["forceRollout"] = request
     run(definition, False)
     time.sleep(120)  # some time to make sure there is no downtime later
@@ -2291,6 +2490,336 @@ def workflow_balancer(c: Composition, parser: WorkflowArgumentParser) -> None:
     definition = setup(c, args)
     init(definition)
     run_balancer(definition, False)
+
+
+def get_materialize_v1alpha1() -> dict[str, Any]:
+    """Get the first Materialize resource at v1alpha1."""
+    data = json.loads(
+        spawn.capture(
+            [
+                "kubectl",
+                "get",
+                "materializes.v1alpha1.materialize.cloud",
+                "-n",
+                "materialize-environment",
+                "-o",
+                "json",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+    )
+    return data["items"][0]
+
+
+def get_materialize_at_stored_version() -> dict[str, Any]:
+    """Get the first Materialize resource at the stored version (currently v1alpha1)."""
+    return get_materialize_v1alpha1()
+
+
+def get_materialize_status_at_stored_version() -> dict[str, Any] | None:
+    """Get the status of the first Materialize resource at the stored version."""
+    return get_materialize_at_stored_version().get("status")
+
+
+def get_materialize_v1alpha2() -> dict[str, Any]:
+    """Get the first Materialize resource at v1alpha2."""
+    data = json.loads(
+        spawn.capture(
+            [
+                "kubectl",
+                "get",
+                "materializes.v1alpha2.materialize.cloud",
+                "-n",
+                "materialize-environment",
+                "-o",
+                "json",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+    )
+    return data["items"][0]
+
+
+def workflow_v1alpha2_opt_in(
+    c: Composition,
+    parser: WorkflowArgumentParser,
+) -> None:
+    """Test that applying a v1alpha2 resource triggers reconciliation only
+    when the spec has changed, and not when it is unchanged.
+
+    The conversion webhook computes a rollout hash from the v1alpha2 spec.
+    When converting to v1alpha1 for storage, it derives a deterministic
+    requestRollout UUID from the hash. When the spec is unchanged, the
+    derived UUID matches lastCompletedRolloutRequest, so no rollout occurs.
+    When the spec changes, the derived UUID differs, triggering a rollout.
+    """
+    parser.add_argument(
+        "--recreate-cluster",
+        action=argparse.BooleanOptionalAction,
+        help="Recreate cluster if it exists already",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help="Custom version tag to use",
+    )
+    parser.add_argument(
+        "--orchestratord-override",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Override orchestratord tag",
+    )
+    args = parser.parse_args()
+
+    definition = setup(c, args)
+
+    # Step 1: Deploy with v1alpha2, complete initial rollout.
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    init(definition)
+    run(definition, False)
+    print("Initial v1alpha2 deployment completed")
+
+    # Record the initial v1alpha1 status.
+    mz_v1 = get_materialize_v1alpha1()
+    initial_request_rollout = mz_v1["spec"]["requestRollout"]
+    initial_last_completed_rollout_request = mz_v1["status"][
+        "lastCompletedRolloutRequest"
+    ]
+    assert (
+        initial_request_rollout == initial_last_completed_rollout_request
+    ), f"Expected completed rollout: requestRollout={initial_request_rollout} != lastCompletedRolloutRequest={initial_last_completed_rollout_request}"
+    print(f"Initial requestRollout: {initial_request_rollout}")
+
+    # Step 2: Re-apply the same spec at v1alpha2 (no changes).
+    # The conversion webhook should compute the same hash, deriving the
+    # same requestRollout UUID, so no new rollout should occur.
+    print("Re-applying same spec at v1alpha2 (expecting no rollout)...")
+    apply_materialize(definition)
+
+    # Wait a bit and verify that no new rollout was triggered.
+    time.sleep(30)
+    mz_v1 = get_materialize_v1alpha1()
+    noop_request_rollout = mz_v1["spec"]["requestRollout"]
+    assert (
+        noop_request_rollout == initial_request_rollout
+    ), f"Expected requestRollout unchanged, but changed from {initial_request_rollout} to {noop_request_rollout}"
+    noop_last_completed_rollout_request = mz_v1["status"]["lastCompletedRolloutRequest"]
+    assert (
+        noop_last_completed_rollout_request == initial_last_completed_rollout_request
+    ), f"Expected lastCompletedRolloutRequest unchanged, but changed from {initial_last_completed_rollout_request} to {noop_last_completed_rollout_request}"
+    print("Confirmed: no rollout triggered by v1alpha2 apply with no changes")
+
+    # Step 3: Apply at v1alpha2 with a spec change (extra env var).
+    # The conversion webhook should compute a different hash, deriving a
+    # different requestRollout UUID, triggering a rollout.
+    print("Applying v1alpha2 with changed environmentdExtraEnv (expecting rollout)...")
+    definition["materialize"]["spec"]["environmentdExtraEnv"] = [
+        {"name": "V1ALPHA2_OPT_IN_TEST", "value": "true"},
+    ]
+    run(definition, False)
+
+    mz_v1 = get_materialize_v1alpha1()
+    changed_request_rollout = mz_v1["spec"]["requestRollout"]
+    assert (
+        changed_request_rollout != initial_request_rollout
+    ), f"Expected requestRollout to change after spec change, but still {changed_request_rollout}"
+
+    def check_rollout_complete():
+        mz_v1 = get_materialize_v1alpha1()
+        changed_last_completed_rollout_request = mz_v1["status"][
+            "lastCompletedRolloutRequest"
+        ]
+        assert (
+            changed_last_completed_rollout_request == changed_request_rollout
+        ), f"Expected rollout to complete: requestRollout={changed_request_rollout} != lastCompletedRolloutRequest={changed_last_completed_rollout_request}"
+
+    retry(check_rollout_complete, 120)
+    print(
+        f"Confirmed: rollout triggered by v1alpha2 spec change. "
+        f"requestRollout changed from {initial_request_rollout} to {changed_request_rollout}"
+    )
+    print("v1alpha2 opt-in test PASSED")
+
+
+def workflow_manually_promote(
+    c: Composition,
+    parser: WorkflowArgumentParser,
+) -> None:
+    """Test ManuallyPromote rollout strategy with both v1alpha1 and v1alpha2
+    force-promote mechanisms.
+
+    Verifies that promotion can be triggered by setting forcePromote to either:
+    - The v1alpha1 requestRollout UUID
+    - The v1alpha2 requestedRolloutHash
+    """
+    parser.add_argument(
+        "--recreate-cluster",
+        action=argparse.BooleanOptionalAction,
+        help="Recreate cluster if it exists already",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help="Custom version tag to use",
+    )
+    parser.add_argument(
+        "--orchestratord-override",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Override orchestratord tag",
+    )
+    args = parser.parse_args()
+
+    definition = setup(c, args)
+
+    # Deploy with v1alpha2 and ManuallyPromote strategy.
+    definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+    definition["materialize"]["spec"]["rolloutStrategy"] = "ManuallyPromote"
+    init(definition)
+    run(definition, False)
+    print("Initial deployment with ManuallyPromote completed")
+
+    # --- Test 1: Promote using v1alpha1 requestRollout UUID ---
+    print("Test 1: Promote using v1alpha1 requestRollout UUID")
+
+    # Make a spec change to trigger a new rollout.
+    definition["materialize"]["spec"]["environmentdExtraEnv"] = [
+        {"name": "MANUALLY_PROMOTE_TEST_1", "value": "true"},
+    ]
+    apply_materialize(definition)
+
+    wait_for_ready_to_promote()
+
+    # Promote using v1alpha1 requestRollout.
+    mz_v1 = get_materialize_v1alpha1()
+    request_rollout = mz_v1["spec"]["requestRollout"]
+    mz_name = mz_v1["metadata"]["name"]
+    print(f"Promoting via v1alpha1 requestRollout: {request_rollout}")
+    spawn.runv(
+        [
+            "kubectl",
+            "patch",
+            "materializes.v1alpha1.materialize.cloud",
+            mz_name,
+            "-n",
+            "materialize-environment",
+            "--type=merge",
+            "-p",
+            json.dumps({"spec": {"forcePromote": request_rollout}}),
+        ],
+    )
+    wait_for_rollout_complete()
+    print("Test 1 PASSED: Promotion via v1alpha1 requestRollout succeeded")
+
+    # --- Test 2: Promote using v1alpha2 requestedRolloutHash ---
+    print("Test 2: Promote using v1alpha2 requestedRolloutHash")
+
+    # Make another spec change to trigger a new rollout.
+    definition["materialize"]["spec"]["environmentdExtraEnv"] = [
+        {"name": "MANUALLY_PROMOTE_TEST_2", "value": "true"},
+    ]
+    apply_materialize(definition)
+
+    wait_for_ready_to_promote()
+
+    # Read the v1alpha2 status to get the requestedRolloutHash.
+    mz_v2 = get_materialize_v1alpha2()
+    requested_rollout_hash = mz_v2["status"]["requestedRolloutHash"]
+    mz_name = mz_v2["metadata"]["name"]
+    print(f"Promoting via v1alpha2 requestedRolloutHash: {requested_rollout_hash}")
+
+    # Patch at v1alpha2 using the hash as forcePromote.
+    spawn.runv(
+        [
+            "kubectl",
+            "patch",
+            "materializes.v1alpha2.materialize.cloud",
+            mz_name,
+            "-n",
+            "materialize-environment",
+            "--type=merge",
+            "-p",
+            json.dumps({"spec": {"forcePromote": requested_rollout_hash}}),
+        ],
+    )
+    wait_for_rollout_complete()
+    print("Test 2 PASSED: Promotion via v1alpha2 requestedRolloutHash succeeded")
+
+    print("workflow_manually_promote PASSED")
+
+
+def apply_materialize(definition: dict[str, Any]) -> None:
+    """Apply the materialize resource definition via kubectl."""
+    defs = [
+        definition["namespace"],
+        definition["secret"],
+        definition["materialize"],
+    ]
+    if "materialize2" in definition:
+        defs.append(definition["materialize2"])
+    if "system_params_configmap" in definition:
+        defs.append(definition["system_params_configmap"])
+    yaml_str = yaml.dump_all(defs)
+    print(f"Attempting to apply:\n{yaml_str}")
+    max_attempts = 120
+    for attempt in range(max_attempts):
+        result = subprocess.run(
+            ["kubectl", "apply", "-f", "-"],
+            input=yaml_str.encode(),
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            break
+        stderr_str = result.stderr.decode(errors="replace")
+        if attempt < max_attempts - 1 and "connection refused" in stderr_str:
+            print(f"Webhook not yet reachable (attempt {attempt + 1}), retrying...")
+            time.sleep(2)
+            continue
+        print(f"Failed to apply: {result.stdout}\nSTDERR:{result.stderr}")
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            result.args,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def wait_for_ready_to_promote() -> None:
+    """Wait for the Materialize resource to reach ReadyToPromote status."""
+    for _ in range(900):
+        time.sleep(1)
+        if is_ready_to_manually_promote():
+            break
+    else:
+        print(yaml.dump(get_materialize_at_stored_version()))
+        raise RuntimeError("Never became ready for manual promotion")
+
+    # Verify it stays in ReadyToPromote (doesn't auto-promote).
+    time.sleep(30)
+    if not is_ready_to_manually_promote():
+        print(yaml.dump(get_materialize_at_stored_version()))
+        raise RuntimeError("Stopped being ready for manual promotion before promoting")
+
+
+def wait_for_rollout_complete() -> None:
+    """Wait for the rollout to complete (UpToDate condition becomes True)."""
+    for _ in range(900):
+        time.sleep(1)
+        try:
+            status = get_materialize_status_at_stored_version()
+            if not status:
+                continue
+            conditions = status.get("conditions", [])
+            if (
+                conditions
+                and conditions[0]["type"] == "UpToDate"
+                and conditions[0]["status"] == "True"
+            ):
+                return
+        except subprocess.CalledProcessError:
+            pass
+    print(yaml.dump(get_materialize_at_stored_version()))
+    raise RuntimeError("Rollout never completed")
 
 
 def workflow_orchestratord_upgrade(
@@ -2391,8 +2920,21 @@ def workflow_orchestratord_upgrade(
     versions = get_all_self_managed_versions()
     versions.append(get_version(args.tag))
 
+    def set_latest_supported_crd_version(definition: dict[str, Any]):
+        if operator_supports_v1alpha2(definition):
+            definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha2"
+        else:
+            definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
+
+    def request_rollout_if_needed(definition: dict[str, Any]):
+        if definition["materialize"]["apiVersion"] == "materialize.cloud/v1alpha1":
+            definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
+        else:
+            definition["materialize"]["spec"].pop("requestRollout", None)
+
     print(f"running orchestratord {versions[-3]}")
     definition["operator"]["operator"]["image"]["tag"] = str(versions[-3])
+    set_latest_supported_crd_version(definition)
     init(definition)
     check_orchestratord_version(versions[-3])
 
@@ -2410,6 +2952,7 @@ def workflow_orchestratord_upgrade(
         print(f"running orchestratord {version}")
         definition["operator"]["operator"]["image"]["tag"] = str(version)
         helm_install_operator(definition["operator"], upgrade=True)
+        wait_for_crd_established()
         check_orchestratord_version(version)
 
         print(f"running environmentd {version}")
@@ -2417,7 +2960,8 @@ def workflow_orchestratord_upgrade(
             c.compose["services"]["environmentd"]["image"],
             str(version),
         )
-        definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
+        set_latest_supported_crd_version(definition)
+        request_rollout_if_needed(definition)
         run(definition, False)
         check_environmentd_version(version)
         check_clusterd_version(version)
@@ -2425,10 +2969,22 @@ def workflow_orchestratord_upgrade(
         if str(version) != "v26.4.0":
             check_balancerd_version(version)
 
+    # We cannot roll back orchestratord versions once the CRD is updated,
+    # so let's just get a clean cluster and start over.
+    spawn.runv(
+        [
+            "kind",
+            "delete",
+            "cluster",
+            "--name",
+            "kind",
+        ]
+    )
     definition = setup(c, args)
 
     print(f"running orchestratord {versions[-3]}")
     definition["operator"]["operator"]["image"]["tag"] = str(versions[-3])
+    set_latest_supported_crd_version(definition)
     init(definition)
     check_orchestratord_version(versions[-3])
 
@@ -2452,7 +3008,8 @@ def workflow_orchestratord_upgrade(
         c.compose["services"]["environmentd"]["image"],
         str(versions[-1]),
     )
-    definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
+    set_latest_supported_crd_version(definition)
+    request_rollout_if_needed(definition)
     run(definition, False)
     check_environmentd_version(versions[-1])
     check_clusterd_version(versions[-1])
@@ -2492,6 +3049,11 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
         # orchestratord creates the Balancer and Console CRs after writing
         # `lastCompletedRolloutRequest`, so `post_run_check` can return
         # before they exist. Retry until the resource shows up.
+        #
+        # Use this only for the Balancer/Console CRs. The Materialize CR must
+        # be read via `get_materialize_at_stored_version`, since a bare
+        # `materializes` resolves to the default-served v1alpha2 version, which
+        # lacks `requestRollout`/`lastCompletedRolloutRequest`.
         result: dict[str, Any] = {}
 
         def fetch() -> None:
@@ -2538,7 +3100,7 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
     init(definition)
     run(definition, False)
 
-    initial_mz = get_cr("materializes")
+    initial_mz = get_materialize_at_stored_version()
     initial_request = initial_mz["spec"]["requestRollout"]
     assert initial_mz["status"]["lastCompletedRolloutRequest"] == initial_request
     assert (
@@ -2587,7 +3149,7 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
         )
         raise RuntimeError("upgrade never became ready for manual promotion")
 
-    parked_mz = get_cr("materializes")
+    parked_mz = get_materialize_at_stored_version()
     assert parked_mz["status"]["lastCompletedRolloutRequest"] == initial_request
     assert (
         parked_mz["status"]["lastCompletedRolloutEnvironmentdImageRef"] == initial_image
@@ -2616,7 +3178,7 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
     )
 
     def check_revert_applied() -> None:
-        mz = get_cr("materializes")
+        mz = get_materialize_at_stored_version()
         assert mz["spec"]["requestRollout"] == initial_request
         assert mz["spec"]["environmentdImageRef"] == upgrade_image
 
@@ -2625,7 +3187,7 @@ def workflow_revert_rollout(c: Composition, parser: WorkflowArgumentParser) -> N
     # Let orchestratord reconcile several times after the revert.
     time.sleep(30)
 
-    final_mz = get_cr("materializes")
+    final_mz = get_materialize_at_stored_version()
     assert final_mz["status"]["lastCompletedRolloutRequest"] == initial_request
     assert (
         final_mz["status"]["lastCompletedRolloutEnvironmentdImageRef"] == initial_image
@@ -2678,22 +3240,6 @@ def workflow_rollout_timeout(c: Composition, parser: WorkflowArgumentParser) -> 
     )
     args = parser.parse_args()
 
-    def get_mz() -> dict[str, Any]:
-        return json.loads(
-            spawn.capture(
-                [
-                    "kubectl",
-                    "get",
-                    "materializes",
-                    "-n",
-                    "materialize-environment",
-                    "-o",
-                    "json",
-                ],
-                stderr=subprocess.DEVNULL,
-            )
-        )["items"][0]
-
     definition = setup(c, args)
 
     # Initial deploy on a prior released version so the upgrade target (current
@@ -2717,11 +3263,9 @@ def workflow_rollout_timeout(c: Composition, parser: WorkflowArgumentParser) -> 
     init(definition)
     run(definition, False)
 
-    initial_mz = get_mz()
-    assert (
-        initial_mz["status"]["lastCompletedRolloutEnvironmentdImageRef"]
-        == initial_image
-    )
+    initial_status = get_materialize_status_at_stored_version()
+    assert initial_status is not None
+    assert initial_status["lastCompletedRolloutEnvironmentdImageRef"] == initial_image
 
     # Start a default (WaitUntilReady) upgrade with a tiny timeout. The new
     # generation cannot become ready within the timeout, so the rollout will be
@@ -2744,7 +3288,7 @@ def workflow_rollout_timeout(c: Composition, parser: WorkflowArgumentParser) -> 
 
     # Wait for orchestratord to observe the timeout and cancel the rollout.
     def check_cancelled() -> None:
-        status = get_mz().get("status") or {}
+        status = get_materialize_status_at_stored_version() or {}
         conditions = status.get("conditions") or []
         assert conditions, "no status conditions yet"
         condition = conditions[0]
@@ -2935,6 +3479,8 @@ def setup(c: Composition, args) -> dict[str, Any]:
     if cluster not in clusters or args.recreate_cluster:
         recreate_kind_cluster()
 
+        helm_install_cert_manager()
+
         spawn.runv(["kubectl", "create", "namespace", "materialize"])
 
         spawn.runv(
@@ -3067,7 +3613,8 @@ def run_scenario(
                 values=definition["operator"],
                 upgrade=True,
             )
-            definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
+            if definition["materialize"]["apiVersion"] == "materialize.cloud/v1alpha1":
+                definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
             run(definition, expect_fail)
         mod_dict = {mod.__class__: mod.value for mod in mods}
         for subclass in all_subclasses(Modification):
@@ -3169,6 +3716,24 @@ def helm_install_operator(
         )
 
 
+def helm_install_cert_manager():
+    spawn.runv(
+        [
+            "helm",
+            "install",
+            "cert-manager",
+            "oci://quay.io/jetstack/charts/cert-manager",
+            "--version",
+            "v1.19.2",
+            "--namespace",
+            "cert-manager",
+            "--create-namespace",
+            "--set",
+            "crds.enabled=true",
+        ]
+    )
+
+
 def init(definition: dict[str, Any]) -> None:
     # `--wait=true` blocks until the namespace is fully terminated. If the
     # timeout is hit and we proceed anyway, the next `kubectl apply` races the
@@ -3239,82 +3804,32 @@ def wait_for_crd_established():
 
 
 def run(definition: dict[str, Any], expect_fail: bool) -> None:
-    defs = [
-        definition["namespace"],
-        definition["secret"],
-        definition["materialize"],
-    ]
-    if "materialize2" in definition:
-        defs.append(definition["materialize2"])
-    if "system_params_configmap" in definition:
-        defs.append(definition["system_params_configmap"])
-    try:
-        spawn.runv(
-            ["kubectl", "apply", "-f", "-"],
-            stdin=yaml.dump_all(defs).encode(),
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to apply: {e.stdout}\nSTDERR:{e.stderr}")
-        raise
+    apply_materialize(definition)
 
     if definition["materialize"]["spec"].get("rolloutStrategy") == "ManuallyPromote":
-        # First wait for it to become ready to promote, but not yet promoted
-        for _ in range(900):
-            time.sleep(1)
-            if is_ready_to_manually_promote():
-                break
-        else:
-            spawn.runv(
-                [
-                    "kubectl",
-                    "get",
-                    "materializes",
-                    "-n",
-                    "materialize-environment",
-                    "-o",
-                    "yaml",
-                ],
-            )
-            raise RuntimeError("Never became ready for manual promotion")
+        wait_for_ready_to_promote()
 
-        # Wait to see that it doesn't promote
-        time.sleep(30)
-        if not is_ready_to_manually_promote():
-            spawn.runv(
-                [
-                    "kubectl",
-                    "get",
-                    "materializes",
-                    "-n",
-                    "materialize-environment",
-                    "-o",
-                    "yaml",
-                ],
-            )
-            raise RuntimeError(
-                "Stopped being ready for manual promotion before promoting"
-            )
-
-        # Manually promote it
-        mz = json.loads(
-            spawn.capture(
-                [
-                    "kubectl",
-                    "get",
-                    "materializes",
-                    "-n",
-                    "materialize-environment",
-                    "-o",
-                    "json",
-                ],
-                stderr=subprocess.DEVNULL,
-            )
-        )["items"][0]
-        definition["materialize"]["spec"]["forcePromote"] = mz["spec"]["requestRollout"]
+        # Manually promote it by reading the v1alpha1 resource to get the
+        # requestRollout UUID, then patching forcePromote to match it.
+        # Alternatively, forcePromote can be set to the v1alpha2
+        # requestedRolloutHash (tested in workflow_manually_promote).
+        mz = get_materialize_v1alpha1()
+        request_rollout = mz["spec"]["requestRollout"]
+        assert request_rollout is not None
+        mz_name = mz["metadata"]["name"]
         try:
             spawn.runv(
-                ["kubectl", "apply", "-f", "-"],
-                stdin=yaml.dump(definition["materialize"]).encode(),
+                [
+                    "kubectl",
+                    "patch",
+                    "materializes.v1alpha1.materialize.cloud",
+                    mz_name,
+                    "-n",
+                    "materialize-environment",
+                    "--type=merge",
+                    "-p",
+                    json.dumps({"spec": {"forcePromote": request_rollout}}),
+                ],
             )
         except subprocess.CalledProcessError as e:
             print(f"Failed to apply: {e.stdout}\nSTDERR:{e.stderr}")
@@ -3324,21 +3839,8 @@ def run(definition: dict[str, Any], expect_fail: bool) -> None:
 
 
 def is_ready_to_manually_promote():
-    data = json.loads(
-        spawn.capture(
-            [
-                "kubectl",
-                "get",
-                "materializes",
-                "-n",
-                "materialize-environment",
-                "-o",
-                "json",
-            ],
-            stderr=subprocess.DEVNULL,
-        )
-    )
-    conditions = data["items"][0].get("status", {}).get("conditions")
+    mz = get_materialize_at_stored_version()
+    conditions = mz.get("status", {}).get("conditions")
     return (
         conditions is not None
         and len(conditions)
@@ -3349,24 +3851,12 @@ def is_ready_to_manually_promote():
 
 
 def post_run_check(definition: dict[str, Any], expect_fail: bool) -> None:
+    # Read at the stored version explicitly to avoid going through the
+    # conversion webhook, which may not be ready yet during initial deployment.
     for i in range(900):
         time.sleep(1)
         try:
-            data = json.loads(
-                spawn.capture(
-                    [
-                        "kubectl",
-                        "get",
-                        "materializes",
-                        "-n",
-                        "materialize-environment",
-                        "-o",
-                        "json",
-                    ],
-                    stderr=subprocess.DEVNULL,
-                )
-            )
-            status = data["items"][0].get("status")
+            status = get_materialize_status_at_stored_version()
             if not status:
                 continue
             if expect_fail:
@@ -3377,10 +3867,10 @@ def post_run_check(definition: dict[str, Any], expect_fail: bool) -> None:
                 or status["conditions"][0]["status"] != "True"
             ):
                 continue
-            if (
-                status["lastCompletedRolloutRequest"]
-                == data["items"][0]["spec"]["requestRollout"]
+            if status.get("lastCompletedRolloutHash") or status.get(
+                "lastCompletedRolloutRequest"
             ):
+                # TODO should I check somehow that this is the latest to handle upgrades?
                 break
         except subprocess.CalledProcessError:
             pass
@@ -3389,7 +3879,7 @@ def post_run_check(definition: dict[str, Any], expect_fail: bool) -> None:
             [
                 "kubectl",
                 "get",
-                "materializes",
+                "materializes.v1alpha1.materialize.cloud",
                 "-n",
                 "materialize-environment",
                 "-o",

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1842,15 +1842,20 @@ class MaterializeCRDVersion(Modification):
         return "materialize.cloud/v1"
 
     def modify(self, definition: dict[str, Any]) -> None:
-        if operator_supports_v1(definition):
+        if self.value == "materialize.cloud/v1" and operator_supports_v1(definition):
+            # The operator only installs and serves the v1 CRD version when
+            # explicitly asked to.
+            enable_v1_crd(definition)
             definition["materialize"]["apiVersion"] = self.value
         else:
-            # Older versions do not support v1
+            # Older versions do not support v1, and without installV1CRD the
+            # operator does not serve it.
             definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
 
     def validate(self, mods: dict[type[Modification], Any]) -> None:
-        # This should be OK without additional validation,
-        # as we check we deployed in post_run_check.
+        # This should be OK without additional validation, as we check we
+        # deployed in post_run_check and check the installed CRD versions in
+        # check_crd_versions.
         return
 
 
@@ -1866,6 +1871,10 @@ class CertificateSource(Modification):
         return "cert-manager"
 
     def modify(self, definition: dict[str, Any]) -> None:
+        # The certificate is only used to serve the conversion webhook, which
+        # is only installed together with the v1 CRD.
+        if operator_supports_v1(definition):
+            enable_v1_crd(definition)
         definition["operator"]["operator"]["certificate"]["source"] = self.value
         if self.value == "secret":
             definition["operator"]["operator"]["certificate"][
@@ -1995,7 +2004,12 @@ class CertificateSource(Modification):
     def validate(self, mods: dict[type[Modification], Any]) -> None:
         def check() -> None:
             orchestratord = get_orchestratord_data()
-            volumes = orchestratord["items"][0]["spec"]["volumes"]
+            container = orchestratord["items"][0]["spec"]["containers"][0]
+            if "--install-v1-crd" not in container["args"]:
+                # The operator does not serve the conversion webhook (e.g. it
+                # is too old to know the flag), so no certificate is mounted.
+                return
+            volumes = orchestratord["items"][0]["spec"].get("volumes") or []
             cert_volume = next(
                 (v for v in volumes if v.get("name") == "certificate"),
                 None,
@@ -2022,6 +2036,24 @@ def operator_supports_v1(definition: dict[str, Any]):
     # the v1 CRD, so anything older must use v1alpha1. Keep this in sync
     # with the release that actually introduces the v1 CRD.
     return operator_version >= MzVersion.parse("v26.29.0-dev.0")
+
+
+def operator_serves_v1(definition: dict[str, Any]) -> bool:
+    """Whether the operator in this definition installs and serves the v1 CRD.
+
+    Even operators that support v1 only install it when the installV1CRD helm
+    value is set."""
+    return operator_supports_v1(definition) and bool(
+        definition["operator"]["operator"]["args"].get("installV1CRD")
+    )
+
+
+def enable_v1_crd(definition: dict[str, Any]) -> None:
+    """Make the operator install the v1 CRD and its conversion webhook."""
+    assert operator_supports_v1(
+        definition
+    ), "the operator version is too old to install the v1 CRD"
+    definition["operator"]["operator"]["args"]["installV1CRD"] = True
 
 
 class Properties(Enum):
@@ -2572,6 +2604,7 @@ def workflow_v1_opt_in(
     args = parser.parse_args()
 
     definition = setup(c, args)
+    enable_v1_crd(definition)
 
     # Step 1: Deploy with v1, complete initial rollout.
     definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
@@ -2760,6 +2793,7 @@ def workflow_webhook_cert_rotation(
     args = parser.parse_args()
 
     definition = setup(c, args)
+    enable_v1_crd(definition)
 
     # Use cert-manager (the default) so we exercise the real rotation path,
     # and reload the certificate aggressively so a rotation is picked up in
@@ -2895,6 +2929,7 @@ def workflow_manually_promote(
     args = parser.parse_args()
 
     definition = setup(c, args)
+    enable_v1_crd(definition)
 
     # Deploy with v1 and ManuallyPromote strategy.
     definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
@@ -3146,6 +3181,7 @@ def workflow_orchestratord_upgrade(
 
     def set_latest_supported_crd_version(definition: dict[str, Any]):
         if operator_supports_v1(definition):
+            enable_v1_crd(definition)
             definition["materialize"]["apiVersion"] = "materialize.cloud/v1"
         else:
             definition["materialize"]["apiVersion"] = "materialize.cloud/v1alpha1"
@@ -3175,8 +3211,13 @@ def workflow_orchestratord_upgrade(
     for version in versions[-2:]:
         print(f"running orchestratord {version}")
         definition["operator"]["operator"]["image"]["tag"] = str(version)
+        # Set before the helm upgrade so that operators which support the v1
+        # CRD are deployed with --install-v1-crd and can serve the v1
+        # apiVersion used below.
+        set_latest_supported_crd_version(definition)
         helm_install_operator(definition["operator"], upgrade=True)
         wait_for_crd_established()
+        check_crd_versions(definition)
         check_orchestratord_version(version)
 
         print(f"running environmentd {version}")
@@ -3224,7 +3265,13 @@ def workflow_orchestratord_upgrade(
 
     print(f"running orchestratord {versions[-1]}")
     definition["operator"]["operator"]["image"]["tag"] = str(versions[-1])
+    # Set before the helm upgrade so that operators which support the v1 CRD
+    # are deployed with --install-v1-crd and can serve the v1 apiVersion used
+    # below.
+    set_latest_supported_crd_version(definition)
     helm_install_operator(definition["operator"], upgrade=True)
+    wait_for_crd_established()
+    check_crd_versions(definition)
     check_orchestratord_version(versions[-1])
 
     print(f"running environmentd {versions[-1]}")
@@ -3837,6 +3884,11 @@ def run_scenario(
                 values=definition["operator"],
                 upgrade=True,
             )
+            # The set of served CRD versions may change between steps (e.g.
+            # when installV1CRD flips), so wait until the operator has
+            # re-registered the CRD before applying resources against it.
+            wait_for_crd_established()
+            check_crd_versions(definition)
             if definition["materialize"]["apiVersion"] == "materialize.cloud/v1alpha1":
                 definition["materialize"]["spec"]["requestRollout"] = str(uuid.uuid4())
             run(definition, expect_fail)
@@ -3988,6 +4040,42 @@ def init(definition: dict[str, Any]) -> None:
     )
 
     wait_for_crd_established()
+    check_crd_versions(definition)
+
+
+def check_crd_versions(definition: dict[str, Any]) -> None:
+    """Check that the v1 CRD version and the conversion webhook are installed
+    if and only if the operator was asked to install them."""
+
+    def check() -> None:
+        crd = json.loads(
+            spawn.capture(
+                ["kubectl", "get", "crd", MATERIALIZE_CRD, "-o", "json"],
+                stderr=subprocess.DEVNULL,
+            )
+        )
+        versions = sorted(version["name"] for version in crd["spec"]["versions"])
+        conversion_strategy = (crd["spec"].get("conversion") or {}).get("strategy")
+        if operator_serves_v1(definition):
+            assert versions == [
+                "v1",
+                "v1alpha1",
+            ], f"expected v1 and v1alpha1 to be served, got {versions}"
+            assert (
+                conversion_strategy == "Webhook"
+            ), f"expected Webhook conversion, got {conversion_strategy}"
+        else:
+            assert versions == [
+                "v1alpha1"
+            ], f"expected only v1alpha1 to be served, got {versions}"
+            # The API server defaults spec.conversion to {"strategy": "None"}
+            # (the string "None") when no conversion is configured.
+            assert conversion_strategy in (
+                None,
+                "None",
+            ), f"expected no conversion, got {conversion_strategy}"
+
+    retry(check, 240)
 
 
 def wait_for_crd_established():


### PR DESCRIPTION
Adds a new `v1` version of the Materialize CRD, and a conversion webhook in orchestratord to convert between `v1` and `v1alpha1`.

The `v1` CRD removes the `requestRollout` field in favor of calculating a hash over a subset of spec fields to determine when a rollout is needed.

`v1alpha1` remains the storage version, and orchestratord still reconciles `v1alpha1`, so this is backwards compatible with existing automation. When a `v1` CR is applied, the conversion webhook converts it to `v1alpha1`, injecting a `requestRollout` UUID derived deterministically (UUIDv5) from the spec hash: when the hash changes a rollout is triggered immediately (the intended `v1` behavior), and when it hasn't, the same UUID is produced and no unintended rollout occurs.

The whole thing is opt-in:

- The `v1` CRD and the conversion webhook are only installed when the `operator.args.installV1CRD` helm value is set (`--install-v1-crd`). Without it, only `v1alpha1` is registered, no webhook serving certificate or service is created, and cert-manager is not required.
- Even with `installV1CRD` set, existing `v1alpha1` CRs behave exactly as before; users switch individual instances by applying a `v1` CR.

The webhook serving certificate is issued from a long-lived root CA (via an intermediate cert-manager issuer), so routine serving-certificate rotations don't invalidate the CA bundle registered in the CRD. orchestratord periodically reloads the certificate from disk (`--webhook-cert-reload-interval`) and re-registers the CRDs with the new CA bundle if the CA itself ever changes.

Separate documentation PR is at https://github.com/MaterializeInc/materialize/pull/35508

Cloud companion PR is at https://github.com/MaterializeInc/cloud/pull/12275

### Motivation

Simplifying rollout behavior.
Part of https://linear.app/materializeinc/issue/DEP-7/design-simplifying-upgrade-rollouts-node-rolls-converted-to-project

### Verification

Added orchestratord nightly tests for the `v1` opt-in flow, webhook certificate rotation (including CA rotation and CRD re-registration), manual promotion, and CRD version checks asserting that `v1` and the conversion webhook are installed if and only if `installV1CRD` is set. Verified the existing `v1alpha1` tests still pass.

Deployed https://github.com/MaterializeInc/cloud/pull/12275 in a personal stack to validate that this works for SaaS at `v1alpha1`.
