### PR TITLE
console: Demure devtools container

### DIFF
--- a/console/src/components/DevtoolsContainer.tsx
+++ b/console/src/components/DevtoolsContainer.tsx
@@ -7,29 +7,190 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Center,
+  HStack,
+  Switch,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { DevTools as JotaiDevtools } from "jotai-devtools";
-import React, { Suspense } from "react";
+import React, { Suspense, useRef, useState } from "react";
 
+import { useDrag } from "~/hooks/useDrag";
 import { getStore } from "~/jotai";
 import { DEVTOOL_BUTTONS_Z_INDEX } from "~/layouts/zIndex";
+import { MaterializeTheme } from "~/theme";
+
+import { MaterializeLogo } from "./MaterializeLogo";
 
 const SwitchStackModal = React.lazy(() => import("./SwitchStackModal"));
 
+// Load the stylesheet alongside the component so the ~1 MB CSS (Mantine fonts
+// inlined as data URIs) only ships when a developer flips the toggle.
+const LazyJotaiDevtools = React.lazy(async () => {
+  const [{ DevTools }] = await Promise.all([
+    import("jotai-devtools"),
+    import("jotai-devtools/styles.css"),
+  ]);
+  return {
+    default: () => <DevTools position="bottom-right" store={getStore()} />,
+  };
+});
+
+const DEVTOOLS_POSITION_KEY = "devtools-position";
+const BUTTON_SIZE = 36;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+const getStoredPosition = (): { x: number; y: number } => {
+  try {
+    const stored = localStorage.getItem(DEVTOOLS_POSITION_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch {
+    // ignore
+  }
+  return { x: 20, y: window.innerHeight - 140 };
+};
+
 export const DevtoolsContainer = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [showRQDevtools, setShowRQDevtools] = useState(false);
+  const [showJotaiDevtools, setShowJotaiDevtools] = useState(false);
+  const [position, setPosition] = useState(getStoredPosition);
+
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  useDrag({
+    ref: buttonRef,
+    onStart: () => setIsDragging(true),
+    onDrag: (_, { pointDelta }) => {
+      if (!pointDelta) return;
+      setPosition((prev) => ({
+        x: clamp(prev.x + pointDelta.x, 0, window.innerWidth - BUTTON_SIZE),
+        y: clamp(prev.y + pointDelta.y, 0, window.innerHeight - BUTTON_SIZE),
+      }));
+    },
+    onStop: () => {
+      setIsDragging(false);
+      setPosition((pos) => {
+        localStorage.setItem(DEVTOOLS_POSITION_KEY, JSON.stringify(pos));
+        return pos;
+      });
+    },
+  });
+
   return (
-    <VStack
-      position="fixed"
-      bottom="4"
-      right="4"
-      zIndex={DEVTOOL_BUTTONS_Z_INDEX}
-    >
-      <ReactQueryDevtools buttonPosition="relative" />
-      <JotaiDevtools position="bottom-right" store={getStore()} />
-      <Suspense fallback={null}>
-        <SwitchStackModal />
-      </Suspense>
-    </VStack>
+    <>
+      {(showRQDevtools || showJotaiDevtools) && (
+        <VStack
+          position="fixed"
+          bottom="20"
+          right="4"
+          zIndex={DEVTOOL_BUTTONS_Z_INDEX + 2}
+          spacing="2"
+          align="flex-end"
+          sx={{
+            ".jotai-devtools-trigger-button": {
+              position: "relative !important",
+              bottom: "unset !important",
+              right: "unset !important",
+              zIndex: "unset !important",
+            },
+          }}
+        >
+          {showRQDevtools && <ReactQueryDevtools buttonPosition="relative" />}
+          {showJotaiDevtools && (
+            <Suspense fallback={null}>
+              <LazyJotaiDevtools />
+            </Suspense>
+          )}
+        </VStack>
+      )}
+
+      <Box
+        position="fixed"
+        left={`${position.x}px`}
+        top={`${position.y}px`}
+        zIndex={DEVTOOL_BUTTONS_Z_INDEX}
+        onMouseEnter={() => {
+          if (!isDragging) setIsExpanded(true);
+        }}
+        onMouseLeave={() => setIsExpanded(false)}
+      >
+        <Center
+          ref={buttonRef}
+          width={`${BUTTON_SIZE}px`}
+          height={`${BUTTON_SIZE}px`}
+          borderRadius="full"
+          bg={colors.background.primary}
+          border="1px"
+          borderColor={colors.border.secondary}
+          boxShadow="md"
+          cursor="grab"
+          opacity={0.7}
+          _hover={{ opacity: 1 }}
+          _active={{ cursor: "grabbing" }}
+          transition="opacity 0.2s"
+        >
+          <MaterializeLogo markOnly height="4" width="4" />
+        </Center>
+
+        {isExpanded && !isDragging && (
+          <VStack
+            position="absolute"
+            bottom="100%"
+            left="0"
+            mb="1"
+            p="3"
+            bg={colors.background.primary}
+            border="1px"
+            borderColor={colors.border.primary}
+            borderRadius="md"
+            boxShadow="lg"
+            spacing="3"
+            align="stretch"
+            minWidth="180px"
+          >
+            <Text
+              fontSize="xs"
+              fontWeight="600"
+              color={colors.foreground.secondary}
+            >
+              Dev Tools
+            </Text>
+
+            <HStack justify="space-between">
+              <Text fontSize="xs">React Query</Text>
+              <Switch
+                size="sm"
+                isChecked={showRQDevtools}
+                onChange={() => setShowRQDevtools((v) => !v)}
+              />
+            </HStack>
+
+            <HStack justify="space-between">
+              <Text fontSize="xs">Jotai</Text>
+              <Switch
+                size="sm"
+                isChecked={showJotaiDevtools}
+                onChange={() => setShowJotaiDevtools((v) => !v)}
+              />
+            </HStack>
+
+            <Box borderTop="1px" borderColor={colors.border.primary} pt="2">
+              <Suspense fallback={null}>
+                <SwitchStackModal />
+              </Suspense>
+            </Box>
+          </VStack>
+        )}
+      </Box>
+    </>
   );
 };

--- a/console/src/index.tsx
+++ b/console/src/index.tsx
@@ -18,7 +18,6 @@ import "~/font/inter.css";
 import "@fontsource/roboto-mono";
 // Initializes Sentry error reporting and tracing
 import "~/sentry";
-import "jotai-devtools/styles.css";
 
 import React from "react";
 import { createRoot } from "react-dom/client";

--- a/console/src/theme/index.tsx
+++ b/console/src/theme/index.tsx
@@ -190,9 +190,6 @@ const collapseOverflowOverrides: SystemStyleInterpolation = {
 };
 
 const devtoolOverrides: SystemStyleInterpolation = {
-  ".jotai-devtools-trigger-button": {
-    position: "initial !important",
-  },
   // React query devtools button
   ".tsqd-open-btn-container": {
     height: "64px",


### PR DESCRIPTION


### Motivation
Right now the dev tools container with jotai dev tools/ React query gets in the way of developing on the bottom left corner. The local stack button is not also obscured by the Matty icon.

<img width="424" height="532" alt="image" src="https://github.com/user-attachments/assets/9573dff4-9278-411b-be7a-24cd443007e8" />


### Description
- toggle rendering of Jotai and react query tools
- menu on hover and is draggable so it doesn't get in the way

https://github.com/user-attachments/assets/1e804dea-2f6d-4ef8-9525-0600349f820e



What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
