### PR TITLE
clusterd: Unified Timely runtime for compute and storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,6 +6078,7 @@ dependencies = [
  "axum",
  "clap",
  "custom-labels",
+ "differential-dataflow",
  "fail",
  "futures",
  "hyper 1.8.1",
@@ -6097,6 +6098,8 @@ dependencies = [
  "mz-ore",
  "mz-persist-client",
  "mz-prof-http",
+ "mz-repr",
+ "mz-rocksdb",
  "mz-service",
  "mz-storage",
  "mz-storage-client",
@@ -6106,9 +6109,11 @@ dependencies = [
  "nix 0.30.1",
  "num_cpus",
  "serde",
+ "timely",
  "tokio",
  "tower 0.5.3",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/doc/developer/design/20260402_unified_timely_runtime.md
+++ b/doc/developer/design/20260402_unified_timely_runtime.md
@@ -1,0 +1,426 @@
+# Unified Timely Runtime for Compute and Storage
+
+- Associated: TODO (tracking issue)
+
+## The Problem
+
+`clusterd` currently creates two separate Timely runtimes: one for compute and
+one for storage (`src/clusterd/src/lib.rs`). Both runtimes have the same
+configuration (same number of workers, same process index) but run on separate
+thread pools with independent networking.
+
+This architecture prevents us from getting **storage introspection** through
+compute's existing logging infrastructure. Compute has comprehensive logging
+dataflows (`src/compute/src/logging/`) that surface Timely, Differential, and
+Reachability events through system tables (`mz_scheduling_elapsed`,
+`mz_arrangement_sizes`, etc.). Storage has no equivalent introspection — its
+Timely events are simply discarded.
+
+We cannot solve this by forwarding events from the storage Timely instance to
+the compute one (e.g. via mpsc channels) because both instances allocate
+operator, channel, and dataflow IDs starting from 0 independently. There is no
+way to disambiguate which instance an event originated from without changing the
+logging schema.
+
+Unifying the runtimes eliminates this problem: a single Timely instance has a
+single ID allocator, and compute's existing logging dataflows automatically
+capture events from storage dataflows with no ID collisions and no schema
+changes.
+
+## Success Criteria
+
+1. **Single Timely runtime**: Both compute and storage dataflows run in the same
+   Timely cluster, sharing worker threads and communication infrastructure.
+
+2. **Storage introspection for free**: Storage operations are visible through
+   compute's existing logging dataflows and system tables. No changes to the
+   logging infrastructure or system table schemas are required.
+
+3. **No behavioral change in standalone mode**: The existing dual-runtime mode
+   continues to work. The unified runtime is gated behind a flag and can be
+   enabled incrementally.
+
+4. **Command distribution unchanged**: Compute's Exchange-based broadcast and
+   storage's internal command sequencer are fundamentally different and remain
+   untouched.
+
+5. **No controller changes**: Both compute and storage controllers continue to
+   connect via separate gRPC connections. The unification is entirely
+   replica-side.
+
+## Out of Scope
+
+1. **Controller unification**: Merging the compute and storage controllers or
+   their protocol connections is a separate effort.
+
+2. **Cross-domain dataflow dependencies**: We do not introduce direct dataflow
+   edges between compute and storage operators within the Timely cluster.
+
+3. **Shared application state**: Compute and storage continue to maintain fully
+   separate state (traces, ingestions, exports). The unification is at the
+   Timely runtime level only.
+
+4. **Performance isolation**: We do not recommend colocating compute and storage
+   objects on the same cluster, so scheduling fairness between domains is not a
+   concern.
+
+5. **New storage-specific log variants**: Extending the logging schema with
+   storage-specific events (e.g. `StorageLog` analogous to `ComputeLog`) is
+   future work. This design only covers making existing Timely/Differential
+   logging capture storage dataflows.
+
+## Solution Proposal
+
+### Overview
+
+We refactor compute and storage worker state so that neither owns the
+`&mut TimelyWorker` reference. Instead, a thin unified loop in `clusterd` owns
+the Timely worker and passes it to each domain's step function sequentially.
+This lets both domains' dataflows live in the same Timely instance while keeping
+their command handling, reconciliation, and state management completely
+independent.
+
+### Key Design Decisions
+
+**No Worker struct duplication.** A prior attempt (PR #34713) created a 658-line
+`UnifiedWorker` that re-implemented both worker loops in a third location. Any
+change to compute or storage worker logic required updating the unified worker
+too. Our approach instead refactors the existing worker types to separate their
+state from the `TimelyWorker` borrow, keeping logic in its original crate.
+
+**Sequential, not concurrent, domain steps.** Within each iteration of the
+unified loop, compute's step runs to completion, then storage's step runs to
+completion. Neither domain blocks (both use `try_recv` patterns), so this is
+equivalent to the existing architecture but interleaved on one thread.
+
+**Reconciliation blocks the other domain.** During (re)connect, each domain
+reconciles by draining commands until `InitializationComplete`. In unified mode,
+this briefly pauses the other domain. This is acceptable because reconciliation
+is infrequent and fast.
+
+### Component Changes
+
+#### 1. Compute: Extract `ComputeWorkerState` from `Worker`
+
+**File: `src/compute/src/server.rs`**
+
+Currently, compute's `Worker` struct bundles the `TimelyWorker` reference with
+all compute-specific state:
+
+```rust
+struct Worker<'w, A: Allocate> {
+    timely_worker: &'w mut TimelyWorker<A>,
+    command_rx: CommandReceiver,
+    response_tx: ResponseSender,
+    compute_state: Option<ComputeState>,
+    metrics: WorkerMetrics,
+    // ... other fields
+}
+```
+
+We split this into a `ComputeWorkerState` that holds everything except the
+Timely worker:
+
+```rust
+pub struct ComputeWorkerState {
+    pub command_rx: CommandReceiver,
+    pub response_tx: ResponseSender,
+    pub compute_state: Option<ComputeState>,
+    pub metrics: WorkerMetrics,
+    pub persist_clients: Arc<PersistClientCache>,
+    pub txns_ctx: TxnsContext,
+    pub tracing_handle: Arc<TracingHandle>,
+    pub context: ComputeInstanceContext,
+    pub metrics_registry: MetricsRegistry,
+    pub workers_per_process: usize,
+}
+```
+
+The existing `Worker` becomes a thin wrapper:
+
+```rust
+struct Worker<'w, A: Allocate> {
+    timely_worker: &'w mut TimelyWorker<A>,
+    state: ComputeWorkerState,
+}
+```
+
+All existing methods delegate through `self.state`, so standalone behavior is
+identical. New public methods on `ComputeWorkerState` take
+`&mut TimelyWorker<A>` as a parameter:
+
+```rust
+impl ComputeWorkerState {
+    pub fn activate_compute<A: Allocate + 'static>(
+        &mut self, tw: &mut TimelyWorker<A>,
+    ) -> Option<ActiveComputeState<'_, A>> { ... }
+
+    pub fn handle_step<A: Allocate + 'static>(
+        &mut self, tw: &mut TimelyWorker<A>,
+    ) -> Result<(), NonceChange> { ... }
+
+    pub fn do_maintenance<A: Allocate + 'static>(
+        &mut self, tw: &mut TimelyWorker<A>,
+    ) { ... }
+}
+```
+
+We also make `ActiveComputeState`, `ResponseSender`, `CommandReceiver`, and
+`NonceChange` public.
+
+#### 2. Storage: Move `handle_internal_storage_command` to `StorageState`
+
+**File: `src/storage/src/storage_state.rs`**
+
+Storage's `Worker` uses `self.timely_worker` in only a few methods:
+
+| Method | Usage |
+|--------|-------|
+| `run_client` | `step_or_park` / `step` (the main loop) |
+| `handle_internal_storage_command` | Renders dataflows, checks `index()`/`peers()` |
+| `handle_async_worker_response` | `assert_eq!(self.timely_worker.index(), 0)` |
+| `reconcile` | `self.timely_worker.index()` |
+
+`StorageState` already stores `timely_worker_index` and `timely_worker_peers`.
+The changes:
+
+- **`handle_internal_storage_command`**: Move the body to a new method on
+  `StorageState` that takes `&mut TimelyWorker<A>` as a parameter. The existing
+  `Worker` method becomes a one-line delegation. Uses of
+  `self.timely_worker.index()` / `peers()` switch to `self.timely_worker_index`
+  / `self.timely_worker_peers` where the actual `TimelyWorker` reference is not
+  needed for dataflow rendering.
+
+- **`handle_async_worker_response`**: Replace
+  `assert_eq!(self.timely_worker.index(), 0)` with
+  `assert_eq!(self.storage_state.timely_worker_index, 0)`. No signature change
+  needed — the method can stay on `Worker` and we add a version on
+  `StorageState`.
+
+- **`reconcile`**: Same treatment — `worker_id` comes from
+  `self.storage_state.timely_worker_index`.
+
+The other per-step methods (`report_frontier_progress`, `report_status_updates`,
+`report_storage_statistics`, `process_oneshot_ingestions`) already operate on
+`self.storage_state` + `response_tx` without touching `timely_worker`. These
+become callable from the unified loop with no changes.
+
+#### 3. Unified Runtime Module
+
+**New file: `src/clusterd/src/unified.rs`** (~200 lines)
+
+```rust
+pub struct UnifiedClientBuilders {
+    pub compute: Box<dyn Fn() -> Box<dyn ComputeClient>>,
+    pub storage: Box<dyn Fn() -> Box<dyn StorageClient>>,
+}
+
+pub async fn serve(
+    timely_config: TimelyConfig,
+    // ... all config for both domains
+) -> Result<UnifiedClientBuilders, Error> {
+    // 1. Set up networking (same as build_cluster)
+    // 2. Create two sets of client_txs channels
+    // 3. Call execute_from with unified_worker_main
+    // 4. Return client builders for both domains
+}
+```
+
+The per-worker entry point:
+
+```rust
+fn unified_worker_main<A: Allocate + 'static>(
+    timely_worker: &mut TimelyWorker<A>,
+    compute_client_rx: ...,
+    storage_client_rx: ...,
+    // ... configs
+) {
+    // Set up compute command channel (broadcast dataflow)
+    let (cmd_tx, cmd_rx) = command_channel::render(timely_worker);
+    let (resp_tx, resp_rx) = mpsc::unbounded_channel();
+    spawn_channel_adapter(compute_client_rx, cmd_tx, resp_rx, worker_id);
+
+    // Set up storage state
+    let (internal_cmd_tx, internal_cmd_rx) =
+        internal_control::setup_command_sequencer(timely_worker);
+    // ... construct StorageState
+
+    // Create compute worker state
+    let mut compute = ComputeWorkerState { ... };
+
+    // Unified loop
+    unified_loop(timely_worker, &mut compute, &mut storage_state, ...);
+}
+```
+
+#### 4. The Unified Loop
+
+```rust
+fn unified_loop<A: Allocate + 'static>(
+    tw: &mut TimelyWorker<A>,
+    compute: &mut ComputeWorkerState,
+    storage_state: &mut StorageState,
+    storage_cmd_rx: &mut CommandReceiver,
+    storage_resp_tx: &ResponseSender,
+) {
+    // Wait for first compute nonce
+    let NonceChange(nonce) = compute.recv_command(tw).expect_err("first nonce");
+    compute.response_tx.set_nonce(nonce);
+
+    // Storage waits for first client connection
+    // (blocks until controller connects — same as standalone)
+
+    let mut last_compute_maintenance = Instant::now();
+    let mut last_storage_maintenance = Instant::now();
+    let mut last_stats_time = Instant::now();
+
+    loop {
+        // Maintenance
+        let compute_sleep = compute.maybe_maintenance(tw, &mut last_compute_maintenance);
+        let storage_sleep = storage_maybe_maintenance(
+            storage_state, storage_resp_tx, &mut last_storage_maintenance,
+        );
+
+        // Determine park-ability
+        let can_park = compute.command_rx_empty()
+            && storage_cmd_rx.is_empty()
+            && storage_state.async_worker.is_empty();
+
+        let stats_interval = storage_state.storage_configuration
+            .parameters.statistics_collection_interval;
+        let stats_remaining = stats_interval
+            .saturating_sub(last_stats_time.elapsed());
+        let sleep = min_durations(compute_sleep, storage_sleep, Some(stats_remaining));
+
+        // Step timely (single call for both domains)
+        if can_park {
+            tw.step_or_park(sleep);
+        } else {
+            tw.step();
+        }
+
+        // Compute step
+        compute.handle_step(tw)?; // NonceChange triggers reconciliation
+
+        // Storage step
+        for id in std::mem::take(&mut storage_state.dropped_ids) {
+            storage_resp_tx.send(StorageResponse::DroppedId(id));
+        }
+        process_oneshot_ingestions(storage_state, storage_resp_tx);
+        report_status_updates(storage_state, storage_resp_tx);
+
+        if last_stats_time.elapsed() >= stats_interval {
+            report_storage_statistics(storage_state, storage_resp_tx);
+            last_stats_time = Instant::now();
+        }
+
+        // Drain storage commands
+        while let Ok(cmd) = storage_cmd_rx.try_recv() {
+            storage_state.handle_storage_command(cmd);
+        }
+
+        // Drain async worker responses
+        while let Ok(resp) = storage_state.async_worker.try_recv() {
+            storage_state.handle_async_worker_response(resp);
+        }
+
+        // Drain internal commands
+        while let Some(cmd) = storage_state.internal_cmd_rx.try_recv() {
+            storage_state.handle_internal_storage_command(tw, cmd);
+        }
+    }
+}
+```
+
+#### 5. Wiring in `clusterd`
+
+**File: `src/clusterd/src/lib.rs`**
+
+Add a `--unified-runtime` CLI flag. When enabled, call `unified::serve()`
+instead of separate `mz_storage::serve()` + `mz_compute::server::serve()`. Both
+code paths coexist; the flag defaults to off.
+
+### How Logging Works
+
+With a unified Timely instance, logging requires **zero changes**:
+
+1. Compute's `initialize()` registers Timely/Differential/Compute loggers with
+   the worker's `log_register()`.
+2. When storage dataflows are rendered in the same Timely worker, their
+   operators, channels, schedule events, and arrangement events automatically
+   flow through the same registered loggers.
+3. The logging dataflows (demux, consolidate, arrange) process these events
+   identically — they are just more Timely events from more operators.
+4. System tables like `mz_scheduling_elapsed` and `mz_arrangement_sizes`
+   automatically include storage operator data.
+
+There are no ID collisions because there is only one ID allocator.
+
+## Minimal Viable Prototype
+
+The prototype validates:
+
+1. A single `execute_from` call runs both compute and storage logic
+2. Both controllers connect and issue commands successfully
+3. Dataflows from both domains execute correctly (sources ingest, queries
+   return results)
+4. `SELECT * FROM mz_scheduling_elapsed` shows operators from storage
+   dataflows (source ingestion operators, upsert operators, etc.)
+5. No deadlock or starvation between domains
+
+Validation:
+
+- Run the existing SLT and testdrive suites with `--unified-runtime`
+- Manually verify that `mz_internal` system tables include storage operators
+- Confirm no regression in compute-only workloads
+
+## Alternatives
+
+### Forward events via mpsc channels
+
+Instead of unifying runtimes, register Timely loggers in the storage instance
+that send events over mpsc channels to compute's logging dataflows.
+
+**Rejected because**: Both Timely instances allocate IDs starting from 0.
+Forwarded events would collide with compute's own operator IDs, making the data
+meaningless. Remapping IDs (e.g. with a large offset) is fragile — any code
+assuming IDs are small or using them as array indices breaks. Adding a
+`source: {compute, storage}` column to logging relations requires schema changes
+and migrations. The unified runtime avoids all of this.
+
+### Keep separate runtimes, add logging to storage
+
+Add a parallel set of logging dataflows inside the storage Timely instance,
+surfacing them through separate system tables.
+
+**Rejected because**: This doubles the logging infrastructure, requires new
+system table schemas, and doesn't reduce the thread/networking overhead of
+running two Timely clusters. Users would need to query different tables for
+compute vs storage introspection.
+
+### Full Worker struct duplication (PR #34713 approach)
+
+Create a unified `UnifiedWorker` in `clusterd` that re-implements both worker
+loops.
+
+**Rejected because**: The 658-line `UnifiedWorker` duplicated reconciliation,
+command handling, maintenance, and async worker response logic. Any change to
+compute or storage requires updating the unified worker. The current approach
+keeps logic in its original crate and only exposes step-level methods.
+
+## Open questions
+
+1. **Reconciliation ordering**: In unified mode, compute reconciles first, then
+   storage. Should we support concurrent reconciliation (compute reconciles
+   while storage commands queue up, and vice versa)? For now, sequential
+   reconciliation is simpler and reconnection is infrequent.
+
+2. **Feature flag graduation**: What criteria should we use to make unified
+   runtime the default? Proposal: pass the full test suite + run in staging for
+   one release cycle with no regressions.
+
+3. **Panic propagation**: A panic in a storage dataflow kills the compute
+   worker (same thread). This matches the current behavior within each domain
+   (a panic in any compute dataflow kills all compute dataflows). Is additional
+   isolation needed? Current assessment: no, because we don't recommend
+   colocating compute and storage objects.

--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -50,25 +50,24 @@ where
 
 /// Metadata about timely workers in this process.
 pub struct TimelyContainer<C: ClusterSpec> {
-    /// Channels over which to send endpoints for wiring up a new Client
-    client_txs: Vec<
+    /// Channels over which to send endpoints for wiring up a new Client.
+    pub client_txs: Vec<
         mpsc::UnboundedSender<(
             Uuid,
             mpsc::UnboundedReceiver<C::Command>,
             mpsc::UnboundedSender<C::Response>,
         )>,
     >,
-    /// Thread guards that keep worker threads alive
-    worker_guards: WorkerGuards<()>,
+    /// Thread guards that keep worker threads alive.
+    pub worker_guards: Option<WorkerGuards<()>>,
+    /// Cached worker thread handles. Populated from `worker_guards` on creation,
+    /// or set directly for containers that share guards with another container.
+    pub worker_threads: Vec<Thread>,
 }
 
 impl<C: ClusterSpec> TimelyContainer<C> {
     fn worker_threads(&self) -> Vec<Thread> {
-        self.worker_guards
-            .guards()
-            .iter()
-            .map(|h| h.thread().clone())
-            .collect()
+        self.worker_threads.clone()
     }
 }
 
@@ -286,9 +285,15 @@ pub trait ClusterSpec: Clone + Send + Sync + 'static {
         })
         .map_err(|e| anyhow!(e))?;
 
+        let worker_threads = worker_guards
+            .guards()
+            .iter()
+            .map(|h| h.thread().clone())
+            .collect();
         Ok(TimelyContainer {
             client_txs,
-            worker_guards,
+            worker_guards: Some(worker_guards),
+            worker_threads,
         })
     }
 }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,8 +37,13 @@ mz-storage = { path = "../storage" }
 mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
