### PR TITLE
Consolidation on read: fully consolidated persist source output

### DIFF
--- a/consolidation_on_read.md
+++ b/consolidation_on_read.md
@@ -1,0 +1,234 @@
+# Consolidation on read
+- Feature name: consolidation on read
+- Associated: <https://github.com/MaterializeInc/materialize/issues/16858>
+
+> **Status (updated 2026-03):** This design was originally written in 2023. Since then, several prerequisites have landed (all parts sorted at write time, per-part statistics, MFP pushdown, monotonic TopK / monotonic one-shot SELECTs in compute) but the core proposals — streaming merge in the source, sorted part assignment, parallel fetching, and full consolidation via fine-grained timestamps — remain unimplemented. The `Subtime` nested scope infrastructure exists in the source but is used only as a batch counter, not for keyspace-based frontier progression. See inline annotations for details.
+
+# Summary
+
+A Persist shard stores its data in sorted order, and sorted data can be efficiently consolidated using a streaming merge.
+
+This design proposes changes to the Persist source that take advantage of the sortedness of Persist data to:
+
+- Reduce the amount of unconsolidated outputs the Persist source produces, in a best-effort fashion;
+- Optionally allow clients to request having the data fully consolidated as it is read from durable storage, to allow further optimizations downstream.
+
+# Motivation
+
+## Background
+
+Persist’s data is organized into batches, ordered by frontier; each batch consists of multiple runs of data, in no particular order; a run consists of multiple parts, ordered by the key-value range they contain; each part contains multiple differential updates, sorted by the serialized key-value. Importantly, this guarantees that entire runs of data are sorted lexicographically by key-value-time.
+
+> **2026-03 update:** Parts are now always written in sorted order (`RunOrder::Structured` is hardcoded in `BatchBuilderConfig::new`), and the sort is by natural structured-data ordering rather than raw serialized bytes. Per-part statistics are also now collected, enabling MFP filter pushdown.
+
+The source will generally emit one batch of updates at a time… with the exception of the first snapshot, where a number of batches may all be emitted in one go, with the lower frontier advanced to the as-of. Otherwise, the snapshot is not generally handled specially by the source; like the individual batches, it’s just a set of runs.
+
+![A set of parts representing some initial snapshot.](static/cor-0.png)
+
+> 📋 A set of parts representing some initial snapshot. (The horizontal axis represents the ordered range of key-values, min to max; parts in the same row are parts of the same run.) A typical snapshot will have many parts that cover the entire key-value range, with perhaps a small number of longer runs from the oldest/largest batches of data.
+
+A single worker can efficiently and fully consolidate a set of runs using a streaming merge: iterate through each of the runs concurrently, pulling from whichever run has the smallest next key-value, and consolidating updates with equal key-value-time as you go.
+
+However — the Persist source runs concurrently across multiple workers and operators, so this simple approach is not available. Instead, we need some design that allows all workers to make progress in parallel.
+
+## Goals
+
+This design covers two related initiatives in the Persist source:
+
+- **Best-effort consolidation.** Any consolidation we can do in the source means fewer allocations and less data for downstream nodes to process; even if we’re not striving for perfect consolidation, it’s still worth expending some modest effort to make our distributed implementation reduce down the dataset more effectively.
+- **Guarantees around full consolidation, or snapshot monotonicity.** Certain downstream operations can be made more efficient when the data they process is monotonic. It’s already possible for downstream code to ensure this for ad-hoc queries by running the output of the Persist source through differential’s `consolidate` operator… but the source can take advantage of the sortedness of the data to make this consolidation more efficient.
+    - Even if this is cheaper than doing consolidation outside the source, it is unlikely to be cheaper than not guaranteeing consolidation at all — so it’s important that this capability have effectively no cost for users that haven’t opted in.
+
+While related, these two goals are separable — we could do the former without the latter — and they will generally be treated separately in the rest of the text.
+
+# Explanation
+
+## Best-effort consolidation
+
+The Persist source consists of three separate stages: assigning part descriptions to workers, fetching the parts, and decoding them and applying MFP. Notably, decoding *already* involves a `ConsolidateBuffer` to help consolidate down data within a single part. One way to think of the best-effort consolidation work is a set of changes to make that existing consolidation more effective, by improving the odds that consolidate-able updates end up in the same consolidation buffer.
+
+> **2026-03 update:** The decode operator now uses a `ConsolidatingContainerBuilder` for output, and within-part consolidation happens via `peek_stash` in `FetchedPart::next_with_storage`. A `ConsolidatingIter` (heap-based N-way merge across sorted runs) exists in `persist-client/src/iter.rs` and is used by compaction, but is **not** used in the source’s decode path. The three proposals below remain unimplemented in the source.
+
+1. Currently, the decode operator will process parts one after the other. Instead of draining an entire part before starting on the next, we can iterate through multiple parts in key-value order. (This is similar to the streaming merge mentioned above, but only operating on the parts that happen to be assigned to a single worker.)
+    - This makes it more likely that, if our worker is assigned the same key-value in distinct parts, those updates will be added to the same buffer and consolidate down.
+    - > **2026-03 status: not yet implemented.** `decode_and_mfp` still processes parts sequentially from a `VecDeque<PendingWork>`.
+2. Currently, we fetch a single part from our blob store before moving on to the next. Instead, we can fetch multiple parts from S3 in parallel.
+    - Aside from the possible concurrency benefit, this makes it more likely that the decode operator will have more than one part to iterate through at a time.
+    - > **2026-03 status: not yet implemented.** `shard_source_fetch` awaits one part at a time per worker. Parallelism comes only from multiple timely workers each having their own fetcher.
+3. Currently, parts are assigned in random order to workers. Ideally, we’d like to hand out parts such that downstream workers will be handling similar ranges of the key-value space at the same time, without impacting fairness.
+    - If we track statistics for each part — planned as part of work on MFP pushdown — we can sort parts by the minimum key-value they contain before assigning them out.
+    - Even without per-part statistics, various heuristics may help improve the odds that overlapping parts end up on the same worker at the same time. (In the diagram above, for example, the first part of the first run is likely to overlap with the first part of the second run… and will definitely not overlap with any other part of the first run.)
+    - > **2026-03 status: not yet implemented.** Assignment is still random (`Instant::now().hashed() % num_workers`). Per-part statistics *are* now collected (the prerequisite has landed), but they are not yet used for part assignment ordering.
+
+Note that none of these changes increase the amount of work done in the source, or change the semantics of the output; they simply rearrange when existing work is done. The primary effect is to reduce the number of updates passed along to downstreams… but they also make it easier to support users opting in to additional guarantees, as described below.
+
+## Full consolidation / snapshot monotonicity
+
+In the compute layer, certain operations can be made much more efficient if their input is monotonic. For example, the monotonic TopK implementation only needs to track the top **k** records, while the more general implementation may need to track state proportional to the input size. Similarly, an ad-hoc `SELECT ... LIMIT k` query can return the first **k** updates it sees to the user, if its input is monotonic… but if not, it also will need to store state proportional to the size of the snapshot.
+
+> **2026-03 update:** The compute layer now has monotonic TopK variants (`MonotonicTop1Plan`, `MonotonicTopKPlan`) and monotonic one-shot SELECTs (stabilized — see `doc/developer/design/20230421_stabilize_monotonic_select.md`). These use `must_consolidate` flags and `PhysicallyMonotonic` analysis (`RelaxMustConsolidate` transform) to conditionally apply consolidation. Today, compute uses an out-of-source `consolidate` operator to achieve logical monotonicity for single-time dataflows — the in-source smooth consolidation proposed below would make this cheaper but is not yet implemented.
+
+It has been observed that [one-off select statements would be monotonic if Persist output was consolidated](https://github.com/MaterializeInc/materialize/issues/17358). (We’ll refer to this property — where the initial snapshot of the data from the source is monotonic — as **snapshot monitonicity**.) One way to ensure snapshot monotonicity for a source is to slap a consolidate operator on the output. This may be worthwhile (if expensive) for TopK, but does not help for the select-limit case, where [buffering up the entire snapshot in the consolidate operator would defeat the point](https://github.com/MaterializeInc/materialize/issues/15962). (We’ll refer to operators that can emit output before the full snapshot is complete as **smooth**.)
+
+However, it is possible to take advantage of the data’s sortedness in the source to fully and smoothly consolidate the data in the shard, which can both be less memory-intensive than an out-of-source consolidate and decrease the “time-to-first-byte” of the output. This could optimizations like the above for users that specifically request it.
+
+### Fine-grained source timestamps
+
+> **2026-03 update:** The nested-scope infrastructure described below partially exists today. `decode_and_mfp` operates in a `Child<’g, G, (Timestamp, Subtime)>` scope, and `Subtime` is defined as an opaque `u64` in `persist_source.rs`. However, `Subtime` is currently used only as a batch counter — it does **not** encode progress through the keyspace. The prefix-timestamp idea (keyspace-based frontier advancement) is not implemented.
+
+Like most of Materialize, the Persist source is currently timestamped with the standard 64-bit system timestamp. The decoding operator in the source maintains a separate capability for each in-progress part, which allows it to emit data at any time within that part’s lower and upper bounds. From the perspective of a downstream operator, the effect is that the frontier will stay the same for long periods as we decode all the parts in a batch or snapshot, then leap forward to the next frontier.
+
+The core idea of this section is to allow decoding in a nested scope, with a timestamp that can be continually downgraded while processing a batch. This allows any downstream operator that can only make progress when the frontier makes progress — like consolidation! — to progress incrementally as a batch is being decoded, instead of buffering up the entire batch and then emitting it all at once.
+
+Specifically, when a user requests a monotonicity guarantee from the source, we can:
+
+- Open a nested scope, enriching our usual system timestamp with an inner timestamp that measures progress through the ordered key-value space within a batch.
+- As the decode operator progresses through a sorted part, periodically downgrade its capability to reflect its progress through that part.
+- Perform the consolidation in the nested scope. Any two updates in the shard with identical key-value-time will consolidate in this nested scope. However, the frontier will progress — and output would be emitted — much more frequently.
+- Leave the scope, returning our decoded updates to their usual system timestamps.
+
+This is not free: it will generally be more expensive than relying on best-effort consolidation. However, if the downstream dataflow can make use of the snapshot monotonicity guarantee to make other optimizations, enabling this option should be worthwhile.
+
+# Reference explanation
+
+We’ve [prototyped](https://github.com/bkirwi/materialize/tree/fine-arrangement) the fine-grained timestamping idea, since it’s the most technically fraught aspect of the proposal. When the text below refers to decisions made “in the prototype”, this is the relevant branch.
+
+> **2026-03 note:** This prototype branch is from 2023 and is likely very stale relative to the current codebase. The `Subtime` type and nested scope that exist today were likely informed by this prototype but diverge significantly from it.
+
+## Timestamp types
+
+Our design for fine-grained timestamps requires a timestamp type that captures progress through our totally ordered key-value space. Using the entire serialized key-value as a timestamp is possible but allocation-intensive. The prototype instead uses a 16-byte prefix of the serialized key of the data — small enough to keep on the stack, still reasonably fine-grained — but any monotonically non-decreasing function of the input data is fine. (For example, if we decide to break up rows into individual columns to enable MFP pushdown, we might choose to pack the first column or two into the timestamp.) In this doc, we’ll refer to this as the **prefix timestamp**, and our usual 64-bit Materialize timestamp as the **system timestamp**.
+
+> **2026-03 update:** MFP pushdown and columnar representation have both landed. The note about packing column data into the timestamp is now a concrete design option rather than speculation. The existing `Subtime(u64)` type would need to be replaced or extended to carry keyspace position information.
+
+The full timestamp in the nested scope is a pair of system time and prefix time. This **hybrid timestamp** is lexicographically ordered. Timely’s implementation for pairs is almost exactly what we need here, but it does not implement `Refines`; the prototype includes a reimplementation with a `Refines` implementation and some other small niceties.
+
+Decoding happens in our nested scope. When it receives a part as input, it also receives a hybrid-timestamp capability with the prefix timestamp at its minimum value. As we iterate through a sorted part, we timestamp each update using the prefix time of that update’s key-value pair, and periodically downgrade the prefix timestamp on our capability to reflect the largest prefix time we’ve seen for any update. (Since our prefix timestamp is monotonic in our sorted input data, we know any later data in the part will have a prefix timestamp at least that large!) Once all parts have downgraded their timestamp past a certain prefix time, our output frontier will advance. The frequency of downgrades is tunable; downgrading and yielding more frequently allows smoother progress, while downgrading less often will tend to lead to larger output batches.
+
+## Interaction with MFP
+
+Our decoding operator in the source is actually `decode_and_mfp`: our parts are decoded, passed through MFP, then the result is best-effort consolidated in a `ConsolidateBuffer` and forwarded on. This MFP is important for performance! Take, for example, a `SELECT count(*) from table` query: MFP will project every row into an empty row, and these will consolidate extremely well in our consolidation buffer. Queries like this are common both in our benchmark suite and in real life.
+
+By grouping similar rows together, the “best-effort consolidation” changes should only improve the effectiveness of this MFP step. Attempting full consolidation will interact with MFP in various ways, however:
+
+- Fine-grained timestamps can cause the best-effort consolidation buffer in `decode_and_mfp` to consolidate less, since updates that were previously made identical by MFP are now distinguishable by timestamp.
+    - Adding an additional `ConsolidateBuffer` at `leave` time mitigates this issue, though we still end up exchanging more data within the source.
+- If mapping or projection is applied, the output from the source may not be fully consolidated. (Put another way: the source behaves as though the raw data was fully consolidated *before* being passed to MFP.)
+    - We only have the opportunity to optimize consolidation in the source because our part data is sorted, but the output of MFP is not necessarily sorted. We believe there is no approach that both provides fully consolidated data post-MFP and is any more efficient than doing a consolidate outside the source.
+    - MFP does not affect our “snapshot monotonicity” property. When full consolidation is requested, the output will be snapshot monotonic regardless of the complexity of the MFP.
+- If the MFP filters out a row, nothing will be emitted from `decode_and_mfp` or go through consolidation, which is ideal. (And none of the optimizations in this doc affect our ability to do things like filter pushdown.)
+
+These tradeoffs generally seem worth it for dataflows that benefit from our smoothness property, or dataflows that do not aggressively transform data during MFP. Dataflows with very aggressive MFPs that don’t benefit from smoothness (like our `count(*)` query) may prefer to consolidate outside the source.
+
+## Unsorted parts
+
+> **2026-03 update: This section is no longer relevant.** All parts are now sorted at write time. `RunOrder::Structured` is hardcoded in `BatchBuilderConfig::new` (`persist-client/src/batch.rs`), and `ConsolidatingIter` panics if it encounters out-of-order data. The concern about unsorted user-provided data has been fully resolved.
+
+~~The above text has generally assumed parts are sorted, but this is not always true… in particular, user-provided data is currently not sorted before it’s written out to S3. The output of compaction is always sorted, though, and for large shards most of the stored data will have been through at least one round of compaction. It’s possible to recognize these two categories of parts from the part metadata.~~
+
+~~One approach to dealing with unsorted parts is to sort them before processing. Another approach — taken in the prototype — is to never downgrade the frontier for those parts, but prioritize emitting them over sorted parts so they don’t unnecessarily hold back the overall frontier. And finally: we’re exploring [sorting every part at write time](https://github.com/MaterializeInc/materialize/pull/17116), which would obviate this concern entirely.~~
+
+# Rollout
+
+The best-effort consolidation work consists of small interventions that can be made incrementally and do not overlap with any other team’s code. These are well covered by existing tests, including nightlies, and can be rolled out in the same way as any ordinary improvement to Persist’s code.
+
+The full consolidation effort should have no impact on downstream code when the option is disabled. Our existing correctness and performance tests should help ensure this is the case.
+
+The most fraught aspect of the rollout is expected to be the first *usage* of the new full-consolidation option, since that is unlikely to be covered well by existing tests and touches a net-new codepath.
+
+## Testing and observability
+
+As noted elsewhere, existing tests do a good job of spotting regressions in correctness or performance for existing Persist functionality, since virtually every Materialize query relies on Persist. However, these tests will not cover the new full-consolidation option, since it’s disabled by default.
+
+- We should run the existing test suite, including nightlies, with full consolidation enabled. Performance-sensitive tests might fail, but we can verify that it does not impact correctness.
+- For any new feature that *does* enable the full-consolidation option, we can test that the output of the query is the same as if it did not, and add a feature benchmark to lock in any improved performance.
+
+Metrics we should either add or watch more closely for this work:
+
+- The count of updates emitted from the source. These numbers should go down as best-effort consolidation improves.
+- Time-to-first-byte: the interval between when the dataflow is created and when the first update is emitted from the source. This allows us to verify that we’re smoothly emitting data on real-world queries.
+
+## Lifecycle
+
+Any uses of the new full-consolidation flag will need targeted tests that cover both performance and correctness. We should work with any future users of the feature to determine an appropriate lifecycle for that particular feature, ensuring that our coverage is good and that we’re seeing the improvements we’d expect.
+
+# Drawbacks
+
+The best-effort consolidation work is purely an optimization, with no drawbacks outside of possible complication to the code. We may decide to skip or postpone this work if we have higher-priority things to address in the source than efficiency or performance.
+
+Full consolidation provides a new option to downstream users. It is only worth providing a new option if it will actually be used, and if it provides a capability that can *only* be performed within the source. We should convince ourselves that the compute layer is likely to take advantage of any knob we provide before doing the work of adding it.
+
+# Conclusion and alternatives
+
+## Alternatives to timestamp-based full consolidation
+
+### Duplicate fetching
+
+Looking back at the diagram above, you can imagine slicing up the keyspace into roughly evenly-sized chunks, one per worker.
+
+![Untitled](static/cor-1.png)
+
+Each worker could then download every part that overlapped with its assigned section of the key-value range, filter out any extra updates that don’t belong in its section of the range, and consolidate down and emit the remaining data.
+
+- This involves quite a lot more part fetching from S3. Fetching parts is the second most expensive part of our S3 usage in Persist, comprising about a third of the cost… and most large shards have dozens of parts that span the full key-value range and would need to be downloaded on every worker. (And if there are too many runs to hold in memory at once, we may even need to refetch the same part multiple times.)
+  - ~~If we gain the ability to push down filters, the read amplification is reduced... but we'd still need the GETs.~~ **2026-03 update:** Filter pushdown is now implemented, so the read amplification would indeed be reduced — but the GET cost remains.
+- This has similar smoothness benefit to the timestamp-based option, without the complexity of actually needing a novel timestamp.
+- Each worker needs to download at least one part from every run before emitting any data. The timestamp-based design can start emitting data as soon as it arrives, leading to possibly-smoother progress.
+- This option requires us to track statistics with the min and max key-value for each part. Without stats, we’ll need to pessimistically assume that the part covers the full range. (The timestamp design works fine with or without stats, and the prototype does not include them.) **2026-03 update:** Per-part statistics are now collected, so this prerequisite is met.
+
+While we believe this is technically viable, it seems more expensive in cost and complexity than the proposed design.
+
+## Write-time bucketing
+
+One issue with the above “duplicate fetching” approach is that our runs don’t split up nicely between workers: there’s just no way to assign parts to workers such that parts with identical key-values will always land on the same worker.
+
+A common approach to this sort of problem is to divide our data into **n** buckets. At write time, we could assign each unique key-value to a particular bucket. (Probably by taking the hash of the key-value modulo **n**.) In the source, we could allocate each bucket to a particular worker. Since each key-value is in at most one bucket, consolidating locally in each worker means that the overall dataset is consolidated as well. Compaction and other operations on the shard would also need to be reworked to proceed bucketwise.
+
+![Untitled](static/cor-2.png)
+
+- This avoids the costs associated with fetching the same part multiple times. It also adds new costs: runs that previously consisted of single part are now split into $n$ parts, one per bucket; and each of those $n$ parts will need to be fetched in the source.
+    - The write amplification might be addressed by grouping multiple buckets into a single part file. The read amplification seems inherent to the design.
+- It’s hard to choose a bucket count that behaves reasonably from `2xsmall` to `6xlarge`; a single shard may be read across replicas with a wide variety of worker counts; those worker counts change over time; the shard itself may grow and shrink. Even a dynamic bucket count struggles to balance this diversity of needs.
+- The bucketing interferes with filter pushdown on a prefix of the row. If you’re filtering down to a reasonably narrow range — but not all the way to a point lookup — Persist’s current design lets you filter to one part per run. With the bucketing approach, you’ll need to fetch one part per run **in every bucket.** For realistic bucket counts and shard sizes, this eliminates most or all of the benefits of pushing down the filter.
+
+Since this interferes with filter pushdown — our best and most exciting optimization opportunity — and significantly constrains how Persist’s data is written, this is not our favourite option.
+
+> **2026-03 update:** Filter pushdown is now live and delivering real value, further confirming that this alternative would have been costly.
+
+### Fast paths
+
+If a snapshot or batch consists of a single run, and the parts in that run have been compacted, the contents of that snapshot or batch are already fully consolidated and can be forwarded along without additional work.
+
+If we don’t care about full consolidation, but we *do* care about snapshot monotonicity, we could add an additional part statistic that tracks whether a run contains retractions or not. If none of the runs in the snapshot or batch contain retractions, it’s certainly monotonic.
+
+- It’s rare that a snapshot will consist of a single run. Append-only sources and similar collections are expected to be retraction-free, though we expect most collections to see occasional retractions.
+- If a user requests a consolidated or snapshot-monotonic source, and these fast paths don’t apply, we’d need a fallback approach.
+
+These fast paths seems like a good complement to one of the more general approaches to consolidation or snapshot monotonicity discussed above.
+
+# Unresolved questions
+
+**Will compute be able to take advantage of the proposed full-consolidation option to optimize downstream dataflows?** In previous discussions, it’s been unclear whether the current optimizer has enough context to determine when enabling consolidation in the source would be a net benefit, or whether the types of queries that benefit from consolidation in the source are an overall priority. We should make sure this knob will be used before adding it in!
+
+> **2026-03 update: Partially resolved.** Compute now has monotonic TopK variants (`MonotonicTop1Plan`, `MonotonicTopKPlan`), monotonic one-shot SELECTs (stabilized), and a `PhysicallyMonotonic` analysis with `must_consolidate` flags and `RelaxMustConsolidate` transforms. Today these use an out-of-source `consolidate` operator when physical monotonicity cannot be guaranteed. The in-source smooth consolidation proposed here would benefit these codepaths, particularly for `SELECT ... LIMIT k` where buffering the full snapshot defeats the purpose.
+
+**Can we safely rely on Persist’s ordering of data in consolidation?** The only reason we can hope to fully consolidate more efficiently in the source than elsewhere is because Persist stores its data in sorted order, but that means that we’re very reliant on the exact details of how Persist orders data. Today, Persist sorts data by its serialized representation… so if two different rows are identical in memory but serialize to different bytes, they may not be sorted similarly and thus might not consolidate out.
+
+For any approach to consolidation on read to work, we’ll need to ensure Persist’s sorting puts equal data together. Today, that means ensuring that when rows are equal, their serializations are too. In a columnized MFP future, we’d need to take similar care with our columnar representation.
+
+> **2026-03 update: Largely resolved.** Persist now uses `RunOrder::Structured` — ordering by the natural structured-data representation rather than raw serialized bytes. The columnar representation is also now in use. `ConsolidatingIter` panics on out-of-order data, which serves as an ongoing correctness check. The concern about serialization divergence is addressed by the move away from codec-byte ordering.
+
+**Are there other users that could benefit from a finer-grained timestamp on source data?** This design has a relatively unusual approach to “smooth rehydration” — is this approach useful outside the source?
+
+For example, Kafka sinks are currently forced to write the entire snapshot in a single transaction… which can be flaky for large snapshots. Could they take advantage of finer-grained timestamps to write smaller, more incremental transactions?
+
+# Future work
+
+Depends largely on the answers to the unresolved questions above.
+
+> **2026-03 update:** The remaining work, roughly in order of expected impact:
+>
+> 1. **Sorted part assignment to workers** — Per-part statistics are already collected; using them to sort parts by key range before distributing to workers is likely the lowest-hanging fruit for improving best-effort consolidation.
+> 2. **Streaming merge across parts in decode** — `ConsolidatingIter` already implements the N-way heap merge for compaction; adapting this pattern for the source’s decode path would enable cross-part consolidation within a worker.
+> 3. **Parallel intra-worker part fetching** — Fetching multiple parts concurrently within a single worker would both improve throughput and provide the decode operator with more parts to merge simultaneously.
+> 4. **Full consolidation via fine-grained timestamps** — The `Subtime` nested scope infrastructure is in place. Repurposing `Subtime` to carry keyspace position (rather than a batch counter) and implementing frontier downgrade based on decode progress would enable smooth, fully-consolidated output. This is the most complex remaining piece but also the most impactful for `SELECT ... LIMIT k` and monotonic TopK.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -296,6 +296,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         compute_state.dataflow_max_inflight_bytes(),
                         start_signal.clone(),
                         ErrorHandler::Halt("compute_import"),
+                        persist_source::SourceConsolidation::BestEffort,
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -412,6 +412,7 @@ where
         compute_state.dataflow_max_inflight_bytes(),
         start_signal,
         ErrorHandler::Halt("compute persist sink"),
+        mz_storage_operators::persist_source::SourceConsolidation::BestEffort,
     );
 
     let streams = OkErr::new(ok_stream, err_stream);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -800,11 +800,17 @@ pub struct FetchedPart<K: Codec, V: Codec, T, D> {
             <V::Schema as Schema<V>>::Decoder,
         ),
     >,
+    /// The structured key ordering, if available. Used by the source's
+    /// streaming merge to compare rows in the same order that parts are
+    /// sorted by (`RunOrder::Structured`).
+    structured_key_ord: Option<ArrayOrd>,
     timestamps: Int64Array,
     diffs: Int64Array,
     migration: PartMigration<K, V>,
     filter_pushdown_audit: Option<LazyPartStats>,
-    peek_stash: Option<((K, V), T, D)>,
+    /// Stashed next row from within-part consolidation. The `usize` is the
+    /// raw columnar index, used for `ArrayOrd` comparison in the merge.
+    peek_stash: Option<(usize, (K, V), T, D)>,
     part_cursor: usize,
     key_storage: Option<K::Storage>,
     val_storage: Option<V::Storage>,
@@ -893,6 +899,11 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
                 }
             };
 
