### PR TITLE
optimizer: Push `COALESCE` into `CASE WHEN`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -73,6 +73,7 @@ def get_minimal_system_parameters(
         "enable_alter_swap": "true",
         "enable_case_literal_transform": "true",
         "enable_cast_elimination": "true",
+        "enable_coalesce_case_transform": "true",
         "enable_columnar_lgalloc": "false",
         "enable_columnation_lgalloc": "false",
         "enable_compute_correction_v2": "true",
@@ -204,7 +205,7 @@ def get_variable_system_parameters(
         ),
         VariableSystemParameter(
             "enable_coalesce_case_transform",
-            "false",
+            "true",
             ["true", "false"],
         ),
         VariableSystemParameter(

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -203,6 +203,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_coalesce_case_transform",
+            "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_cast_elimination",
             "true",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1582,6 +1582,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_upsert_v2"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_coalesce_case_transform"] = BOOLEAN_FLAG_VALUES
 
         # If you are adding a new config flag in Materialize, consider using it
         # here instead of just marking it as uninteresting to silence the

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -854,6 +854,9 @@ mod scalar {
                 } else if input.eat(kw::OR) {
                     exp_opd = true;
                     Op::Var(VariadicFunc::Or(func::variadic::Or))
+                } else if input.eat(kw::coalesce) {
+                    exp_opd = true;
+                    Op::Var(VariadicFunc::Coalesce(func::variadic::Coalesce))
                 } else if input.eat(kw::IS) {
                     let negate = input.eat(kw::NOT);
 
@@ -1172,6 +1175,7 @@ mod scalar {
             "ltrim" => parse_binary(func::TrimLeading.into()),
             // Supported variadic functions:
             "greatest" => parse_variadic(VariadicFunc::Greatest(func::variadic::Greatest)),
+            "coalesce" => parse_variadic(VariadicFunc::Coalesce(func::variadic::Coalesce)),
             _ => Err(Error::new(ident.span(), "unsupported function name")),
         }
     }
@@ -1639,6 +1643,7 @@ mod kw {
     syn::custom_keyword!(asc);
     // case when ... then ... else ... end
     syn::custom_keyword!(case);
+    syn::custom_keyword!(coalesce);
     syn::custom_keyword!(Constant);
     syn::custom_keyword!(CrossJoin);
     syn::custom_keyword!(cte);

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1225,6 +1225,49 @@ impl MirScalarExpr {
                             if exprs.len() == 1 {
                                 // Only one argument, so the coalesce is a no-op.
                                 *e = exprs[0].take();
+                            } else {
+                                // COALESCE(CASE WHEN e_cond THEN NULL ELSE e_else END, ...)
+                                // ->
+                                // CASE WHEN e_cond THEN COALESCE(...) ELSE e_else END
+                                //
+                                // ... and flipped
+                                if let MirScalarExpr::If { cond: _, then, els } = &exprs[0] {
+                                    if then.is_literal_null() {
+                                        let MirScalarExpr::If {
+                                            mut cond,
+                                            then: _,
+                                            mut els,
+                                        } = exprs.remove(0)
+                                        else {
+                                            unreachable!();
+                                        };
+                                        *e = MirScalarExpr::if_then_else(
+                                            cond.take(),
+                                            MirScalarExpr::CallVariadic {
+                                                func: VariadicFunc::Coalesce(Coalesce),
+                                                exprs: std::mem::take(exprs),
+                                            },
+                                            els.take(),
+                                        );
+                                    } else if els.is_literal_null() {
+                                        let MirScalarExpr::If {
+                                            mut cond,
+                                            mut then,
+                                            els: _,
+                                        } = exprs.remove(0)
+                                        else {
+                                            unreachable!();
+                                        };
+                                        *e = MirScalarExpr::if_then_else(
+                                            cond.take(),
+                                            then.take(),
+                                            MirScalarExpr::CallVariadic {
+                                                func: VariadicFunc::Coalesce(Coalesce),
+                                                exprs: std::mem::take(exprs),
+                                            },
+                                        );
+                                    }
+                                }
                             }
                         } else if exprs.iter().all(|e| e.is_literal()) {
                             *e = eval(e);

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1225,49 +1225,6 @@ impl MirScalarExpr {
                             if exprs.len() == 1 {
                                 // Only one argument, so the coalesce is a no-op.
                                 *e = exprs[0].take();
-                            } else {
-                                // COALESCE(CASE WHEN e_cond THEN NULL ELSE e_else END, ...)
-                                // ->
-                                // CASE WHEN e_cond THEN COALESCE(...) ELSE e_else END
-                                //
-                                // ... and flipped
-                                if let MirScalarExpr::If { cond: _, then, els } = &exprs[0] {
-                                    if then.is_literal_null() {
-                                        let MirScalarExpr::If {
-                                            mut cond,
-                                            then: _,
-                                            mut els,
-                                        } = exprs.remove(0)
-                                        else {
-                                            unreachable!();
-                                        };
-                                        *e = MirScalarExpr::if_then_else(
-                                            cond.take(),
-                                            MirScalarExpr::CallVariadic {
-                                                func: VariadicFunc::Coalesce(Coalesce),
-                                                exprs: std::mem::take(exprs),
-                                            },
-                                            els.take(),
-                                        );
-                                    } else if els.is_literal_null() {
-                                        let MirScalarExpr::If {
-                                            mut cond,
-                                            mut then,
-                                            els: _,
-                                        } = exprs.remove(0)
-                                        else {
-                                            unreachable!();
-                                        };
-                                        *e = MirScalarExpr::if_then_else(
-                                            cond.take(),
-                                            then.take(),
-                                            MirScalarExpr::CallVariadic {
-                                                func: VariadicFunc::Coalesce(Coalesce),
-                                                exprs: std::mem::take(exprs),
-                                            },
-                                        );
-                                    }
-                                }
                             }
                         } else if exprs.iter().all(|e| e.is_literal()) {
                             *e = eval(e);

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -136,6 +136,8 @@ optimizer_feature_flags!({
     enable_case_literal_transform: bool,
     // See the feature flag of the same name.
     enable_simplify_quantified_comparisons: bool,
+    // See the feature flag of the same name.
+    enable_coalesce_case_transform: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5169,6 +5169,7 @@ pub fn unplan_create_cluster(
                 enable_cast_elimination: _,
                 enable_case_literal_transform: _,
                 enable_simplify_quantified_comparisons: _,
+                enable_coalesce_case_transform: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -651,6 +651,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_cast_elimination: Default::default(),
                 enable_case_literal_transform: Default::default(),
                 enable_simplify_quantified_comparisons: Default::default(),
+                enable_coalesce_case_transform: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2268,6 +2268,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_coalesce_case_transform,
+        desc: "Allow the optimizer to `COALESCE` of a `NULL`-returning `CASE` into a single `CASE`.",
+        default: false,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2293,6 +2299,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_cast_elimination: vars.enable_cast_elimination(),
             enable_case_literal_transform: vars.enable_case_literal_transform(),
             enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
+            enable_coalesce_case_transform: vars.enable_coalesce_case_transform(),
         }
     }
 }
@@ -2335,6 +2342,7 @@ mod tests {
             enable_cast_elimination,
             enable_case_literal_transform,
             enable_simplify_quantified_comparisons,
+            enable_coalesce_case_transform,
         } = false_features;
 
         let mut vars = SystemVars::new();
@@ -2365,6 +2373,7 @@ mod tests {
         set_var!(enable_cast_elimination);
         set_var!(enable_case_literal_transform);
         set_var!(enable_simplify_quantified_comparisons);
+        set_var!(enable_coalesce_case_transform);
 
         // Enable for item parsing, then ensure we still get the same optimizer features.
         vars.enable_for_item_parsing();

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2270,7 +2270,7 @@ feature_flags!(
     },
     {
         name: enable_coalesce_case_transform,
-        desc: "Allow the optimizer to `COALESCE` of a `NULL`-returning `CASE` into a single `CASE`.",
+        desc: "Allow the optimizer to push `COALESCE` into `CASE WHEN`.",
         default: false,
         enable_for_item_parsing: false,
     },

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2271,7 +2271,7 @@ feature_flags!(
     {
         name: enable_coalesce_case_transform,
         desc: "Allow the optimizer to push `COALESCE` into `CASE WHEN`.",
-        default: false,
+        default: true,
         enable_for_item_parsing: false,
     },
 );

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -139,10 +139,7 @@ impl CoalesceCase {
                             .chain(exprs.iter().cloned())
                             .collect(),
                     );
-                    let t = MirScalarExpr::call_variadic(
-                        VariadicFunc::Coalesce(Coalesce),
-                        exprs,
-                    );
+                    let t = MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), exprs);
                     *expr = cond.take().if_then_else(t, f);
                 } else if els.is_literal_null() {
                     let MirScalarExpr::If {

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -1,0 +1,163 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Turn `COALESCE` of `NULL`-returning `CASE` into just a `CASE`
+
+use mz_expr::func::variadic::Coalesce;
+use mz_expr::visit::Visit;
+use mz_expr::{AggregateExpr, JoinImplementation, MirRelationExpr, MirScalarExpr, VariadicFunc};
+use mz_ore::soft_assert_eq_or_log;
+
+use crate::{TransformCtx, TransformError};
+
+/// Replace operators on constant collections with constant collections.
+#[derive(Debug)]
+pub struct CoalesceCase {}
+
+impl Default for CoalesceCase {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl crate::Transform for CoalesceCase {
+    fn name(&self) -> &'static str {
+        "FoldConstants"
+    }
+
+    #[mz_ore::instrument(
+        target = "optimizer",
+        level = "debug",
+        fields(path.segment = "fold_constants")
+    )]
+    fn actually_perform_transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        _: &mut TransformCtx,
+    ) -> Result<(), TransformError> {
+        relation.try_visit_mut_post(&mut |e| self.action(e))?;
+        mz_repr::explain::trace_plan(&*relation);
+        Ok(())
+    }
+}
+
+impl CoalesceCase {
+    fn action(&self, relation: &mut MirRelationExpr) -> Result<(), TransformError> {
+        match relation {
+            MirRelationExpr::Constant { .. } |
+            MirRelationExpr::Get { .. } |
+            MirRelationExpr::Let { .. } |
+            MirRelationExpr::LetRec { .. } |
+            MirRelationExpr::Project { .. } |
+            MirRelationExpr::Negate { .. } |
+            MirRelationExpr::Threshold { .. } |
+            MirRelationExpr::Union { .. } |
+            // don't mess with arrangements, even though their keys have MSEs in them
+            // these _mostly_ shouldn't occur, since we run before join implementation, but some may be inserted earlier for us
+            MirRelationExpr::ArrangeBy { .. } => (),
+            MirRelationExpr::Map { scalars: exprs, .. } |
+            MirRelationExpr::Filter { predicates: exprs, .. } |
+            MirRelationExpr::FlatMap { exprs, .. } => {
+                // NB TableFunc doesn't ever hold an MSE
+                for expr in exprs.iter_mut() {
+                    self.rewrite_scalar(expr)?;
+                }
+            }
+            MirRelationExpr::Join { equivalences, implementation, .. } => {
+                if implementation.is_implemented() {
+                    soft_assert_eq_or_log!(*implementation, JoinImplementation::Unimplemented, "unexpected implemented Join when optimizing coalesce/case, skipping");
+                    return Ok(());
+                }
+
+                for equivalence in equivalences.iter_mut() {
+                    for expr in equivalence {
+                        self.rewrite_scalar(expr)?;
+                    }
+                }
+            }
+            MirRelationExpr::Reduce { group_key, aggregates, .. } => {
+                for expr in group_key.iter_mut() {
+                    self.rewrite_scalar(expr)?;
+                }
+
+                for agg in aggregates.iter_mut() {
+                    self.rewrite_aggreagte(agg)?;
+                }
+            }
+            MirRelationExpr::TopK { limit, .. } => {
+                if let Some(expr) = limit {
+                    self.rewrite_scalar(expr)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn rewrite_scalar(&self, expr: &mut MirScalarExpr) -> Result<(), TransformError> {
+        expr.visit_mut_post(&mut |e| self.try_combine_coalesce_case(e))
+            .map_err(TransformError::from)
+    }
+
+    fn rewrite_aggreagte(&self, agg: &mut AggregateExpr) -> Result<(), TransformError> {
+        // NB AggregateFunc doesn't contain any MSEs
+        self.rewrite_scalar(&mut agg.expr)
+    }
+
+    fn try_combine_coalesce_case(&self, expr: &mut MirScalarExpr) {
+        // COALESCE(CASE WHEN e_cond THEN NULL ELSE e_else END, ...)
+        // ->
+        // CASE WHEN e_cond THEN COALESCE(...) ELSE e_else END
+        //
+        // ... and flipped
+        expr.flatten_associative();
+
+        if let MirScalarExpr::CallVariadic { func, exprs } = expr
+            && *func == VariadicFunc::Coalesce(Coalesce)
+        {
+            if let MirScalarExpr::If { cond: _, then, els } = &exprs[0] {
+                if then.is_literal_null() {
+                    let MirScalarExpr::If {
+                        mut cond,
+                        then: _,
+                        mut els,
+                    } = exprs.remove(0)
+                    else {
+                        unreachable!();
+                    };
+                    *expr = MirScalarExpr::if_then_else(
+                        cond.take(),
+                        MirScalarExpr::CallVariadic {
+                            func: VariadicFunc::Coalesce(Coalesce),
+                            exprs: std::mem::take(exprs),
+                        },
+                        els.take(),
+                    );
+                } else if els.is_literal_null() {
+                    let MirScalarExpr::If {
+                        mut cond,
+                        mut then,
+                        els: _,
+                    } = exprs.remove(0)
+                    else {
+                        unreachable!();
+                    };
+                    *expr = MirScalarExpr::if_then_else(
+                        cond.take(),
+                        then.take(),
+                        MirScalarExpr::CallVariadic {
+                            func: VariadicFunc::Coalesce(Coalesce),
+                            exprs: std::mem::take(exprs),
+                        },
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -11,8 +11,8 @@
 
 use mz_expr::func::variadic::Coalesce;
 use mz_expr::visit::Visit;
-use mz_expr::{AggregateExpr, JoinImplementation, MirRelationExpr, MirScalarExpr, VariadicFunc};
-use mz_ore::soft_assert_eq_or_log;
+use mz_expr::{AggregateExpr, MirRelationExpr, MirScalarExpr, VariadicFunc};
+use mz_ore::soft_panic_or_log;
 
 use crate::{TransformCtx, TransformError};
 
@@ -71,7 +71,7 @@ impl CoalesceCase {
             }
             MirRelationExpr::Join { equivalences, implementation, .. } => {
                 if implementation.is_implemented() {
-                    soft_assert_eq_or_log!(*implementation, JoinImplementation::Unimplemented, "unexpected implemented Join when optimizing coalesce/case, skipping");
+                    soft_panic_or_log!("unexpected implemented Join when optimizing coalesce/case, skipping: {implementation:?}");
                     return Ok(());
                 }
 

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Turn `COALESCE` of `NULL`-returning `CASE` into just a `CASE`
+//! Pushes `COALESCE` into `CASE WHEN`
 
 use mz_expr::func::variadic::Coalesce;
 use mz_expr::visit::Visit;
@@ -115,8 +115,6 @@ impl CoalesceCase {
         // COALESCE(CASE WHEN e_cond THEN e_then ELSE e_else END, ...)
         // ->
         // CASE WHEN e_cond THEN COALESCE(e_then, ...) ELSE COALESCE(e_else, ...) END
-        //
-        // ... and flipped
         expr.flatten_associative();
 
         if let MirScalarExpr::CallVariadic { func, exprs } = expr

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -16,9 +16,9 @@ use mz_ore::soft_assert_eq_or_log;
 
 use crate::{TransformCtx, TransformError};
 
-/// Replace operators on constant collections with constant collections.
+/// Push `COALESCE` into `CASE WHEN` as possible.
 #[derive(Debug)]
-pub struct CoalesceCase {}
+pub struct CoalesceCase;
 
 impl Default for CoalesceCase {
     fn default() -> Self {
@@ -28,13 +28,13 @@ impl Default for CoalesceCase {
 
 impl crate::Transform for CoalesceCase {
     fn name(&self) -> &'static str {
-        "FoldConstants"
+        "CoalesceCase"
     }
 
     #[mz_ore::instrument(
         target = "optimizer",
         level = "debug",
-        fields(path.segment = "fold_constants")
+        fields(path.segment = "coalesce_case")
     )]
     fn actually_perform_transform(
         &self,
@@ -101,7 +101,8 @@ impl CoalesceCase {
     }
 
     fn rewrite_scalar(&self, expr: &mut MirScalarExpr) -> Result<(), TransformError> {
-        expr.visit_mut_post(&mut |e| self.try_combine_coalesce_case(e))
+        // Visiting in pre-order means that when we push a `COALESCE` down, we'll keep pushing if the `CASE` chain continues.
+        expr.visit_mut_pre(&mut |e| self.try_combine_coalesce_case(e))
             .map_err(TransformError::from)
     }
 
@@ -113,7 +114,7 @@ impl CoalesceCase {
     fn try_combine_coalesce_case(&self, expr: &mut MirScalarExpr) {
         // COALESCE(CASE WHEN e_cond THEN NULL ELSE e_else END, ...)
         // ->
-        // CASE WHEN e_cond THEN COALESCE(...) ELSE e_else END
+        // CASE WHEN e_cond THEN COALESCE(...) ELSE COALESCE(e_else, ...) END
         //
         // ... and flipped
         expr.flatten_associative();
@@ -131,14 +132,18 @@ impl CoalesceCase {
                     else {
                         unreachable!();
                     };
-                    *expr = MirScalarExpr::if_then_else(
-                        cond.take(),
-                        MirScalarExpr::CallVariadic {
-                            func: VariadicFunc::Coalesce(Coalesce),
-                            exprs: std::mem::take(exprs),
-                        },
-                        els.take(),
+                    let exprs = std::mem::take(exprs);
+                    let f = MirScalarExpr::call_variadic(
+                        VariadicFunc::Coalesce(Coalesce),
+                        std::iter::once(els.take())
+                            .chain(exprs.iter().cloned())
+                            .collect(),
                     );
+                    let t = MirScalarExpr::call_variadic(
+                        VariadicFunc::Coalesce(Coalesce),
+                        exprs,
+                    );
+                    *expr = cond.take().if_then_else(t, f);
                 } else if els.is_literal_null() {
                     let MirScalarExpr::If {
                         mut cond,
@@ -148,14 +153,15 @@ impl CoalesceCase {
                     else {
                         unreachable!();
                     };
-                    *expr = MirScalarExpr::if_then_else(
-                        cond.take(),
-                        then.take(),
-                        MirScalarExpr::CallVariadic {
-                            func: VariadicFunc::Coalesce(Coalesce),
-                            exprs: std::mem::take(exprs),
-                        },
+                    let exprs = std::mem::take(exprs);
+                    let t = MirScalarExpr::call_variadic(
+                        VariadicFunc::Coalesce(Coalesce),
+                        std::iter::once(then.take())
+                            .chain(exprs.iter().cloned())
+                            .collect(),
                     );
+                    let f = MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), exprs);
+                    *expr = cond.take().if_then_else(t, f);
                 }
             }
         }

--- a/src/transform/src/coalesce_case.rs
+++ b/src/transform/src/coalesce_case.rs
@@ -112,9 +112,9 @@ impl CoalesceCase {
     }
 
     fn try_combine_coalesce_case(&self, expr: &mut MirScalarExpr) {
-        // COALESCE(CASE WHEN e_cond THEN NULL ELSE e_else END, ...)
+        // COALESCE(CASE WHEN e_cond THEN e_then ELSE e_else END, ...)
         // ->
-        // CASE WHEN e_cond THEN COALESCE(...) ELSE COALESCE(e_else, ...) END
+        // CASE WHEN e_cond THEN COALESCE(e_then, ...) ELSE COALESCE(e_else, ...) END
         //
         // ... and flipped
         expr.flatten_associative();
@@ -122,44 +122,32 @@ impl CoalesceCase {
         if let MirScalarExpr::CallVariadic { func, exprs } = expr
             && *func == VariadicFunc::Coalesce(Coalesce)
         {
-            if let MirScalarExpr::If { cond: _, then, els } = &exprs[0] {
-                if then.is_literal_null() {
-                    let MirScalarExpr::If {
-                        mut cond,
-                        then: _,
-                        mut els,
-                    } = exprs.remove(0)
-                    else {
-                        unreachable!();
-                    };
-                    let exprs = std::mem::take(exprs);
-                    let f = MirScalarExpr::call_variadic(
-                        VariadicFunc::Coalesce(Coalesce),
-                        std::iter::once(els.take())
-                            .chain(exprs.iter().cloned())
-                            .collect(),
-                    );
-                    let t = MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), exprs);
-                    *expr = cond.take().if_then_else(t, f);
-                } else if els.is_literal_null() {
-                    let MirScalarExpr::If {
-                        mut cond,
-                        mut then,
-                        els: _,
-                    } = exprs.remove(0)
-                    else {
-                        unreachable!();
-                    };
-                    let exprs = std::mem::take(exprs);
-                    let t = MirScalarExpr::call_variadic(
-                        VariadicFunc::Coalesce(Coalesce),
-                        std::iter::once(then.take())
-                            .chain(exprs.iter().cloned())
-                            .collect(),
-                    );
-                    let f = MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), exprs);
-                    *expr = cond.take().if_then_else(t, f);
-                }
+            if let MirScalarExpr::If { .. } = &exprs[0] {
+                let mut exprs = std::mem::take(exprs);
+                if let MirScalarExpr::If {
+                    mut cond,
+                    mut then,
+                    mut els,
+                } = exprs.remove(0)
+                {
+                    let cond = cond.take();
+
+                    let mut then_exprs = Vec::with_capacity(exprs.len() + 1);
+                    then_exprs.push(then.take());
+                    then_exprs.extend(exprs.iter().cloned());
+
+                    let mut else_exprs = Vec::with_capacity(exprs.len() + 1);
+                    else_exprs.push(els.take());
+                    else_exprs.append(&mut exprs);
+
+                    let t =
+                        MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), then_exprs);
+                    let f =
+                        MirScalarExpr::call_variadic(VariadicFunc::Coalesce(Coalesce), else_exprs);
+                    *expr = cond.if_then_else(t, f);
+                } else {
+                    unreachable!();
+                };
             }
         }
     }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -843,10 +843,11 @@ impl Optimizer {
             Box::new(Fixpoint {
                 name: "fixpoint_physical_01",
                 limit: 100,
-                transforms: vec![
+                transforms: transforms![
                     Box::new(EquivalencePropagation::default()),
                     Box::new(fold_constants_fixpoint(true)),
-                    Box::new(coalesce_case::CoalesceCase::default()),
+                    Box::new(coalesce_case::CoalesceCase::default());
+                        if ctx.features.enable_coalesce_case_transform,
                     Box::new(Demand::default()),
                     // Demand might have introduced dummies, so let's also do a ProjectionPushdown.
                     Box::new(ProjectionPushdown::default()),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -67,6 +67,7 @@ pub mod analysis;
 pub mod canonicalization;
 pub mod canonicalize_mfp;
 pub mod case_literal;
+pub mod coalesce_case;
 pub mod collect_notices;
 pub mod column_knowledge;
 pub mod compound;
@@ -845,6 +846,7 @@ impl Optimizer {
                 transforms: vec![
                     Box::new(EquivalencePropagation::default()),
                     Box::new(fold_constants_fixpoint(true)),
+                    Box::new(coalesce_case::CoalesceCase::default()),
                     Box::new(Demand::default()),
                     // Demand might have introduced dummies, so let's also do a ProjectionPushdown.
                     Box::new(ProjectionPushdown::default()),

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -245,7 +245,7 @@ fn handle_apply(
         }
         "coalesce_case" => {
             use mz_transform::coalesce_case::CoalesceCase;
-            let transform =  CoalesceCase;
+            let transform = CoalesceCase;
             apply_transform(transform, catalog, input)
         }
         "threshold_elision" => {

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -243,6 +243,11 @@ fn handle_apply(
             let transform = CaseLiteralTransform;
             apply_transform(transform, catalog, input)
         }
+        "coalesce_case" => {
+            use mz_transform::coalesce_case::CoalesceCase;
+            let transform =  CoalesceCase;
+            apply_transform(transform, catalog, input)
+        }
         "threshold_elision" => {
             use mz_transform::threshold_elision::ThresholdElision;
             let transform = ThresholdElision;

--- a/src/transform/tests/test_transforms/coalesce_case.spec
+++ b/src/transform/tests/test_transforms/coalesce_case.spec
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+define
+DefSource name=t0
+  - c0: bigint
+  - c1: bigint?
+----
+Source defined as t0
+
+# then branch
+
+apply pipeline=coalesce_case
+Map (coalesce(case when (#0 = 0) then null::bigint else 2 end, 1))
+  Get t0
+----
+Map (case when (#0 = 0) then coalesce(1) else coalesce(2, 1) end)
+  Get t0
+
+# else branch
+
+apply pipeline=coalesce_case
+Map (coalesce(case when (#0 = 0) then 1 else null::bigint end, 2))
+  Get t0
+----
+Map (case when (#0 = 0) then coalesce(1, 2) else coalesce(2) end)
+  Get t0
+
+# doesn't apply
+
+apply pipeline=coalesce_case
+Map (coalesce(case when (#0 = 0) then 1 else 2 end, 3))
+  Get t0
+----
+Map (coalesce(case when (#0 = 0) then 1 else 2 end, 3))
+  Get t0
+
+# then branch, nullable else
+
+apply pipeline=coalesce_case
+Map (coalesce(case when (#0 = 0) then null::bigint else #1 end, 1))
+  Get t0
+----
+Map (case when (#0 = 0) then coalesce(1) else coalesce(#1, 1) end)
+  Get t0
+
+# else branch, nullable then
+
+apply pipeline=coalesce_case
+Map (coalesce(case when (#0 = 0) then #1 else null::bigint end, 2))
+  Get t0
+----
+Map (case when (#0 = 0) then coalesce(#1, 2) else coalesce(2) end)
+  Get t0

--- a/src/transform/tests/test_transforms/coalesce_case.spec
+++ b/src/transform/tests/test_transforms/coalesce_case.spec
@@ -23,7 +23,7 @@ apply pipeline=coalesce_case
 Map (coalesce(case when (#0 = 0) then null::bigint else 2 end, 1))
   Get t0
 ----
-Map (case when (#0 = 0) then coalesce(1) else coalesce(2, 1) end)
+Map (case when (#0 = 0) then coalesce(null, 1) else coalesce(2, 1) end)
   Get t0
 
 # else branch
@@ -32,7 +32,7 @@ apply pipeline=coalesce_case
 Map (coalesce(case when (#0 = 0) then 1 else null::bigint end, 2))
   Get t0
 ----
-Map (case when (#0 = 0) then coalesce(1, 2) else coalesce(2) end)
+Map (case when (#0 = 0) then coalesce(1, 2) else coalesce(null, 2) end)
   Get t0
 
 # doesn't apply
@@ -41,7 +41,7 @@ apply pipeline=coalesce_case
 Map (coalesce(case when (#0 = 0) then 1 else 2 end, 3))
   Get t0
 ----
-Map (coalesce(case when (#0 = 0) then 1 else 2 end, 3))
+Map (case when (#0 = 0) then coalesce(1, 3) else coalesce(2, 3) end)
   Get t0
 
 # then branch, nullable else
@@ -50,7 +50,7 @@ apply pipeline=coalesce_case
 Map (coalesce(case when (#0 = 0) then null::bigint else #1 end, 1))
   Get t0
 ----
-Map (case when (#0 = 0) then coalesce(1) else coalesce(#1, 1) end)
+Map (case when (#0 = 0) then coalesce(null, 1) else coalesce(#1, 1) end)
   Get t0
 
 # else branch, nullable then
@@ -59,5 +59,5 @@ apply pipeline=coalesce_case
 Map (coalesce(case when (#0 = 0) then #1 else null::bigint end, 2))
   Get t0
 ----
-Map (case when (#0 = 0) then coalesce(#1, 2) else coalesce(2) end)
+Map (case when (#0 = 0) then coalesce(#1, 2) else coalesce(null, 2) end)
   Get t0

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -874,7 +874,7 @@ Explained Query:
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else #1{count} end), sum(case when (#4) IS NULL then 0 else #3{count} end), count(*)] // { arity: 4 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else coalesce(#1{count}, 0) end), sum(case when (#4) IS NULL then 0 else coalesce(#3{count}, 0) end), count(*)] // { arity: 4 }
           Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -874,7 +874,7 @@ Explained Query:
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else #1{count} end), sum(case when (#4) IS NULL then 0 else #3{count} end), count(*)] // { arity: 4 }
           Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -881,7 +881,7 @@ Explained Query:
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else #1{count} end), sum(case when (#4) IS NULL then 0 else #3{count} end), count(*)] // { arity: 4 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else coalesce(#1{count}, 0) end), sum(case when (#4) IS NULL then 0 else coalesce(#3{count}, 0) end), count(*)] // { arity: 4 }
           Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -881,7 +881,7 @@ Explained Query:
             Get l0 // { arity: 3 }
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(case when (#2) IS NULL then 0 else #1{count} end), sum(case when (#4) IS NULL then 0 else #3{count} end), count(*)] // { arity: 4 }
           Project (#1{creatorpersonid}, #3{count}, #4, #6{count}, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation

--- a/test/sqllogictest/transform/coalesce_case.slt
+++ b/test/sqllogictest/transform/coalesce_case.slt
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the CoalesceCase optimizer transform, which pushes
+# COALESCE into CASE when one of the branches is a literal null
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_coalesce_case_transform TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t (x int, y int, z int not null)
+
+# rewrite a CASE where the ELSE branch is a not-null constant
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT
+  COALESCE(
+    CASE WHEN x = 1
+      THEN NULL
+      ELSE 0
+    END,
+    2)
+FROM t
+----
+Explained Query:
+  Project (#3)
+    Map (case when (#0{x} = 1) then 2 else 0 end)
+      ReadStorage materialize.public.t
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# rewrite a CASE where the ELSE branch is a not-null column reference
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT
+  COALESCE(
+    CASE WHEN x = 1
+      THEN NULL
+      ELSE z
+    END,
+    2)
+FROM t
+----
+Explained Query:
+  Project (#3)
+    Map (case when (#0{x} = 1) then 2 else #2{z} end)
+      ReadStorage materialize.public.t
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# rewrite a CASE where the ELSE branch is a nullable column reference
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT
+  COALESCE(
+    CASE WHEN x = 1
+      THEN NULL
+      ELSE y
+    END,
+    2)
+FROM t
+----
+Explained Query:
+  Project (#3)
+    Map (case when (#0{x} = 1) then 2 else coalesce(#1{y}, 2) end)
+      ReadStorage materialize.public.t
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF


### PR DESCRIPTION
### Motivation

https://materializeinc.slack.com/archives/C0246GEHL8N/p1774867717130349?thread_ts=1774866513.092989&cid=C0246GEHL8N

### Description

Implements the optimization: 
```
COALESCE((CASE WHEN e1 THEN e2 ELSE e3), ...)
=>
CASE WHEN e1 THEN COALESCE(e2, ...) ELSE COALESCE(e3, ...)
```
In order to not pile onto `MSE::reduce`, I implemented this as an optimization that runs in the fixpoint before join implementation.

(Before join implementation is important: https://github.com/MaterializeInc/database-issues/issues/11300 it's not clear what updates are possible once we've settled on arrangements, and others get this wrong [and should be fixed].)

### Verification

SLT updates, spec tests.