+differential-dataflow = "0.21.1"
+mz-repr = { path = "../repr" }
+mz-rocksdb = { path = "../rocksdb" }
 mz-txn-wal = { path = "../txn-wal" }
 nix = { version = "0.30.1", features = ["fs"] }
+timely = "0.28.0"
+uuid = "1"
 num_cpus = "1.17.0"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.49.0", features = ["fs", "rt", "sync", "test-util"] }

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -43,6 +43,7 @@ use tokio::runtime::Handle;
 use tower::Service;
 use tracing::{Instrument, error, info, info_span};
 
+mod unified;
 mod usage_metrics;
 
 const BUILD_INFO: BuildInfo = build_info!();
@@ -166,6 +167,14 @@ struct Args {
     /// affinity might degrade dataflow performance rather than improving it.
     #[clap(long)]
     worker_core_affinity: bool,
+
+    /// Use a unified Timely runtime for compute and storage.
+    ///
+    /// When enabled, both compute and storage dataflows run within a single Timely runtime,
+    /// sharing worker threads and communication infrastructure. This enables compute's logging
+    /// dataflows to automatically capture events from storage dataflows.
+    #[clap(long)]
+    unified_runtime: bool,
 }
 
 pub fn main() {
@@ -368,67 +377,138 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut compute_timely_config = args.compute_timely_config;
     compute_timely_config.process = args.process;
 
-    // Start storage server.
-    let storage_client_builder = mz_storage::serve(
-        storage_timely_config,
-        &metrics_registry,
-        Arc::clone(&persist_clients),
-        txns_ctx.clone(),
-        Arc::clone(&tracing_handle),
-        SYSTEM_TIME.clone(),
-        connection_context.clone(),
-        StorageInstanceContext::new(args.scratch_directory.clone(), args.announce_memory_limit)?,
-    )
-    .await?;
-    info!(
-        "listening for storage controller connections on {}",
-        args.storage_controller_listen_addr
-    );
-    mz_ore::task::spawn(
-        || "storage_server",
-        transport::serve(
-            args.storage_controller_listen_addr,
-            BUILD_INFO.semver_version(),
-            grpc_host.clone(),
-            Duration::MAX,
-            storage_client_builder,
-            grpc_server_metrics.for_server("storage"),
-        )
-        .instrument(info_span!("ctp", name = "storage")),
-    );
+    if args.unified_runtime {
+        // EXPERIMENTAL: Use unified Timely runtime for both compute and storage.
+        info!("using unified Timely runtime (experimental)");
 
-    // Start compute server.
-    let compute_client_builder = mz_compute::server::serve(
-        compute_timely_config,
-        &metrics_registry,
-        persist_clients,
-        txns_ctx,
-        tracing_handle,
-        ComputeInstanceContext {
-            scratch_directory: args.scratch_directory,
-            worker_core_affinity: args.worker_core_affinity,
-            connection_context,
-        },
-    )
-    .await?;
-    info!(
-        "listening for compute controller connections on {}",
-        args.compute_controller_listen_addr
-    );
-    mz_ore::task::spawn(
-        || "compute_server",
-        transport::serve(
-            args.compute_controller_listen_addr,
-            BUILD_INFO.semver_version(),
-            grpc_host.clone(),
-            Duration::MAX,
-            compute_client_builder,
-            grpc_server_metrics.for_server("compute"),
-        )
-        .instrument(info_span!("ctp", name = "compute")),
-    );
+        if storage_timely_config.workers != compute_timely_config.workers {
+            anyhow::bail!(
+                "unified runtime requires same worker count for storage ({}) and compute ({})",
+                storage_timely_config.workers,
+                compute_timely_config.workers
+            );
+        }
 
-    // TODO: unify storage and compute servers to use one timely cluster.
+        let storage_instance_context = StorageInstanceContext::new(
+            args.scratch_directory.clone(),
+            args.announce_memory_limit,
+        )?;
+        let unified_clients = unified::serve(
+            compute_timely_config,
+            &metrics_registry,
+            persist_clients,
+            txns_ctx,
+            tracing_handle,
+            SYSTEM_TIME.clone(),
+            connection_context.clone(),
+            ComputeInstanceContext {
+                scratch_directory: args.scratch_directory,
+                worker_core_affinity: args.worker_core_affinity,
+                connection_context,
+            },
+            storage_instance_context,
+        )
+        .await?;
+
+        info!(
+            "listening for storage controller connections on {}",
+            args.storage_controller_listen_addr
+        );
+        mz_ore::task::spawn(
+            || "unified_storage_server",
+            transport::serve(
+                args.storage_controller_listen_addr,
+                BUILD_INFO.semver_version(),
+                grpc_host.clone(),
+                Duration::MAX,
+                unified_clients.storage,
+                grpc_server_metrics.for_server("storage"),
+            )
+            .instrument(info_span!("ctp", name = "storage")),
+        );
+
+        info!(
+            "listening for compute controller connections on {}",
+            args.compute_controller_listen_addr
+        );
+        mz_ore::task::spawn(
+            || "unified_compute_server",
+            transport::serve(
+                args.compute_controller_listen_addr,
+                BUILD_INFO.semver_version(),
+                grpc_host.clone(),
+                Duration::MAX,
+                unified_clients.compute,
+                grpc_server_metrics.for_server("compute"),
+            )
+            .instrument(info_span!("ctp", name = "compute")),
+        );
+    } else {
+        // Default: Use separate Timely runtimes for storage and compute.
+
+        // Start storage server.
+        let storage_client_builder = mz_storage::serve(
+            storage_timely_config,
+            &metrics_registry,
+            Arc::clone(&persist_clients),
+            txns_ctx.clone(),
+            Arc::clone(&tracing_handle),
+            SYSTEM_TIME.clone(),
+            connection_context.clone(),
+            StorageInstanceContext::new(
+                args.scratch_directory.clone(),
+                args.announce_memory_limit,
+            )?,
+        )
+        .await?;
+        info!(
+            "listening for storage controller connections on {}",
+            args.storage_controller_listen_addr
+        );
+        mz_ore::task::spawn(
+            || "storage_server",
+            transport::serve(
+                args.storage_controller_listen_addr,
+                BUILD_INFO.semver_version(),
+                grpc_host.clone(),
+                Duration::MAX,
+                storage_client_builder,
+                grpc_server_metrics.for_server("storage"),
+            )
+            .instrument(info_span!("ctp", name = "storage")),
+        );
+
+        // Start compute server.
+        let compute_client_builder = mz_compute::server::serve(
+            compute_timely_config,
+            &metrics_registry,
+            persist_clients,
+            txns_ctx,
+            tracing_handle,
+            ComputeInstanceContext {
+                scratch_directory: args.scratch_directory,
+                worker_core_affinity: args.worker_core_affinity,
+                connection_context,
+            },
+        )
+        .await?;
+        info!(
+            "listening for compute controller connections on {}",
+            args.compute_controller_listen_addr
+        );
+        mz_ore::task::spawn(
+            || "compute_server",
+            transport::serve(
+                args.compute_controller_listen_addr,
+                BUILD_INFO.semver_version(),
+                grpc_host.clone(),
+                Duration::MAX,
+                compute_client_builder,
+                grpc_server_metrics.for_server("compute"),
+            )
+            .instrument(info_span!("ctp", name = "compute")),
+        );
+    }
 
     // Block forever.
     future::pending().await

--- a/src/clusterd/src/unified.rs
+++ b/src/clusterd/src/unified.rs
@@ -1,0 +1,629 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Unified Timely runtime for compute and storage.
+//!
+//! This module provides a single Timely runtime that runs both compute and storage
+//! dataflows, sharing worker threads and communication infrastructure. This enables
+//! compute's logging dataflows to automatically capture events from storage dataflows.
+//!
+//! See `doc/developer/design/20260402_unified_timely_runtime.md` for the design.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Error, anyhow};
+use differential_dataflow::trace::ExertionLogic;
+use mz_cluster::client::{ClusterClient, TimelyContainer};
+use mz_cluster::communication::initialize_networking;
+use mz_cluster_client::client::TimelyConfig;
+use mz_compute::command_channel;
+use mz_compute::metrics::ComputeMetrics;
+use mz_compute::server::{
+    CommandReceiver, ComputeInstanceContext, NonceChange, ResponseSender, Worker as ComputeWorker,
+    spawn_channel_adapter,
+};
+use mz_compute_client::protocol::command::ComputeCommand;
+use mz_compute_client::protocol::response::ComputeResponse;
+use mz_compute_client::service::ComputeClient;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::NowFn;
+use mz_ore::tracing::TracingHandle;
+use mz_persist_client::cache::PersistClientCache;
+use mz_rocksdb::config::SharedWriteBufferManager;
+use mz_storage::internal_control;
+use mz_storage::statistics::AggregatedStatistics;
+use mz_storage::storage_state::{StorageInstanceContext, StorageState};
+use mz_storage_client::client::{StorageClient, StorageCommand, StorageResponse};
+use mz_storage_types::configuration::StorageConfiguration;
+use mz_storage_types::connections::ConnectionContext;
+use mz_txn_wal::operator::TxnsContext;
+use timely::WorkerConfig;
+use timely::communication::Allocate;
+use timely::communication::allocator::GenericBuilder;
+use timely::communication::allocator::zero_copy::bytes_slab::BytesRefill;
+use timely::execute::execute_from;
+use timely::worker::Worker as TimelyWorker;
+use tokio::runtime::Handle;
+use tokio::sync::{mpsc, watch};
+use tracing::{info, info_span};
+use uuid::Uuid;
+
+use mz_storage::internal_control::DataflowParameters;
+use mz_storage::storage_state::async_storage_worker::AsyncStorageWorker;
+
+/// Client builders returned by [`serve`], one for each domain.
+pub struct UnifiedClientBuilders {
+    /// Builder for compute clients.
+    pub compute: Box<dyn Fn() -> Box<dyn ComputeClient> + Send + Sync>,
+    /// Builder for storage clients.
+    pub storage: Box<dyn Fn() -> Box<dyn StorageClient> + Send + Sync>,
+}
+
+/// Lightweight [`ClusterSpec`] impl for compute in the unified runtime.
+///
+/// This is only used to create [`TimelyContainer`] and [`ClusterClient`] instances.
+/// The actual worker logic is in [`run_unified_worker`].
+#[derive(Clone)]
+struct ComputeSpec;
+
+impl mz_cluster::client::ClusterSpec for ComputeSpec {
+    type Command = ComputeCommand;
+    type Response = ComputeResponse;
+    const NAME: &str = "compute";
+    fn run_worker<A: Allocate + 'static>(
+        &self,
+        _: &mut TimelyWorker<A>,
+        _: mpsc::UnboundedReceiver<(Uuid, mpsc::UnboundedReceiver<ComputeCommand>, mpsc::UnboundedSender<ComputeResponse>)>,
+    ) {
+        unreachable!("unified runtime does not use ClusterSpec::run_worker");
+    }
+}
+
+/// Lightweight [`ClusterSpec`] impl for storage in the unified runtime.
+#[derive(Clone)]
+struct StorageSpec;
+
+impl mz_cluster::client::ClusterSpec for StorageSpec {
+    type Command = StorageCommand;
+    type Response = StorageResponse;
+    const NAME: &str = "storage";
+    fn run_worker<A: Allocate + 'static>(
+        &self,
+        _: &mut TimelyWorker<A>,
+        _: mpsc::UnboundedReceiver<(Uuid, mpsc::UnboundedReceiver<StorageCommand>, mpsc::UnboundedSender<StorageResponse>)>,
+    ) {
+        unreachable!("unified runtime does not use ClusterSpec::run_worker");
+    }
+}
+
+/// Configuration for the unified runtime.
+#[derive(Clone)]
+struct UnifiedConfig {
+    persist_clients: Arc<PersistClientCache>,
+    txns_ctx: TxnsContext,
+    tracing_handle: Arc<TracingHandle>,
+    compute_metrics: ComputeMetrics,
+    compute_context: ComputeInstanceContext,
+    metrics_registry: MetricsRegistry,
+    workers_per_process: usize,
+    // Storage config
+    storage_metrics: mz_storage::metrics::StorageMetrics,
+    now: NowFn,
+    connection_context: ConnectionContext,
+    storage_instance_context: StorageInstanceContext,
+    shared_rocksdb_write_buffer_manager: SharedWriteBufferManager,
+}
+
+/// Start the unified Timely runtime for both compute and storage.
+pub async fn serve(
+    timely_config: TimelyConfig,
+    metrics_registry: &MetricsRegistry,
+    persist_clients: Arc<PersistClientCache>,
+    txns_ctx: TxnsContext,
+    tracing_handle: Arc<TracingHandle>,
+    now: NowFn,
+    connection_context: ConnectionContext,
+    compute_context: ComputeInstanceContext,
+    storage_context: StorageInstanceContext,
+) -> Result<UnifiedClientBuilders, Error> {
+    let config = UnifiedConfig {
+        persist_clients,
+        txns_ctx,
+        tracing_handle,
+        compute_metrics: ComputeMetrics::register_with(metrics_registry),
+        compute_context,
+        metrics_registry: metrics_registry.clone(),
+        workers_per_process: timely_config.workers,
+        storage_metrics: mz_storage::metrics::StorageMetrics::register_with(metrics_registry),
+        now,
+        connection_context,
+        storage_instance_context: storage_context,
+        shared_rocksdb_write_buffer_manager: Default::default(),
+    };
+
+    let tokio_executor = Handle::current();
+    let (compute_container, storage_container) =
+        build_unified_cluster(config, timely_config, tokio_executor).await?;
+
+    // Build compute client factory using ClusterClient (intercepts Hello for reconnection).
+    let compute_container = Arc::new(Mutex::new(compute_container));
+    let compute_builder: Box<dyn Fn() -> Box<dyn ComputeClient> + Send + Sync> =
+        Box::new(move || {
+            let client: Box<dyn ComputeClient> =
+                Box::new(ClusterClient::new(Arc::clone(&compute_container)));
+            client
+        });
+
+    // Build storage client factory using ClusterClient.
+    let storage_container = Arc::new(Mutex::new(storage_container));
+    let storage_builder: Box<dyn Fn() -> Box<dyn StorageClient> + Send + Sync> =
+        Box::new(move || {
+            let client: Box<dyn StorageClient> =
+                Box::new(ClusterClient::new(Arc::clone(&storage_container)));
+            client
+        });
+
+    Ok(UnifiedClientBuilders {
+        compute: compute_builder,
+        storage: storage_builder,
+    })
+}
+
+async fn build_unified_cluster(
+    config: UnifiedConfig,
+    timely_config: TimelyConfig,
+    tokio_executor: Handle,
+) -> Result<(TimelyContainer<ComputeSpec>, TimelyContainer<StorageSpec>), Error> {
+    info!("Building unified timely container with config {timely_config:?}");
+
+    // Create client channels for both domains
+    let (compute_client_txs, compute_client_rxs): (Vec<_>, Vec<_>) = (0..timely_config.workers)
+        .map(|_| mpsc::unbounded_channel())
+        .unzip();
+    let compute_client_rxs: Mutex<Vec<_>> =
+        Mutex::new(compute_client_rxs.into_iter().map(Some).collect());
+
+    let (storage_client_txs, storage_client_rxs): (Vec<_>, Vec<_>) = (0..timely_config.workers)
+        .map(|_| mpsc::unbounded_channel())
+        .unzip();
+    let storage_client_rxs: Mutex<Vec<_>> =
+        Mutex::new(storage_client_rxs.into_iter().map(Some).collect());
+
+    // Initialize networking (same as ClusterSpec::build_cluster).
+    // TODO: Add lgalloc support for zero-copy allocations.
+    let refill = BytesRefill {
+        logic: Arc::new(|size| Box::new(vec![0; size])),
+        limit: timely_config.zero_copy_limit,
+    };
+
+    let (builders, other) = if timely_config.enable_zero_copy {
+        use timely::communication::allocator::zero_copy::allocator_process::ProcessBuilder;
+        initialize_networking::<ProcessBuilder>(
+            timely_config.workers,
+            timely_config.process,
+            timely_config.addresses.clone(),
+            refill,
+            GenericBuilder::ZeroCopyBinary,
+        )
+        .await?
+    } else {
+        initialize_networking::<timely::communication::allocator::Process>(
+            timely_config.workers,
+            timely_config.process,
+            timely_config.addresses.clone(),
+            refill,
+            GenericBuilder::ZeroCopy,
+        )
+        .await?
+    };
+
+    // Configure the worker
+    let mut worker_config = WorkerConfig::default();
+    if timely_config.arrangement_exert_proportionality > 0 {
+        let merge_effort = Some(1000);
+        let prop = timely_config.arrangement_exert_proportionality;
+        let arc: ExertionLogic = Arc::new(move |layers| {
+            let mut prop = prop;
+            let layers = layers
+                .iter()
+                .copied()
+                .skip_while(|(_idx, count, _len)| *count == 0);
+            let mut first = true;
+            for (_idx, count, len) in layers {
+                if count > 1 {
+                    return merge_effort;
+                }
+                if !first && prop > 0 && len > 0 {
+                    return merge_effort;
+                }
+                first = false;
+                prop /= 2;
+            }
+            None
+        });
+        worker_config.set::<ExertionLogic>("differential/default_exert_logic".to_string(), arc);
+    }
+
+    let workers = timely_config.workers;
+    let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
+        let worker_idx = timely_worker.index();
+
+        let span = info_span!("timely", name = "unified", worker_id = worker_idx);
+        let _span_guard = span.enter();
+        let _tokio_guard = tokio_executor.enter();
+
+        let compute_client_rx = compute_client_rxs.lock().unwrap()[worker_idx % workers]
+            .take()
+            .unwrap();
+        let storage_client_rx = storage_client_rxs.lock().unwrap()[worker_idx % workers]
+            .take()
+            .unwrap();
+
+        run_unified_worker(timely_worker, &config, compute_client_rx, storage_client_rx);
+    })
+    .map_err(|e| anyhow!(e))?;
+
+    let worker_threads: Vec<_> = worker_guards
+        .guards()
+        .iter()
+        .map(|h| h.thread().clone())
+        .collect();
+
+    let compute_container = TimelyContainer {
+        client_txs: compute_client_txs,
+        worker_guards: Some(worker_guards),
+        worker_threads: worker_threads.clone(),
+    };
+    let storage_container = TimelyContainer {
+        client_txs: storage_client_txs,
+        worker_guards: None,
+        worker_threads,
+    };
+
+    Ok((compute_container, storage_container))
+}
+
+/// Entry point for each unified worker thread.
+fn run_unified_worker<A: Allocate + 'static>(
+    timely_worker: &mut TimelyWorker<A>,
+    config: &UnifiedConfig,
+    compute_client_rx: mpsc::UnboundedReceiver<(
+        Uuid,
+        mpsc::UnboundedReceiver<ComputeCommand>,
+        mpsc::UnboundedSender<ComputeResponse>,
+    )>,
+    storage_client_rx: mpsc::UnboundedReceiver<(
+        Uuid,
+        mpsc::UnboundedReceiver<StorageCommand>,
+        mpsc::UnboundedSender<StorageResponse>,
+    )>,
+) {
+    let worker_id = timely_worker.index();
+
+    if config.compute_context.worker_core_affinity {
+        // Core affinity setting is handled by compute's set_core_affinity.
+        // For now, we skip it in the unified path as it's platform-specific.
+    }
+
+    // --- Set up compute command channel ---
+    let (cmd_tx, cmd_rx) = command_channel::render(timely_worker);
+    let (resp_tx, resp_rx) = mpsc::unbounded_channel();
+    spawn_channel_adapter(compute_client_rx, cmd_tx, resp_rx, worker_id);
+
+    let compute_metrics = config.compute_metrics.for_worker(worker_id);
+
+    // --- Set up storage channel adapter ---
+    // The adapter handles reconnections: it buffers commands until
+    // InitializationComplete, then delivers the batch for reconciliation.
+    // Ongoing commands and responses flow through persistent channels.
+    let (storage_reconcile_tx, storage_reconcile_rx) = std::sync::mpsc::channel();
+    let (storage_cmd_tx, storage_cmd_rx) = std::sync::mpsc::channel();
+    let (storage_resp_tx, storage_resp_rx) = mpsc::unbounded_channel();
+    spawn_storage_channel_adapter(
+        storage_client_rx,
+        storage_reconcile_tx,
+        storage_cmd_tx,
+        storage_resp_rx,
+        thread::current(),
+    );
+
+    // --- Set up storage state ---
+    let (internal_cmd_tx, internal_cmd_rx) =
+        internal_control::setup_command_sequencer(timely_worker);
+
+    let storage_configuration =
+        StorageConfiguration::new(config.connection_context.clone(), mz_dyncfgs::all_dyncfgs());
+
+    let (read_only_tx, read_only_rx) = watch::channel(true);
+
+    let async_worker =
+        AsyncStorageWorker::new(thread::current(), Arc::clone(&config.persist_clients));
+
+    let cluster_memory_limit = config.storage_instance_context.cluster_memory_limit;
+
+    let mut storage_state = StorageState {
+        source_uppers: BTreeMap::new(),
+        source_tokens: BTreeMap::new(),
+        metrics: config.storage_metrics.clone(),
+        reported_frontiers: BTreeMap::new(),
+        ingestions: BTreeMap::new(),
+        exports: BTreeMap::new(),
+        oneshot_ingestions: BTreeMap::new(),
+        now: config.now.clone(),
+        timely_worker_index: timely_worker.index(),
+        timely_worker_peers: timely_worker.peers(),
+        instance_context: config.storage_instance_context.clone(),
+        persist_clients: Arc::clone(&config.persist_clients),
+        txns_ctx: config.txns_ctx.clone(),
+        sink_tokens: BTreeMap::new(),
+        sink_write_frontiers: BTreeMap::new(),
+        dropped_ids: Vec::new(),
+        aggregated_statistics: AggregatedStatistics::new(
+            timely_worker.index(),
+            timely_worker.peers(),
+        ),
+        shared_status_updates: Default::default(),
+        latest_status_updates: Default::default(),
+        initial_status_reported: Default::default(),
+        internal_cmd_tx,
+        internal_cmd_rx,
+        read_only_tx,
+        read_only_rx,
+        async_worker,
+        storage_configuration,
+        dataflow_parameters: DataflowParameters::new(
+            config.shared_rocksdb_write_buffer_manager.clone(),
+            cluster_memory_limit,
+        ),
+        tracing_handle: Arc::clone(&config.tracing_handle),
+        server_maintenance_interval: Duration::ZERO,
+    };
+
+    // --- Build a compute Worker (which owns the timely_worker reference) ---
+    // We create the compute Worker struct and use it to drive both domains.
+    // The storage step methods are called on StorageState directly,
+    // borrowing timely_worker from the compute Worker when needed.
+
+    let mut compute_worker = ComputeWorker {
+        timely_worker,
+        command_rx: CommandReceiver::new(cmd_rx, worker_id),
+        response_tx: ResponseSender::new(resp_tx, worker_id),
+        compute_state: None,
+        metrics: compute_metrics,
+        persist_clients: Arc::clone(&config.persist_clients),
+        txns_ctx: config.txns_ctx.clone(),
+        tracing_handle: Arc::clone(&config.tracing_handle),
+        context: config.compute_context.clone(),
+        metrics_registry: config.metrics_registry.clone(),
+        workers_per_process: config.workers_per_process,
+    };
+
+    // --- Run the unified loop ---
+
+    // Wait for first compute nonce (blocks, stepping timely while waiting).
+    let NonceChange(nonce) = compute_worker
+        .recv_command()
+        .expect_err("change to first nonce");
+    compute_worker.set_nonce(nonce);
+
+    // Main unified loop.
+    // Compute reconnection: handled by spawn_channel_adapter + nonce mechanism.
+    // Storage reconnection: handled by spawn_storage_channel_adapter which
+    // delivers reconciliation batches through storage_reconcile_rx.
+    loop {
+        let Err(NonceChange(nonce)) = run_unified_loop(
+            &mut compute_worker,
+            &mut storage_state,
+            &storage_reconcile_rx,
+            &storage_cmd_rx,
+            &storage_resp_tx,
+        );
+        compute_worker.set_nonce(nonce);
+    }
+}
+
+fn run_unified_loop<A: Allocate + 'static>(
+    compute: &mut ComputeWorker<'_, A>,
+    storage_state: &mut StorageState,
+    storage_reconcile_rx: &std::sync::mpsc::Receiver<Vec<StorageCommand>>,
+    storage_cmd_rx: &std::sync::mpsc::Receiver<StorageCommand>,
+    storage_resp_tx: &mpsc::UnboundedSender<StorageResponse>,
+) -> Result<std::convert::Infallible, NonceChange> {
+    // Reconcile compute.
+    compute.reconcile()?;
+
+    let mut last_compute_maintenance = Instant::now();
+    let mut last_storage_maintenance = Instant::now();
+    let mut last_stats_time = Instant::now();
+
+    loop {
+        // --- Check for storage reconnection ---
+        if let Ok(commands) = storage_reconcile_rx.try_recv() {
+            // Drain any stale commands from the previous connection before
+            // reconciling with the new one.
+            while storage_cmd_rx.try_recv().is_ok() {}
+            storage_state.reconcile_with_commands(commands);
+        }
+
+        // --- Compute maintenance ---
+        let compute_maintenance_interval = compute
+            .compute_state
+            .as_ref()
+            .map_or(Duration::ZERO, |state| state.server_maintenance_interval);
+
+        let now = Instant::now();
+        let compute_sleep;
+        if now >= last_compute_maintenance + compute_maintenance_interval {
+            last_compute_maintenance = now;
+            compute_sleep = None;
+
+            if let Some(mut cs) = compute.activate_compute() {
+                cs.compute_state.traces.maintenance();
+                cs.report_frontiers();
+                cs.report_metrics();
+                cs.check_expiration();
+            }
+            compute.metrics.record_shared_row_metrics();
+        } else {
+            let next = last_compute_maintenance + compute_maintenance_interval;
+            compute_sleep = Some(next.saturating_duration_since(now));
+        }
+
+        // --- Storage maintenance ---
+        let storage_maintenance_interval = storage_state.server_maintenance_interval;
+        let storage_sleep;
+        if now >= last_storage_maintenance + storage_maintenance_interval {
+            last_storage_maintenance = now;
+            storage_sleep = None;
+
+            storage_state.report_frontier_progress(storage_resp_tx);
+        } else {
+            let next = last_storage_maintenance + storage_maintenance_interval;
+            storage_sleep = Some(next.saturating_duration_since(now));
+        }
+
+        // --- Determine park duration ---
+        let stats_interval = storage_state
+            .storage_configuration
+            .parameters
+            .statistics_collection_interval;
+        let stats_remaining = stats_interval.saturating_sub(last_stats_time.elapsed());
+
+        // The storage channel adapter unparks the worker thread when it sends
+        // commands, so we don't need to check storage_cmd_rx here.
+        let can_park = compute.command_rx.is_empty()
+            && storage_state.async_worker.is_empty();
+
+        let sleep = min_durations(&[compute_sleep, storage_sleep, Some(stats_remaining)]);
+
+        // --- Step Timely ---
+        let timer = compute.metrics.timely_step_duration_seconds.start_timer();
+        if can_park {
+            compute.timely_worker.step_or_park(sleep);
+        } else {
+            compute.timely_worker.step();
+        }
+        timer.observe_duration();
+
+        // --- Compute step ---
+        compute.handle_pending_commands()?;
+        if let Some(mut cs) = compute.activate_compute() {
+            cs.process_peeks();
+            cs.process_subscribes();
+            cs.process_copy_tos();
+        }
+
+        // --- Storage step ---
+        // Dropped IDs
+        for id in std::mem::take(&mut storage_state.dropped_ids) {
+            let _ = storage_resp_tx.send(StorageResponse::DroppedId(id));
+        }
+
+        // Oneshot ingestions
+        storage_state.process_oneshot_ingestions(storage_resp_tx);
+
+        // Status updates
+        storage_state.report_status_updates(storage_resp_tx);
+
+        // Statistics
+        if last_stats_time.elapsed() >= stats_interval {
+            storage_state.report_storage_statistics(storage_resp_tx);
+            last_stats_time = Instant::now();
+        }
+
+        // Drain storage commands
+        while let Ok(cmd) = storage_cmd_rx.try_recv() {
+            storage_state.handle_storage_command(cmd);
+        }
+
+        // Drain async worker responses
+        while let Ok(response) = storage_state.async_worker.try_recv() {
+            storage_state.handle_async_worker_response_inner(response);
+        }
+
+        // Drain internal commands (these may render dataflows)
+        while let Some(cmd) = storage_state.internal_cmd_rx.try_recv() {
+            storage_state.handle_internal_storage_command_with(compute.timely_worker, cmd);
+        }
+    }
+}
+
+/// Spawn a task that bridges [`ClusterClient`] connections to persistent worker channels.
+///
+/// For each new storage client connection:
+/// 1. Drains commands until `InitializationComplete`, collecting them into a batch
+/// 2. Sends the batch through `reconcile_tx` for the worker to reconcile in one go
+/// 3. Forwards ongoing commands through `command_tx`
+/// 4. Forwards worker responses from `response_rx` back to the active client
+///
+/// This ensures the worker thread never blocks waiting for a new client connection.
+fn spawn_storage_channel_adapter(
+    mut client_rx: mpsc::UnboundedReceiver<(
+        Uuid,
+        mpsc::UnboundedReceiver<StorageCommand>,
+        mpsc::UnboundedSender<StorageResponse>,
+    )>,
+    reconcile_tx: std::sync::mpsc::Sender<Vec<StorageCommand>>,
+    command_tx: std::sync::mpsc::Sender<StorageCommand>,
+    mut response_rx: mpsc::UnboundedReceiver<StorageResponse>,
+    worker_thread: thread::Thread,
+) {
+    mz_ore::task::spawn(
+        || "storage-channel-adapter",
+        async move {
+            while let Some((_nonce, mut cmd_rx, resp_tx)) = client_rx.recv().await {
+                // Phase 1: Buffer commands until InitializationComplete.
+                let mut commands = vec![];
+                let init_complete = loop {
+                    match cmd_rx.recv().await {
+                        Some(StorageCommand::InitializationComplete) => break true,
+                        Some(cmd) => commands.push(cmd),
+                        None => break false,
+                    }
+                };
+                if !init_complete {
+                    continue;
+                }
+
+                // Deliver reconciliation batch to the worker.
+                if reconcile_tx.send(commands).is_err() {
+                    break;
+                }
+                worker_thread.unpark();
+
+                // Phase 2: Forward ongoing commands and responses.
+                loop {
+                    tokio::select! {
+                        cmd = cmd_rx.recv() => match cmd {
+                            Some(cmd) => {
+                                if command_tx.send(cmd).is_err() {
+                                    return;
+                                }
+                                worker_thread.unpark();
+                            }
+                            None => break, // Client disconnected, wait for next.
+                        },
+                        resp = response_rx.recv() => match resp {
+                            Some(resp) => { let _ = resp_tx.send(resp); }
+                            None => return, // Worker gone.
+                        },
+                    }
+                }
+            }
+        },
+    );
+}
+
+/// Returns the minimum of a set of optional durations.
+fn min_durations(durations: &[Option<Duration>]) -> Option<Duration> {
+    durations.iter().copied().flatten().min()
+}

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -355,7 +355,8 @@ impl ComputeState {
 }
 
 /// A wrapper around [ComputeState] with a live timely worker and response channel.
