### PR TITLE
frontegg-auth: Add cross-tenant tests and harden tenant validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6626,6 +6626,7 @@ name = "mz-frontegg-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "axum",
  "base64 0.22.1",
  "clap",
@@ -6636,6 +6637,7 @@ dependencies = [
  "mz-auth",
  "mz-ore",
  "mz-repr",
+ "pem",
  "prometheus",
  "reqwest",
  "reqwest-middleware",

--- a/src/balancerd/src/bin/balancerd.rs
+++ b/src/balancerd/src/bin/balancerd.rs
@@ -26,7 +26,7 @@ use mz_balancerd::{
 };
 use mz_frontegg_auth::{
     Authenticator, AuthenticatorConfig, DEFAULT_REFRESH_DROP_FACTOR,
-    DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE, TenantScope,
 };
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
@@ -225,7 +225,7 @@ pub async fn run(args: ServiceArgs, tracing_handle: TracingHandle) -> Result<(),
                             "exactly one of --frontegg-jwk or --frontegg-jwk-file must be present"
                         ),
                     },
-                    tenant_id: None,
+                    tenant_id: TenantScope::AcceptAny,
                     now: mz_ore::now::SYSTEM_TIME.clone(),
                     admin_role: args.frontegg_admin_role.expect("clap enforced"),
                     refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -28,7 +28,7 @@ use mz_balancerd::{
 use mz_environmentd::test_util::{self, Ca, make_pg_tls};
 use mz_frontegg_auth::{
     Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
-    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE, TenantScope,
 };
 use mz_frontegg_mock::{FronteggMockServer, models::ApiToken, models::UserConfig};
 use mz_ore::cast::CastFrom;
@@ -108,7 +108,7 @@ async fn test_balancer() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -43,6 +43,7 @@ use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
     Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig, ClaimMetadata,
     ClaimTokenType, Claims, DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    TenantScope,
 };
 use mz_frontegg_mock::{
     FronteggMockServer, models::ApiToken, models::TenantApiTokenConfig, models::UserConfig,
@@ -527,7 +528,7 @@ async fn test_auth_expiry() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -813,7 +814,7 @@ async fn test_auth_base_require_tls_frontegg() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now,
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -2706,7 +2707,7 @@ async fn test_auth_admin_non_superuser() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now,
             admin_role: admin_role.to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -2854,7 +2855,7 @@ async fn test_auth_admin_superuser() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now,
             admin_role: admin_role.to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3002,7 +3003,7 @@ async fn test_auth_admin_superuser_revoked() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now,
             admin_role: admin_role.to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3134,7 +3135,7 @@ async fn test_auth_deduplication() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3306,7 +3307,7 @@ async fn test_refresh_task_metrics() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3470,7 +3471,7 @@ async fn test_superuser_can_alter_cluster() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now,
             admin_role: admin_role.to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3593,7 +3594,7 @@ async fn test_refresh_dropped_session() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -3771,7 +3772,7 @@ async fn test_refresh_dropped_session_lru() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             // Make the refresh LRU cache very small, and the window size very large so it's easy
@@ -3961,7 +3962,7 @@ async fn test_transient_auth_failures() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -4085,7 +4086,7 @@ async fn test_transient_auth_failure_on_refresh() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -5099,7 +5100,7 @@ async fn test_auth_autoprovision_frontegg_audit_log() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -5364,6 +5365,250 @@ async fn test_auth_oidc_non_login_role() {
             options: Some("--oidc_auth_enabled=true"),
             configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
             assert: Assert::Success,
+        }],
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// SEC-132: Cross-tenant regression tests
+// ---------------------------------------------------------------------------
+//
+// All organizations share a single Frontegg workspace (and RSA signing key).
+// The tenant_id check in validate_access_token is the sole Materialize-side
+// defense against cross-org access. These tests ensure that defense holds.
+
+/// A user from tenant B must be rejected by an environmentd configured for
+/// tenant A, even though the JWT signature is valid (same signing key).
+/// Verified across pgwire (app-password), HTTP (bearer), and WebSocket.
+#[allow(clippy::unit_arg)]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl`
+async fn test_auth_cross_tenant_rejected() {
+    let ca = Ca::new_root("test ca").unwrap();
+    let (server_cert, server_key) = ca
+        .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+        .unwrap();
+    let metrics_registry = MetricsRegistry::new();
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+
+    // -- Tenant A user (should succeed) --
+    let user_a_email = "alice@tenant-a.com";
+    let user_a_client_id = Uuid::new_v4();
+    let user_a_secret = Uuid::new_v4();
+
+    // -- Tenant B user (should be rejected) --
+    let user_b_email = "bob@tenant-b.com";
+    let user_b_client_id = Uuid::new_v4();
+    let user_b_secret = Uuid::new_v4();
+
+    let users = BTreeMap::from([
+        (
+            user_a_email.to_string(),
+            UserConfig {
+                id: Uuid::new_v4(),
+                email: user_a_email.to_string(),
+                password: Uuid::new_v4().to_string(),
+                tenant_id: tenant_a,
+                initial_api_tokens: vec![ApiToken {
+                    client_id: user_a_client_id,
+                    secret: user_a_secret,
+                    description: None,
+                    created_at: Utc::now(),
+                }],
+                roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
+            },
+        ),
+        (
+            user_b_email.to_string(),
+            UserConfig {
+                id: Uuid::new_v4(),
+                email: user_b_email.to_string(),
+                password: Uuid::new_v4().to_string(),
+                tenant_id: tenant_b,
+                initial_api_tokens: vec![ApiToken {
+                    client_id: user_b_client_id,
+                    secret: user_b_secret,
+                    description: None,
+                    created_at: Utc::now(),
+                }],
+                roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
+            },
+        ),
+    ]);
+
+    let issuer = "frontegg-mock".to_owned();
+    let encoding_key =
+        EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
+    let decoding_key = DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap();
+    let now = SYSTEM_TIME.clone();
+
+    let frontegg_server = FronteggMockServer::start(
+        None,
+        issuer,
+        encoding_key.clone(),
+        decoding_key,
+        users,
+        BTreeMap::new(),
+        None,
+        now.clone(),
+        i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // environmentd is configured for tenant_a only.
+    let frontegg_auth = FronteggAuthentication::new(
+        FronteggConfig {
+            admin_api_token_url: frontegg_server.auth_api_token_url(),
+            decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
+            tenant_id: TenantScope::Specific(tenant_a),
+            now: now.clone(),
+            admin_role: "mzadmin".to_string(),
+            refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+            refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
+        },
+        mz_frontegg_auth::Client::default(),
+        &metrics_registry,
+    );
+
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert, server_key)
+        .with_frontegg_auth(&frontegg_auth)
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
+
+    let password_a = format!("mzp_{user_a_client_id}{user_a_secret}");
+    let password_b = format!("mzp_{user_b_client_id}{user_b_secret}");
+
+    // Mint a bearer token for tenant_b user (valid signature, wrong tenant).
+    let cross_tenant_claims = Claims {
+        exp: now.as_secs() + i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        email: Some(user_b_email.to_string()),
+        iss: "frontegg-mock".to_string(),
+        sub: Uuid::new_v4(),
+        user_id: None,
+        tenant_id: tenant_b,
+        roles: Vec::new(),
+        permissions: Vec::new(),
+        token_type: ClaimTokenType::UserToken,
+        metadata: None,
+    };
+    let cross_tenant_jwt = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &cross_tenant_claims,
+        &encoding_key,
+    )
+    .unwrap();
+
+    let no_headers = HeaderMap::new();
+
+    // ---- Tenant A user should succeed across all transports ----
+    run_tests(
+        "Cross-tenant: tenant A user accepted",
+        &server,
+        &[
+            TestCase::Pgwire {
+                user_to_auth_as: user_a_email,
+                user_reported_by_system: user_a_email,
+                password: Some(Cow::Borrowed(&password_a)),
+                ssl_mode: SslMode::Require,
+                options: None,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
+            TestCase::Http {
+                user_to_auth_as: user_a_email,
+                user_reported_by_system: user_a_email,
+                scheme: Scheme::HTTPS,
+                headers: &make_header(Authorization::basic(user_a_email, &password_a)),
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
+            TestCase::Ws {
+                user_reported_by_system: user_a_email,
+                auth: &WebSocketAuth::Basic {
+                    user: user_a_email.to_string(),
+                    password: Password(password_a.clone()),
+                    options: BTreeMap::default(),
+                },
+                headers: &no_headers,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Success,
+            },
+        ],
+    )
+    .await;
+
+    // ---- Tenant B user must be REJECTED across all transports ----
+    run_tests(
+        "Cross-tenant: tenant B user rejected via pgwire app-password",
+        &server,
+        &[TestCase::Pgwire {
+            user_to_auth_as: user_b_email,
+            user_reported_by_system: user_b_email,
+            password: Some(Cow::Borrowed(&password_b)),
+            ssl_mode: SslMode::Require,
+            options: None,
+            configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+            // The pgwire layer does not expose the specific Frontegg error
+            // reason; any auth failure becomes "invalid password" at the wire
+            // protocol level. The cross-tenant rejection is verified via the
+            // HTTP and WebSocket tests below which do surface the error.
+            assert: Assert::Err(Box::new(|err| {
+                assert_contains!(err.to_string_with_causes(), "invalid password");
+            })),
+        }],
+    )
+    .await;
+
+    run_tests(
+        "Cross-tenant: tenant B bearer token rejected via HTTP",
+        &server,
+        &[TestCase::Http {
+            user_to_auth_as: user_b_email,
+            user_reported_by_system: user_b_email,
+            scheme: Scheme::HTTPS,
+            headers: &make_header(Authorization::bearer(&cross_tenant_jwt).unwrap()),
+            configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+            assert: Assert::Err(Box::new(|code, message| {
+                assert_eq!(
+                    code,
+                    Some(StatusCode::UNAUTHORIZED),
+                    "cross-tenant HTTP bearer must get 401"
+                );
+                assert_eq!(message, "unauthorized");
+            })),
+        }],
+    )
+    .await;
+
+    run_tests(
+        "Cross-tenant: tenant B bearer token rejected via WebSocket",
+        &server,
+        &[TestCase::Ws {
+            user_reported_by_system: user_b_email,
+            auth: &WebSocketAuth::Bearer {
+                token: cross_tenant_jwt.clone(),
+                options: BTreeMap::default(),
+            },
+            headers: &no_headers,
+            configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+            assert: Assert::Err(Box::new(|code, message| {
+                assert_eq!(code, CloseCode::Protocol);
+                assert_eq!(message, "unauthorized");
+            })),
         }],
     )
     .await;

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -34,7 +34,7 @@ use mz_environmentd::test_util::{self, Ca, KAFKA_ADDRS, PostgresErrorExt, make_p
 use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
     Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
-    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE, TenantScope,
 };
 use mz_frontegg_mock::{FronteggMockServer, models::ApiToken, models::UserConfig};
 use mz_ore::cast::CastFrom;
@@ -2436,7 +2436,7 @@ async fn test_max_connections_limits() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -4663,7 +4663,7 @@ async fn test_cert_reloading() {
         FronteggConfig {
             admin_api_token_url: frontegg_server.auth_api_token_url(),
             decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem().unwrap()).unwrap(),
-            tenant_id: Some(tenant_id),
+            tenant_id: TenantScope::Specific(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -32,8 +32,10 @@ tracing.workspace = true
 uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
+aws-lc-rs.workspace = true
 axum.workspace = true
 mz-ore = { path = "../ore", features = ["network", "test"] }
+pem.workspace = true
 tokio.workspace = true
 
 [features]

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -46,6 +46,24 @@ pub const DEFAULT_REFRESH_DROP_FACTOR: f64 = 0.05;
 /// The maximum length of a user name.
 pub const MAX_USER_NAME_LENGTH: usize = 255;
 
+/// Specifies how tenant validation is performed on incoming JWTs.
+///
+/// All organizations share a single Frontegg workspace (and thus a single RSA
+/// signing key). The `tenant_id` claim in the JWT and the per-environmentd
+/// tenant check are the **only** controls preventing cross-organization access.
+/// This enum forces callers to explicitly declare their tenant validation
+/// strategy rather than accidentally passing `None`.
+#[derive(Clone, Debug)]
+pub enum TenantScope {
+    /// Validate that the JWT's `tenant_id` matches this specific tenant.
+    /// Used by environmentd, where cross-tenant isolation is critical.
+    Specific(Uuid),
+    /// Accept JWTs from any tenant without checking `tenant_id`.
+    /// Only appropriate for routing services like balancerd that rely on
+    /// downstream environmentd instances to enforce tenant isolation.
+    AcceptAny,
+}
+
 /// Configures an [`Authenticator`].
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
@@ -55,8 +73,8 @@ pub struct AuthenticatorConfig {
     /// JWK used to validate JWTs.
     #[derivative(Debug = "ignore")]
     pub decoding_key: DecodingKey,
-    /// Optional tenant id used to validate JWTs.
-    pub tenant_id: Option<Uuid>,
+    /// Tenant validation strategy. See [`TenantScope`] for details.
+    pub tenant_id: TenantScope,
     /// Function to provide system time to validate exp (expires at) field of JWTs.
     pub now: NowFn,
     /// Name of admin role.
@@ -156,7 +174,7 @@ impl Authenticator {
                 AuthenticatorConfig {
                     admin_api_token_url,
                     decoding_key,
-                    tenant_id: Some(tenant_id),
+                    tenant_id: TenantScope::Specific(tenant_id),
                     now: mz_ore::now::SYSTEM_TIME.clone(),
                     admin_role,
                     refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
@@ -390,7 +408,7 @@ struct AuthenticatorInner {
     validation: Validation,
     #[derivative(Debug = "ignore")]
     decoding_key: DecodingKey,
-    tenant_id: Option<Uuid>,
+    tenant_id: TenantScope,
     admin_role: String,
     now: NowFn,
     /// Session tracking.
@@ -574,9 +592,14 @@ impl AuthenticatorInner {
         if msg.claims.exp < self.now.as_secs() {
             return Err(Error::TokenExpired);
         }
-        if let Some(expected_tenant_id) = self.tenant_id {
-            if msg.claims.tenant_id != expected_tenant_id {
-                return Err(Error::UnauthorizedTenant);
+        match &self.tenant_id {
+            TenantScope::Specific(expected_tenant_id) => {
+                if msg.claims.tenant_id != *expected_tenant_id {
+                    return Err(Error::UnauthorizedTenant);
+                }
+            }
+            TenantScope::AcceptAny => {
+                // No tenant validation — caller has explicitly opted out.
             }
         }
 
@@ -810,4 +833,224 @@ fn validate_user(user: &str, expected_user: &str) -> Result<(), Error> {
 
 const fn bool_as_str(x: bool) -> &'static str {
     if x { "true" } else { "false" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_lc_rs::encoding::AsDer;
+    use aws_lc_rs::rsa::{KeyPair, KeySize};
+    use aws_lc_rs::signature::KeyPair as _;
+    use jsonwebtoken::{EncodingKey, Header};
+    use mz_ore::now::SYSTEM_TIME;
+
+    /// Helper: generate an RSA key pair and return (encoding_key, decoding_key).
+    fn generate_keys() -> (EncodingKey, DecodingKey) {
+        let key_pair = KeyPair::generate(KeySize::Rsa2048).unwrap();
+        let private_der = key_pair.as_der().unwrap();
+        let private_pem = pem::encode(&pem::Pem::new("PRIVATE KEY", private_der.as_ref()));
+        let public_der = key_pair.public_key().as_der().unwrap();
+        let public_pem = pem::encode(&pem::Pem::new("PUBLIC KEY", public_der.as_ref()));
+        (
+            EncodingKey::from_rsa_pem(private_pem.as_bytes()).unwrap(),
+            DecodingKey::from_rsa_pem(public_pem.as_bytes()).unwrap(),
+        )
+    }
+
+    /// Helper: create an Authenticator with the given tenant scope.
+    fn make_authenticator(decoding_key: DecodingKey, tenant_id: TenantScope) -> Authenticator {
+        let registry = mz_ore::metrics::MetricsRegistry::new();
+        Authenticator::new(
+            AuthenticatorConfig {
+                admin_api_token_url: "http://localhost:0/not-used".to_string(),
+                decoding_key,
+                tenant_id,
+                now: SYSTEM_TIME.clone(),
+                admin_role: "mzadmin".to_string(),
+                refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+                refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
+            },
+            crate::Client::default(),
+            &registry,
+        )
+    }
+
+    /// Helper: mint a JWT signed with the given key.
+    fn mint_token(
+        encoding_key: &EncodingKey,
+        tenant_id: Uuid,
+        email: &str,
+        roles: Vec<String>,
+    ) -> String {
+        let claims = Claims {
+            sub: Uuid::new_v4(),
+            exp: SYSTEM_TIME.as_secs() + 600,
+            iss: "test-issuer".to_string(),
+            token_type: ClaimTokenType::UserToken,
+            email: Some(email.to_string()),
+            user_id: None,
+            tenant_id,
+            roles,
+            permissions: vec![],
+            metadata: None,
+        };
+        jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, encoding_key).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // SEC-132: Cross-tenant regression tests
+    // -----------------------------------------------------------------------
+
+    #[mz_ore::test]
+    fn test_cross_tenant_token_rejected() {
+        // A JWT minted for tenant_b must be rejected by an authenticator
+        // configured for tenant_a, even though the signature is valid.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant_a = Uuid::new_v4();
+        let tenant_b = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::Specific(tenant_a));
+        let token = mint_token(&encoding_key, tenant_b, "user@example.com", vec![]);
+
+        let result = authenticator.validate_access_token(&token, None);
+        let err = result.expect_err("cross-tenant token must be rejected");
+        assert!(
+            matches!(err, Error::UnauthorizedTenant),
+            "expected UnauthorizedTenant, got: {err:?}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_same_tenant_token_accepted() {
+        // A JWT minted for tenant_a is accepted by an authenticator for tenant_a.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant_a = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::Specific(tenant_a));
+        let token = mint_token(&encoding_key, tenant_a, "user@example.com", vec![]);
+
+        let (claims, _authenticated) = authenticator
+            .validate_access_token(&token, None)
+            .expect("same-tenant token must be accepted");
+        assert_eq!(claims.tenant_id, tenant_a);
+    }
+
+    #[mz_ore::test]
+    fn test_none_tenant_id_accepts_any_tenant() {
+        // When AuthenticatorConfig.tenant_id is None (balancerd mode),
+        // JWTs from any tenant are accepted.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant_a = Uuid::new_v4();
+        let tenant_b = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::AcceptAny);
+
+        let token_a = mint_token(&encoding_key, tenant_a, "alice@example.com", vec![]);
+        let token_b = mint_token(&encoding_key, tenant_b, "bob@example.com", vec![]);
+
+        let (claims_a, _) = authenticator
+            .validate_access_token(&token_a, None)
+            .expect("tenant_a token must be accepted when tenant_id is None");
+        assert_eq!(claims_a.tenant_id, tenant_a);
+
+        let (claims_b, _) = authenticator
+            .validate_access_token(&token_b, None)
+            .expect("tenant_b token must be accepted when tenant_id is None");
+        assert_eq!(claims_b.tenant_id, tenant_b);
+    }
+
+    #[mz_ore::test]
+    fn test_cross_tenant_with_valid_user_still_rejected() {
+        // Even if the expected_user matches the token's email, a tenant
+        // mismatch must still cause rejection. The tenant check must happen
+        // before (or regardless of) user validation.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant_a = Uuid::new_v4();
+        let tenant_b = Uuid::new_v4();
+        let email = "user@example.com";
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::Specific(tenant_a));
+        let token = mint_token(&encoding_key, tenant_b, email, vec![]);
+
+        let result = authenticator.validate_access_token(&token, Some(email));
+        let err = result.expect_err("cross-tenant must be rejected even with matching user");
+        assert!(
+            matches!(err, Error::UnauthorizedTenant),
+            "expected UnauthorizedTenant, got: {err:?}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_cross_tenant_admin_token_rejected() {
+        // An admin token from a different tenant must be rejected.
+        // This ensures admin role does not bypass tenant isolation.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant_a = Uuid::new_v4();
+        let tenant_b = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::Specific(tenant_a));
+        let token = mint_token(
+            &encoding_key,
+            tenant_b,
+            "admin@evil.com",
+            vec!["mzadmin".to_string()],
+        );
+
+        let result = authenticator.validate_access_token(&token, None);
+        let err = result.expect_err("cross-tenant admin token must be rejected");
+        assert!(
+            matches!(err, Error::UnauthorizedTenant),
+            "expected UnauthorizedTenant, got: {err:?}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_wrong_signing_key_rejected() {
+        // A JWT signed by a different key must be rejected, even with a
+        // matching tenant_id. This is the baseline control.
+        let (_encoding_key_a, decoding_key_a) = generate_keys();
+        let (encoding_key_b, _decoding_key_b) = generate_keys();
+        let tenant = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key_a, TenantScope::Specific(tenant));
+        let token = mint_token(&encoding_key_b, tenant, "user@example.com", vec![]);
+
+        let result = authenticator.validate_access_token(&token, None);
+        assert!(
+            result.is_err(),
+            "token with wrong signing key must be rejected"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_expired_token_rejected() {
+        // Expired tokens must be rejected regardless of tenant match.
+        let (encoding_key, decoding_key) = generate_keys();
+        let tenant = Uuid::new_v4();
+
+        let authenticator = make_authenticator(decoding_key, TenantScope::Specific(tenant));
+
+        // Mint a token that expired 10 minutes ago.
+        let claims = Claims {
+            sub: Uuid::new_v4(),
+            exp: SYSTEM_TIME.as_secs() - 600,
+            iss: "test-issuer".to_string(),
+            token_type: ClaimTokenType::UserToken,
+            email: Some("user@example.com".to_string()),
+            user_id: None,
+            tenant_id: tenant,
+            roles: vec![],
+            permissions: vec![],
+            metadata: None,
+        };
+        let token =
+            jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, &encoding_key).unwrap();
+
+        let result = authenticator.validate_access_token(&token, None);
+        let err = result.expect_err("expired token must be rejected");
+        assert!(
+            matches!(err, Error::TokenExpired),
+            "expected TokenExpired, got: {err:?}"
+        );
+    }
 }

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 pub use auth::{
     Authenticator, AuthenticatorConfig, ClaimMetadata, ClaimTokenType, Claims,
-    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE, TenantScope,
 };
 pub use client::Client;
 pub use client::tokens::{ApiTokenArgs, ApiTokenResponse};


### PR DESCRIPTION
## Summary

- Add 7 unit tests for cross-tenant JWT rejection in `mz-frontegg-auth` (**[SEC-132](https://linear.app/materializeinc/issue/SEC-132)**)
- Add integration test verifying cross-tenant rejection across pgwire, HTTP, and WebSocket
- Replace `Option<Uuid>` with `TenantScope` enum to prevent accidental skip of tenant validation (**[SEC-126](https://linear.app/materializeinc/issue/SEC-126)**)

## Motivation

The `tenant_id` check in `validate_access_token` is a key Materialize-side defense against cross-org access. This PR levels up our testing of this important validation check.

## Changes

### [SEC-132](https://linear.app/materializeinc/issue/SEC-132): Cross-tenant regression tests

Unit tests added to `src/frontegg-auth/src/auth.rs`:
- `test_cross_tenant_token_rejected` — JWT for tenant B rejected by authenticator for tenant A
- `test_same_tenant_token_accepted` — JWT for matching tenant accepted
- `test_none_tenant_id_accepts_any_tenant` — `TenantScope::AcceptAny` documents balancerd behavior
- `test_cross_tenant_with_valid_user_still_rejected` — tenant mismatch rejects even with matching user
- `test_cross_tenant_admin_token_rejected` — admin role does not bypass tenant isolation
- `test_wrong_signing_key_rejected` — baseline: wrong signing key always rejects
- `test_expired_token_rejected` — baseline: expired tokens always reject

Integration test added to `src/environmentd/tests/auth.rs`:
- `test_auth_cross_tenant_rejected` — two tenants, verifies tenant A user succeeds and tenant B user is rejected across pgwire (app-password), HTTP (bearer token), and WebSocket

### [SEC-126](https://linear.app/materializeinc/issue/SEC-126): Structural hardening

New `TenantScope` enum replaces `Option<Uuid>` on `AuthenticatorConfig`:
```rust
pub enum TenantScope {
    Specific(Uuid),  // environmentd: enforces cross-tenant isolation
    AcceptAny,       // balancerd: routes by tenant, delegates validation downstream
}
```

Every construction site now explicitly declares its tenant validation intent.

## Test plan

- [x] `cargo test -p mz-frontegg-auth --lib -- tests::` — all 7 new unit tests pass
- [ ] `test_auth_cross_tenant_rejected` integration test (requires `METADATA_BACKEND_URL` — runs in CI)
- [x] `cargo check` — clean build across full workspace
- [x] `cargo clippy` — no warnings on affected crates
- [x] `cargo fmt` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)