+            // Build an ArrayOrd from the structured key before creating decoders.
+            // This is used by the streaming merge in the source to compare rows
+            // in the same order that parts are sorted by (RunOrder::Structured).
+            let structured_key_ord = ArrayOrd::new(&*structured.key);
+
             let read_schema = migration.codec_read();
             let key = K::Schema::decoder_any(&*read_schema.key, &*structured.key);
             let val = V::Schema::decoder_any(&*read_schema.val, &*structured.val);
@@ -911,34 +922,36 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
                 }
             }
 
-            Some((key.ok()?, val.ok()?))
+            Some((key.ok()?, val.ok()?, structured_key_ord))
         };
 
         let updates = part.normalize(&metrics.columnar);
         let timestamps = updates.timestamps().clone();
         let diffs = updates.diffs().clone();
-        let part = match updates {
+        let (part, structured_key_ord) = match updates {
             // If only one encoding is available, decode via that encoding.
-            BlobTraceUpdates::Row(records) => EitherOrBoth::Left(records),
-            BlobTraceUpdates::Structured { key_values, .. } => EitherOrBoth::Right(
+            BlobTraceUpdates::Row(records) => (EitherOrBoth::Left(records), None),
+            BlobTraceUpdates::Structured { key_values, .. } => {
                 // The structured-only data format was added after schema ids were recorded everywhere,
                 // so we expect this data to be present.
-                downcast_structured(key_values, true).expect("valid schemas for structured data"),
-            ),
+                let (k, v, ord) =
+                    downcast_structured(key_values, true).expect("valid schemas for structured data");
+                (EitherOrBoth::Right((k, v)), Some(ord))
+            }
             // If both are available, respect the specified part decode format.
             BlobTraceUpdates::Both(records, ext) => match part_decode_format {
                 PartDecodeFormat::Row {
                     validate_structured: false,
-                } => EitherOrBoth::Left(records),
+                } => (EitherOrBoth::Left(records), None),
                 PartDecodeFormat::Row {
                     validate_structured: true,
                 } => match downcast_structured(ext, false) {
-                    Some(decoders) => EitherOrBoth::Both(records, decoders),
-                    None => EitherOrBoth::Left(records),
+                    Some((k, v, ord)) => (EitherOrBoth::Both(records, (k, v)), Some(ord)),
+                    None => (EitherOrBoth::Left(records), None),
                 },
                 PartDecodeFormat::Arrow => match downcast_structured(ext, false) {
-                    Some(decoders) => EitherOrBoth::Right(decoders),
-                    None => EitherOrBoth::Left(records),
+                    Some((k, v, ord)) => (EitherOrBoth::Right((k, v)), Some(ord)),
+                    None => (EitherOrBoth::Left(records), None),
                 },
             },
         };
@@ -947,6 +960,7 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
             metrics,
             ts_filter,
             part,
+            structured_key_ord,
             peek_stash: None,
             timestamps,
             diffs,
@@ -987,6 +1001,13 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Monoid + Codec64 + Send + Sync,
 {
+    /// Returns the structured key ordering for this part, if available.
+    /// Used by the source's streaming merge to compare rows in
+    /// `RunOrder::Structured` order.
+    pub fn structured_key_ord(&self) -> Option<&ArrayOrd> {
+        self.structured_key_ord.as_ref()
+    }
+
     /// [Self::next] but optionally providing a `K` and `V` for alloc reuse.
     ///
     /// When `result_override` is specified, return it instead of decoding data.
@@ -996,6 +1017,17 @@ where
         key: &mut Option<K>,
         val: &mut Option<V>,
     ) -> Option<((K, V), T, D)> {
+        self.next_with_index(key, val).map(|(_idx, kv, t, d)| (kv, t, d))
+    }
+
+    /// Like [`Self::next_with_storage`], but also returns the raw columnar
+    /// index of the decoded row. This index can be used with
+    /// [`Self::structured_key_ord`] for comparison in the merge heap.
+    pub fn next_with_index(
+        &mut self,
+        key: &mut Option<K>,
+        val: &mut Option<V>,
+    ) -> Option<(usize, (K, V), T, D)> {
         let mut consolidated = self.peek_stash.take();
         loop {
             // Fetch and decode the next tuple in the sequence. (Or break if there is none.)
@@ -1013,14 +1045,14 @@ where
                     continue;
                 }
                 let kv = self.decode_kv(next_idx, key, val);
-                (kv, t, d)
+                (next_idx, kv, t, d)
             } else {
                 break;
             };
 
             // Attempt to consolidate in the next tuple, stashing it if that's not possible.
-            if let Some((kv, t, d)) = &mut consolidated {
-                let (kv_next, t_next, d_next) = &next;
+            if let Some((_idx, kv, t, d)) = &mut consolidated {
+                let (_next_idx, kv_next, t_next, d_next) = &next;
                 if kv == kv_next && t == t_next {
                     d.plus_equals(d_next);
                     if d.is_zero() {
@@ -1035,9 +1067,7 @@ where
             }
         }
 
-        let (kv, t, d) = consolidated?;
-
-        Some((kv, t, d))
+        consolidated
     }
 
     fn decode_kv(&mut self, index: usize, key: &mut Option<K>, val: &mut Option<V>) -> (K, V) {

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -155,6 +155,10 @@ pub fn shard_source<'g, K, V, T, D, DT, G, C>(
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: ErrorHandler,
+    // When true, sort parts by their structured key lower bound before distributing
+    // to workers. This improves consolidation by ensuring workers get contiguous
+    // key ranges. Has no effect on listen (non-snapshot) batches.
+    sorted_part_assignment: bool,
 ) -> (
     StreamVec<Child<'g, G, T>, FetchedBlob<K, V, G::Timestamp, D>>,
     Vec<PressOnDropButton>,
@@ -222,6 +226,7 @@ where
         listen_sleep,
         start_signal,
         error_handler.clone(),
+        sorted_part_assignment,
     );
     tokens.push(descs_token);
 
@@ -309,6 +314,7 @@ pub(crate) fn shard_source_descs<K, V, D, G>(
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: ErrorHandler,
+    sorted_part_assignment: bool,
 ) -> (
     StreamVec<G, (usize, ExchangeableBatchPart<G::Timestamp>)>,
     PressOnDropButton,
@@ -503,6 +509,8 @@ where
                 .expect("until should always be <= the empty frontier");
             let session_cap = cap_set.delayed(current_ts);
 
+            // Filter parts (stats pushdown, auditing), collecting survivors.
+            let mut filtered_parts = Vec::new();
             for mut part_desc in parts {
                 // TODO: Push more of this logic into LeasedBatchPart like we've
                 // done for project?
@@ -562,14 +570,37 @@ where
                         metrics.pushdown.parts_fetched_bytes.inc_by(bytes);
                     }
                 }
+                filtered_parts.push(part_desc);
+            }
 
-                // Give the part to a random worker. This isn't round robin in an attempt to avoid
-                // skew issues: if your parts alternate size large, small, then you'll end up only
-                // using half of your workers.
-                //
-                // There's certainly some other things we could be doing instead here, but this has
-                // seemed to work okay so far. Continue to revisit as necessary.
-                let worker_idx = usize::cast_from(Instant::now().hashed()) % num_workers;
+            // When sorted part assignment is enabled, sort parts by their
+            // structured key lower bound so that each worker gets a contiguous
+            // slice of the keyspace. This improves consolidation effectiveness
+            // by making it more likely that updates for the same key land on the
+            // same worker. Parts without a structured key lower (e.g. inline
+            // parts) sort first.
+            if sorted_part_assignment {
+                filtered_parts.sort_by(|a, b| {
+                    let a_lower = a.part.structured_key_lower();
+                    let b_lower = b.part.structured_key_lower();
+                    match (a_lower, b_lower) {
+                        (None, None) => std::cmp::Ordering::Equal,
+                        (None, Some(_)) => std::cmp::Ordering::Less,
+                        (Some(_), None) => std::cmp::Ordering::Greater,
+                        (Some(a), Some(b)) => a.get().cmp(&b.get()),
+                    }
+                });
+            }
+
+            for (i, part_desc) in filtered_parts.into_iter().enumerate() {
+                let worker_idx = if sorted_part_assignment {
+                    // Round-robin assignment in sorted order gives each worker
+                    // a contiguous key range.
+                    i % num_workers
+                } else {
+                    // Random assignment avoids skew when parts alternate in size.
+                    usize::cast_from(Instant::now().hashed()) % num_workers
+                };
                 let (part, lease) = part_desc.into_exchangeable_part();
                 leases.borrow_mut().push_at(current_ts.clone(), lease);
                 descs_output.give(&session_cap, (worker_idx, part));
@@ -767,6 +798,7 @@ mod tests {
                         false.then_some(|| unreachable!()),
                         async {},
                         ErrorHandler::Halt("test"),
+                        false,
                     );
                     (stream.leave(), tokens)
                 });
@@ -837,6 +869,7 @@ mod tests {
                         false.then_some(|| unreachable!()),
                         async {},
                         ErrorHandler::Halt("test"),
+                        false,
                     );
                     (stream.leave(), tokens)
                 });

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -157,7 +157,7 @@ pub fn shard_source<'g, K, V, T, D, DT, G, C>(
     error_handler: ErrorHandler,
     // When true, sort parts by their structured key lower bound before distributing
     // to workers. This improves consolidation by ensuring workers get contiguous
-    // key ranges. Has no effect on listen (non-snapshot) batches.
+    // key ranges. Applied to all batches (snapshot and listen).
     sorted_part_assignment: bool,
 ) -> (
     StreamVec<Child<'g, G, T>, FetchedBlob<K, V, G::Timestamp, D>>,

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -156,12 +156,10 @@ impl Subtime {
 /// timestamp in the consolidation scope to enable smooth frontier advancement
 /// during snapshot consolidation.
 ///
-/// Encoded as `(row_length, first_6_bytes)` packed into a u64 to match
-/// `Row::Ord`, which sorts by (length first, then bytes). This ensures
-/// `KeyProgress` is monotonically non-decreasing in `SourceData::Ord` order.
-///
-/// For `SourceData(Err(_))`, we use `u64::MAX` since errors sort after
-/// valid rows in `Result::Ord`.
+/// Values are monotonically increasing counters maintained by
+/// [`SourcePartMerger`], incremented on each distinct key emitted.
+/// The merge iterates in `ArrayOrd` order (matching persist's
+/// `RunOrder::Structured`), so the counter is naturally monotonic.
 #[derive(
     Copy, Clone, PartialEq, Default, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize, Hash,
 )]