-pub(crate) struct ActiveComputeState<'a, A: Allocate> {
+/// Active compute state, with access to the timely worker.
+pub struct ActiveComputeState<'a, A: Allocate> {
     /// The underlying Timely worker.
     pub timely_worker: &'a mut TimelyWorker<A>,
     /// The compute state itself.
@@ -827,7 +828,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     }
 
     /// Report per-worker metrics.
-    pub(crate) fn report_metrics(&self) {
+    pub fn report_metrics(&self) {
         if let Some(expiration) = self.compute_state.replica_expiration.as_option() {
             let now = Duration::from_millis(mz_ore::now::SYSTEM_TIME()).as_secs_f64();
             let expiration = Duration::from_millis(<u64>::from(expiration)).as_secs_f64();
@@ -1050,7 +1051,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     }
 
     /// Checks for dataflow expiration. Panics if we're past the replica expiration time.
-    pub(crate) fn check_expiration(&self) {
+    pub fn check_expiration(&self) {
         let now = mz_ore::now::SYSTEM_TIME();
         if self.compute_state.replica_expiration.less_than(&now.into()) {
             let now_datetime = mz_ore::now::to_datetime(now);

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -15,11 +15,11 @@ pub mod memory_limiter;
 pub mod server;
 
 mod arrangement;
-mod command_channel;
-mod compute_state;
+pub mod command_channel;
+pub mod compute_state;
 mod extensions;
 mod logging;
-mod metrics;
+pub mod metrics;
 mod render;
 mod row_spine;
 mod sink;

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -316,7 +316,7 @@ pub struct WorkerMetrics {
     /// maintenance completes
     pub(crate) arrangement_maintenance_active_info: UIntGauge,
     /// Histogram of Timely step timings.
-    pub(crate) timely_step_duration_seconds: Histogram,
+    pub timely_step_duration_seconds: Histogram,
     /// Histogram of persist peek durations.
     pub(crate) persist_peek_seconds: Histogram,
     /// Histogram of stashed peek durations.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -110,12 +110,12 @@ pub async fn serve(
 ///
 /// A nonce change informs workers that subsequent commands come a from a new client connection
 /// and therefore require reconciliation.
-struct NonceChange(Uuid);
+pub struct NonceChange(pub Uuid);
 
 /// Endpoint used by workers to receive compute commands.
 ///
 /// Observes nonce changes in the command stream and converts them into receive errors.
-struct CommandReceiver {
+pub struct CommandReceiver {
     /// The channel supplying commands.
     inner: command_channel::Receiver,
     /// The ID of the Timely worker.
@@ -127,7 +127,8 @@ struct CommandReceiver {
 }
 
 impl CommandReceiver {
-    fn new(inner: command_channel::Receiver, worker_id: usize) -> Self {
+    /// Create a new `CommandReceiver`.
+    pub fn new(inner: command_channel::Receiver, worker_id: usize) -> Self {
         Self {
             inner,
             worker_id,
@@ -140,7 +141,7 @@ impl CommandReceiver {
     ///
     /// If the next command has a different nonce, this method instead returns an `Err`
     /// containing the new nonce.
-    fn try_recv(&mut self) -> Result<Option<ComputeCommand>, NonceChange> {
+    pub fn try_recv(&mut self) -> Result<Option<ComputeCommand>, NonceChange> {
         if let Some(command) = self.stashed_command.take() {
             return Ok(Some(command));
         }
@@ -158,13 +159,18 @@ impl CommandReceiver {
             Err(NonceChange(nonce))
         }
     }
+
+    /// Returns `true` if there are no pending commands.
+    pub fn is_empty(&self) -> bool {
+        self.stashed_command.is_none()
+    }
 }
 
-/// Endpoint used by workers to send sending compute responses.
+/// Endpoint used by workers to send compute responses.
 ///
 /// Tags responses with the current nonce, allowing receivers to filter out responses intended for
 /// previous client connections.
-pub(crate) struct ResponseSender {
+pub struct ResponseSender {
     /// The channel consuming responses.
     inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>,
     /// The ID of the Timely worker.
@@ -174,7 +180,8 @@ pub(crate) struct ResponseSender {
 }
 
 impl ResponseSender {
-    fn new(inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>, worker_id: usize) -> Self {
+    /// Create a new `ResponseSender`.
+    pub fn new(inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>, worker_id: usize) -> Self {
         Self {
             inner,
             worker_id,
@@ -183,7 +190,7 @@ impl ResponseSender {
     }
 
     /// Set the cluster protocol nonce.
-    fn set_nonce(&mut self, nonce: Uuid) {
+    pub fn set_nonce(&mut self, nonce: Uuid) {
         self.nonce = Some(nonce);
     }
 
@@ -202,28 +209,30 @@ impl ResponseSender {
 ///
 /// Much of this state can be viewed as local variables for the worker thread,
 /// holding state that persists across function calls.
-struct Worker<'w, A: Allocate> {
+pub struct Worker<'w, A: Allocate> {
     /// The underlying Timely worker.
-    timely_worker: &'w mut TimelyWorker<A>,
+    pub timely_worker: &'w mut TimelyWorker<A>,
     /// The channel over which commands are received.
-    command_rx: CommandReceiver,
+    pub command_rx: CommandReceiver,
     /// The channel over which responses are sent.
-    response_tx: ResponseSender,
-    compute_state: Option<ComputeState>,
+    pub response_tx: ResponseSender,
+    /// The compute state, present after `CreateInstance`.
+    pub compute_state: Option<ComputeState>,
     /// Compute metrics.
-    metrics: WorkerMetrics,
+    pub metrics: WorkerMetrics,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
-    persist_clients: Arc<PersistClientCache>,
+    pub persist_clients: Arc<PersistClientCache>,
     /// Context necessary for rendering txn-wal operators.
-    txns_ctx: TxnsContext,
+    pub txns_ctx: TxnsContext,
     /// A process-global handle to tracing configuration.
-    tracing_handle: Arc<TracingHandle>,
-    context: ComputeInstanceContext,
+    pub tracing_handle: Arc<TracingHandle>,
+    /// Other configuration for compute.
+    pub context: ComputeInstanceContext,
     /// The process-global metrics registry.
-    metrics_registry: MetricsRegistry,
+    pub metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
-    workers_per_process: usize,
+    pub workers_per_process: usize,
 }
 
 impl ClusterSpec for Config {
@@ -332,12 +341,13 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         }
     }
 
-    fn set_nonce(&mut self, nonce: Uuid) {
+    /// Set the nonce on the response sender.
+    pub fn set_nonce(&mut self, nonce: Uuid) {
         self.response_tx.set_nonce(nonce);
     }
 
     /// Handles commands for a client connection, returns when the nonce changes.
-    fn run_client(&mut self) -> Result<Infallible, NonceChange> {
+    pub fn run_client(&mut self) -> Result<Infallible, NonceChange> {
         self.reconcile()?;
 
         // The last time we did periodic maintenance.
@@ -389,14 +399,16 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         }
     }
 
-    fn handle_pending_commands(&mut self) -> Result<(), NonceChange> {
+    /// Handle all pending commands in the command channel.
+    pub fn handle_pending_commands(&mut self) -> Result<(), NonceChange> {
         while let Some(cmd) = self.command_rx.try_recv()? {
             self.handle_command(cmd);
         }
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ComputeCommand) {
+    /// Handle a single compute command.
+    pub fn handle_command(&mut self, cmd: ComputeCommand) {
         match &cmd {
             ComputeCommand::CreateInstance(_) => {
                 self.compute_state = Some(ComputeState::new(
@@ -414,7 +426,8 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         self.activate_compute().unwrap().handle_compute_command(cmd);
     }
 
-    fn activate_compute(&mut self) -> Option<ActiveComputeState<'_, A>> {
+    /// Activate compute state, creating an `ActiveComputeState` with access to the timely worker.
+    pub fn activate_compute(&mut self) -> Option<ActiveComputeState<'_, A>> {
         if let Some(compute_state) = &mut self.compute_state {
             Some(ActiveComputeState {
                 timely_worker: &mut *self.timely_worker,
@@ -430,7 +443,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
     ///
     /// This method blocks if no command is currently available, but takes care to step the Timely
     /// worker while doing so.
-    fn recv_command(&mut self) -> Result<ComputeCommand, NonceChange> {
+    pub fn recv_command(&mut self) -> Result<ComputeCommand, NonceChange> {
         loop {
             if let Some(cmd) = self.command_rx.try_recv()? {
                 return Ok(cmd);
@@ -462,7 +475,8 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
     /// Some additional tidying happens, cleaning up pending peeks, reported frontiers, and creating a new
     /// subscribe response buffer. We will need to be vigilant with future modifications to `ComputeState` to
     /// line up changes there with clean resets here.
-    fn reconcile(&mut self) -> Result<(), NonceChange> {
+    /// Reconcile compute state after a nonce change.
+    pub fn reconcile(&mut self) -> Result<(), NonceChange> {
         // To initialize the connection, we want to drain all commands until we receive a
         // `ComputeCommand::InitializationComplete` command to form a target command state.
         let mut new_commands = Vec::new();
@@ -747,7 +761,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
 ///
 /// The [`Worker`] expects a pair of persistent channels, with punctuation marking reconnects,
 /// while the [`ClusterClient`] provides a new pair of channels on each reconnect.
-fn spawn_channel_adapter(
+pub fn spawn_channel_adapter(
     mut client_rx: mpsc::UnboundedReceiver<(
         Uuid,
         mpsc::UnboundedReceiver<ComputeCommand>,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -166,7 +166,7 @@ impl InternalCommandReceiver {
     }
 }
 
-pub(crate) fn setup_command_sequencer<'w, A: Allocate>(
+pub fn setup_command_sequencer<'w, A: Allocate>(
     timely_worker: &'w mut TimelyWorker<A>,
 ) -> (InternalCommandSender, InternalCommandReceiver) {
     let (input_tx, input_rx) = mpsc::channel();

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -527,329 +527,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
         &self,
         async_response: AsyncStorageWorkerResponse<mz_repr::Timestamp>,
     ) {
-        // NOTE: If we want to share the load of async processing we
-        // have to change `handle_storage_command` and change this
-        // assert.
-        assert_eq!(
-            self.timely_worker.index(),
-            0,
-            "only worker #0 is doing async processing"
-        );
-        match async_response {
-            AsyncStorageWorkerResponse::IngestionFrontiersUpdated {
-                id,
-                ingestion_description,
-                as_of,
-                resume_uppers,
-                source_resume_uppers,
-            } => {
-                self.storage_state.internal_cmd_tx.send(
-                    InternalStorageCommand::CreateIngestionDataflow {
-                        id,
-                        ingestion_description,
-                        as_of,
-                        resume_uppers,
-                        source_resume_uppers,
-                    },
-                );
-            }
-            AsyncStorageWorkerResponse::ExportFrontiersUpdated { id, description } => {
-                self.storage_state
-                    .internal_cmd_tx
-                    .send(InternalStorageCommand::RunSinkDataflow(id, description));
-            }
-            AsyncStorageWorkerResponse::DropDataflow(id) => {
-                self.storage_state
-                    .internal_cmd_tx
-                    .send(InternalStorageCommand::DropDataflow(vec![id]));
-            }
-        }
+        self.storage_state
+            .handle_async_worker_response_inner(async_response);
     }
 
     /// Entry point for applying an internal storage command.
     pub fn handle_internal_storage_command(&mut self, internal_cmd: InternalStorageCommand) {
-        match internal_cmd {
-            InternalStorageCommand::SuspendAndRestart { id, reason } => {
-                info!(
-                    "worker {}/{} initiating suspend-and-restart for {id} because of: {reason}",
-                    self.timely_worker.index(),
-                    self.timely_worker.peers(),
-                );
-
-                let maybe_ingestion = self.storage_state.ingestions.get(&id).cloned();
-                if let Some(ingestion_description) = maybe_ingestion {
-                    // Yank the token of the previously existing source dataflow.Note that this
-                    // token also includes any source exports/subsources.
-                    let maybe_token = self.storage_state.source_tokens.remove(&id);
-                    if maybe_token.is_none() {
-                        // Something has dropped the source. Make sure we don't
-                        // accidentally re-create it.
-                        return;
-                    }
-
-                    // This needs to be done by one worker, which will
-                    // broadcasts a `CreateIngestionDataflow` command to all
-                    // workers based on the response that contains the
-                    // resumption upper.
-                    //
-                    // Doing this separately on each worker could lead to
-                    // differing resume_uppers which might lead to all kinds of
-                    // mayhem.
-                    //
-                    // TODO(aljoscha): If we ever become worried that this is
-                    // putting undue pressure on worker 0 we can pick the
-                    // designated worker for a source/sink based on `id.hash()`.
-                    if self.timely_worker.index() == 0 {
-                        for (id, _) in ingestion_description.source_exports.iter() {
-                            self.storage_state
-                                .aggregated_statistics
-                                .advance_global_epoch(*id);
-                        }
-                        self.storage_state
-                            .async_worker
-                            .update_ingestion_frontiers(id, ingestion_description);
-                    }
-
-                    // Continue with other commands.
-                    return;
-                }
-
-                let maybe_sink = self.storage_state.exports.get(&id).cloned();
-                if let Some(sink_description) = maybe_sink {
-                    // Yank the token of the previously existing sink
-                    // dataflow.
-                    let maybe_token = self.storage_state.sink_tokens.remove(&id);
-
-                    if maybe_token.is_none() {
-                        // Something has dropped the sink. Make sure we don't
-                        // accidentally re-create it.
-                        return;
-                    }
-
-                    // This needs to be broadcast by one worker and go through
-                    // the internal command fabric, to ensure consistent
-                    // ordering of dataflow rendering across all workers.
-                    if self.timely_worker.index() == 0 {
-                        self.storage_state
-                            .aggregated_statistics
-                            .advance_global_epoch(id);
-                        self.storage_state
-                            .async_worker
-                            .update_sink_frontiers(id, sink_description);
-                    }
-
-                    // Continue with other commands.
-                    return;
-                }
-
-                if !self
-                    .storage_state
-                    .ingestions
-                    .values()
-                    .any(|v| v.source_exports.contains_key(&id))
-                {
-                    // Our current approach to dropping a source results in a race between shard
-                    // finalization (which happens in the controller) and dataflow shutdown (which
-                    // happens in clusterd). If a source is created and dropped fast enough -or the
-                    // two commands get sufficiently delayed- then it's possible to receive a
-                    // SuspendAndRestart command for an unknown source. We cannot assert that this
-                    // never happens but we log an error here to track how often this happens.
-                    warn!(
-                        "got InternalStorageCommand::SuspendAndRestart for something that is not a source or sink: {id}"
-                    );
-                }
-            }
-            InternalStorageCommand::CreateIngestionDataflow {
-                id: ingestion_id,
-                mut ingestion_description,
-                as_of,
-                mut resume_uppers,
-                mut source_resume_uppers,
-            } => {
-                info!(
-                    ?as_of,
-                    ?resume_uppers,
-                    "worker {}/{} trying to (re-)start ingestion {ingestion_id}",
-                    self.timely_worker.index(),
-                    self.timely_worker.peers(),
-                );
-
-                // We initialize statistics before we prune finished exports. We
-                // still want to export statistics for these, plus the rendering
-                // machinery will get confused if there are not at least
-                // statistics for the "main" source.
-                for (export_id, export) in ingestion_description.source_exports.iter() {
-                    let resume_upper = resume_uppers[export_id].clone();
-                    self.storage_state.aggregated_statistics.initialize_source(
-                        *export_id,
-                        ingestion_id,
-                        resume_upper.clone(),
-                        || {
-                            SourceStatistics::new(
-                                *export_id,
-                                self.storage_state.timely_worker_index,
-                                &self.storage_state.metrics.source_statistics,
-                                ingestion_id,
-                                &export.storage_metadata.data_shard,
-                                export.data_config.envelope.clone(),
-                                resume_upper,
-                            )
-                        },
-                    );
-                }
-
-                let finished_exports: BTreeSet<GlobalId> = resume_uppers
-                    .iter()
-                    .filter(|(_, frontier)| frontier.is_empty())
-                    .map(|(id, _)| *id)
-                    .collect();
-
-                resume_uppers.retain(|id, _| !finished_exports.contains(id));
-                source_resume_uppers.retain(|id, _| !finished_exports.contains(id));
-                ingestion_description
-                    .source_exports
-                    .retain(|id, _| !finished_exports.contains(id));
-
-                for id in ingestion_description.collection_ids() {
-                    // If there is already a shared upper, we re-use it, to make
-                    // sure that parties that are already using the shared upper
-                    // can continue doing so.
-                    let source_upper = self
-                        .storage_state
-                        .source_uppers
-                        .entry(id.clone())
-                        .or_insert_with(|| {
-                            Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())))
-                        });
-
-                    let mut source_upper = source_upper.borrow_mut();
-                    if !source_upper.is_empty() {
-                        source_upper.clear();
-                        source_upper.insert(mz_repr::Timestamp::minimum());
-                    }
-                }
-
-                // If all subsources of the source are finished, we can skip rendering entirely.
-                // Also, if `as_of` is empty, the dataflow has been finalized, so we can skip it as
-                // well.
-                //
-                // TODO(guswynn|petrosagg): this is a bit hacky, and is a consequence of storage state
-                // management being a bit of a mess. we should clean this up and remove weird if
-                // statements like this.
-                if resume_uppers.values().all(|frontier| frontier.is_empty()) || as_of.is_empty() {
-                    info!(
-                        ?resume_uppers,
-                        ?as_of,
-                        "worker {}/{} skipping building ingestion dataflow \
-                        for {ingestion_id} because the ingestion is finished",
-                        self.timely_worker.index(),
-                        self.timely_worker.peers(),
-                    );
-                    return;
-                }
-
-                crate::render::build_ingestion_dataflow(
-                    self.timely_worker,
-                    &mut self.storage_state,
-                    ingestion_id,
-                    ingestion_description,
-                    as_of,
-                    resume_uppers,
-                    source_resume_uppers,
-                );
-            }
-            InternalStorageCommand::RunOneshotIngestion {
-                ingestion_id,
-                collection_id,
-                collection_meta,
-                request,
-            } => {
-                crate::render::build_oneshot_ingestion_dataflow(
-                    self.timely_worker,
-                    &mut self.storage_state,
-                    ingestion_id,
-                    collection_id,
-                    collection_meta,
-                    request,
-                );
-            }
-            InternalStorageCommand::RunSinkDataflow(sink_id, sink_description) => {
-                info!(
-                    "worker {}/{} trying to (re-)start sink {sink_id}",
-                    self.timely_worker.index(),
-                    self.timely_worker.peers(),
-                );
-
-                {
-                    // If there is already a shared write frontier, we re-use it, to
-                    // make sure that parties that are already using the shared
-                    // frontier can continue doing so.
-                    let sink_write_frontier = self
-                        .storage_state
-                        .sink_write_frontiers
-                        .entry(sink_id.clone())
-                        .or_insert_with(|| Rc::new(RefCell::new(Antichain::new())));
-
-                    let mut sink_write_frontier = sink_write_frontier.borrow_mut();
-                    sink_write_frontier.clear();
-                    sink_write_frontier.insert(mz_repr::Timestamp::minimum());
-                }
-                self.storage_state
-                    .aggregated_statistics
-                    .initialize_sink(sink_id, || {
-                        SinkStatistics::new(
-                            sink_id,
-                            self.storage_state.timely_worker_index,
-                            &self.storage_state.metrics.sink_statistics,
-                        )
-                    });
-
-                crate::render::build_export_dataflow(
-                    self.timely_worker,
-                    &mut self.storage_state,
-                    sink_id,
-                    sink_description,
-                );
-            }
-            InternalStorageCommand::DropDataflow(ids) => {
-                for id in &ids {
-                    // Clean up per-source / per-sink state.
-                    self.storage_state.source_uppers.remove(id);
-                    self.storage_state.source_tokens.remove(id);
-
-                    self.storage_state.sink_tokens.remove(id);
-                    self.storage_state.sink_write_frontiers.remove(id);
-
-                    self.storage_state.aggregated_statistics.deinitialize(*id);
-                }
-            }
-            InternalStorageCommand::UpdateConfiguration { storage_parameters } => {
-                self.storage_state
-                    .dataflow_parameters
-                    .update(storage_parameters.clone());
-                self.storage_state
-                    .storage_configuration
-                    .update(storage_parameters);
-
-                // Clear out the updates as we no longer forward them to anyone else to process.
-                // We clone `StorageState::storage_configuration` many times during rendering
-                // and want to avoid cloning these unused updates.
-                self.storage_state
-                    .storage_configuration
-                    .parameters
-                    .dyncfg_updates = Default::default();
-
-                // Remember the maintenance interval locally to avoid reading it from the config set on
-                // every server iteration.
-                self.storage_state.server_maintenance_interval =
-                    STORAGE_SERVER_MAINTENANCE_INTERVAL
-                        .get(self.storage_state.storage_configuration.config_set());
-            }
-            InternalStorageCommand::StatisticsUpdate { sources, sinks } => self
-                .storage_state
-                .aggregated_statistics
-                .ingest(sources, sinks),
-        }
+        self.storage_state
+            .handle_internal_storage_command_with(self.timely_worker, internal_cmd);
     }
 
     /// Emit information about write frontier progress, along with information that should
@@ -985,11 +670,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
     /// reflect those commands. If the worker can not be made to reflect the
     /// commands, return an error.
     fn reconcile(&mut self, command_rx: &mut CommandReceiver) -> Result<(), ()> {
-        let worker_id = self.timely_worker.index();
-
-        // To initialize the connection, we want to drain all commands until we
-        // receive a `StorageCommand::InitializationComplete` command to form a
-        // target command state.
+        // Drain all commands until InitializationComplete.
         let mut commands = vec![];
         loop {
             match command_rx.blocking_recv().ok_or(())? {
@@ -998,14 +679,29 @@ impl<'w, A: Allocate> Worker<'w, A> {
             }
         }
 
+        self.storage_state.reconcile_with_commands(commands);
+        Ok(())
+    }
+}
+
+impl StorageState {
+    /// Reconcile storage state with the given commands.
+    ///
+    /// The commands should be collected from a new client connection (everything
+    /// before `InitializationComplete`). This method processes them to determine
+    /// which objects to keep, drop, or recreate, then applies the resulting
+    /// filtered command set.
+    pub fn reconcile_with_commands(&mut self, mut commands: Vec<StorageCommand>) {
+        let worker_id = self.timely_worker_index;
+
         // Track which frontiers this envd expects; we will also set their
         // initial timestamp to the minimum timestamp to reset them as we don't
         // know what frontiers the new envd expects.
         let mut expected_objects = BTreeSet::new();
 
         let mut drop_commands = BTreeSet::new();
-        let mut running_ingestion_descriptions = self.storage_state.ingestions.clone();
-        let mut running_exports_descriptions = self.storage_state.exports.clone();
+        let mut running_ingestion_descriptions = self.ingestions.clone();
+        let mut running_exports_descriptions = self.exports.clone();
 
         let mut create_oneshot_ingestions: BTreeSet<Uuid> = BTreeSet::new();
         let mut cancel_oneshot_ingestions: BTreeSet<Uuid> = BTreeSet::new();
@@ -1094,12 +790,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     {
                         if drop_commands.remove(export_id) {
                             info!(%worker_id, %export_id, "reconcile: dropping subsource");
-                            self.storage_state.dropped_ids.push(*export_id);
+                            self.dropped_ids.push(*export_id);
                         }
                     }
 
                     if drop_commands.remove(&ingestion.id)
-                        || self.storage_state.dropped_ids.contains(&ingestion.id)
+                        || self.dropped_ids.contains(&ingestion.id)
                     {
                         info!(%worker_id, %ingestion.id, "reconcile: dropping ingestion");
 
@@ -1108,7 +804,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         // as its progress subsource).
                         for id in ingestion.description.collection_ids() {
                             drop_commands.remove(&id);
-                            self.storage_state.dropped_ids.push(id);
+                            self.dropped_ids.push(id);
                         }
                         should_keep = false;
                     } else {
@@ -1121,7 +817,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             // reconciliation completes. This definition
                             // must not include any dropped subsources.
                             ingestion.description.source_exports.retain(|export_id, _| {
-                                !self.storage_state.dropped_ids.contains(export_id)
+                                !self.dropped_ids.contains(export_id)
                             });
 
                             // After clearing any dropped subsources, we can
@@ -1129,7 +825,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             expected_objects.extend(ingestion.description.collection_ids());
                         }
 
-                        let running_ingestion = self.storage_state.ingestions.get(&ingestion.id);
+                        let running_ingestion = self.ingestions.get(&ingestion.id);
 
                         // We keep only:
                         // - The most recent version of the ingestion, which
@@ -1145,19 +841,19 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         // If there were multiple `RunSink` in the command
                         // stream, we want to ensure none of them are
                         // retained.
-                        || self.storage_state.dropped_ids.contains(&export.id)
+                        || self.dropped_ids.contains(&export.id)
                     {
                         info!(%worker_id, %export.id, "reconcile: dropping sink");
 
                         // Make sure that we report back that the ID was
                         // dropped.
-                        self.storage_state.dropped_ids.push(export.id);
+                        self.dropped_ids.push(export.id);
 
                         should_keep = false
                     } else {
                         expected_objects.insert(export.id);
 
-                        let running_sink = self.storage_state.exports.get(&export.id);
+                        let running_sink = self.exports.get(&export.id);
 
                         // We keep only:
                         // - The most recent version of the sink, which
@@ -1170,7 +866,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::RunOneshotIngestion(ingestion) => {
                     let already_running = self
-                        .storage_state
                         .oneshot_ingestions
                         .contains_key(&ingestion.ingestion_id);
                     let was_canceled = cancel_oneshot_ingestions.contains(&ingestion.ingestion_id);
@@ -1179,7 +874,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::CancelOneshotIngestion(ingestion_id) => {
                     let already_running = self
-                        .storage_state
                         .oneshot_ingestions
                         .contains_key(ingestion_id);
                     should_keep = already_running;
@@ -1207,17 +901,15 @@ impl<'w, A: Allocate> Worker<'w, A> {
         // Determine the ID of all objects we did _not_ see; these are
         // considered stale.
         let stale_objects = self
-            .storage_state
             .ingestions
             .values()
             .map(|i| i.collection_ids())
             .flatten()
-            .chain(self.storage_state.exports.keys().copied())
+            .chain(self.exports.keys().copied())
             // Objects are considered stale if we did not see them re-created.
             .filter(|id| !expected_objects.contains(id))
             .collect::<Vec<_>>();
         let stale_oneshot_ingestions = self
-            .storage_state
             .oneshot_ingestions
             .keys()
             .filter(|ingestion_id| {
@@ -1238,39 +930,35 @@ impl<'w, A: Allocate> Worker<'w, A> {
         );
 
         for id in stale_objects {
-            self.storage_state.drop_collection(id);
+            self.drop_collection(id);
         }
         for id in stale_oneshot_ingestions {
-            self.storage_state.drop_oneshot_ingestion(id);
+            self.drop_oneshot_ingestion(id);
         }
 
         // Do not report dropping any objects that do not belong to expected
         // objects.
-        self.storage_state
-            .dropped_ids
+        self.dropped_ids
             .retain(|id| expected_objects.contains(id));
 
         // Do not report any frontiers that do not belong to expected objects.
         // Note that this set of objects can differ from the set of sources and
         // sinks.
-        self.storage_state
-            .reported_frontiers
+        self.reported_frontiers
             .retain(|id, _| expected_objects.contains(id));
 
         // Reset the reported frontiers for the remaining objects.
-        for (_, frontier) in &mut self.storage_state.reported_frontiers {
+        for (_, frontier) in &mut self.reported_frontiers {
             *frontier = Antichain::from_elem(<_>::minimum());
         }
 
         // Reset the initial status reported flag when a new client connects
-        self.storage_state.initial_status_reported = false;
+        self.initial_status_reported = false;
 
         // Execute the modified commands.
         for command in commands {
-            self.storage_state.handle_storage_command(command);
+            self.handle_storage_command(command);
         }
-
-        Ok(())
     }
 }
 
@@ -1444,5 +1132,347 @@ impl StorageState {
     fn drop_oneshot_ingestion(&mut self, ingestion_id: uuid::Uuid) {
         let prev = self.oneshot_ingestions.remove(&ingestion_id);
         info!(%ingestion_id, existed = %prev.is_some(), "dropping oneshot ingestion");
+    }
+
+    /// Entry point for applying a response from the async storage worker.
+    ///
+    /// This is a version of [`Worker::handle_async_worker_response`] that does not require
+    /// access to the timely worker, using the stored `timely_worker_index` instead.
+    pub fn handle_async_worker_response_inner(
+        &self,
+        async_response: AsyncStorageWorkerResponse<mz_repr::Timestamp>,
+    ) {
+        assert_eq!(
+            self.timely_worker_index, 0,
+            "only worker #0 is doing async processing"
+        );
+        match async_response {
+            AsyncStorageWorkerResponse::IngestionFrontiersUpdated {
+                id,
+                ingestion_description,
+                as_of,
+                resume_uppers,
+                source_resume_uppers,
+            } => {
+                self.internal_cmd_tx
+                    .send(InternalStorageCommand::CreateIngestionDataflow {
+                        id,
+                        ingestion_description,
+                        as_of,
+                        resume_uppers,
+                        source_resume_uppers,
+                    });
+            }
+            AsyncStorageWorkerResponse::ExportFrontiersUpdated { id, description } => {
+                self.internal_cmd_tx
+                    .send(InternalStorageCommand::RunSinkDataflow(id, description));
+            }
+            AsyncStorageWorkerResponse::DropDataflow(id) => {
+                self.internal_cmd_tx
+                    .send(InternalStorageCommand::DropDataflow(vec![id]));
+            }
+        }
+    }
+
+    /// Entry point for applying an internal storage command.
+    ///
+    /// This is a version of [`Worker::handle_internal_storage_command`] that takes
+    /// `&mut TimelyWorker` as a parameter instead of accessing it through `self`.
+    pub fn handle_internal_storage_command_with<A: Allocate>(
+        &mut self,
+        timely_worker: &mut TimelyWorker<A>,
+        internal_cmd: InternalStorageCommand,
+    ) {
+        match internal_cmd {
+            InternalStorageCommand::SuspendAndRestart { id, reason } => {
+                info!(
+                    "worker {}/{} initiating suspend-and-restart for {id} because of: {reason}",
+                    self.timely_worker_index, self.timely_worker_peers,
+                );
+
+                let maybe_ingestion = self.ingestions.get(&id).cloned();
+                if let Some(ingestion_description) = maybe_ingestion {
+                    let maybe_token = self.source_tokens.remove(&id);
+                    if maybe_token.is_none() {
+                        return;
+                    }
+
+                    if self.timely_worker_index == 0 {
+                        for (id, _) in ingestion_description.source_exports.iter() {
+                            self.aggregated_statistics.advance_global_epoch(*id);
+                        }
+                        self.async_worker
+                            .update_ingestion_frontiers(id, ingestion_description);
+                    }
+
+                    return;
+                }
+
+                let maybe_sink = self.exports.get(&id).cloned();
+                if let Some(sink_description) = maybe_sink {
+                    let maybe_token = self.sink_tokens.remove(&id);
+                    if maybe_token.is_none() {
+                        return;
+                    }
+
+                    if self.timely_worker_index == 0 {
+                        self.aggregated_statistics.advance_global_epoch(id);
+                        self.async_worker
+                            .update_sink_frontiers(id, sink_description);
+                    }
+
+                    return;
+                }
+
+                if !self
+                    .ingestions
+                    .values()
+                    .any(|v| v.source_exports.contains_key(&id))
+                {
+                    warn!(
+                        "got InternalStorageCommand::SuspendAndRestart for something that is not a source or sink: {id}"
+                    );
+                }
+            }
+            InternalStorageCommand::CreateIngestionDataflow {
+                id: ingestion_id,
+                mut ingestion_description,
+                as_of,
+                mut resume_uppers,
+                mut source_resume_uppers,
+            } => {
+                info!(
+                    ?as_of,
+                    ?resume_uppers,
+                    "worker {}/{} trying to (re-)start ingestion {ingestion_id}",
+                    self.timely_worker_index,
+                    self.timely_worker_peers,
+                );
+
+                for (export_id, export) in ingestion_description.source_exports.iter() {
+                    let resume_upper = resume_uppers[export_id].clone();
+                    self.aggregated_statistics.initialize_source(
+                        *export_id,
+                        ingestion_id,
+                        resume_upper.clone(),
+                        || {
+                            SourceStatistics::new(
+                                *export_id,
+                                self.timely_worker_index,
+                                &self.metrics.source_statistics,
+                                ingestion_id,
+                                &export.storage_metadata.data_shard,
+                                export.data_config.envelope.clone(),
+                                resume_upper,
+                            )
+                        },
+                    );
+                }
+
+                let finished_exports: BTreeSet<GlobalId> = resume_uppers
+                    .iter()
+                    .filter(|(_, frontier)| frontier.is_empty())
+                    .map(|(id, _)| *id)
+                    .collect();
+
+                resume_uppers.retain(|id, _| !finished_exports.contains(id));
+                source_resume_uppers.retain(|id, _| !finished_exports.contains(id));
+                ingestion_description
+                    .source_exports
+                    .retain(|id, _| !finished_exports.contains(id));
+
+                for id in ingestion_description.collection_ids() {
+                    let source_upper = self.source_uppers.entry(id.clone()).or_insert_with(|| {
+                        Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())))
+                    });
+
+                    let mut source_upper = source_upper.borrow_mut();
+                    if !source_upper.is_empty() {
+                        source_upper.clear();
+                        source_upper.insert(mz_repr::Timestamp::minimum());
+                    }
+                }
+
+                if resume_uppers.values().all(|frontier| frontier.is_empty()) || as_of.is_empty() {
+                    info!(
+                        ?resume_uppers,
+                        ?as_of,
+                        "worker {}/{} skipping building ingestion dataflow \
+                        for {ingestion_id} because the ingestion is finished",
+                        self.timely_worker_index,
+                        self.timely_worker_peers,
+                    );
+                    return;
+                }
+
+                crate::render::build_ingestion_dataflow(
+                    timely_worker,
+                    self,
+                    ingestion_id,
+                    ingestion_description,
+                    as_of,
+                    resume_uppers,
+                    source_resume_uppers,
+                );
+            }
+            InternalStorageCommand::RunOneshotIngestion {
+                ingestion_id,
+                collection_id,
+                collection_meta,
+                request,
+            } => {
+                crate::render::build_oneshot_ingestion_dataflow(
+                    timely_worker,
+                    self,
+                    ingestion_id,
+                    collection_id,
+                    collection_meta,
+                    request,
+                );
+            }
+            InternalStorageCommand::RunSinkDataflow(sink_id, sink_description) => {
+                info!(
+                    "worker {}/{} trying to (re-)start sink {sink_id}",
+                    self.timely_worker_index, self.timely_worker_peers,
+                );
+
+                {
+                    let sink_write_frontier = self
+                        .sink_write_frontiers
+                        .entry(sink_id.clone())
+                        .or_insert_with(|| Rc::new(RefCell::new(Antichain::new())));
+
+                    let mut sink_write_frontier = sink_write_frontier.borrow_mut();
+                    sink_write_frontier.clear();
+                    sink_write_frontier.insert(mz_repr::Timestamp::minimum());
+                }
+                self.aggregated_statistics.initialize_sink(sink_id, || {
+                    SinkStatistics::new(
+                        sink_id,
+                        self.timely_worker_index,
+                        &self.metrics.sink_statistics,
+                    )
+                });
+
+                crate::render::build_export_dataflow(
+                    timely_worker,
+                    self,
+                    sink_id,
+                    sink_description,
+                );
+            }
+            InternalStorageCommand::DropDataflow(ids) => {
+                for id in &ids {
+                    self.source_uppers.remove(id);
+                    self.source_tokens.remove(id);
+                    self.sink_tokens.remove(id);
+                    self.sink_write_frontiers.remove(id);
+                    self.aggregated_statistics.deinitialize(*id);
+                }
+            }
+            InternalStorageCommand::UpdateConfiguration { storage_parameters } => {
+                self.dataflow_parameters.update(storage_parameters.clone());
+                self.storage_configuration.update(storage_parameters);
+                self.storage_configuration.parameters.dyncfg_updates = Default::default();
+                self.server_maintenance_interval = STORAGE_SERVER_MAINTENANCE_INTERVAL
+                    .get(self.storage_configuration.config_set());
+            }
+            InternalStorageCommand::StatisticsUpdate { sources, sinks } => {
+                self.aggregated_statistics.ingest(sources, sinks)
+            }
+        }
+    }
+
+    /// Report frontier progress for all storage collections.
+    pub fn report_frontier_progress(&mut self, response_tx: &ResponseSender) {
+        let mut new_uppers = Vec::new();
+
+        for (id, frontier) in self.reported_frontiers.iter_mut() {
+            let Some(source_upper) = self.source_uppers.get(id) else {
+                continue;
+            };
+            let upper = source_upper.borrow();
+
+            if PartialOrder::less_than(frontier, &*upper) {
+                new_uppers.push((*id, upper.clone()));
+                frontier.clone_from(&upper);
+            }
+        }
+
+        for (id, frontier) in self.sink_write_frontiers.iter() {
+            let upper = frontier.borrow();
+            let Some(reported) = self.reported_frontiers.get_mut(id) else {
+                continue;
+            };
+
+            if PartialOrder::less_than(reported, &*upper) {
+                new_uppers.push((*id, upper.clone()));
+                reported.clone_from(&upper);
+            }
+        }
+
+        if !new_uppers.is_empty() {
+            for (id, upper) in new_uppers {
+                let _ = response_tx.send(StorageResponse::FrontierUpper(id, upper));
+            }
+        }
+    }
+
+    /// Report status updates to the coordinator.
+    pub fn report_status_updates(&mut self, response_tx: &ResponseSender) {
+        if !self.initial_status_reported {
+            let now_ts = mz_ore::now::to_datetime((self.now)());
+            let status_updates = self
+                .latest_status_updates
+                .values()
+                .cloned()
+                .map(|mut update| {
+                    update.timestamp = now_ts.clone();
+                    update
+                });
+            for update in status_updates {
+                let _ = response_tx.send(StorageResponse::StatusUpdate(update));
+            }
+            self.initial_status_reported = true;
+        }
+
+        for shared_update in self.shared_status_updates.take() {
+            let _ = response_tx.send(StorageResponse::StatusUpdate(shared_update.clone()));
+            self.latest_status_updates
+                .insert(shared_update.id, shared_update);
+        }
+    }
+
+    /// Report storage statistics.
+    pub fn report_storage_statistics(&mut self, response_tx: &ResponseSender) {
+        let (sources, sinks) = self.aggregated_statistics.emit_local();
+        if !sources.is_empty() || !sinks.is_empty() {
+            self.internal_cmd_tx
+                .send(InternalStorageCommand::StatisticsUpdate { sources, sinks })
+        }
+
+        let (sources, sinks) = self.aggregated_statistics.snapshot();
+        if !sources.is_empty() || !sinks.is_empty() {
+            let _ = response_tx.send(StorageResponse::StatisticsUpdates(sources, sinks));
+        }
+    }
+
+    /// Process oneshot ingestion results.
+    pub fn process_oneshot_ingestions(&mut self, response_tx: &ResponseSender) {
+        for (ingestion_id, ingestion_state) in &mut self.oneshot_ingestions {
+            loop {
+                match ingestion_state.results.try_recv() {
+                    Ok(result) => {
+                        let response = match result {
+                            Ok(maybe_batch) => maybe_batch.into_iter().map(Result::Ok).collect(),
+                            Err(err) => vec![Err(err)],
+                        };
+                        let staged_batches = BTreeMap::from([(*ingestion_id, response)]);
+                        let _ = response_tx.send(StorageResponse::StagedBatches(staged_batches));
+                    }
+                    Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

**EXPERIMENTAL** — This PR is a proof of concept. See "Known Limitations" below.

- Add a unified Timely runtime that runs both compute and storage dataflows in a single Timely cluster, sharing worker threads and communication infrastructure
- Enable it by default via `--unified-runtime` (can be disabled with `--unified-runtime=false`)
- Compute's existing logging dataflows automatically capture storage Timely/Differential events — no schema changes, no ID collisions

## Motivation

Storage has no introspection today — its Timely events are discarded. Forwarding events via mpsc channels doesn't work because both Timely instances allocate IDs starting from 0, making it impossible to disambiguate origins. A unified runtime eliminates this by having a single ID allocator.

## Approach

- Refactor compute `Worker` to expose step methods and make key types pub (`CommandReceiver`, `ResponseSender`, `ActiveComputeState`)
- Move storage's `handle_internal_storage_command` to `StorageState` with an explicit `&mut TimelyWorker` parameter
- New `unified.rs` module in clusterd: sets up networking once, creates two sets of client channels, runs a merged event loop
- Non-blocking storage reconnection via a channel adapter that buffers commands until `InitializationComplete`, then delivers reconciliation batches
- Command distribution unchanged: compute uses Exchange-based broadcast, storage uses internal command sequencer
- Controllers connect via separate gRPC connections as before

See `doc/developer/design/20260402_unified_timely_runtime.md` for the full design.

## Known Limitations

**Deterministic dataflow ordering.** Timely requires that all workers render dataflows in the same deterministic order. In this prototype, compute and storage dataflows are rendered through independent command paths (compute via Exchange-based broadcast, storage via its internal command sequencer), and there is no canonical ordering between them. On multi-worker clusters, this can lead to workers rendering dataflows in different orders, which Timely does not tolerate. Fixing this properly likely requires unifying the command protocols at the protocol level, which is a significantly larger effort. For this reason, this PR should be considered **experimental** and is not safe for production use with multi-worker replicas.

## Test plan

- [x] `cargo check` passes for mz-clusterd, mz-compute, mz-storage
- [x] Storage dataflows visible in `mz_introspection.mz_dataflows`
- [x] Storage operators visible in `mz_introspection.mz_dataflow_operators`
- [ ] Full SLT/testdrive suite (pending — experimental)
- [ ] Multi-worker correctness (blocked on deterministic ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)