@@ -203,35 +201,6 @@ impl Lattice for KeyProgress {
 impl differential_dataflow::lattice::Maximum for KeyProgress {
     fn maximum() -> Self {
         KeyProgress(u64::MAX)
-    }
-}
-
-impl KeyProgress {
-    /// Derive a `KeyProgress` value from a `SourceData` key.
-    ///
-    /// Encodes `(length, first_6_bytes)` into a u64 to match `Row::Ord`,
-    /// which sorts by (length first, then bytes). The top 2 bytes hold the
-    /// row length (capped at u16::MAX), and the bottom 6 bytes hold the
-    /// first 6 bytes of row data. This ensures `KeyProgress` is
-    /// monotonically non-decreasing in `Row::Ord` order.
-    ///
-    /// For `SourceData(Err(_))`, returns `u64::MAX` since errors sort after
-    /// valid rows in `Result::Ord`.
-    fn from_source_data(key: &SourceData) -> Self {
-        match &key.0 {
-            Ok(row) => {
-                let data = row.data();
-                // Top 2 bytes: row length (capped). Bottom 6 bytes: data prefix.
-                let len_part = (data.len().min(u16::MAX as usize) as u64) << 48;
-                let mut prefix = [0u8; 6];
-                let copy_len = data.len().min(6);
-                prefix[..copy_len].copy_from_slice(&data[..copy_len]);
-                // Interpret the 6 bytes as a big-endian u48 in the lower bits.
-                let data_part = u64::from_be_bytes([0, 0, prefix[0], prefix[1], prefix[2], prefix[3], prefix[4], prefix[5]]);
-                KeyProgress(len_part | data_part)
-            }
-            Err(_) => KeyProgress(u64::MAX),
-        }
     }
 }
 
@@ -817,11 +786,15 @@ impl PendingWork {
 // ============================================================================
 
 /// A cursor over a single `FetchedPart`, with a peeked next value for use in a
-/// merge heap. Parts are sorted by `RunOrder::Structured`, so calling
-/// `next_with_storage` yields rows in key-value-time order within the part.
+/// merge heap. Compares rows using `ArrayOrd` (persist's structured columnar
+/// ordering) so that the merge interleaves parts in the same order they're
+/// sorted by (`RunOrder::Structured`).
 struct MergeCursor {
     part: FetchedPart<SourceData, (), Timestamp, StorageDiff>,
-    /// The next KVT from this part (peeked ahead for comparison in the heap).
+    /// The raw columnar index of the peeked row. Used with
+    /// `part.structured_key_ord()` for heap comparison in `ArrayOrd` order.
+    peeked_index: usize,
+    /// The decoded KVT from this part (peeked ahead).
     peeked: ((SourceData, ()), Timestamp, StorageDiff),
     /// Re-usable allocation for decoded `SourceData`.
     row_buf: Option<SourceData>,
@@ -837,10 +810,11 @@ impl MergeCursor {
             .is_filter_pushdown_audit()
             .map(|s| Box::new(s) as Box<dyn Debug>);
         let mut row_buf = None;
-        let peeked = part.part.next_with_storage(&mut row_buf, &mut None)?;
+        let (idx, kv, t, d) = part.part.next_with_index(&mut row_buf, &mut None)?;
         Some(MergeCursor {
             part: part.part,
-            peeked,
+            peeked_index: idx,
+            peeked: (kv, t, d),
             row_buf,
             filter_pushdown_audit,
         })
@@ -849,9 +823,10 @@ impl MergeCursor {
     /// Advance to the next row. Returns `Some(self)` if there is a next row,
     /// `None` if the part is exhausted.
     fn advance(mut self) -> Option<Self> {
-        match self.part.next_with_storage(&mut self.row_buf, &mut None) {
-            Some(next) => {
-                self.peeked = next;
+        match self.part.next_with_index(&mut self.row_buf, &mut None) {
+            Some((idx, kv, t, d)) => {
+                self.peeked_index = idx;
+                self.peeked = (kv, t, d);
                 Some(self)
             }
             None => None,
@@ -859,8 +834,9 @@ impl MergeCursor {
     }
 }
 
-/// Order `MergeCursor`s by their peeked (key, time), so the `BinaryHeap` with
-/// `Reverse` gives us the minimum.
+/// Order `MergeCursor`s by their peeked key using `ArrayOrd` (structured
+/// columnar ordering), falling back to decoded `SourceData::Ord` for legacy
+/// parts without structured keys.
 impl PartialEq for MergeCursor {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == std::cmp::Ordering::Equal
@@ -877,22 +853,40 @@ impl PartialOrd for MergeCursor {
 
 impl Ord for MergeCursor {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let ((ref kv_a, _), ref t_a, _) = self.peeked;
-        let ((ref kv_b, _), ref t_b, _) = other.peeked;
-        (kv_a, t_a).cmp(&(kv_b, t_b))
+        // Compare using ArrayOrd (structured columnar ordering) when available.
+        // This matches the order parts are sorted by (RunOrder::Structured).
+        let key_ord = match (
+            self.part.structured_key_ord(),
+            other.part.structured_key_ord(),
+        ) {
+            (Some(a_ord), Some(b_ord)) => {
+                a_ord.at(self.peeked_index).cmp(&b_ord.at(other.peeked_index))
+            }
+            _ => {
+                // Fallback for legacy parts without structured keys.
+                let ((ref kv_a, _), _, _) = self.peeked;
+                let ((ref kv_b, _), _, _) = other.peeked;
+                kv_a.cmp(kv_b)
+            }
+        };
+        key_ord.then_with(|| self.peeked.1.cmp(&other.peeked.1))
     }
 }
 
 /// A streaming merge across multiple sorted `FetchedPart`s. Iterates through
-/// all parts in key-value-time order, consolidating updates with identical KVT.
+/// all parts in structured key order, consolidating updates with identical KVT.
 struct SourcePartMerger {
     heap: BinaryHeap<Reverse<MergeCursor>>,
+    /// Monotonically increasing counter, incremented on each distinct key
+    /// emitted. Used as `KeyProgress` for smooth frontier advancement.
+    key_counter: u64,
 }
 
 impl SourcePartMerger {
     fn new() -> Self {
         SourcePartMerger {
             heap: BinaryHeap::new(),
+            key_counter: 0,
         }
     }
 
@@ -907,36 +901,82 @@ impl SourcePartMerger {
         self.heap.is_empty()
     }
 
-    /// Returns the next consolidated (key, val, time, diff) from the merge,
-    /// along with whether this row is part of a filter pushdown audit.
+    /// Check if the top of the heap has the same key as the given cursor,
+    /// using `ArrayOrd` when available.
+    fn heap_top_matches_key(
+        heap: &BinaryHeap<Reverse<MergeCursor>>,
+        popped_cursor: &MergeCursor,
+        popped_time: &Timestamp,
+    ) -> bool {
+        let Some(Reverse(top)) = heap.peek() else {
+            return false;
+        };
+        let time_eq = top.peeked.1 == *popped_time;
+        if !time_eq {
+            return false;
+        }
+        match (
+            popped_cursor.part.structured_key_ord(),
+            top.part.structured_key_ord(),
+        ) {
+            (Some(a_ord), Some(b_ord)) => {
+                a_ord.at(popped_cursor.peeked_index) == b_ord.at(top.peeked_index)
+            }
+            _ => {
+                let ((ref popped_key, _), _, _) = popped_cursor.peeked;
+                let ((ref top_key, _), _, _) = top.peeked;
+                popped_key == top_key
+            }
+        }
+    }
+
+    /// Returns the next consolidated (key, val, time, diff, key_progress) from
+    /// the merge, along with whether this row is part of a filter pushdown
+    /// audit.
     ///
     /// Consecutive updates with identical (key, val, time) are consolidated
     /// into a single update. Zero diffs are suppressed.
-    fn next(&mut self) -> Option<((SourceData, ()), Timestamp, StorageDiff, bool)> {
+    ///
+    /// `key_progress` is a monotonically increasing counter that advances on
+    /// each distinct key, suitable for use as a `KeyProgress` timestamp.
+    fn next(&mut self) -> Option<((SourceData, ()), Timestamp, StorageDiff, bool, KeyProgress)> {
         loop {
             let Reverse(cursor) = self.heap.pop()?;
             let ((key, val), time, diff) = cursor.peeked.clone();
             let is_audit = cursor.filter_pushdown_audit.is_some();
 
-            // Re-insert the cursor after advancing.
-            if let Some(advanced) = cursor.advance() {
-                self.heap.push(Reverse(advanced));
+            // Consolidate: absorb any subsequent entries with the same KVT.
+            // We compare using ArrayOrd before advancing the popped cursor.
+            let mut consolidated_diff = diff;
+            while Self::heap_top_matches_key(&self.heap, &cursor, &time) {
+                let Reverse(next_cursor) = self.heap.pop().unwrap();
+                let (_, _, next_diff) = next_cursor.peeked.clone();
+                consolidated_diff.plus_equals(&next_diff);
+                if let Some(advanced) = next_cursor.advance() {
+                    self.heap.push(Reverse(advanced));
+                }
             }
 
-            // Consolidate: absorb any subsequent entries with the same KVT.
-            let mut consolidated_diff = diff;
-            while let Some(Reverse(top)) = self.heap.peek() {
-                let ((ref next_key, _), ref next_time, _) = top.peeked;
-                if next_key == &key && next_time == &time {
-                    let Reverse(next_cursor) = self.heap.pop().unwrap();
-                    let (_, _, next_diff) = next_cursor.peeked.clone();
-                    consolidated_diff.plus_equals(&next_diff);
-                    if let Some(advanced) = next_cursor.advance() {
-                        self.heap.push(Reverse(advanced));
+            // Check if the next key in the heap is different from the current
+            // one, and if so, bump the key counter.
+            let next_is_different = self.heap.peek().map_or(true, |Reverse(top)| {
+                match (
+                    cursor.part.structured_key_ord(),
+                    top.part.structured_key_ord(),
+                ) {
+                    (Some(a_ord), Some(b_ord)) => {
+                        a_ord.at(cursor.peeked_index) != b_ord.at(top.peeked_index)
                     }
-                } else {
-                    break;
+                    _ => {
+                        let ((ref top_key, _), _, _) = top.peeked;
+                        top_key != &key
+                    }
                 }
+            });
+
+            // Re-insert the popped cursor after all comparisons are done.
+            if let Some(advanced) = cursor.advance() {
+                self.heap.push(Reverse(advanced));
             }
 
             // Suppress zero diffs.
@@ -944,7 +984,12 @@ impl SourcePartMerger {
                 continue;
             }
 
-            return Some(((key, val), time, consolidated_diff, is_audit));
+            if next_is_different {
+                self.key_counter += 1;
+            }
+            let progress = KeyProgress(self.key_counter);
+
+            return Some(((key, val), time, consolidated_diff, is_audit, progress));
         }
     }
 }
@@ -1105,26 +1150,19 @@ where
                 let exhausted = {
                     let (cap, merger) = pending_mergers.front_mut().unwrap();
 
-                    while let Some(((key, _val), time, diff, is_audit)) = merger.next() {
+                    while let Some(((key, _val), time, diff, is_audit, key_progress)) = merger.next() {
                         if until.less_equal(&time) {
                             continue;
                         }
 
-                        // Derive KeyProgress from the key prefix and downgrade
-                        // our capability so the consolidate frontier advances.
-                        let key_progress = KeyProgress::from_source_data(&key);
-                        debug_assert!(
-                            key_progress >= cap.time().1,
-                            "KeyProgress went backwards: {:?} < {:?} for key {:?}",
-                            key_progress,
-                            cap.time().1,
-                            key,
-                        );
                         let emit_time: InnerTime = (
                             (time, cap.time().0 .1),
                             key_progress,
                         );
                         // Downgrade to signal we won't emit earlier key positions.
+                        // key_progress is monotonically non-decreasing because the
+                        // merger iterates in ArrayOrd order and increments the
+                        // counter on each distinct key.
                         cap.downgrade(&emit_time);
                         let mut session = output.session_with_builder(cap);
 

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -89,6 +89,18 @@ use crate::metrics::BackpressureMetrics;
 )]
 pub struct Subtime(u64);
 
+/// How the persist source should consolidate its output.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum SourceConsolidation {
+    /// Best-effort consolidation within parts. Current behavior.
+    #[default]
+    BestEffort,
+    /// Fully consolidated, snapshot-monotonic output.
+    /// Enables sorted part assignment and (in future phases)
+    /// streaming merge and fine-grained-timestamp-based consolidation.
+    Full,
+}
+
 impl PartialOrder for Subtime {
     fn less_equal(&self, other: &Self) -> bool {
         self.0.less_equal(&other.0)
@@ -158,6 +170,7 @@ pub fn persist_source<G>(
     max_inflight_bytes: Option<usize>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: ErrorHandler,
+    consolidation: SourceConsolidation,
 ) -> (
     StreamVec<G, (Row, Timestamp, Diff)>,
     StreamVec<G, (DataflowError, Timestamp, Diff)>,
@@ -223,6 +236,7 @@ where
             subscribe_sleep,
             start_signal,
             error_handler,
+            consolidation,
         );
         tokens.extend(source_tokens);
 
@@ -294,6 +308,7 @@ pub fn persist_source_core<'g, G>(
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: ErrorHandler,
+    consolidation: SourceConsolidation,
 ) -> (
     Stream<
         RefinedScope<'g, G>,
@@ -382,6 +397,7 @@ where
         listen_sleep,
         start_signal,
         error_handler,
+        matches!(consolidation, SourceConsolidation::Full),
     );
     let rows = decode_and_mfp(cfg, fetched, &name, until, map_filter_project);
     (rows, token)

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -10,8 +10,6 @@
 //! A source that reads from an a persist shard.
 
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
@@ -19,7 +17,6 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Instant;
 
-use differential_dataflow::difference::{IsZero, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use futures::{StreamExt, future::Either};
 use mz_expr::{ColumnSpecs, Interpreter, MfpPlan, ResultSpec, UnmaterializableFunc};
@@ -781,219 +778,6 @@ impl PendingWork {
     }
 }
 
-// ============================================================================
-// Consolidating decode path
-// ============================================================================
-
-/// A cursor over a single `FetchedPart`, with a peeked next value for use in a
-/// merge heap. Compares rows using `ArrayOrd` (persist's structured columnar
-/// ordering) so that the merge interleaves parts in the same order they're
-/// sorted by (`RunOrder::Structured`).
-struct MergeCursor {
-    part: FetchedPart<SourceData, (), Timestamp, StorageDiff>,
-    /// The raw columnar index of the peeked row. Used with
-    /// `part.structured_key_ord()` for heap comparison in `ArrayOrd` order.
-    peeked_index: usize,
-    /// The decoded KVT from this part (peeked ahead).
-    peeked: ((SourceData, ()), Timestamp, StorageDiff),
-    /// Re-usable allocation for decoded `SourceData`.
-    row_buf: Option<SourceData>,
-    /// Stats for filter pushdown audit, if this part is being audited.
-    filter_pushdown_audit: Option<Box<dyn Debug>>,
-}
-
-impl MergeCursor {
-    /// Create a cursor from a parsed part, returning `None` if the part is empty.
-    fn new(mut part: ShardSourcePart<SourceData, (), Timestamp, StorageDiff>) -> Option<Self> {
-        let filter_pushdown_audit = part
-            .part
-            .is_filter_pushdown_audit()
-            .map(|s| Box::new(s) as Box<dyn Debug>);
-        let mut row_buf = None;
-        let (idx, kv, t, d) = part.part.next_with_index(&mut row_buf, &mut None)?;
-        Some(MergeCursor {
-            part: part.part,
-            peeked_index: idx,
-            peeked: (kv, t, d),
-            row_buf,
-            filter_pushdown_audit,
-        })
-    }
-
-    /// Advance to the next row. Returns `Some(self)` if there is a next row,
-    /// `None` if the part is exhausted.
-    fn advance(mut self) -> Option<Self> {
-        match self.part.next_with_index(&mut self.row_buf, &mut None) {
-            Some((idx, kv, t, d)) => {
-                self.peeked_index = idx;
-                self.peeked = (kv, t, d);
-                Some(self)
-            }
-            None => None,
-        }
-    }
-}
-
-/// Order `MergeCursor`s by their peeked key using `ArrayOrd` (structured
-/// columnar ordering), falling back to decoded `SourceData::Ord` for legacy
-/// parts without structured keys.
-impl PartialEq for MergeCursor {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == std::cmp::Ordering::Equal
-    }
-}
-
-impl Eq for MergeCursor {}
-
-impl PartialOrd for MergeCursor {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MergeCursor {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Compare using ArrayOrd (structured columnar ordering) when available.
-        // This matches the order parts are sorted by (RunOrder::Structured).
-        let key_ord = match (
-            self.part.structured_key_ord(),
-            other.part.structured_key_ord(),
-        ) {
-            (Some(a_ord), Some(b_ord)) => {
-                a_ord.at(self.peeked_index).cmp(&b_ord.at(other.peeked_index))
-            }
-            _ => {
-                // Fallback for legacy parts without structured keys.
-                let ((ref kv_a, _), _, _) = self.peeked;
-                let ((ref kv_b, _), _, _) = other.peeked;
-                kv_a.cmp(kv_b)
-            }
-        };
-        key_ord.then_with(|| self.peeked.1.cmp(&other.peeked.1))
-    }
-}
-
-/// A streaming merge across multiple sorted `FetchedPart`s. Iterates through
-/// all parts in structured key order, consolidating updates with identical KVT.
-struct SourcePartMerger {
-    heap: BinaryHeap<Reverse<MergeCursor>>,
-    /// Monotonically increasing counter, incremented on each distinct key
-    /// emitted. Used as `KeyProgress` for smooth frontier advancement.
-    key_counter: u64,
-}
-
-impl SourcePartMerger {
-    fn new() -> Self {
-        SourcePartMerger {
-            heap: BinaryHeap::new(),
-            key_counter: 0,
-        }
-    }
-
-    /// Add a parsed part to the merge.
-    fn push(&mut self, part: ShardSourcePart<SourceData, (), Timestamp, StorageDiff>) {
-        if let Some(cursor) = MergeCursor::new(part) {
-            self.heap.push(Reverse(cursor));
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.heap.is_empty()
-    }
-
-    /// Check if the top of the heap has the same key as the given cursor,
-    /// using `ArrayOrd` when available.
-    fn heap_top_matches_key(
-        heap: &BinaryHeap<Reverse<MergeCursor>>,
-        popped_cursor: &MergeCursor,
-        popped_time: &Timestamp,
-    ) -> bool {
-        let Some(Reverse(top)) = heap.peek() else {
-            return false;
-        };
-        let time_eq = top.peeked.1 == *popped_time;
-        if !time_eq {
-            return false;
-        }
-        match (
-            popped_cursor.part.structured_key_ord(),
-            top.part.structured_key_ord(),
-        ) {
-            (Some(a_ord), Some(b_ord)) => {
-                a_ord.at(popped_cursor.peeked_index) == b_ord.at(top.peeked_index)
-            }
-            _ => {
-                let ((ref popped_key, _), _, _) = popped_cursor.peeked;
-                let ((ref top_key, _), _, _) = top.peeked;
-                popped_key == top_key
-            }
-        }
-    }
-
-    /// Returns the next consolidated (key, val, time, diff, key_progress) from
-    /// the merge, along with whether this row is part of a filter pushdown
-    /// audit.
-    ///
-    /// Consecutive updates with identical (key, val, time) are consolidated
-    /// into a single update. Zero diffs are suppressed.
-    ///
-    /// `key_progress` is a monotonically increasing counter that advances on
-    /// each distinct key, suitable for use as a `KeyProgress` timestamp.
-    fn next(&mut self) -> Option<((SourceData, ()), Timestamp, StorageDiff, bool, KeyProgress)> {
-        loop {
-            let Reverse(cursor) = self.heap.pop()?;
-            let ((key, val), time, diff) = cursor.peeked.clone();
-            let is_audit = cursor.filter_pushdown_audit.is_some();
-
-            // Consolidate: absorb any subsequent entries with the same KVT.
-            // We compare using ArrayOrd before advancing the popped cursor.
-            let mut consolidated_diff = diff;
-            while Self::heap_top_matches_key(&self.heap, &cursor, &time) {
-                let Reverse(next_cursor) = self.heap.pop().unwrap();
-                let (_, _, next_diff) = next_cursor.peeked.clone();
-                consolidated_diff.plus_equals(&next_diff);
-                if let Some(advanced) = next_cursor.advance() {
-                    self.heap.push(Reverse(advanced));
-                }
-            }
-
-            // Check if the next key in the heap is different from the current
-            // one, and if so, bump the key counter.
-            let next_is_different = self.heap.peek().map_or(true, |Reverse(top)| {
-                match (
-                    cursor.part.structured_key_ord(),
-                    top.part.structured_key_ord(),
-                ) {
-                    (Some(a_ord), Some(b_ord)) => {
-                        a_ord.at(cursor.peeked_index) != b_ord.at(top.peeked_index)
-                    }
-                    _ => {
-                        let ((ref top_key, _), _, _) = top.peeked;
-                        top_key != &key
-                    }
-                }
-            });
-
-            // Re-insert the popped cursor after all comparisons are done.
-            if let Some(advanced) = cursor.advance() {
-                self.heap.push(Reverse(advanced));
-            }
-
-            // Suppress zero diffs.
-            if consolidated_diff.is_zero() {
-                continue;
-            }
-
-            if next_is_different {
-                self.key_counter += 1;
-            }
-            let progress = KeyProgress(self.key_counter);
-
-            return Some(((key, val), time, consolidated_diff, is_audit, progress));
-        }
-    }
-}
-
 /// A variant of [`decode_and_mfp`] that performs a streaming merge across all
 /// fetched parts at the same timestamp, consolidating updates with identical
 /// key-value-time before applying MFP.
@@ -1029,7 +813,7 @@ where
 
                 // Build the streaming merge decode operator in the inner scope.
                 // It manages KeyProgress capabilities based on the key prefix.
-                let decoded = streaming_merge_decode(
+                let decoded = decode_with_key_progress(
                     cfg,
                     fetched_inner,
                     &name_owned,
@@ -1061,13 +845,14 @@ where
         )
 }
 
-/// The streaming merge decode operator for the consolidation inner scope.
+/// Decode operator for the consolidation inner scope. Processes fetched parts
+/// one at a time (like [`decode_and_mfp`]), but emits rows with monotonically
+/// increasing [`KeyProgress`] timestamps so the downstream `consolidate` can
+/// make incremental progress.
 ///
-/// Receives fetched blobs, merges them using [`SourcePartMerger`], applies MFP,
-/// and emits rows with [`KeyProgress`] timestamps derived from key prefixes.
-/// Periodically downgrades capabilities to allow the downstream `consolidate`
-/// to make incremental progress.
-fn streaming_merge_decode<G>(
+/// Cross-part consolidation is handled by the `consolidate()` operator in the
+/// enclosing scope, not by merging here.
+fn decode_with_key_progress<G>(
     cfg: PersistConfig,
     fetched: StreamVec<G, FetchedBlob<SourceData, (), Timestamp, StorageDiff>>,
     name: &str,
@@ -1079,7 +864,7 @@ where
 {
     let scope = fetched.scope();
     let mut builder = OperatorBuilder::new(
-        format!("persist_source::streaming_merge_decode({})", name),
+        format!("persist_source::decode_with_key_progress({})", name),
         scope.clone(),
     );
     let operator_info = builder.operator_info();
@@ -1110,31 +895,19 @@ where
         let activations = scope.activations();
         let activator = Activator::new(operator_info.address, activations);
 
-        // Each entry: a capability (for creating delayed caps / dropped when
-        // done), the merger, and the current max KeyProgress for downgrading.
-        let mut pending_mergers: std::collections::VecDeque<(
+        // Pending parts, each with its own capability and a row counter for
+        // KeyProgress. Processed front-to-back, one part at a time.
+        let mut pending_work: std::collections::VecDeque<(
             Capability<InnerTime>,
-            SourcePartMerger,
+            ShardSourcePart<SourceData, (), Timestamp, StorageDiff>,
+            u64, // row counter for KeyProgress
         )> = std::collections::VecDeque::new();
 
         move |_frontier| {
             fetched_input.for_each(|time, data| {
                 let capability = time.retain(0);
-
-                // Find or create a merger for this time.
-                let merger = if let Some((_, m)) = pending_mergers
-                    .iter_mut()
-                    .find(|(c, _)| c.time() == capability.time())
-                {
-                    m
-                } else {
-                    pending_mergers
-                        .push_back((capability, SourcePartMerger::new()));
-                    &mut pending_mergers.back_mut().unwrap().1
-                };
-
                 for fetched_blob in data.drain(..) {
-                    merger.push(fetched_blob.parse());
+                    pending_work.push_back((capability.clone(), fetched_blob.parse(), 0));
                 }
             });
 
@@ -1145,29 +918,27 @@ where
             let mut work = 0;
             let start_time = Instant::now();
             let mut output = updates_output.activate();
+            let mut row_buf = None;
 
-            while !pending_mergers.is_empty() && !yield_fn(start_time, work) {
+            while !pending_work.is_empty() && !yield_fn(start_time, work) {
                 let exhausted = {
-                    let (cap, merger) = pending_mergers.front_mut().unwrap();
+                    let (cap, part, row_counter) = pending_work.front_mut().unwrap();
+                    let is_filter_pushdown_audit = part.part.is_filter_pushdown_audit();
 
-                    while let Some(((key, _val), time, diff, is_audit, key_progress)) = merger.next() {
+                    while let Some(((key, val), time, diff)) =
+                        part.part.next_with_storage(&mut row_buf, &mut None)
+                    {
                         if until.less_equal(&time) {
                             continue;
                         }
 
-                        let emit_time: InnerTime = (
-                            (time, cap.time().0 .1),
-                            key_progress,
-                        );
-                        // Downgrade to signal we won't emit earlier key positions.
-                        // key_progress is monotonically non-decreasing because the
-                        // merger iterates in ArrayOrd order and increments the
-                        // counter on each distinct key.
+                        *row_counter += 1;
+                        let key_progress = KeyProgress(*row_counter);
+                        let emit_time: InnerTime = ((time, cap.time().0 .1), key_progress);
                         cap.downgrade(&emit_time);
-                        let mut session = output.session_with_builder(cap);
 
-                        match key {
-                            SourceData(Ok(row)) => {
+                        match (key, val) {
+                            (SourceData(Ok(row)), ()) => {
                                 if let Some(mfp) = map_filter_project.as_ref() {
                                     work += 1;
                                     let arena = RowArena::new();
@@ -1180,13 +951,15 @@ where
                                         |time| !until.less_equal(time),
                                         &mut row_builder,
                                     ) {
-                                        if is_audit {
+                                        if is_filter_pushdown_audit.is_some() {
                                             report_pushdown_audit(&name, panic_on_audit);
                                         }
                                         match result {
                                             Ok((row, time, diff)) => {
                                                 if !until.less_equal(&time) {
                                                     let et = ((time, emit_time.0 .1), key_progress);
+                                                    let mut session =
+                                                        output.session_with_builder(cap);
                                                     session.give((Ok(row), et, diff));
                                                     work += 1;
                                                 }
@@ -1194,39 +967,45 @@ where
                                             Err((err, time, diff)) => {
                                                 if !until.less_equal(&time) {
                                                     let et = ((time, emit_time.0 .1), key_progress);
+                                                    let mut session =
+                                                        output.session_with_builder(cap);
                                                     session.give((Err(err), et, diff));
                                                     work += 1;
                                                 }
                                             }
                                         }
                                     }
+                                    drop(datums_local);
+                                    row_buf.replace(SourceData(Ok(row)));
                                 } else {
+                                    let mut session = output.session_with_builder(cap);
                                     session.give((Ok(row.clone()), emit_time, diff.into()));
+                                    row_buf.replace(SourceData(Ok(row)));
                                     work += 1;
                                 }
                             }
-                            SourceData(Err(err)) => {
+                            (SourceData(Err(err)), ()) => {
+                                let mut session = output.session_with_builder(cap);
                                 session.give((Err(err), emit_time, diff.into()));
                                 work += 1;
                             }
                         }
-                        // Drop session before next iteration to avoid borrow conflict.
-                        drop(session);
                         if yield_fn(start_time, work) {
                             break;
                         }
                     }
 
-                    merger.is_empty()
+                    // Part is exhausted if the while loop ended without a yield break.
+                    !yield_fn(start_time, work)
                 };
                 if exhausted {
-                    pending_mergers.pop_front();
+                    pending_work.pop_front();
                 } else {
                     break;
                 }
             }
 
-            if !pending_mergers.is_empty() {
+            if !pending_work.is_empty() {
                 activator.activate();
             }
         }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -156,10 +156,9 @@ impl Subtime {
 /// timestamp in the consolidation scope to enable smooth frontier advancement
 /// during snapshot consolidation.
 ///
-/// Derived from the first 8 bytes of the row's internal representation,
-/// interpreted as a big-endian u64. Since `Row::Ord` compares by
-/// (length, then bytes) and rows within a shard share a schema (same length),
-/// this is monotonically non-decreasing in `Row::Ord` order.
+/// Encoded as `(row_length, first_6_bytes)` packed into a u64 to match
+/// `Row::Ord`, which sorts by (length first, then bytes). This ensures
+/// `KeyProgress` is monotonically non-decreasing in `SourceData::Ord` order.
 ///
 /// For `SourceData(Err(_))`, we use `u64::MAX` since errors sort after
 /// valid rows in `Result::Ord`.
@@ -210,18 +209,26 @@ impl differential_dataflow::lattice::Maximum for KeyProgress {
 impl KeyProgress {
     /// Derive a `KeyProgress` value from a `SourceData` key.
     ///
-    /// Takes the first 8 bytes of the row's internal byte representation and
-    /// interprets them as a big-endian u64. For rows shorter than 8 bytes, the
-    /// value is zero-padded on the right. For errors, returns `u64::MAX` since
-    /// `Err` sorts after `Ok` in `Result::Ord`.
+    /// Encodes `(length, first_6_bytes)` into a u64 to match `Row::Ord`,
+    /// which sorts by (length first, then bytes). The top 2 bytes hold the
+    /// row length (capped at u16::MAX), and the bottom 6 bytes hold the
+    /// first 6 bytes of row data. This ensures `KeyProgress` is
+    /// monotonically non-decreasing in `Row::Ord` order.
+    ///
+    /// For `SourceData(Err(_))`, returns `u64::MAX` since errors sort after
+    /// valid rows in `Result::Ord`.
     fn from_source_data(key: &SourceData) -> Self {
         match &key.0 {
             Ok(row) => {
                 let data = row.data();
-                let mut buf = [0u8; 8];
-                let len = std::cmp::min(data.len(), 8);
-                buf[..len].copy_from_slice(&data[..len]);
-                KeyProgress(u64::from_be_bytes(buf))
+                // Top 2 bytes: row length (capped). Bottom 6 bytes: data prefix.
+                let len_part = (data.len().min(u16::MAX as usize) as u64) << 48;
+                let mut prefix = [0u8; 6];
+                let copy_len = data.len().min(6);
+                prefix[..copy_len].copy_from_slice(&data[..copy_len]);
+                // Interpret the 6 bytes as a big-endian u48 in the lower bits.
+                let data_part = u64::from_be_bytes([0, 0, prefix[0], prefix[1], prefix[2], prefix[3], prefix[4], prefix[5]]);
+                KeyProgress(len_part | data_part)
             }
             Err(_) => KeyProgress(u64::MAX),
         }
@@ -1106,6 +1113,13 @@ where
                         // Derive KeyProgress from the key prefix and downgrade
                         // our capability so the consolidate frontier advances.
                         let key_progress = KeyProgress::from_source_data(&key);
+                        debug_assert!(
+                            key_progress >= cap.time().1,
+                            "KeyProgress went backwards: {:?} < {:?} for key {:?}",
+                            key_progress,
+                            cap.time().1,
+                            key,
+                        );
                         let emit_time: InnerTime = (
                             (time, cap.time().0 .1),
                             key_progress,

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -10,6 +10,8 @@
 //! A source that reads from an a persist shard.
 
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
@@ -17,6 +19,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Instant;
 
+use differential_dataflow::difference::{IsZero, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use futures::{StreamExt, future::Either};
 use mz_expr::{ColumnSpecs, Interpreter, MfpPlan, ResultSpec, UnmaterializableFunc};
@@ -399,7 +402,14 @@ where
         error_handler,
         matches!(consolidation, SourceConsolidation::Full),
     );
-    let rows = decode_and_mfp(cfg, fetched, &name, until, map_filter_project);
+    let rows = match consolidation {
+        SourceConsolidation::BestEffort => {
+            decode_and_mfp(cfg, fetched, &name, until, map_filter_project)
+        }
+        SourceConsolidation::Full => {
+            decode_and_mfp_consolidating(cfg, fetched, &name, until, map_filter_project)
+        }
+    };
     (rows, token)
 }
 
@@ -702,6 +712,336 @@ impl PendingWork {
         }
         true
     }
+}
+
+// ============================================================================
+// Consolidating decode path
+// ============================================================================
+
+/// A cursor over a single `FetchedPart`, with a peeked next value for use in a
+/// merge heap. Parts are sorted by `RunOrder::Structured`, so calling
+/// `next_with_storage` yields rows in key-value-time order within the part.
+struct MergeCursor {
+    part: FetchedPart<SourceData, (), Timestamp, StorageDiff>,
+    /// The next KVT from this part (peeked ahead for comparison in the heap).
+    peeked: ((SourceData, ()), Timestamp, StorageDiff),
+    /// Re-usable allocation for decoded `SourceData`.
+    row_buf: Option<SourceData>,
+    /// Stats for filter pushdown audit, if this part is being audited.
+    filter_pushdown_audit: Option<Box<dyn Debug>>,
+}
+
+impl MergeCursor {
+    /// Create a cursor from a parsed part, returning `None` if the part is empty.
+    fn new(mut part: ShardSourcePart<SourceData, (), Timestamp, StorageDiff>) -> Option<Self> {
+        let filter_pushdown_audit = part
+            .part
+            .is_filter_pushdown_audit()
+            .map(|s| Box::new(s) as Box<dyn Debug>);
+        let mut row_buf = None;
+        let peeked = part.part.next_with_storage(&mut row_buf, &mut None)?;
+        Some(MergeCursor {
+            part: part.part,
+            peeked,
+            row_buf,
+            filter_pushdown_audit,
+        })
+    }
+
+    /// Advance to the next row. Returns `Some(self)` if there is a next row,
+    /// `None` if the part is exhausted.
+    fn advance(mut self) -> Option<Self> {
+        match self.part.next_with_storage(&mut self.row_buf, &mut None) {
+            Some(next) => {
+                self.peeked = next;
+                Some(self)
+            }
+            None => None,
+        }
+    }
+}
+
+/// Order `MergeCursor`s by their peeked (key, time), so the `BinaryHeap` with
+/// `Reverse` gives us the minimum.
+impl PartialEq for MergeCursor {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for MergeCursor {}
+
+impl PartialOrd for MergeCursor {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MergeCursor {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let ((ref kv_a, _), ref t_a, _) = self.peeked;
+        let ((ref kv_b, _), ref t_b, _) = other.peeked;
+        (kv_a, t_a).cmp(&(kv_b, t_b))
+    }
+}
+
+/// A streaming merge across multiple sorted `FetchedPart`s. Iterates through
+/// all parts in key-value-time order, consolidating updates with identical KVT.
+struct SourcePartMerger {
+    heap: BinaryHeap<Reverse<MergeCursor>>,
+}
+
+impl SourcePartMerger {
+    fn new() -> Self {
+        SourcePartMerger {
+            heap: BinaryHeap::new(),
+        }
+    }
+
+    /// Add a parsed part to the merge.
+    fn push(&mut self, part: ShardSourcePart<SourceData, (), Timestamp, StorageDiff>) {
+        if let Some(cursor) = MergeCursor::new(part) {
+            self.heap.push(Reverse(cursor));
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
+    /// Returns the next consolidated (key, val, time, diff) from the merge,
+    /// along with whether this row is part of a filter pushdown audit.
+    ///
+    /// Consecutive updates with identical (key, val, time) are consolidated
+    /// into a single update. Zero diffs are suppressed.
+    fn next(&mut self) -> Option<((SourceData, ()), Timestamp, StorageDiff, bool)> {
+        loop {
+            let Reverse(cursor) = self.heap.pop()?;
+            let ((key, val), time, diff) = cursor.peeked.clone();
+            let is_audit = cursor.filter_pushdown_audit.is_some();
+
+            // Re-insert the cursor after advancing.
+            if let Some(advanced) = cursor.advance() {
+                self.heap.push(Reverse(advanced));
+            }
+
+            // Consolidate: absorb any subsequent entries with the same KVT.
+            let mut consolidated_diff = diff;
+            while let Some(Reverse(top)) = self.heap.peek() {
+                let ((ref next_key, _), ref next_time, _) = top.peeked;
+                if next_key == &key && next_time == &time {
+                    let Reverse(next_cursor) = self.heap.pop().unwrap();
+                    let (_, _, next_diff) = next_cursor.peeked.clone();
+                    consolidated_diff.plus_equals(&next_diff);
+                    if let Some(advanced) = next_cursor.advance() {
+                        self.heap.push(Reverse(advanced));
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            // Suppress zero diffs.
+            if consolidated_diff.is_zero() {
+                continue;
+            }
+
+            return Some(((key, val), time, consolidated_diff, is_audit));
+        }
+    }
+}
+
+/// A variant of [`decode_and_mfp`] that performs a streaming merge across all
+/// fetched parts at the same timestamp, consolidating updates with identical
+/// key-value-time before applying MFP. This produces fewer downstream updates
+/// than the sequential approach when parts contain overlapping key ranges.
+///
+/// Used when [`SourceConsolidation::Full`] is requested.
+pub fn decode_and_mfp_consolidating<G>(
+    cfg: PersistConfig,
+    fetched: StreamVec<G, FetchedBlob<SourceData, (), Timestamp, StorageDiff>>,
+    name: &str,
+    until: Antichain<Timestamp>,
+    mut map_filter_project: Option<&mut MfpPlan>,
+) -> StreamVec<G, (Result<Row, DataflowError>, G::Timestamp, Diff)>
+where
+    G: Scope<Timestamp = (mz_repr::Timestamp, Subtime)>,
+{
+    let scope = fetched.scope();
+    let mut builder = OperatorBuilder::new(
+        format!("persist_source::decode_and_mfp_consolidating({})", name),
+        scope.clone(),
+    );
+    let operator_info = builder.operator_info();
+
+    let mut fetched_input = builder.new_input(fetched, Pipeline);
+    let (updates_output, updates_stream) = builder.new_output();
+    let mut updates_output: OutputBuilder<
+        _,
+        ConsolidatingContainerBuilder<
+            Vec<(
+                Result<Row, DataflowError>,
+                (mz_repr::Timestamp, Subtime),
+                Diff,
+            )>,
+        >,
+    > = OutputBuilder::from(updates_output);
+
+    // Re-used state for processing and building rows.
+    let mut datum_vec = mz_repr::DatumVec::new();
+    let mut row_builder = Row::default();
+
+    // Extract the MFP if it exists; leave behind an identity MFP in that case.
+    let map_filter_project = map_filter_project.as_mut().map(|mfp| mfp.take());
+    let panic_on_audit_failure = STATS_AUDIT_PANIC.handle(&cfg);
+
+    builder.build(move |_caps| {
+        let name = name.to_owned();
+        // Acquire an activator to reschedule the operator when it has unfinished work.
+        let activations = scope.activations();
+        let activator = Activator::new(operator_info.address, activations);
+
+        // Groups of pending parts by their capability. We merge all parts at the
+        // same time together to maximize consolidation.
+        let mut pending_mergers: std::collections::VecDeque<(
+            Capability<(mz_repr::Timestamp, Subtime)>,
+            SourcePartMerger,
+        )> = std::collections::VecDeque::new();
+
+        move |_frontier| {
+            // Collect newly arrived blobs, grouping by time.
+            fetched_input.for_each(|time, data| {
+                let capability = time.retain(0);
+
+                // Find or create a merger for this time.
+                let merger = if let Some((_, m)) =
+                    pending_mergers.iter_mut().find(|(c, _)| c.time() == capability.time())
+                {
+                    m
+                } else {
+                    pending_mergers.push_back((capability.clone(), SourcePartMerger::new()));
+                    &mut pending_mergers.back_mut().unwrap().1
+                };
+
+                for fetched_blob in data.drain(..) {
+                    merger.push(fetched_blob.parse());
+                }
+            });
+
+            let yield_fuel = cfg.storage_source_decode_fuel();
+            let yield_fn = |_, work| work >= yield_fuel;
+            let panic_on_audit = panic_on_audit_failure.get();
+
+            let mut work = 0;
+            let start_time = Instant::now();
+            let mut output = updates_output.activate();
+
+            while !pending_mergers.is_empty() && !yield_fn(start_time, work) {
+                let exhausted = {
+                    let (cap, merger) = pending_mergers.front_mut().unwrap();
+                    let mut session = output.session_with_builder(cap);
+
+                    while let Some(((key, _val), time, diff, is_audit)) = merger.next() {
+                        if until.less_equal(&time) {
+                            continue;
+                        }
+                        match key {
+                            SourceData(Ok(row)) => {
+                                if let Some(mfp) = map_filter_project.as_ref() {
+                                    work += 1;
+                                    let arena = RowArena::new();
+                                    let mut datums_local = datum_vec.borrow_with(&row);
+                                    for result in mfp.evaluate(
+                                        &mut datums_local,
+                                        &arena,
+                                        time,
+                                        diff.into(),
+                                        |time| !until.less_equal(time),
+                                        &mut row_builder,
+                                    ) {
+                                        if is_audit {
+                                            report_pushdown_audit(
+                                                &name,
+                                                panic_on_audit,
+                                            );
+                                        }
+                                        match result {
+                                            Ok((row, time, diff)) => {
+                                                if !until.less_equal(&time) {
+                                                    let mut emit_time = *cap.time();
+                                                    emit_time.0 = time;
+                                                    session.give((Ok(row), emit_time, diff));
+                                                    work += 1;
+                                                }
+                                            }
+                                            Err((err, time, diff)) => {
+                                                if !until.less_equal(&time) {
+                                                    let mut emit_time = *cap.time();
+                                                    emit_time.0 = time;
+                                                    session.give((Err(err), emit_time, diff));
+                                                    work += 1;
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    let mut emit_time = *cap.time();
+                                    emit_time.0 = time;
+                                    session.give((Ok(row.clone()), emit_time, diff.into()));
+                                    work += 1;
+                                }
+                            }
+                            SourceData(Err(err)) => {
+                                let mut emit_time = *cap.time();
+                                emit_time.0 = time;
+                                session.give((Err(err), emit_time, diff.into()));
+                                work += 1;
+                            }
+                        }
+                        if yield_fn(start_time, work) {
+                            break;
+                        }
+                    }
+
+                    merger.is_empty()
+                };
+                // The session is dropped here (end of the block above), releasing
+                // the borrow on pending_mergers.
+                if exhausted {
+                    pending_mergers.pop_front();
+                } else {
+                    // Merger still has data — we yielded.
+                    break;
+                }
+            }
+
+            if !pending_mergers.is_empty() {
+                activator.activate();
+            }
+        }
+    });
+
+    updates_stream
+}
+
+/// Reports a filter pushdown audit violation. Extracted to keep the main
+/// decode loops readable.
+fn report_pushdown_audit(name: &str, panic_on_failure: bool) {
+    sentry::with_scope(
+        |scope| scope.set_tag("alert_id", "persist_pushdown_audit_violation"),
+        || {
+            error!(
+                name,
+                "persist filter pushdown correctness violation (consolidating path)!"
+            );
+            if panic_on_failure {
+                panic!(
+                    "persist filter pushdown correctness violation! {}",
+                    name
+                );
+            }
+        },
+    );
 }
 
 /// A trait representing a type that can be used in `backpressure`.

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -56,7 +56,7 @@ use timely::dataflow::ScopeParent;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OutputBuilder, OutputBuilderSession};
-use timely::dataflow::operators::{Capability, Leave, OkErr};
+use timely::dataflow::operators::{Capability, Enter, Leave, OkErr};
 use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream, StreamVec};
@@ -130,10 +130,101 @@ impl TimelyTimestamp for Subtime {
     }
 }
 
+impl Lattice for Subtime {
+    fn join(&self, other: &Self) -> Self {
+        Subtime(std::cmp::max(self.0, other.0))
+    }
+    fn meet(&self, other: &Self) -> Self {
+        Subtime(std::cmp::min(self.0, other.0))
+    }
+}
+
+impl differential_dataflow::lattice::Maximum for Subtime {
+    fn maximum() -> Self {
+        Subtime(u64::MAX)
+    }
+}
+
 impl Subtime {
     /// The smallest non-zero summary for the opaque timestamp type.
     pub const fn least_summary() -> Self {
         Subtime(1)
+    }
+}
+
+/// Tracks progress through the keyspace within a batch. Used as the innermost
+/// timestamp in the consolidation scope to enable smooth frontier advancement
+/// during snapshot consolidation.
+///
+/// Derived from the first 8 bytes of the row's internal representation,
+/// interpreted as a big-endian u64. Since `Row::Ord` compares by
+/// (length, then bytes) and rows within a shard share a schema (same length),
+/// this is monotonically non-decreasing in `Row::Ord` order.
+///
+/// For `SourceData(Err(_))`, we use `u64::MAX` since errors sort after
+/// valid rows in `Result::Ord`.
+#[derive(
+    Copy, Clone, PartialEq, Default, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize, Hash,
+)]
+pub struct KeyProgress(u64);
+
+impl PartialOrder for KeyProgress {
+    fn less_equal(&self, other: &Self) -> bool {
+        self.0.less_equal(&other.0)
+    }
+}
+
+impl TotalOrder for KeyProgress {}
+
+impl PathSummary<KeyProgress> for KeyProgress {
+    fn results_in(&self, src: &KeyProgress) -> Option<KeyProgress> {
+        self.0.results_in(&src.0).map(KeyProgress)
+    }
+    fn followed_by(&self, other: &Self) -> Option<Self> {
+        self.0.followed_by(&other.0).map(KeyProgress)
+    }
+}
+
+impl TimelyTimestamp for KeyProgress {
+    type Summary = KeyProgress;
+    fn minimum() -> Self {
+        KeyProgress(0)
+    }
+}
+
+impl Lattice for KeyProgress {
+    fn join(&self, other: &Self) -> Self {
+        KeyProgress(std::cmp::max(self.0, other.0))
+    }
+    fn meet(&self, other: &Self) -> Self {
+        KeyProgress(std::cmp::min(self.0, other.0))
+    }
+}
+
+impl differential_dataflow::lattice::Maximum for KeyProgress {
+    fn maximum() -> Self {
+        KeyProgress(u64::MAX)
+    }
+}
+
+impl KeyProgress {
+    /// Derive a `KeyProgress` value from a `SourceData` key.
+    ///
+    /// Takes the first 8 bytes of the row's internal byte representation and
+    /// interprets them as a big-endian u64. For rows shorter than 8 bytes, the
+    /// value is zero-padded on the right. For errors, returns `u64::MAX` since
+    /// `Err` sorts after `Ok` in `Result::Ord`.
+    fn from_source_data(key: &SourceData) -> Self {
+        match &key.0 {
+            Ok(row) => {
+                let data = row.data();
+                let mut buf = [0u8; 8];
+                let len = std::cmp::min(data.len(), 8);
+                buf[..len].copy_from_slice(&data[..len]);
+                KeyProgress(u64::from_be_bytes(buf))
+            }
+            Err(_) => KeyProgress(u64::MAX),
+        }
     }
 }
 
@@ -853,8 +944,12 @@ impl SourcePartMerger {
 
 /// A variant of [`decode_and_mfp`] that performs a streaming merge across all
 /// fetched parts at the same timestamp, consolidating updates with identical
-/// key-value-time before applying MFP. This produces fewer downstream updates
-/// than the sequential approach when parts contain overlapping key ranges.
+/// key-value-time before applying MFP.
+///
+/// Opens a nested scope with [`KeyProgress`] timestamps derived from key
+/// prefixes. This allows a `consolidate` operator to make incremental progress
+/// as the merge moves through the keyspace, enabling smooth "time-to-first-byte"
+/// for queries like `SELECT ... LIMIT k`.
 ///
 /// Used when [`SourceConsolidation::Full`] is requested.
 pub fn decode_and_mfp_consolidating<G>(
@@ -867,9 +962,72 @@ pub fn decode_and_mfp_consolidating<G>(
 where
     G: Scope<Timestamp = (mz_repr::Timestamp, Subtime)>,
 {
+    use differential_dataflow::AsCollection;
+
+    let name_owned = name.to_owned();
+    let map_filter_project = map_filter_project.as_mut().map(|mfp| mfp.take());
+    fetched
+        .scope()
+        .scoped::<((mz_repr::Timestamp, Subtime), KeyProgress), _, _>(
+            &format!("persist_source::consolidation({})", name),
+            move |inner| {
+                // Move the fetched stream into the inner scope. Data arrives at
+                // ((T, S), KeyProgress::minimum()).
+                let fetched_inner = fetched.enter(inner);
+
+                // Build the streaming merge decode operator in the inner scope.
+                // It manages KeyProgress capabilities based on the key prefix.
+                let decoded = streaming_merge_decode(
+                    cfg,
+                    fetched_inner,
+                    &name_owned,
+                    until,
+                    map_filter_project,
+                );
+
+                // Consolidate across workers in the inner scope. Because
+                // KeyProgress advances smoothly, the consolidation processes
+                // data in keyspace chunks rather than buffering the entire batch.
+                let consolidated = decoded.as_collection().consolidate().inner;
+
+                // Leave the inner scope, stripping KeyProgress from data
+                // timestamps. Use a simple unary to map the tuples.
+                use timely::dataflow::operators::Operator;
+                consolidated
+                    .unary(Pipeline, "StripKeyProgress", |_, _| {
+                        move |input, output| {
+                            input.for_each(|time, data| {
+                                let mut session = output.session(&time);
+                                for (d, t, r) in data.drain(..) {
+                                    session.give((d, t.0, r));
+                                }
+                            });
+                        }
+                    })
+                    .leave()
+            },
+        )
+}
+
+/// The streaming merge decode operator for the consolidation inner scope.
+///
+/// Receives fetched blobs, merges them using [`SourcePartMerger`], applies MFP,
+/// and emits rows with [`KeyProgress`] timestamps derived from key prefixes.
+/// Periodically downgrades capabilities to allow the downstream `consolidate`
+/// to make incremental progress.
+fn streaming_merge_decode<G>(
+    cfg: PersistConfig,
+    fetched: StreamVec<G, FetchedBlob<SourceData, (), Timestamp, StorageDiff>>,
+    name: &str,
+    until: Antichain<Timestamp>,
+    map_filter_project: Option<MfpPlan>,
+) -> StreamVec<G, (Result<Row, DataflowError>, G::Timestamp, Diff)>
+where
+    G: Scope<Timestamp = ((mz_repr::Timestamp, Subtime), KeyProgress)>,
+{
     let scope = fetched.scope();
     let mut builder = OperatorBuilder::new(
-        format!("persist_source::decode_and_mfp_consolidating({})", name),
+        format!("persist_source::streaming_merge_decode({})", name),
         scope.clone(),
     );
     let operator_info = builder.operator_info();
@@ -881,7 +1039,7 @@ where
         ConsolidatingContainerBuilder<
             Vec<(
                 Result<Row, DataflowError>,
-                (mz_repr::Timestamp, Subtime),
+                ((mz_repr::Timestamp, Subtime), KeyProgress),
                 Diff,
             )>,
         >,
@@ -891,35 +1049,35 @@ where
     let mut datum_vec = mz_repr::DatumVec::new();
     let mut row_builder = Row::default();
 
-    // Extract the MFP if it exists; leave behind an identity MFP in that case.
-    let map_filter_project = map_filter_project.as_mut().map(|mfp| mfp.take());
     let panic_on_audit_failure = STATS_AUDIT_PANIC.handle(&cfg);
+
+    type InnerTime = ((mz_repr::Timestamp, Subtime), KeyProgress);
 
     builder.build(move |_caps| {
         let name = name.to_owned();
-        // Acquire an activator to reschedule the operator when it has unfinished work.
         let activations = scope.activations();
         let activator = Activator::new(operator_info.address, activations);
 
-        // Groups of pending parts by their capability. We merge all parts at the
-        // same time together to maximize consolidation.
+        // Each entry: a capability (for creating delayed caps / dropped when
+        // done), the merger, and the current max KeyProgress for downgrading.
         let mut pending_mergers: std::collections::VecDeque<(
-            Capability<(mz_repr::Timestamp, Subtime)>,
+            Capability<InnerTime>,
             SourcePartMerger,
         )> = std::collections::VecDeque::new();
 
         move |_frontier| {
-            // Collect newly arrived blobs, grouping by time.
             fetched_input.for_each(|time, data| {
                 let capability = time.retain(0);
 
                 // Find or create a merger for this time.
-                let merger = if let Some((_, m)) =
-                    pending_mergers.iter_mut().find(|(c, _)| c.time() == capability.time())
+                let merger = if let Some((_, m)) = pending_mergers
+                    .iter_mut()
+                    .find(|(c, _)| c.time() == capability.time())
                 {
                     m
                 } else {
-                    pending_mergers.push_back((capability.clone(), SourcePartMerger::new()));
+                    pending_mergers
+                        .push_back((capability, SourcePartMerger::new()));
                     &mut pending_mergers.back_mut().unwrap().1
                 };
 
@@ -939,12 +1097,23 @@ where
             while !pending_mergers.is_empty() && !yield_fn(start_time, work) {
                 let exhausted = {
                     let (cap, merger) = pending_mergers.front_mut().unwrap();
-                    let mut session = output.session_with_builder(cap);
 
                     while let Some(((key, _val), time, diff, is_audit)) = merger.next() {
                         if until.less_equal(&time) {
                             continue;
                         }
+
+                        // Derive KeyProgress from the key prefix and downgrade
+                        // our capability so the consolidate frontier advances.
+                        let key_progress = KeyProgress::from_source_data(&key);
+                        let emit_time: InnerTime = (
+                            (time, cap.time().0 .1),
+                            key_progress,
+                        );
+                        // Downgrade to signal we won't emit earlier key positions.
+                        cap.downgrade(&emit_time);
+                        let mut session = output.session_with_builder(cap);
+
                         match key {
                             SourceData(Ok(row)) => {
                                 if let Some(mfp) = map_filter_project.as_ref() {
@@ -960,44 +1129,37 @@ where
                                         &mut row_builder,
                                     ) {
                                         if is_audit {
-                                            report_pushdown_audit(
-                                                &name,
-                                                panic_on_audit,
-                                            );
+                                            report_pushdown_audit(&name, panic_on_audit);
                                         }
                                         match result {
                                             Ok((row, time, diff)) => {
                                                 if !until.less_equal(&time) {
-                                                    let mut emit_time = *cap.time();
-                                                    emit_time.0 = time;
-                                                    session.give((Ok(row), emit_time, diff));
+                                                    let et = ((time, emit_time.0 .1), key_progress);
+                                                    session.give((Ok(row), et, diff));
                                                     work += 1;
                                                 }
                                             }
                                             Err((err, time, diff)) => {
                                                 if !until.less_equal(&time) {
-                                                    let mut emit_time = *cap.time();
-                                                    emit_time.0 = time;
-                                                    session.give((Err(err), emit_time, diff));
+                                                    let et = ((time, emit_time.0 .1), key_progress);
+                                                    session.give((Err(err), et, diff));
                                                     work += 1;
                                                 }
                                             }
                                         }
                                     }
                                 } else {
-                                    let mut emit_time = *cap.time();
-                                    emit_time.0 = time;
                                     session.give((Ok(row.clone()), emit_time, diff.into()));
                                     work += 1;
                                 }
                             }
                             SourceData(Err(err)) => {
-                                let mut emit_time = *cap.time();
-                                emit_time.0 = time;
                                 session.give((Err(err), emit_time, diff.into()));
                                 work += 1;
                             }
                         }
+                        // Drop session before next iteration to avoid borrow conflict.
+                        drop(session);
                         if yield_fn(start_time, work) {
                             break;
                         }
@@ -1005,12 +1167,9 @@ where
 
                     merger.is_empty()
                 };
-                // The session is dropped here (end of the block above), releasing
-                // the borrow on pending_mergers.
                 if exhausted {
                     pending_mergers.pop_front();
                 } else {
-                    // Merger still has data — we yielded.
                     break;
                 }
             }

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -73,6 +73,7 @@ where
             None,
             async {},
             error_handler,
+            persist_source::SourceConsolidation::BestEffort,
         );
         tokens.extend(persist_tokens);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -311,6 +311,7 @@ where
                             false.then_some(|| unreachable!()),
                             async {},
                             error_handler,
+                            persist_source::SourceConsolidation::BestEffort,
                         );
                         (
                             stream.as_collection(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -311,7 +311,11 @@ where
                             false.then_some(|| unreachable!()),
                             async {},
                             error_handler,
-                            persist_source::SourceConsolidation::BestEffort,
+                            // Use Full consolidation so the upsert operator
+                            // receives consolidated feedback. This reduces
+                            // the work in consolidate_chunk and ensures each
+                            // key appears at most once per batch.
+                            persist_source::SourceConsolidation::Full,
                         );
                         (
                             stream.as_collection(),

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -15,19 +15,15 @@ use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use differential_dataflow::hashable::Hashable;
 use differential_dataflow::{AsCollection, VecCollection};
 use futures::StreamExt;
-use futures::future::FutureExt;
-use indexmap::map::Entry;
 use itertools::Itertools;
 use mz_ore::error::ErrorExt;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
-use mz_rocksdb::ValueIterator;
 use mz_storage_operators::metrics::BackpressureMetrics;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::dyncfgs;
-use mz_storage_types::errors::{DataflowError, EnvelopeError, UpsertError};
+use mz_storage_types::errors::{DataflowError, UpsertError};
 use mz_storage_types::sources::envelope::UpsertEnvelope;
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
@@ -35,7 +31,6 @@ use mz_timely_util::builder_async::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::{Capability, InputCapability, Operator};
 use timely::dataflow::{Scope, ScopeParent, StreamVec};
 use timely::order::{PartialOrder, TotalOrder};
@@ -46,10 +41,7 @@ use crate::healthcheck::HealthStatusUpdate;
 use crate::metrics::upsert::UpsertMetrics;
 use crate::storage_state::StorageInstanceContext;
 use crate::upsert_continual_feedback;
-use types::{
-    BincodeOpts, StateValue, UpsertState, UpsertStateBackend, consolidating_merge_function,
-    upsert_bincode_opts,
-};
+use types::{UpsertStateBackend, upsert_bincode_opts};
 
 #[cfg(test)]
 pub mod memory;
@@ -174,8 +166,6 @@ use std::convert::Infallible;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 
-use self::types::ValueMetadata;
-
 /// This leaf operator drops `token` after the input reaches the `resume_upper`.
 /// This is useful to take coordinated actions across all workers, after the `upsert`
 /// operator has rehydrated.
@@ -259,11 +249,6 @@ where
     let snapshot_buffering_max = dyncfgs::STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING
         .get(storage_configuration.config_set());
 
-    // Whether we should provide the upsert state merge operator to the RocksDB instance
-    // (for faster performance during snapshot hydration).
-    let rocksdb_use_native_merge_operator =
-        dyncfgs::STORAGE_ROCKSDB_USE_MERGE_OPERATOR.get(storage_configuration.config_set());
-
     let upsert_config = UpsertConfig {
         shrink_upsert_unused_buffers_by_ratio: storage_configuration
             .parameters
@@ -292,7 +277,6 @@ where
         source_id = %source_config.id,
         ?rocksdb_dir,
         ?tuning,
-        ?rocksdb_use_native_merge_operator,
         "rendering upsert source"
     );
 
@@ -303,25 +287,13 @@ where
 
     // A closure that will initialize and return a configured RocksDB instance
     let rocksdb_init_fn = move || async move {
-        let merge_operator = if rocksdb_use_native_merge_operator {
-            Some((
-                "upsert_state_snapshot_merge_v1".to_string(),
-                |a: &[u8], b: ValueIterator<BincodeOpts, StateValue<G::Timestamp, FromTime>>| {
-                    consolidating_merge_function::<G::Timestamp, FromTime>(a.into(), b)
-                },
-            ))
-        } else {
-            None
-        };
         rocksdb::RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 &rocksdb_dir,
-                mz_rocksdb::InstanceOptions::new(
+                mz_rocksdb::InstanceOptions::<_, types::StateValue<G::Timestamp, FromTime>, mz_rocksdb::StubMergeOperator<types::StateValue<G::Timestamp, FromTime>>>::new(
                     env,
                     rocksdb_cleanup_tries,
-                    merge_operator,
-                    // For now, just use the same config as the one used for
-                    // merging snapshots.
+                    None,
                     upsert_bincode_opts(),
                 ),
                 tuning,
@@ -348,8 +320,7 @@ where
     )
 }
 
-// A shim so we can dispatch based on the dyncfg that tells us which upsert
-// operator to use.
+// A shim that delegates to the continual feedback upsert implementation.
 fn upsert_operator<G: Scope, FromTime, F, Fut, US>(
     input: VecCollection<G, (UpsertKey, Option<UpsertValue>, FromTime), Diff>,
     key_indices: Vec<usize>,
@@ -377,42 +348,19 @@ where
     US: UpsertStateBackend<G::Timestamp, FromTime>,
     FromTime: Debug + timely::ExchangeData + Clone + Ord + Sync,
 {
-    // Hard-coded to true because classic UPSERT cannot be used safely with
-    // concurrent ingestions, which we need for both 0dt upgrades and
-    // multi-replica ingestions.
-    let use_continual_feedback_upsert = true;
-
-    tracing::info!(id = %source_config.id, %use_continual_feedback_upsert, "upsert operator implementation");
-
-    if use_continual_feedback_upsert {
-        upsert_continual_feedback::upsert_inner(
-            input,
-            key_indices,
-            resume_upper,
-            persist_input,
-            persist_token,
-            upsert_metrics,
-            source_config,
-            state,
-            upsert_config,
-            prevent_snapshot_buffering,
-            snapshot_buffering_max,
-        )
-    } else {
-        upsert_classic(
-            input,
-            key_indices,
-            resume_upper,
-            persist_input,
-            persist_token,
-            upsert_metrics,
-            source_config,
-            state,
-            upsert_config,
-            prevent_snapshot_buffering,
-            snapshot_buffering_max,
-        )
-    }
+    upsert_continual_feedback::upsert_inner(
+        input,
+        key_indices,
+        resume_upper,
+        persist_input,
+        persist_token,
+        upsert_metrics,
+        source_config,
+        state,
+        upsert_config,
+        prevent_snapshot_buffering,
+        snapshot_buffering_max,
+    )
 }
 
 /// Renders an operator that discards updates that are known to not affect the outcome of upsert in
@@ -475,481 +423,10 @@ where
         .as_collection()
 }
 
-/// Helper method for `upsert_classic` used to stage `data` updates
-/// from the input/source timely edge.
-fn stage_input<T, FromTime>(
-    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
-    data: &mut Vec<((UpsertKey, Option<UpsertValue>, FromTime), T, Diff)>,
-    input_upper: &Antichain<T>,
-    resume_upper: &Antichain<T>,
-    storage_shrink_upsert_unused_buffers_by_ratio: usize,
-) where
-    T: PartialOrder,
-    FromTime: Ord,
-{
-    if PartialOrder::less_equal(input_upper, resume_upper) {
-        data.retain(|(_, ts, _)| resume_upper.less_equal(ts));
-    }
-
-    stash.extend(data.drain(..).map(|((key, value, order), time, diff)| {
-        assert!(diff.is_positive(), "invalid upsert input");
-        (time, key, Reverse(order), value)
-    }));
-
-    if storage_shrink_upsert_unused_buffers_by_ratio > 0 {
-        let reduced_capacity = stash.capacity() / storage_shrink_upsert_unused_buffers_by_ratio;
-        if reduced_capacity > stash.len() {
-            stash.shrink_to(reduced_capacity);
-        }
-    }
-}
-
-/// The style of drain we are performing on the stash. `AtTime`-drains cannot
-/// assume that all values have been seen, and must leave tombstones behind for deleted values.
-#[derive(Debug)]
-enum DrainStyle<'a, T> {
-    ToUpper(&'a Antichain<T>),
-    AtTime(T),
-}
-
-/// Helper method for `upsert_inner` used to stage `data` updates
-/// from the input timely edge.
-async fn drain_staged_input<S, G, T, FromTime, E>(
-    stash: &mut Vec<(T, UpsertKey, Reverse<FromTime>, Option<UpsertValue>)>,
-    commands_state: &mut indexmap::IndexMap<UpsertKey, types::UpsertValueAndSize<T, FromTime>>,
-    output_updates: &mut Vec<(UpsertValue, T, Diff)>,
-    multi_get_scratch: &mut Vec<UpsertKey>,
-    drain_style: DrainStyle<'_, T>,
-    error_emitter: &mut E,
-    state: &mut UpsertState<'_, S, T, FromTime>,
-    source_config: &crate::source::SourceExportCreationConfig,
-) where
-    S: UpsertStateBackend<T, FromTime>,
-    G: Scope,
-    T: PartialOrder + Ord + Clone + Send + Sync + Serialize + Debug + 'static,
-    FromTime: timely::ExchangeData + Clone + Ord + Sync,
-    E: UpsertErrorEmitter<G>,
-{
-    stash.sort_unstable();
-
-    // Find the prefix that we can emit
-    let idx = stash.partition_point(|(ts, _, _, _)| match &drain_style {
-        DrainStyle::ToUpper(upper) => !upper.less_equal(ts),
-        DrainStyle::AtTime(time) => ts <= time,
-    });
-
-    tracing::trace!(?drain_style, updates = idx, "draining stash in upsert");
-
-    // Read the previous values _per key_ out of `state`, recording it
-    // along with the value with the _latest timestamp for that key_.
-    commands_state.clear();
-    for (_, key, _, _) in stash.iter().take(idx) {
-        commands_state.entry(*key).or_default();
-    }
-
-    // These iterators iterate in the same order because `commands_state`
-    // is an `IndexMap`.
-    multi_get_scratch.clear();
-    multi_get_scratch.extend(commands_state.iter().map(|(k, _)| *k));
-    match state
-        .multi_get(multi_get_scratch.drain(..), commands_state.values_mut())
-        .await
-    {
-        Ok(_) => {}
-        Err(e) => {
-            error_emitter
-                .emit("Failed to fetch records from state".to_string(), e)
-                .await;
-        }
-    }
-
-    // From the prefix that can be emitted we can deduplicate based on (ts, key) in
-    // order to only process the command with the maximum order within the (ts,
-    // key) group. This is achieved by wrapping order in `Reverse(FromTime)` above.;
-    let mut commands = stash.drain(..idx).dedup_by(|a, b| {
-        let ((a_ts, a_key, _, _), (b_ts, b_key, _, _)) = (a, b);
-        a_ts == b_ts && a_key == b_key
-    });
-
-    let bincode_opts = types::upsert_bincode_opts();
-    // Upsert the values into `commands_state`, by recording the latest
-    // value (or deletion). These will be synced at the end to the `state`.
-    //
-    // Note that we are effectively doing "mini-upsert" here, using
-    // `command_state`. This "mini-upsert" is seeded with data from `state`, using
-    // a single `multi_get` above, and the final state is written out into
-    // `state` using a single `multi_put`. This simplifies `UpsertStateBackend`
-    // implementations, and reduces the number of reads and write we need to do.
-    //
-    // This "mini-upsert" technique is actually useful in `UpsertState`'s
-    // `consolidate_snapshot_read_write_inner` implementation, minimizing gets and puts on
-    // the `UpsertStateBackend` implementations. In some sense, its "upsert all the way down".
-    while let Some((ts, key, from_time, value)) = commands.next() {
-        let mut command_state = if let Entry::Occupied(command_state) = commands_state.entry(key) {
-            command_state
-        } else {
-            panic!("key missing from commands_state");
-        };
-
-        let existing_value = &mut command_state.get_mut().value;
-
-        if let Some(cs) = existing_value.as_mut() {
-            cs.ensure_decoded(bincode_opts, source_config.id, Some(&key));
-        }
-
-        // Skip this command if its order key is below the one in the upsert state.
-        // Note that the existing order key may be `None` if the existing value
-        // is from snapshotting, which always sorts below new values/deletes.
-        let existing_order = existing_value
-            .as_ref()
-            .and_then(|cs| cs.provisional_order(&ts));
-        if existing_order >= Some(&from_time.0) {
-            // Skip this update. If no later updates adjust this key, then we just
-            // end up writing the same value back to state. If there
-            // is nothing in the state, `existing_order` is `None`, and this
-            // does not occur.
-            continue;
-        }
-
-        match value {
-            Some(value) => {
-                if let Some(old_value) =
-                    existing_value.replace(StateValue::finalized_value(value.clone()))
-                {
-                    if let Some(old_value) = old_value.into_decoded().finalized {
-                        output_updates.push((old_value, ts.clone(), Diff::MINUS_ONE));
-                    }
-                }
-                output_updates.push((value, ts, Diff::ONE));
-            }
-            None => {
-                if let Some(old_value) = existing_value.take() {
-                    if let Some(old_value) = old_value.into_decoded().finalized {
-                        output_updates.push((old_value, ts, Diff::MINUS_ONE));
-                    }
-                }
-
-                // Record a tombstone for deletes.
-                *existing_value = Some(StateValue::tombstone());
-            }
-        }
-    }
-
-    match state
-        .multi_put(
-            true, // Do update per-update stats.
-            commands_state.drain(..).map(|(k, cv)| {
-                (
-                    k,
-                    types::PutValue {
-                        value: cv.value.map(|cv| cv.into_decoded()),
-                        previous_value_metadata: cv.metadata.map(|v| ValueMetadata {
-                            size: v.size.try_into().expect("less than i64 size"),
-                            is_tombstone: v.is_tombstone,
-                        }),
-                    },
-                )
-            }),
-        )
-        .await
-    {
-        Ok(_) => {}
-        Err(e) => {
-            error_emitter
-                .emit("Failed to update records in state".to_string(), e)
-                .await;
-        }
-    }
-}
-
 // Created a struct to hold the configs for upserts.
 // So that new configs don't require a new method parameter.
 pub(crate) struct UpsertConfig {
     pub shrink_upsert_unused_buffers_by_ratio: usize,
-}
-
-fn upsert_classic<G: Scope, FromTime, F, Fut, US>(
-    input: VecCollection<G, (UpsertKey, Option<UpsertValue>, FromTime), Diff>,
-    key_indices: Vec<usize>,
-    resume_upper: Antichain<G::Timestamp>,
-    previous: VecCollection<G, Result<Row, DataflowError>, Diff>,
-    previous_token: Option<Vec<PressOnDropButton>>,
-    upsert_metrics: UpsertMetrics,
-    source_config: crate::source::SourceExportCreationConfig,
-    state: F,
-    upsert_config: UpsertConfig,
-    prevent_snapshot_buffering: bool,
-    snapshot_buffering_max: Option<usize>,
-) -> (
-    VecCollection<G, Result<Row, DataflowError>, Diff>,
-    StreamVec<G, (Option<GlobalId>, HealthStatusUpdate)>,
-    StreamVec<G, Infallible>,
-    PressOnDropButton,
-)
-where
-    G::Timestamp: TotalOrder + Sync,
-    F: FnOnce() -> Fut + 'static,
-    Fut: std::future::Future<Output = US>,
-    US: UpsertStateBackend<G::Timestamp, FromTime>,
-    FromTime: timely::ExchangeData + Clone + Ord + Sync,
-{
-    let mut builder = AsyncOperatorBuilder::new("Upsert".to_string(), input.scope());
-
-    // We only care about UpsertValueError since this is the only error that we can retract
-    let previous = previous.flat_map(move |result| {
-        let value = match result {
-            Ok(ok) => Ok(ok),
-            Err(DataflowError::EnvelopeError(err)) => match *err {
-                EnvelopeError::Upsert(err) => Err(Box::new(err)),
-                _ => return None,
-            },
-            Err(_) => return None,
-        };
-        let value_ref = match value {
-            Ok(ref row) => Ok(row),
-            Err(ref err) => Err(&**err),
-        };
-        Some((UpsertKey::from_value(value_ref, &key_indices), value))
-    });
-    let (output_handle, output) = builder.new_output();
-
-    // An output that just reports progress of the snapshot consolidation process upstream to the
-    // persist source to ensure that backpressure is applied
-    let (_snapshot_handle, snapshot_stream) =
-        builder.new_output::<CapacityContainerBuilder<Vec<Infallible>>>();
-
-    let (mut health_output, health_stream) = builder.new_output();
-    let mut input = builder.new_input_for(
-        input.inner,
-        Exchange::new(move |((key, _, _), _, _)| UpsertKey::hashed(key)),
-        &output_handle,
-    );
-
-    let mut previous = builder.new_input_for(
-        previous.inner,
-        Exchange::new(|((key, _), _, _)| UpsertKey::hashed(key)),
-        &output_handle,
-    );
-
-    let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
-    let shutdown_button = builder.build(move |caps| async move {
-        let [mut output_cap, mut snapshot_cap, health_cap]: [_; 3] = caps.try_into().unwrap();
-
-        let mut state = UpsertState::<_, _, FromTime>::new(
-            state().await,
-            upsert_shared_metrics,
-            &upsert_metrics,
-            source_config.source_statistics.clone(),
-            upsert_config.shrink_upsert_unused_buffers_by_ratio,
-        );
-        let mut events = vec![];
-        let mut snapshot_upper = Antichain::from_elem(Timestamp::minimum());
-
-        let mut stash = vec![];
-
-        let mut error_emitter = (&mut health_output, &health_cap);
-
-        tracing::info!(
-            ?resume_upper,
-            ?snapshot_upper,
-            "timely-{} upsert source {} starting rehydration",
-            source_config.worker_id,
-            source_config.id
-        );
-        // Read and consolidate the snapshot from the 'previous' input until it
-        // reaches the `resume_upper`.
-        while !PartialOrder::less_equal(&resume_upper, &snapshot_upper) {
-            previous.ready().await;
-            while let Some(event) = previous.next_sync() {
-                match event {
-                    AsyncEvent::Data(_cap, data) => {
-                        events.extend(data.into_iter().filter_map(|((key, value), ts, diff)| {
-                            if !resume_upper.less_equal(&ts) {
-                                Some((key, value, diff))
-                            } else {
-                                None
-                            }
-                        }))
-                    }
-                    AsyncEvent::Progress(upper) => {
-                        snapshot_upper = upper;
-                    }
-                };
-            }
-
-            match state
-                .consolidate_chunk(
-                    events.drain(..),
-                    PartialOrder::less_equal(&resume_upper, &snapshot_upper),
-                )
-                .await
-            {
-                Ok(_) => {
-                    if let Some(ts) = snapshot_upper.clone().into_option() {
-                        // As we shutdown, we could ostensibly get data from later than the
-                        // `resume_upper`, which we ignore above. We don't want our output capability to make
-                        // it further than the `resume_upper`.
-                        if !resume_upper.less_equal(&ts) {
-                            snapshot_cap.downgrade(&ts);
-                            output_cap.downgrade(&ts);
-                        }
-                    }
-                }
-                Err(e) => {
-                    UpsertErrorEmitter::<G>::emit(
-                        &mut error_emitter,
-                        "Failed to rehydrate state".to_string(),
-                        e,
-                    )
-                    .await;
-                }
-            }
-        }
-
-        drop(events);
-        drop(previous_token);
-        drop(snapshot_cap);
-
-        // Exchaust the previous input. It is expected to immediately reach the empty
-        // antichain since we have dropped its token.
-        //
-        // Note that we do not need to also process the `input` during this, as the dropped token
-        // will shutdown the `backpressure` operator
-        while let Some(_event) = previous.next().await {}
-
-        // After snapshotting, our output frontier is exactly the `resume_upper`
-        if let Some(ts) = resume_upper.as_option() {
-            output_cap.downgrade(ts);
-        }
-
-        tracing::info!(
-            "timely-{} upsert source {} finished rehydration",
-            source_config.worker_id,
-            source_config.id
-        );
-
-        // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
-        // and have a consistent iteration order.
-        let mut commands_state: indexmap::IndexMap<
-            _,
-            types::UpsertValueAndSize<G::Timestamp, FromTime>,
-        > = indexmap::IndexMap::new();
-        let mut multi_get_scratch = Vec::new();
-
-        // Now can can resume consuming the collection
-        let mut output_updates = vec![];
-        let mut input_upper = Antichain::from_elem(Timestamp::minimum());
-
-        while let Some(event) = input.next().await {
-            // Buffer as many events as possible. This should be bounded, as new data can't be
-            // produced in this worker until we yield to timely.
-            let events = [event]
-                .into_iter()
-                .chain(std::iter::from_fn(|| input.next().now_or_never().flatten()))
-                .enumerate();
-
-            let mut partial_drain_time = None;
-            for (i, event) in events {
-                match event {
-                    AsyncEvent::Data(cap, mut data) => {
-                        tracing::trace!(
-                            time=?cap.time(),
-                            updates=%data.len(),
-                            "received data in upsert"
-                        );
-                        stage_input(
-                            &mut stash,
-                            &mut data,
-                            &input_upper,
-                            &resume_upper,
-                            upsert_config.shrink_upsert_unused_buffers_by_ratio,
-                        );
-
-                        let event_time = cap.time();
-                        // If the data is at _exactly_ the output frontier, we can preemptively drain it into the state.
-                        // Data within this set events strictly beyond this time are staged as
-                        // normal.
-                        //
-                        // This is a load-bearing optimization, as it is required to avoid buffering
-                        // the entire source snapshot in the `stash`.
-                        if prevent_snapshot_buffering && output_cap.time() == event_time {
-                            partial_drain_time = Some(event_time.clone());
-                        }
-                    }
-                    AsyncEvent::Progress(upper) => {
-                        tracing::trace!(?upper, "received progress in upsert");
-                        // Ignore progress updates before the `resume_upper`, which is our initial
-                        // capability post-snapshotting.
-                        if PartialOrder::less_than(&upper, &resume_upper) {
-                            continue;
-                        }
-
-                        // Disable the partial drain as this progress event covers
-                        // the `output_cap` time.
-                        partial_drain_time = None;
-                        drain_staged_input::<_, G, _, _, _>(
-                            &mut stash,
-                            &mut commands_state,
-                            &mut output_updates,
-                            &mut multi_get_scratch,
-                            DrainStyle::ToUpper(&upper),
-                            &mut error_emitter,
-                            &mut state,
-                            &source_config,
-                        )
-                        .await;
-
-                        output_handle.give_container(&output_cap, &mut output_updates);
-
-                        if let Some(ts) = upper.as_option() {
-                            output_cap.downgrade(ts);
-                        }
-                        input_upper = upper;
-                    }
-                }
-                let events_processed = i + 1;
-                if let Some(max) = snapshot_buffering_max {
-                    if events_processed >= max {
-                        break;
-                    }
-                }
-            }
-
-            // If there were staged events that occurred at the capability time, drain
-            // them. This is safe because out-of-order updates to the same key that are
-            // drained in separate calls to `drain_staged_input` are correctly ordered by
-            // their `FromTime` in `drain_staged_input`.
-            //
-            // Note also that this may result in more updates in the output collection than
-            // the minimum. However, because the frontier only advances on `Progress` updates,
-            // the collection always accumulates correctly for all keys.
-            if let Some(partial_drain_time) = partial_drain_time {
-                drain_staged_input::<_, G, _, _, _>(
-                    &mut stash,
-                    &mut commands_state,
-                    &mut output_updates,
-                    &mut multi_get_scratch,
-                    DrainStyle::AtTime(partial_drain_time),
-                    &mut error_emitter,
-                    &mut state,
-                    &source_config,
-                )
-                .await;
-
-                output_handle.give_container(&output_cap, &mut output_updates);
-            }
-        }
-    });
-
-    (
-        output.as_collection().map(|result| match result {
-            Ok(ok) => Ok(ok),
-            Err(err) => Err(DataflowError::from(EnvelopeError::Upsert(*err))),
-        }),
-        health_stream,
-        snapshot_stream,
-        shutdown_button.press_on_drop(),
-    )
 }
 
 #[async_trait::async_trait(?Send)]

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -21,8 +21,8 @@ use mz_ore::cast::CastFrom;
 
 use super::UpsertKey;
 use super::types::{
-    GetStats, MergeStats, MergeValue, PutStats, PutValue, StateValue, UpsertStateBackend,
-    UpsertValueAndSize, ValueMetadata,
+    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+    ValueMetadata,
 };
 
 /// A `HashMap` tracking its total size
@@ -46,10 +46,6 @@ where
     O: Clone + 'static,
     T: Clone + 'static,
 {
-    fn supports_merge(&self) -> bool {
-        false
-    }
-
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
@@ -71,13 +67,6 @@ where
         }
         self.total_size += stats.size_diff;
         Ok(stats)
-    }
-
-    async fn multi_merge<M>(&mut self, _merges: M) -> Result<MergeStats, anyhow::Error>
-    where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
-    {
-        anyhow::bail!("InMemoryHashMap does not support merging");
     }
 
     async fn multi_get<'r, G, R>(

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -14,8 +14,8 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use super::UpsertKey;
 use super::types::{
-    GetStats, MergeStats, MergeValue, PutStats, PutValue, StateValue, UpsertStateBackend,
-    UpsertValueAndSize, ValueMetadata,
+    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+    ValueMetadata,
 };
 
 /// A `UpsertStateBackend` implementation backed by RocksDB.
@@ -36,10 +36,6 @@ where
     O: Send + Sync + Serialize + DeserializeOwned + 'static,
     T: Send + Sync + Serialize + DeserializeOwned + 'static,
 {
-    fn supports_merge(&self) -> bool {
-        self.rocksdb.supports_merges
-    }
-
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<T, O>>)>,
@@ -69,25 +65,6 @@ where
         p_stats.size_diff += size;
 
         Ok(p_stats)
-    }
-
-    async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
-    where
-        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>,
-    {
-        let mut m_stats = MergeStats::default();
-        let stats =
-            self.rocksdb
-                .multi_update(merges.into_iter().map(|(k, MergeValue { value, diff })| {
-                    (k, KeyUpdate::Merge(value), Some(diff))
-                }))
-                .await?;
-        m_stats.written_merge_operands += stats.processed_updates;
-        m_stats.size_written += stats.size_written;
-        if let Some(diff) = stats.size_diff {
-            m_stats.size_diff += diff.into_inner();
-        }
-        Ok(m_stats)
     }
 
     async fn multi_get<'r, G, R>(

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -79,19 +79,13 @@
 //! `InMemoryHashMap`, they may be rough estimates of actual memory usage. See
 //! `StateValue::memory_size` for more information.
 //!
-//! Note also that after consolidation, additional space may be used if `StateValue` is
-//! used.
-//!
 
 use std::fmt;
-use std::num::Wrapping;
 use std::sync::Arc;
 use std::time::Instant;
 
-use bincode::Options;
-use itertools::Itertools;
 use mz_ore::error::ErrorExt;
-use mz_repr::{Diff, GlobalId};
+use mz_repr::Diff;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::metrics::upsert::{UpsertMetrics, UpsertSharedMetrics};
@@ -161,43 +155,25 @@ pub struct PutValue<V> {
     pub previous_value_metadata: Option<ValueMetadata<i64>>,
 }
 
-/// A value to put in with a `multi_merge`.
-pub struct MergeValue<V> {
-    /// The value of the merge operand to write to the backend.
-    pub value: V,
-    /// The 'diff' of this merge operand value, used to estimate the overall size diff
-    /// of the working set after this merge operand is merged by the backend.
-    pub diff: Diff,
-}
-
-/// `UpsertState` has 2 modes:
-/// - Normal operation
-/// - Consolidation.
-///
-/// This struct and its substructs are helpers to simplify the logic that
-/// individual `UpsertState` implementations need to do to manage these 2 modes.
+/// `UpsertState` stores values associated with keys, supporting both finalized and provisional
+/// values.
 ///
 /// Normal operation is simple, we just store an ordinary `UpsertValue`, and allow the implementer
-/// to store it any way they want. During consolidation, the logic is more complex.
-/// See the docs on `StateValue::merge_update` for more information.
+/// to store it any way they want.
 ///
 /// Note also that this type is designed to support _partial updates_. All values are
 /// associated with an _order key_ `O` that can be used to determine if a value existing in the
 /// `UpsertStateBackend` occurred before or after a value being considered for insertion.
 ///
 /// `O` typically required to be `: Default`, with the default value sorting below all others.
-/// During consolidation, values consolidate correctly (as they are actual
-/// differential updates with diffs), so order keys are not required.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub enum StateValue<T, O> {
-    Consolidating(Consolidating),
     Value(Value<T, O>),
 }
 
 impl<T, O> std::fmt::Debug for StateValue<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StateValue::Consolidating(c) => std::fmt::Display::fmt(c, f),
             StateValue::Value(_) => write!(f, "Value"),
         }
     }
@@ -243,35 +219,7 @@ pub struct ProvisionalValue<T, O> {
     pub value: Option<UpsertValue>,
 }
 
-/// A value as produced during consolidation.
-#[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
-pub struct Consolidating {
-    #[serde(with = "serde_bytes")]
-    value_xor: Vec<u8>,
-    len_sum: Wrapping<i64>,
-    checksum_sum: Wrapping<i64>,
-    diff_sum: Wrapping<i64>,
-}
-
-impl fmt::Display for Consolidating {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Consolidating")
-            .field("len_sum", &self.len_sum)
-            .field("checksum_sum", &self.checksum_sum)
-            .field("diff_sum", &self.diff_sum)
-            .finish_non_exhaustive()
-    }
-}
-
 impl<T, O> StateValue<T, O> {
-    /// A finalized, that is (assumed) persistent, value.
-    pub fn finalized_value(value: UpsertValue) -> Self {
-        Self::Value(Value {
-            finalized: Some(value),
-            provisional: None,
-        })
-    }
-
     #[allow(unused)]
     /// A tombstoned value.
     pub fn tombstone() -> Self {
@@ -285,15 +233,13 @@ impl<T, O> StateValue<T, O> {
     pub fn is_tombstone(&self) -> bool {
         match self {
             Self::Value(value) => value.finalized.is_none(),
-            _ => false,
         }
     }
 
-    /// Pull out the `Value` value for a `StateValue`, after `ensure_decoded` has been called.
+    /// Pull out the `Value` value for a `StateValue`.
     pub fn into_decoded(self) -> Value<T, O> {
         match self {
             Self::Value(value) => value,
-            _ => panic!("called `into_decoded without calling `ensure_decoded`"),
         }
     }
 
@@ -308,7 +254,6 @@ impl<T, O> StateValue<T, O> {
         use std::mem::size_of;
 
         let heap_size = match self {
-            Self::Consolidating(Consolidating { value_xor, .. }) => value_xor.len(),
             Self::Value(value) => {
                 let finalized_heap_size = match value.finalized {
                     Some(Ok(ref row)) => {
@@ -363,9 +308,6 @@ impl<T: Eq, O> StateValue<T, O> {
                     order,
                 }),
             }),
-            StateValue::Consolidating(_) => {
-                panic!("called `into_provisional_value` without calling `ensure_decoded`")
-            }
         }
     }
 
@@ -397,9 +339,6 @@ impl<T: Eq, O> StateValue<T, O> {
                     order,
                 }),
             }),
-            StateValue::Consolidating(_) => {
-                panic!("called `into_provisional_tombstone` without calling `ensure_decoded`")
-            }
         }
     }
 
@@ -410,9 +349,6 @@ impl<T: Eq, O> StateValue<T, O> {
                 Some(p) if &p.timestamp == ts => Some(&p.order),
                 _ => None,
             },
-            Self::Consolidating(_) => {
-                panic!("called `provisional_order` without calling `ensure_decoded`")
-            }
         }
     }
 
@@ -424,263 +360,17 @@ impl<T: Eq, O> StateValue<T, O> {
                 Some(p) if &p.timestamp == ts => p.value.as_ref(),
                 _ => value.finalized.as_ref(),
             },
-            Self::Consolidating(_) => {
-                panic!("called `provisional_value_ref` without calling `ensure_decoded`")
-            }
         }
     }
 
-    /// Returns the the finalized value, if one is present.
-    pub fn into_finalized_value(self) -> Option<UpsertValue> {
-        match self {
-            Self::Value(v) => v.finalized,
-            _ => panic!("called `into_finalized_value` without calling `ensure_decoded`"),
-        }
-    }
-}
-
-impl<T: Eq, O> StateValue<T, O> {
-    /// We use a XOR trick in order to accumulate the values without having to store the full
-    /// unconsolidated history in memory. For all (value, diff) updates of a key we track:
-    /// - diff_sum = SUM(diff)
-    /// - checksum_sum = SUM(checksum(bincode(value)) * diff)
-    /// - len_sum = SUM(len(bincode(value)) * diff)
-    /// - value_xor = XOR(bincode(value))
-    ///
-    /// ## Return value
-    /// Returns a `bool` indicating whether or not the current merged value is able to be deleted.
-    ///
-    /// ## Correctness
-    ///
-    /// The method is correct because a well formed upsert collection at a given
-    /// timestamp will have for each key:
-    /// - Zero or one updates of the form (cur_value, +1)
-    /// - Zero or more pairs of updates of the form (prev_value, +1), (prev_value, -1)
-    ///
-    /// We are interested in extracting the cur_value of each key and discard all prev_values
-    /// that might be included in the stream. Since the history of prev_values always comes in
-    /// pairs, computing the XOR of those is always going to cancel their effects out. Also,
-    /// since XOR is commutative this property is true independent of the order. The same is
-    /// true for the summations of the length and checksum since the sum will contain the
-    /// unrelated values zero times.
-    ///
-    /// Therefore the accumulators will end up precisely in one of two states:
-    /// 1. diff == 0, checksum == 0, value == [0..] => the key is not present
-    /// 2. diff == 1, checksum == checksum(cur_value) value == cur_value => the key is present
-    ///
-    /// ## Robustness
-    ///
-    /// In the absense of bugs, accumulating the diff and checksum is not required since we know
-    /// that a well formed collection always satisfies XOR(bincode(values)) == bincode(cur_value).
-    /// However bugs may happen and so storing 16 more bytes per key to have a very high
-    /// guarantee that we're not decoding garbage is more than worth it.
-    /// The main key->value used to store previous values.
-    #[allow(clippy::as_conversions)]
-    pub fn merge_update(
-        &mut self,
-        value: UpsertValue,
-        diff: mz_repr::Diff,
-        bincode_opts: BincodeOpts,
-        bincode_buffer: &mut Vec<u8>,
-    ) -> bool {
-        match self {
-            Self::Consolidating(Consolidating {
-                value_xor,
-                len_sum,
-                checksum_sum,
-                diff_sum,
-            }) => {
-                bincode_buffer.clear();
-                bincode_opts
-                    .serialize_into(&mut *bincode_buffer, &value)
-                    .unwrap();
-                let len = i64::try_from(bincode_buffer.len()).unwrap();
-
-                *diff_sum += diff.into_inner();
-                *len_sum += len.wrapping_mul(diff.into_inner());
-                // Truncation is fine (using `as`) as this is just a checksum
-                *checksum_sum +=
-                    (seahash::hash(&*bincode_buffer) as i64).wrapping_mul(diff.into_inner());
-
-                // XOR of even diffs cancel out, so we only do it if diff is odd
-                if diff.abs() % Diff::from(2) == Diff::ONE {
-                    if value_xor.len() < bincode_buffer.len() {
-                        value_xor.resize(bincode_buffer.len(), 0);
-                    }
-                    // Note that if the new value is _smaller_ than the `value_xor`, and
-                    // the values at the end are zeroed out, we can shrink the buffer. This
-                    // is extremely sensitive code, so we don't (yet) do that.
-                    for (acc, val) in value_xor[0..bincode_buffer.len()]
-                        .iter_mut()
-                        .zip_eq(bincode_buffer.drain(..))
-                    {
-                        *acc ^= val;
-                    }
-                }
-
-                // Returns whether or not the value can be deleted. This allows
-                // us to delete values in `UpsertState::consolidate_chunk` (even
-                // if they come back later), to minimize space usage.
-                diff_sum.0 == 0 && checksum_sum.0 == 0 && value_xor.iter().all(|&x| x == 0)
-            }
-            StateValue::Value(_value) => {
-                // We can turn a Value back into a Consolidating state:
-                // `std::mem::take` will leave behind a default value, which
-                // happens to be a default `Consolidating` `StateValue`.
-                let this = std::mem::take(self);
-
-                let finalized_value = this.into_finalized_value();
-                if let Some(finalized_value) = finalized_value {
-                    // If we had a value before, merge it into the
-                    // now-consolidating state first.
-                    let _ =
-                        self.merge_update(finalized_value, Diff::ONE, bincode_opts, bincode_buffer);
-
-                    // Then merge the new value in.
-                    self.merge_update(value, diff, bincode_opts, bincode_buffer)
-                } else {
-                    // We didn't have a value before, might have been a
-                    // tombstone. So just merge in the new value.
-                    self.merge_update(value, diff, bincode_opts, bincode_buffer)
-                }
-            }
-        }
-    }
-
-    /// Merge an existing StateValue into this one, using the same method described in `merge_update`.
-    /// See the docstring above for more information on correctness and robustness.
-    pub fn merge_update_state(&mut self, other: &Self) {
-        match (self, other) {
-            (
-                Self::Consolidating(Consolidating {
-                    value_xor,
-                    len_sum,
-                    checksum_sum,
-                    diff_sum,
-                }),
-                Self::Consolidating(other_consolidating),
-            ) => {
-                *diff_sum += other_consolidating.diff_sum;
-                *len_sum += other_consolidating.len_sum;
-                *checksum_sum += other_consolidating.checksum_sum;
-                if other_consolidating.value_xor.len() > value_xor.len() {
-                    value_xor.resize(other_consolidating.value_xor.len(), 0);
-                }
-                for (acc, val) in value_xor[0..other_consolidating.value_xor.len()]
-                    .iter_mut()
-                    .zip_eq(other_consolidating.value_xor.iter())
-                {
-                    *acc ^= val;
-                }
-            }
-            _ => panic!("`merge_update_state` called with non-consolidating state"),
-        }
-    }
-
-    /// During and after consolidation, we assume that values in the `UpsertStateBackend` implementation
-    /// can be `Self::Consolidating`, with a `diff_sum` of 1 (or 0, if they have been deleted).
-    /// Afterwards, if we need to retract one of these values, we need to assert that its in this correct state,
-    /// then mutate it to its `Value` state, so the `upsert` operator can use it.
-    #[allow(clippy::as_conversions)]
-    pub fn ensure_decoded(
-        &mut self,
-        bincode_opts: BincodeOpts,
-        source_id: GlobalId,
-        key: Option<&UpsertKey>,
-    ) {
-        match self {
-            StateValue::Consolidating(consolidating) => {
-                match consolidating.diff_sum.0 {
-                    1 => {
-                        let len = usize::try_from(consolidating.len_sum.0)
-                            .map_err(|_| {
-                                format!(
-                                    "len_sum can't be made into a usize, state: {}, {}",
-                                    consolidating, source_id,
-                                )
-                            })
-                            .expect("invalid upsert state");
-                        let value = &consolidating
-                            .value_xor
-                            .get(..len)
-                            .ok_or_else(|| {
-                                format!(
-                                    "value_xor is not the same length ({}) as len ({}), state: {}, {}",
-                                    consolidating.value_xor.len(),
-                                    len,
-                                    consolidating,
-                                    source_id,
-                                )
-                            })
-                            .expect("invalid upsert state");
-                        // Truncation is fine (using `as`) as this is just a checksum
-                        assert_eq!(
-                            consolidating.checksum_sum.0,
-                            // Hash the value, not the full buffer, which may have extra 0's
-                            seahash::hash(value) as i64,
-                            "invalid upsert state: checksum_sum does not match, state: {}, {}",
-                            consolidating,
-                            source_id,
-                        );
-                        *self = Self::finalized_value(bincode_opts.deserialize(value).unwrap());
-                    }
-                    0 => {
-                        assert_eq!(
-                            consolidating.len_sum.0, 0,
-                            "invalid upsert state: len_sum is non-0, state: {}, {}",
-                            consolidating, source_id,
-                        );
-                        assert_eq!(
-                            consolidating.checksum_sum.0, 0,
-                            "invalid upsert state: checksum_sum is non-0, state: {}, {}",
-                            consolidating, source_id,
-                        );
-                        assert!(
-                            consolidating.value_xor.iter().all(|&x| x == 0),
-                            "invalid upsert state: value_xor not all 0s with 0 diff. \
-                            Non-zero positions: {:?}, state: {}, {}",
-                            consolidating
-                                .value_xor
-                                .iter()
-                                .positions(|&x| x != 0)
-                                .collect::<Vec<_>>(),
-                            consolidating,
-                            source_id,
-                        );
-                        *self = Self::tombstone();
-                    }
-                    other => {
-                        // If diff_sum is odd, value_xor holds the bincode of a
-                        // single value (even XORs cancel out). Try to decode it
-                        // so we can log the shape (not contents) for debugging.
-                        let value_byte_len = usize::try_from(consolidating.len_sum.0 / other).ok();
-                        let decode_ok = value_byte_len
-                            .and_then(|l| consolidating.value_xor.get(..l))
-                            .and_then(|bytes| bincode_opts.deserialize::<UpsertValue>(bytes).ok())
-                            .map(|v| match v {
-                                Ok(row) => format!(
-                                    "Ok(Row(byte_len={}, col_count={}))",
-                                    row.byte_len(),
-                                    row.iter().count(),
-                                ),
-                                Err(_) => "Err(UpsertValueError)".to_string(),
-                            });
-                        panic!(
-                            "invalid upsert state: non 0/1 diff_sum: {}, state: {}, {}, \
-                            key: {:?}, value_byte_len: {:?}, decodable: {:?}",
-                            other, consolidating, source_id, key, value_byte_len, decode_ok,
-                        )
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
 }
 
 impl<T, O> Default for StateValue<T, O> {
     fn default() -> Self {
-        Self::Consolidating(Consolidating::default())
+        Self::Value(Value {
+            finalized: None,
+            provisional: None,
+        })
     }
 }
 
@@ -709,22 +399,6 @@ impl std::ops::AddAssign for SnapshotStats {
         self.inserts += rhs.inserts;
         self.deletes += rhs.deletes;
     }
-}
-
-/// Statistics for a single call to `multi_merge`.
-#[derive(Clone, Default, Debug)]
-pub struct MergeStats {
-    /// The number of updates written as merge operands to the backend, for the backend
-    /// to process async in the `consolidating_merge_function`.
-    /// Should be equal to number of inserts + deletes
-    pub written_merge_operands: u64,
-    /// The total size of values provided to `multi_merge`. The backend will write these
-    /// down and then later merge them in the `consolidating_merge_function`.
-    pub size_written: u64,
-    /// The estimated diff of the total size of the working set after the merge operands
-    /// are merged by the backend. This is an estimate since it can't account for the
-    /// size overhead of `StateValue` for values that consolidate to 0 (tombstoned-values).
-    pub size_diff: i64,
 }
 
 /// Statistics for a single call to `multi_put`.
@@ -860,9 +534,6 @@ where
     T: 'static,
     O: 'static,
 {
-    /// Whether this backend supports the `multi_merge` operation.
-    fn supports_merge(&self) -> bool;
-
     /// Insert or delete for all `puts` keys, prioritizing the last value for
     /// repeated keys.
     ///
@@ -892,76 +563,10 @@ where
     where
         G: IntoIterator<Item = UpsertKey>,
         R: IntoIterator<Item = &'r mut UpsertValueAndSize<T, O>>;
-
-    /// For each key in `merges` writes a 'merge operand' to the backend. The backend stores these
-    /// merge operands and periodically calls the `consolidating_merge_function` to merge them into
-    /// any existing value for each key. The backend will merge the merge operands in the order
-    /// they are provided, and the merge function will always be run for a given key when a `get`
-    /// operation is performed on that key, or when the backend decides to run the merge based
-    /// on its own internal logic.
-    /// This allows avoiding the read-modify-write method of updating many values to
-    /// improve performance.
-    ///
-    /// The `MergeValue` should include a `diff` field that represents the update diff for the
-    /// value. This is used to estimate the overall size diff of the working set
-    /// after the merge operands are merged by the backend `sum[merges: m](m.diff * m.size)`.
-    ///
-    /// `MergeStats` **must** be populated correctly, according to these semantics:
-    /// - `written_merge_operands` must record the number of merge operands written to the backend.
-    /// - `size_written` must record the total size of values written to the backend.
-    ///     Note that the size of the post-merge values are not known, so this is the size of the
-    ///     values written to the backend as merge operands.
-    /// - `size_diff` must record the estimated diff of the total size of the working set after the
-    ///    merge operands are merged by the backend.
-    async fn multi_merge<P>(&mut self, merges: P) -> Result<MergeStats, anyhow::Error>
-    where
-        P: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<T, O>>)>;
 }
 
-/// A function that merges a set of updates for a key into the existing value
-/// for the key. This is called by the backend implementation when it has
-/// accumulated a set of updates for a key, and needs to merge them into the
-/// existing value for the key.
-///
-/// The function is called with the following arguments:
-/// - The key for which the merge is being performed.
-/// - An iterator over any current value and merge operands queued for the key.
-///
-/// The function should return the new value for the key after merging all the updates.
-pub(crate) fn consolidating_merge_function<T: Eq, O>(
-    _key: UpsertKey,
-    updates: impl Iterator<Item = StateValue<T, O>>,
-) -> StateValue<T, O> {
-    let mut current: StateValue<T, O> = Default::default();
-
-    let mut bincode_buf = Vec::new();
-    for update in updates {
-        match update {
-            StateValue::Consolidating(_) => {
-                current.merge_update_state(&update);
-            }
-            StateValue::Value(_) => {
-                // This branch is more expensive, but we hopefully rarely hit
-                // it.
-                if let Some(finalized_value) = update.into_finalized_value() {
-                    let mut update = StateValue::default();
-                    update.merge_update(
-                        finalized_value,
-                        Diff::ONE,
-                        upsert_bincode_opts(),
-                        &mut bincode_buf,
-                    );
-                    current.merge_update_state(&update);
-                }
-            }
-        }
-    }
-
-    current
-}
-
-/// An `UpsertStateBackend` wrapper that supports consolidating merging, and
-/// reports basic metrics about the usage of the `UpsertStateBackend`.
+/// An `UpsertStateBackend` wrapper that reports basic metrics about the usage
+/// of the `UpsertStateBackend`.
 pub struct UpsertState<'metrics, S, T, O> {
     inner: S,
 
@@ -976,10 +581,6 @@ pub struct UpsertState<'metrics, S, T, O> {
     worker_metrics: &'metrics UpsertMetrics,
     // User-facing statistics.
     stats: SourceStatistics,
-
-    // Bincode options and buffer used in `consolidate_chunk`.
-    bincode_opts: BincodeOpts,
-    bincode_buffer: Vec<u8>,
 
     // We need to iterate over `updates` in `consolidate_chunk` twice, so we
     // have a scratch vector for this.
@@ -1007,8 +608,6 @@ impl<'metrics, S, T, O> UpsertState<'metrics, S, T, O> {
             metrics,
             worker_metrics,
             stats,
-            bincode_opts: upsert_bincode_opts(),
-            bincode_buffer: Vec::new(),
             consolidate_scratch: Vec::new(),
             consolidate_upsert_scratch: indexmap::IndexMap::new(),
             multi_get_scratch: Vec::new(),
@@ -1026,19 +625,14 @@ where
     /// Consolidate the following differential updates into the state. Updates
     /// provided to this method can be assumed to consolidate into a single
     /// value per-key, after all chunks of updates for a given timestamp have
-    /// been processed,
-    ///
-    /// Therefore, after all updates of a given timestamp have been
-    /// `consolidated`, all values must be in the correct state (as determined
-    /// by `StateValue::ensure_decoded`).
+    /// been processed.
     ///
     /// The `completed` boolean communicates whether or not this is the final
     /// chunk of updates for the initial "snapshot" from persist.
     ///
-    /// If the backend supports it, this method will use `multi_merge` to
-    /// consolidate the updates to avoid having to read the existing value for
-    /// each key first. On some backends (like RocksDB), this can be
-    /// significantly faster than the read-then-write consolidation strategy.
+    /// Since persist delivers fully consolidated data, each (key, value) update
+    /// has diff exactly +1 or -1. This method reads existing state, applies the
+    /// updates, and writes the results back.
     ///
     /// Also note that we use `self.inner.multi_*`, not `self.multi_*`. This is
     /// to avoid erroneously changing metric and stats values.
@@ -1090,15 +684,9 @@ where
             }
         }
 
-        // Depending on if the backend supports multi_merge, call the appropriate method.
-        let stats = if self.inner.supports_merge() {
-            self.consolidate_merge_inner(updates).await?
-        } else {
-            self.consolidate_read_write_inner(updates).await?
-        };
+        let stats = self.consolidate_read_write_inner(updates).await?;
 
         // NOTE: These metrics use the term `merge` to refer to the consolidation of values.
-        // This is because they were introduced before we the `multi_merge` operation was added.
         self.metrics
             .merge_snapshot_latency
             .observe(now.elapsed().as_secs_f64());
@@ -1158,66 +746,9 @@ where
         Ok(())
     }
 
-    /// Consolidate the updates into the state. This method requires the backend
-    /// has support for the `multi_merge` operation, and will panic if
-    /// `self.inner.supports_merge()` was not checked before calling this
-    /// method. `multi_merge` will write the updates as 'merge operands' to the
-    /// backend, and then the backend will consolidate those updates with any
-    /// existing state using the `consolidating_merge_function`.
-    ///
-    /// This method can have significant performance benefits over the
-    /// read-then-write method of `consolidate_read_write_inner`.
-    async fn consolidate_merge_inner<U>(
-        &mut self,
-        updates: U,
-    ) -> Result<SnapshotStats, anyhow::Error>
-    where
-        U: IntoIterator<Item = (UpsertKey, UpsertValue, mz_repr::Diff)> + ExactSizeIterator,
-    {
-        let mut updates = updates.into_iter().peekable();
-
-        let mut stats = SnapshotStats::default();
-
-        if updates.peek().is_some() {
-            let m_stats = self
-                .inner
-                .multi_merge(updates.map(|(k, v, diff)| {
-                    // Transform into a `StateValue<O>` that can be used by the
-                    // `consolidating_merge_function` to merge with any existing
-                    // value for the key.
-                    let mut val: StateValue<T, O> = Default::default();
-                    val.merge_update(v, diff, self.bincode_opts, &mut self.bincode_buffer);
-
-                    stats.updates += 1;
-                    if diff.is_positive() {
-                        stats.inserts += 1;
-                    } else if diff.is_negative() {
-                        stats.deletes += 1;
-                    }
-
-                    // To keep track of the overall `values_diff` we can use the sum of diffs which
-                    // should be equal to the number of non-tombstoned values in the backend.
-                    // This is a bit misleading as this represents the eventual state after the
-                    // `consolidating_merge_function` has been called to merge all the updates,
-                    // and not the state after this `multi_merge` call.
-                    //
-                    // This does not accurately report values that have been consolidated to diff == 0, as tracking that
-                    // per-key is extremely difficult.
-                    stats.values_diff += diff;
-
-                    (k, MergeValue { value: val, diff })
-                }))
-                .await?;
-
-            stats.size_diff = m_stats.size_diff;
-        }
-
-        Ok(stats)
-    }
-
     /// Consolidates the updates into the state. This method reads the existing
-    /// values for each key, consolidates the updates, and writes the new values
-    /// back to the state.
+    /// values for each key, applies the consolidated updates (each with diff +1
+    /// or -1), and writes the new values back to the state.
     async fn consolidate_read_write_inner<U>(
         &mut self,
         updates: U,
@@ -1254,29 +785,50 @@ where
                 }
 
                 // We rely on the diffs in our input instead of the result of
-                // multi_put below. This makes sure we report the same stats as
-                // `consolidate_merge_inner`, regardless of what values
-                // there were in state before.
+                // multi_put below. This makes sure we report the same stats
+                // regardless of what values there were in state before.
                 stats.values_diff += diff;
 
                 let entry = self.consolidate_upsert_scratch.get_mut(&key).unwrap();
-                let val = entry.value.get_or_insert_with(Default::default);
+                let val = entry
+                    .value
+                    .get_or_insert_with(|| StateValue::tombstone());
 
-                if val.merge_update(value, diff, self.bincode_opts, &mut self.bincode_buffer) {
-                    entry.value = None;
+                // Since persist delivers fully consolidated data, each update
+                // has diff exactly +1 or -1.
+                if diff.is_positive() {
+                    // Insertion: set the finalized value.
+                    match val {
+                        StateValue::Value(v) => {
+                            v.finalized = Some(value);
+                        }
+                    }
+                } else {
+                    // Retraction: clear the finalized value (tombstone).
+                    match val {
+                        StateValue::Value(v) => {
+                            v.finalized = None;
+                        }
+                    }
                 }
             }
 
+            // If a key ended up as a tombstone (finalized == None), remove it
+            // from state entirely (value = None in PutValue means delete).
             // Note we do 1 `multi_get` and 1 `multi_put` while processing a _batch of updates_.
             // Within the batch, we effectively consolidate each key, before persisting that
             // consolidated value. Easy!!
             let p_stats = self
                 .inner
                 .multi_put(self.consolidate_upsert_scratch.drain(..).map(|(k, v)| {
+                    let is_tombstone = v
+                        .value
+                        .as_ref()
+                        .map_or(true, |sv| sv.is_tombstone());
                     (
                         k,
                         PutValue {
-                            value: v.value,
+                            value: if is_tombstone { None } else { v.value },
                             previous_value_metadata: v.metadata.map(|v| ValueMetadata {
                                 size: v.size.try_into().expect("less than i64 size"),
                                 is_tombstone: v.is_tombstone,
@@ -1381,31 +933,15 @@ mod tests {
     use mz_repr::Row;
 
     use super::*;
-    #[mz_ore::test]
-    fn test_merge_update() {
-        let mut buf = Vec::new();
-        let opts = upsert_bincode_opts();
-
-        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
-
-        let small_row = Ok(Row::default());
-        let longer_row = Ok(Row::pack([mz_repr::Datum::Null]));
-        s.merge_update(small_row, Diff::ONE, opts, &mut buf);
-        s.merge_update(longer_row.clone(), Diff::MINUS_ONE, opts, &mut buf);
-        // This clears the retraction of the `longer_row`, but the
-        // `value_xor` is the length of the `longer_row`. This tests
-        // that we are tracking checksums correctly.
-        s.merge_update(longer_row, Diff::ONE, opts, &mut buf);
-
-        // Assert that the `Consolidating` value is fully merged.
-        s.ensure_decoded(opts, GlobalId::User(1), None);
-    }
 
     // We guard some of our assumptions. Increasing in-memory size of StateValue
     // has a direct impact on memory usage of in-memory UPSERT sources.
     #[mz_ore::test]
     fn test_memory_size() {
-        let finalized_value: StateValue<(), ()> = StateValue::finalized_value(Ok(Row::default()));
+        let finalized_value: StateValue<(), ()> = StateValue::Value(Value {
+            finalized: Some(Ok(Row::default())),
+            provisional: None,
+        });
         assert!(
             finalized_value.memory_size() <= 64,
             "memory size is {}",
@@ -1427,72 +963,5 @@ mod tests {
             "memory size is {}",
             provisional_value_without_finalized_value.memory_size(),
         );
-
-        let mut consolidating_value: StateValue<(), ()> = StateValue::default();
-        consolidating_value.merge_update(
-            Ok(Row::default()),
-            Diff::ONE,
-            upsert_bincode_opts(),
-            &mut Vec::new(),
-        );
-        assert!(
-            consolidating_value.memory_size() <= 66,
-            "memory size is {}",
-            consolidating_value.memory_size(),
-        );
-    }
-
-    #[mz_ore::test]
-    #[should_panic(
-        expected = "invalid upsert state: len_sum is non-0, state: Consolidating { len_sum: 1"
-    )]
-    fn test_merge_update_len_0_assert() {
-        let mut buf = Vec::new();
-        let opts = upsert_bincode_opts();
-
-        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
-
-        let small_row = Ok(mz_repr::Row::default());
-        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
-        s.merge_update(longer_row.clone(), Diff::ONE, opts, &mut buf);
-        s.merge_update(small_row.clone(), Diff::MINUS_ONE, opts, &mut buf);
-
-        s.ensure_decoded(opts, GlobalId::User(1), None);
-    }
-
-    #[mz_ore::test]
-    #[should_panic(
-        expected = "invalid upsert state: \"value_xor is not the same length (3) as len (4), state: Consolidating { len_sum: 4"
-    )]
-    fn test_merge_update_len_to_long_assert() {
-        let mut buf = Vec::new();
-        let opts = upsert_bincode_opts();
-
-        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
-
-        let small_row = Ok(mz_repr::Row::default());
-        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
-        s.merge_update(longer_row.clone(), Diff::ONE, opts, &mut buf);
-        s.merge_update(small_row.clone(), Diff::MINUS_ONE, opts, &mut buf);
-        s.merge_update(longer_row.clone(), Diff::ONE, opts, &mut buf);
-
-        s.ensure_decoded(opts, GlobalId::User(1), None);
-    }
-
-    #[mz_ore::test]
-    #[should_panic(expected = "invalid upsert state: checksum_sum does not match")]
-    fn test_merge_update_checksum_doesnt_match() {
-        let mut buf = Vec::new();
-        let opts = upsert_bincode_opts();
-
-        let mut s = StateValue::<(), ()>::Consolidating(Consolidating::default());
-
-        let small_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(2)]));
-        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(1)]));
-        s.merge_update(longer_row.clone(), Diff::ONE, opts, &mut buf);
-        s.merge_update(small_row.clone(), Diff::MINUS_ONE, opts, &mut buf);
-        s.merge_update(longer_row.clone(), Diff::ONE, opts, &mut buf);
-
-        s.ensure_decoded(opts, GlobalId::User(1), None);
     }
 }

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -776,6 +776,14 @@ where
                 )
                 .await?;
 
+            // Process retractions before insertions. A key update in
+            // persist is (key, old_value, -1) + (key, new_value, +1).
+            // These are different (key, value, time) triples so both
+            // survive consolidation. We must apply the retraction first
+            // so the insertion wins.
+            self.consolidate_scratch
+                .sort_by_key(|(_, _, diff)| if diff.is_positive() { 1i8 } else { 0 });
+
             for (key, value, diff) in self.consolidate_scratch.drain(..) {
                 stats.updates += 1;
                 if diff.is_positive() {
@@ -784,9 +792,6 @@ where
                     stats.deletes += 1;
                 }
 
-                // We rely on the diffs in our input instead of the result of
-                // multi_put below. This makes sure we report the same stats
-                // regardless of what values there were in state before.
                 stats.values_diff += diff;
 
                 let entry = self.consolidate_upsert_scratch.get_mut(&key).unwrap();
@@ -794,17 +799,13 @@ where
                     .value
                     .get_or_insert_with(|| StateValue::tombstone());
 
-                // Since persist delivers fully consolidated data, each update
-                // has diff exactly +1 or -1.
                 if diff.is_positive() {
-                    // Insertion: set the finalized value.
                     match val {
                         StateValue::Value(v) => {
                             v.finalized = Some(value);
                         }
                     }
                 } else {
-                    // Retraction: clear the finalized value (tombstone).
                     match val {
                         StateValue::Value(v) => {
                             v.finalized = None;

--- a/src/storage/src/upsert_continual_feedback.rs
+++ b/src/storage/src/upsert_continual_feedback.rs
@@ -94,11 +94,8 @@ use crate::upsert::types::{StateValue, UpsertState, UpsertStateBackend};
 /// ## Processing the Persist Input
 ///
 /// We continually ingest updates from the persist input into our state using
-/// `UpsertState::consolidate_chunk`. We might be ingesting updates from the
-/// initial snapshot (when starting the operator) that are not consolidated or
-/// we might be ingesting updates from a partial emission (see above). In either
-/// case, our input might not be consolidated and `consolidate_chunk` is able to
-/// handle that.
+/// `UpsertState::consolidate_chunk`. The input is guaranteed to be consolidated
+/// by `SourceConsolidation::Full`.
 pub fn upsert_inner<G: Scope, FromTime, F, Fut, US>(
     input: VecCollection<G, (UpsertKey, Option<UpsertValue>, FromTime), Diff>,
     key_indices: Vec<usize>,
@@ -203,22 +200,6 @@ where
         let mut persist_stash = vec![];
         let mut persist_upper = Antichain::from_elem(Timestamp::minimum());
 
-        // We keep track of the largest timestamp seen on the persist input so
-        // that we can block processing source input while that timestamp is
-        // beyond the persist frontier. While ingesting updates of a timestamp,
-        // our upsert state is in a consolidating state, and trying to read it
-        // at that time would yield a panic.
-        //
-        // NOTE(aljoscha): You would think that it cannot happen that we even
-        // attempt to process source updates while the state is in a
-        // consolidating state, because we always wait until the persist
-        // frontier "catches up" with the timestamp of the source input. If
-        // there is only this here UPSERT operator and no concurrent instances,
-        // this is true. But with concurrent instances it can happen that an
-        // operator that is faster than us makes it so updates get written to
-        // persist. And we would then be ingesting them.
-        let mut largest_seen_persist_ts: Option<G::Timestamp> = None;
-
         // A buffer for our output.
         let mut output_updates = vec![];
 
@@ -240,12 +221,6 @@ where
 
                                 persist_stash.extend(data.into_iter().map(
                                     |((key, value), ts, diff)| {
-                                        largest_seen_persist_ts =
-                                            std::cmp::max(
-                                                largest_seen_persist_ts
-                                                    .clone(),
-                                                Some(ts.clone()),
-                                            );
                                         (key, value, ts, diff)
                                     },
                                 ));
@@ -274,15 +249,10 @@ where
                         ?persist_upper,
                         "ingesting persist snapshot chunk");
 
-                    // Log any (key, ts) pairs in this batch that have a suspicious
-                    // net diff, to help diagnose how diff_sum corruption enters the
-                    // system.
-                    //
-                    // Consolidating by key alone is too noisy during hydration,
-                    // because a single batch can legitimately contain multiple
-                    // timestamps for the same key. The suspicious shape for this
-                    // bug is multiple net updates for the same key at one logical
-                    // timestamp.
+                    // Check that (key, ts) pairs in this batch have expected
+                    // net diffs after consolidation. With SourceConsolidation::Full
+                    // the input is guaranteed to be consolidated, so any net diff
+                    // with absolute value > 1 indicates a bug.
                     {
                         let mut key_ts_diffs: Vec<(
                             (UpsertKey, G::Timestamp),
@@ -293,19 +263,20 @@ where
                             .collect();
                         differential_dataflow::consolidation::consolidate(&mut key_ts_diffs);
                         for ((key, ts), net_diff) in &key_ts_diffs {
-                            if net_diff.into_inner() > 1 || net_diff.into_inner() < -1 {
-                                tracing::warn!(
-                                    worker_id = %source_config.worker_id,
-                                    source_id = %source_config.id,
-                                    ?key,
-                                    ?ts,
-                                    net_diff = net_diff.into_inner(),
-                                    %hydrating,
-                                    ?persist_upper,
-                                    "persist feedback batch has (key, ts) with suspicious net diff \
-                                    (expected -1, 0, or 1 after per-(key, ts) consolidation)"
-                                );
-                            }
+                            debug_assert!(
+                                net_diff.into_inner().abs() <= 1,
+                                "persist feedback batch has (key, ts) with suspicious net diff \
+                                (expected -1, 0, or 1 after per-(key, ts) consolidation): \
+                                worker_id={}, source_id={}, key={:?}, ts={:?}, net_diff={}, \
+                                hydrating={}, persist_upper={:?}",
+                                source_config.worker_id,
+                                source_config.id,
+                                key,
+                                ts,
+                                net_diff.into_inner(),
+                                hydrating,
+                                persist_upper,
+                            );
                         }
                     }
 
@@ -462,18 +433,6 @@ where
                     }
                 }
             };
-
-            // While we have partially ingested updates of a timestamp our state
-            // is in an inconsistent/consolidating state and accessing it would
-            // panic.
-            if let Some(largest_seen_persist_ts) = largest_seen_persist_ts.as_ref() {
-                let largest_seen_outer_persist_ts = largest_seen_persist_ts.clone().to_outer();
-                let outer_persist_upper = persist_upper.iter().map(|ts| ts.clone().to_outer());
-                let outer_persist_upper = Antichain::from_iter(outer_persist_upper);
-                if outer_persist_upper.less_equal(&largest_seen_outer_persist_ts) {
-                    continue;
-                }
-            }
 
             // We try and drain from our stash every time we go through the
             // loop. More of our stash can become eligible for draining both
@@ -781,7 +740,6 @@ where
         a_ts == b_ts && a_key == b_key
     });
 
-    let bincode_opts = upsert_types::upsert_bincode_opts();
     // Upsert the values into `commands_state`, by recording the latest
     // value (or deletion). These will be synced at the end to the `state`.
     //
@@ -802,10 +760,6 @@ where
         };
 
         let existing_state_cell = &mut command_state.get_mut().value;
-
-        if let Some(cs) = existing_state_cell.as_mut() {
-            cs.ensure_decoded(bincode_opts, source_config.id, Some(&key));
-        }
 
         // Skip this command if its order key is below the one in the upsert state.
         // Note that the existing order key may be `None` if the existing value
@@ -946,7 +900,7 @@ mod test {
     use mz_ore::metrics::MetricsRegistry;
     use mz_persist_types::ShardId;
     use mz_repr::{Datum, Timestamp as MzTimestamp};
-    use mz_rocksdb::{RocksDBConfig, ValueIterator};
+    use mz_rocksdb::RocksDBConfig;
     use mz_storage_operators::persist_source::Subtime;
     use mz_storage_types::sources::SourceEnvelope;
     use mz_storage_types::sources::envelope::{KeyEnvelope, UpsertEnvelope, UpsertStyle};
@@ -960,7 +914,7 @@ mod test {
     use crate::source::SourceExportCreationConfig;
     use crate::statistics::{SourceStatistics, SourceStatisticsMetricDefs};
     use crate::upsert::memory::InMemoryHashMap;
-    use crate::upsert::types::{BincodeOpts, consolidating_merge_function, upsert_bincode_opts};
+    use crate::upsert::types::upsert_bincode_opts;
 
     use super::*;
 
@@ -1175,29 +1129,14 @@ mod test {
 
                         // A closure that will initialize and return a configured RocksDB instance
                         let rocksdb_init_fn = move || async move {
-                            let merge_operator = Some((
-                                "upsert_state_snapshot_merge_v1".to_string(),
-                                |a: &[u8],
-                                 b: ValueIterator<
-                                    BincodeOpts,
-                                    StateValue<(MzTimestamp, Subtime), u64>,
-                                >| {
-                                    consolidating_merge_function::<(MzTimestamp, Subtime), u64>(
-                                        a.into(),
-                                        b,
-                                    )
-                                },
-                            ));
                             let rocksdb_cleanup_tries = 5;
                             let tuning = RocksDBConfig::new(Default::default(), None);
                             let mut rocksdb_inst = mz_rocksdb::RocksDBInstance::new(
                                 rocksdb_dir.path(),
-                                mz_rocksdb::InstanceOptions::new(
+                                mz_rocksdb::InstanceOptions::<_, StateValue<(MzTimestamp, Subtime), u64>, mz_rocksdb::StubMergeOperator<StateValue<(MzTimestamp, Subtime), u64>>>::new(
                                     Env::mem_env().unwrap(),
                                     rocksdb_cleanup_tries,
-                                    merge_operator,
-                                    // For now, just use the same config as the one used for
-                                    // merging snapshots.
+                                    None,
                                     upsert_bincode_opts(),
                                 ),
                                 tuning,

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -543,6 +543,7 @@ impl DataSubscribe {
                     false.then_some(|| unreachable!()),
                     async {},
                     ErrorHandler::Halt("data_subscribe"),
+                    false,
                 );
                 (data_stream.leave(), token)
             });


### PR DESCRIPTION
## Summary
Implements the "consolidation on read" design (https://github.com/MaterializeInc/materialize/issues/16858) as an optional SourceConsolidation::Full mode for the persist source. When enabled, the source delivers fully consolidated, snapshot-monotonic output — each (key, value, time) appears at most once with diff exactly +1 or -1.

Uses this as the first consumer in the upsert feedback path, enabling removal of ~1,260 lines of consolidation machinery from the upsert state backend.

## Motivation
The upsert operator maintained complex consolidation infrastructure (XOR/checksum accumulators, RocksDB merge operators, dual read-write/merge codepaths) to handle unconsolidated persist feedback. By consolidating in the persist source — which can exploit the sorted structure of persist data — we eliminate this complexity downstream and reduce RocksDB write amplification during rehydration.

Heavily assisted by claude