### PR TITLE
[SS-101] Storage introspection mirrored in compute

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -103,6 +103,7 @@ def get_minimal_system_parameters(
         "enable_sql_server_source": "true",
         "enable_s3_tables_region_check": "false",
         "enable_statement_lifecycle_logging": "true",
+        "enable_storage_introspection_logs": "true",
         "enable_compute_temporal_bucketing": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2075,6 +2075,10 @@ impl Coordinator {
 
         let enable_worker_core_affinity =
             self.catalog().system_config().enable_worker_core_affinity();
+        let enable_storage_introspection_logs = self
+            .catalog()
+            .system_config()
+            .enable_storage_introspection_logs();
         for instance in self.catalog.clusters() {
             self.controller.create_cluster(
                 instance.id,
@@ -2093,6 +2097,7 @@ impl Coordinator {
                     role,
                     replica.config.clone(),
                     enable_worker_core_affinity,
+                    enable_storage_introspection_logs,
                 )?;
             }
         }

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1591,6 +1591,10 @@ impl Coordinator {
     ) {
         let enable_worker_core_affinity =
             self.catalog().system_config().enable_worker_core_affinity();
+        let enable_storage_introspection_logs = self
+            .catalog()
+            .system_config()
+            .enable_storage_introspection_logs();
 
         self.controller
             .create_replica(
@@ -1601,6 +1605,7 @@ impl Coordinator {
                 role,
                 replica_config,
                 enable_worker_core_affinity,
+                enable_storage_introspection_logs,
             )
             .expect("creating replicas must not fail");
 

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -167,6 +167,11 @@ struct Args {
     /// affinity might degrade dataflow performance rather than improving it.
     #[clap(long)]
     worker_core_affinity: bool,
+
+    /// Forward storage's timely logging events to compute so storage operators appear in
+    /// `mz_introspection.mz_dataflow_*` tables.
+    #[clap(long)]
+    enable_storage_introspection_logs: bool,
 }
 
 pub fn main() {
@@ -379,9 +384,14 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     compute_timely_config.process = args.process;
 
     // Create per-worker bridges for forwarding storage timely logging events to compute.
-    let num_workers = storage_timely_config.workers;
-    let (storage_log_writers, storage_log_readers): (Vec<_>, Vec<_>) =
-        (0..num_workers).map(|_| arc_event_link()).unzip();
+    let (storage_log_writers, storage_log_readers) =
+        if args.enable_storage_introspection_logs {
+            (0..storage_timely_config.workers)
+                .map(|_| arc_event_link())
+                .unzip()
+        } else {
+            (Vec::new(), Vec::new())
+        };
 
     // Start storage server.
     let storage_client_builder = mz_storage::serve(

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -383,15 +383,20 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut compute_timely_config = args.compute_timely_config;
     compute_timely_config.process = args.process;
 
+    // We assume each storage worker has a corresponding compute worker that can process its logs.
+    assert_eq!(
+        storage_timely_config.workers, compute_timely_config.workers,
+        "storage and compute must have equal workers-per-process",
+    );
+
     // Create per-worker bridges for forwarding storage timely logging events to compute.
-    let (storage_log_writers, storage_log_readers) =
-        if args.enable_storage_introspection_logs {
-            (0..storage_timely_config.workers)
-                .map(|_| arc_event_link())
-                .unzip()
-        } else {
-            (Vec::new(), Vec::new())
-        };
+    let (storage_log_writers, storage_log_readers) = if args.enable_storage_introspection_logs {
+        (0..storage_timely_config.workers)
+            .map(|_| arc_event_link())
+            .unzip()
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     // Start storage server.
     let storage_client_builder = mz_storage::serve(

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -38,6 +38,7 @@ use mz_service::secrets::SecretsReaderCliArgs;
 use mz_service::transport;
 use mz_storage::storage_state::StorageInstanceContext;
 use mz_storage_types::connections::ConnectionContext;
+use mz_timely_util::capture::arc_event_link;
 use mz_txn_wal::operator::TxnsContext;
 use tokio::runtime::Handle;
 use tower::Service;
@@ -377,6 +378,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut compute_timely_config = args.compute_timely_config;
     compute_timely_config.process = args.process;
 
+    // Create per-worker bridges for forwarding storage timely logging events to compute.
+    let num_workers = storage_timely_config.workers;
+    let (storage_log_writers, storage_log_readers): (Vec<_>, Vec<_>) =
+        (0..num_workers).map(|_| arc_event_link()).unzip();
+
     // Start storage server.
     let storage_client_builder = mz_storage::serve(
         storage_timely_config,
@@ -387,6 +393,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         SYSTEM_TIME.clone(),
         connection_context.clone(),
         StorageInstanceContext::new(args.scratch_directory.clone(), args.announce_memory_limit)?,
+        storage_log_writers,
     )
     .await?;
     info!(
@@ -418,6 +425,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             worker_core_affinity: args.worker_core_affinity,
             connection_context,
         },
+        storage_log_readers,
     )
     .await?;
     info!(

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -361,6 +361,8 @@ pub(crate) struct ActiveComputeState<'a> {
     pub compute_state: &'a mut ComputeState,
     /// The channel over which frontier information is reported.
     pub response_tx: &'a mut ResponseSender,
+    /// Reader for storage timely logging events (consumed during CreateInstance).
+    pub storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 }
 
 /// A token that keeps a sink alive.
@@ -417,7 +419,8 @@ impl<'a> ActiveComputeState<'a> {
             self.compute_state.apply_expiration_offset(offset);
         }
 
-        self.initialize_logging(config.logging);
+        let storage_log_reader = self.storage_log_reader.take();
+        self.initialize_logging(config.logging, storage_log_reader);
 
         self.compute_state.peek_stash_persist_location = Some(config.peek_stash_persist_location);
     }
@@ -670,7 +673,11 @@ impl<'a> ActiveComputeState<'a> {
     }
 
     /// Initializes timely dataflow logging and publishes as a view.
-    pub fn initialize_logging(&mut self, config: LoggingConfig) {
+    pub fn initialize_logging(
+        &mut self,
+        config: LoggingConfig,
+        storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
+    ) {
         if self.compute_state.compute_logger.is_some() {
             panic!("dataflow server has already initialized logging");
         }
@@ -685,6 +692,7 @@ impl<'a> ActiveComputeState<'a> {
             self.compute_state.metrics_registry.clone(),
             Rc::clone(&self.compute_state.worker_config),
             self.compute_state.workers_per_process,
+            storage_log_reader,
         );
 
         let dataflow_index = Rc::new(dataflow_index);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -168,6 +168,9 @@ pub struct ComputeState {
     /// replica can drop diffs associated with timestamps beyond the replica expiration.
     /// The replica will panic if such dataflows are not dropped before the replica has expired.
     pub replica_expiration: Antichain<Timestamp>,
+
+    /// The storage worker forwards its introspection logs to the compute worker.
+    pub storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 }
 
 impl ComputeState {
@@ -180,6 +183,7 @@ impl ComputeState {
         context: ComputeInstanceContext,
         metrics_registry: MetricsRegistry,
         workers_per_process: usize,
+        storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
     ) -> Self {
         let traces = TraceManager::new(metrics.clone());
         let command_history = ComputeCommandHistory::new(metrics.for_history());
@@ -207,6 +211,7 @@ impl ComputeState {
             server_maintenance_interval: Duration::ZERO,
             init_system_time: mz_ore::now::SYSTEM_TIME(),
             replica_expiration: Antichain::default(),
+            storage_log_reader,
         }
     }
 
@@ -361,8 +366,6 @@ pub(crate) struct ActiveComputeState<'a> {
     pub compute_state: &'a mut ComputeState,
     /// The channel over which frontier information is reported.
     pub response_tx: &'a mut ResponseSender,
-    /// Reader for storage timely logging events (consumed during CreateInstance).
-    pub storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 }
 
 /// A token that keeps a sink alive.
@@ -419,7 +422,7 @@ impl<'a> ActiveComputeState<'a> {
             self.compute_state.apply_expiration_offset(offset);
         }
 
-        let storage_log_reader = self.storage_log_reader.take();
+        let storage_log_reader = self.compute_state.storage_log_reader.take();
         self.initialize_logging(config.logging, storage_log_reader);
 
         self.compute_state.peek_stash_persist_location = Some(config.peek_stash_persist_location);

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -45,6 +45,7 @@ pub fn initialize(
     metrics_registry: MetricsRegistry,
     worker_config: Rc<ConfigSet>,
     workers_per_process: usize,
+    storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 ) -> LoggingTraces {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
 
@@ -70,6 +71,7 @@ pub fn initialize(
         metrics_registry,
         worker_config,
         workers_per_process,
+        storage_log_reader,
     };
 
     // Depending on whether we should log the creation of the logging dataflows, we register the
@@ -108,6 +110,8 @@ struct LoggingContext<'a> {
     metrics_registry: MetricsRegistry,
     worker_config: Rc<ConfigSet>,
     workers_per_process: usize,
+    /// Optional reader for storage timely logging events.
+    storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 }
 
 pub(crate) struct LoggingTraces {
@@ -133,6 +137,7 @@ impl LoggingContext<'_> {
                 self.config,
                 self.t_event_queue.clone(),
                 Rc::clone(&self.shared_state),
+                self.storage_log_reader.take(),
             );
             collections.extend(timely_collections);
 

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -173,14 +173,10 @@ pub(super) fn construct(
                     };
 
                     for (time, event) in data.drain(..) {
-                        // Note: we skip the worker_id assertion for storage events,
-                        // whose channel IDs have been offset by STORAGE_ID_OFFSET.
                         if let TimelyEvent::Messages(msg) = &event {
-                            if msg.channel < STORAGE_ID_OFFSET {
-                                match msg.is_send {
-                                    true => assert_eq!(msg.source, worker_id),
-                                    false => assert_eq!(msg.target, worker_id),
-                                }
+                            match msg.is_send {
+                                true => assert_eq!(msg.source, worker_id),
+                                false => assert_eq!(msg.target, worker_id),
                             }
                         }
 

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -25,6 +25,7 @@ use mz_timely_util::replay::MzReplay;
 use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::core::Filter;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::operator::empty;
@@ -87,19 +88,22 @@ pub(super) fn construct(
             let (storage_logs, s_token) =
                 [reader].mz_replay(scope, "storage timely logs", config.interval, activator);
 
-            // Remap storage IDs so they don't collide with compute IDs.
-            let storage_logs = storage_logs.unary(Pipeline, "Remap Storage IDs", |_cap, _info| {
-                move |input, output| {
-                    input.for_each(|time, data| {
-                        output.session(&time).give_iterator(data.drain(..).map(
-                            |(t, mut event)| {
-                                remap_timely_event_ids(&mut event);
-                                (t, event)
-                            },
-                        ));
-                    });
-                }
-            });
+            let storage_logs = storage_logs
+                // Ignore storage park/unpark events.
+                .filter(|(_, x)| !matches!(x, TimelyEvent::Park { .. }))
+                // Remap storage IDs so they don't collide with compute IDs.
+                .unary(Pipeline, "Remap Storage IDs", |_cap, _info| {
+                    move |input, output| {
+                        input.for_each(|time, data| {
+                            output.session(&time).give_iterator(data.drain(..).map(
+                                |(t, mut event)| {
+                                    remap_timely_event_ids(&mut event);
+                                    (t, event)
+                                },
+                            ));
+                        });
+                    }
+                });
 
             let merged = scope.concatenate([logs, storage_logs]);
             (merged, Some(s_token))

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -25,7 +25,6 @@ use mz_timely_util::replay::MzReplay;
 use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::Operator;
-use timely::dataflow::operators::core::Filter;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::operator::empty;
@@ -78,8 +77,7 @@ pub(super) fn construct(
             (empty(scope), token)
         };
 
-        // If we have a storage log reader, replay it, remap its IDs to avoid
-        // collisions with compute IDs, and concatenate with compute logs.
+        // If we have a storage log reader, replay it and concatenate with compute logs.
         let (logs, storage_token) = if let Some(reader) = storage_log_reader {
             use mz_timely_util::activator::RcActivator;
             use timely::dataflow::operators::Concatenate;
@@ -87,24 +85,6 @@ pub(super) fn construct(
             let activator = RcActivator::new("storage_timely_activator".to_string(), 128);
             let (storage_logs, s_token) =
                 [reader].mz_replay(scope, "storage timely logs", config.interval, activator);
-
-            let storage_logs = storage_logs
-                // Ignore storage park/unpark events.
-                .filter(|(_, x)| !matches!(x, TimelyEvent::Park { .. }))
-                // Remap storage IDs so they don't collide with compute IDs.
-                .unary(Pipeline, "Remap Storage IDs", |_cap, _info| {
-                    move |input, output| {
-                        input.for_each(|time, data| {
-                            output.session(&time).give_iterator(data.drain(..).map(
-                                |(t, mut event)| {
-                                    remap_timely_event_ids(&mut event);
-                                    (t, event)
-                                },
-                            ));
-                        });
-                    }
-                });
-
             let merged = scope.concatenate([logs, storage_logs]);
             (merged, Some(s_token))
         } else {
@@ -825,58 +805,5 @@ where
 {
     if vec.len() <= index {
         vec.resize(index + 1, Default::default());
-    }
-}
-
-/// Offset added to storage operator/channel IDs to avoid collisions with compute IDs.
-///
-/// This is large enough that compute IDs (which start from 0 and grow) will never reach it,
-/// but small enough to be representable as a `u64` with room for many storage operators.
-const STORAGE_ID_OFFSET: usize = 1 << 48;
-
-/// Remaps operator, channel, and address IDs in a `TimelyEvent` originating from a storage
-/// timely instance so they don't collide with compute's IDs.
-fn remap_timely_event_ids(event: &mut TimelyEvent) {
-    match event {
-        TimelyEvent::Operates(OperatesEvent { id, addr, .. }) => {
-            *id = id.wrapping_add(STORAGE_ID_OFFSET);
-            if let Some(first) = addr.first_mut() {
-                *first = first.wrapping_add(STORAGE_ID_OFFSET);
-            }
-        }
-        TimelyEvent::Channels(ChannelsEvent {
-            id,
-            scope_addr,
-            source,
-            target,
-            ..
-        }) => {
-            *id = id.wrapping_add(STORAGE_ID_OFFSET);
-            if let Some(first) = scope_addr.first_mut() {
-                *first = first.wrapping_add(STORAGE_ID_OFFSET);
-            }
-            source.0 = source.0.wrapping_add(STORAGE_ID_OFFSET);
-            target.0 = target.0.wrapping_add(STORAGE_ID_OFFSET);
-        }
-        TimelyEvent::Shutdown(ShutdownEvent { id }) => {
-            *id = id.wrapping_add(STORAGE_ID_OFFSET);
-        }
-        TimelyEvent::Schedule(ScheduleEvent { id, .. }) => {
-            *id = id.wrapping_add(STORAGE_ID_OFFSET);
-        }
-        TimelyEvent::Messages(MessagesEvent { channel, .. }) => {
-            *channel = channel.wrapping_add(STORAGE_ID_OFFSET);
-            // Note: source/target in Messages are *worker* IDs, not operator IDs.
-            // We leave them as-is.
-        }
-        TimelyEvent::PushProgress(e) => {
-            e.op_id = e.op_id.wrapping_add(STORAGE_ID_OFFSET);
-        }
-        TimelyEvent::CommChannels(e) => {
-            e.identifier = e.identifier.wrapping_add(STORAGE_ID_OFFSET);
-        }
-        TimelyEvent::Park(_) | TimelyEvent::Text(_) => {
-            // No IDs to remap.
-        }
     }
 }

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -61,6 +61,7 @@ pub(super) fn construct(
     config: &LoggingConfig,
     event_queue: EventQueue<Vec<(Duration, TimelyEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
+    storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
 ) -> Return {
     scope.scoped("timely logging", move |scope| {
         let enable_logging = config.enable_logging;
@@ -74,6 +75,41 @@ pub(super) fn construct(
         } else {
             let token: Rc<dyn std::any::Any> = Rc::new(Box::new(()));
             (empty(scope), token)
+        };
+
+        // If we have a storage log reader, replay it, remap its IDs to avoid
+        // collisions with compute IDs, and concatenate with compute logs.
+        let (logs, storage_token) = if let Some(reader) = storage_log_reader {
+            use mz_timely_util::activator::RcActivator;
+            use timely::dataflow::operators::Concatenate;
+
+            let activator = RcActivator::new("storage_timely_activator".to_string(), 128);
+            let (storage_logs, s_token) =
+                [reader].mz_replay(scope, "storage timely logs", config.interval, activator);
+
+            // Remap storage IDs so they don't collide with compute IDs.
+            let storage_logs = storage_logs.unary(Pipeline, "Remap Storage IDs", |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        output.session(&time).give_iterator(data.drain(..).map(
+                            |(t, mut event)| {
+                                remap_timely_event_ids(&mut event);
+                                (t, event)
+                            },
+                        ));
+                    });
+                }
+            });
+
+            let merged = scope.concatenate([logs, storage_logs]);
+            (merged, Some(s_token))
+        } else {
+            (logs, None)
+        };
+        // Convert storage token to Rc<dyn Any> so we can stash it alongside the compute token.
+        let storage_token: Rc<dyn std::any::Any> = match storage_token {
+            Some(t) => t,
+            None => Rc::new(()),
         };
 
         // Build a demux operator that splits the replayed event stream up into the separate
@@ -133,10 +169,14 @@ pub(super) fn construct(
                     };
 
                     for (time, event) in data.drain(..) {
+                        // Note: we skip the worker_id assertion for storage events,
+                        // whose channel IDs have been offset by STORAGE_ID_OFFSET.
                         if let TimelyEvent::Messages(msg) = &event {
-                            match msg.is_send {
-                                true => assert_eq!(msg.source, worker_id),
-                                false => assert_eq!(msg.target, worker_id),
+                            if msg.channel < STORAGE_ID_OFFSET {
+                                match msg.is_send {
+                                    true => assert_eq!(msg.source, worker_id),
+                                    false => assert_eq!(msg.target, worker_id),
+                                }
                             }
                         }
 
@@ -367,9 +407,11 @@ pub(super) fn construct(
                         &format!("Arrange {variant:?}"),
                     )
                     .trace;
+                let combined_token: Rc<dyn std::any::Any> =
+                    Rc::new((Rc::clone(&token), Rc::clone(&storage_token)));
                 let collection = LogCollection {
                     trace,
-                    token: Rc::clone(&token),
+                    token: combined_token,
                 };
                 collections.insert(variant, collection);
             }
@@ -783,5 +825,58 @@ where
 {
     if vec.len() <= index {
         vec.resize(index + 1, Default::default());
+    }
+}
+
+/// Offset added to storage operator/channel IDs to avoid collisions with compute IDs.
+///
+/// This is large enough that compute IDs (which start from 0 and grow) will never reach it,
+/// but small enough to be representable as a `u64` with room for many storage operators.
+const STORAGE_ID_OFFSET: usize = 1 << 48;
+
+/// Remaps operator, channel, and address IDs in a `TimelyEvent` originating from a storage
+/// timely instance so they don't collide with compute's IDs.
+fn remap_timely_event_ids(event: &mut TimelyEvent) {
+    match event {
+        TimelyEvent::Operates(OperatesEvent { id, addr, .. }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+            if let Some(first) = addr.first_mut() {
+                *first = first.wrapping_add(STORAGE_ID_OFFSET);
+            }
+        }
+        TimelyEvent::Channels(ChannelsEvent {
+            id,
+            scope_addr,
+            source,
+            target,
+            ..
+        }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+            if let Some(first) = scope_addr.first_mut() {
+                *first = first.wrapping_add(STORAGE_ID_OFFSET);
+            }
+            source.0 = source.0.wrapping_add(STORAGE_ID_OFFSET);
+            target.0 = target.0.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Shutdown(ShutdownEvent { id }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Schedule(ScheduleEvent { id, .. }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Messages(MessagesEvent { channel, .. }) => {
+            *channel = channel.wrapping_add(STORAGE_ID_OFFSET);
+            // Note: source/target in Messages are *worker* IDs, not operator IDs.
+            // We leave them as-is.
+        }
+        TimelyEvent::PushProgress(e) => {
+            e.op_id = e.op_id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::CommChannels(e) => {
+            e.identifier = e.identifier.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Park(_) | TimelyEvent::Text(_) => {
+            // No IDs to remap.
+        }
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -77,10 +77,8 @@ struct Config {
     pub metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     pub workers_per_process: usize,
-    /// Per-worker readers for storage timely logging events.
-    // TODO: Consider using the timely config's `process` and `workers` fields to
-    // deterministically assign readers to workers by local index, rather than pop().
-    pub storage_log_readers: Arc<Mutex<Vec<StorageTimelyLogReader>>>,
+    /// A reader for each storage worker in this process.
+    pub storage_log_readers: Arc<Mutex<Vec<Option<StorageTimelyLogReader>>>>,
 }
 
 /// Initiates a timely dataflow computation, processing compute commands.
@@ -93,6 +91,16 @@ pub async fn serve(
     context: ComputeInstanceContext,
     storage_log_readers: Vec<StorageTimelyLogReader>,
 ) -> Result<impl Fn() -> Box<dyn ComputeClient> + use<>, Error> {
+    let workers_per_process = timely_config.workers;
+    // Normalize the log-reader vec to exactly one slot per local worker. Empty
+    // input means logging is disabled; pad with `None` so index-based access is
+    // always in bounds.
+    let storage_log_readers = if storage_log_readers.is_empty() {
+        (0..workers_per_process).map(|_| None).collect()
+    } else {
+        assert_eq!(storage_log_readers.len(), workers_per_process);
+        storage_log_readers.into_iter().map(Some).collect()
+    };
     let config = Config {
         persist_clients,
         txns_ctx,
@@ -100,7 +108,7 @@ pub async fn serve(
         metrics: ComputeMetrics::register_with(metrics_registry),
         context,
         metrics_registry: metrics_registry.clone(),
-        workers_per_process: timely_config.workers,
+        workers_per_process,
         storage_log_readers: Arc::new(Mutex::new(storage_log_readers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
@@ -261,8 +269,10 @@ impl ClusterSpec for Config {
         let worker_id = timely_worker.index();
         let metrics = self.metrics.for_worker(worker_id);
 
-        // Take this worker's storage log reader.
-        let storage_log_reader = self.storage_log_readers.lock().unwrap().pop();
+        // Take this worker's storage log reader, indexed by local worker index
+        // so compute worker x matches storage worker x.
+        let local_index = worker_id % self.workers_per_process;
+        let storage_log_reader = self.storage_log_readers.lock().unwrap()[local_index].take();
 
         // Create the command channel that broadcasts commands from worker 0 to other workers. We
         // reuse this channel between client connections, to avoid bugs where different workers end

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -30,7 +30,9 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
 use mz_storage_types::connections::ConnectionContext;
+use mz_timely_util::capture::ArcEventLink;
 use mz_txn_wal::operator::TxnsContext;
+use timely::logging::TimelyEvent;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
@@ -54,8 +56,12 @@ pub struct ComputeInstanceContext {
     pub connection_context: ConnectionContext,
 }
 
+/// Type alias for the storage timely log reader.
+pub(crate) type StorageTimelyLogReader =
+    Arc<ArcEventLink<mz_repr::Timestamp, Vec<(Duration, TimelyEvent)>>>;
+
 /// Configures the server with compute-specific metrics.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Config {
     /// `persist` client cache.
     pub persist_clients: Arc<PersistClientCache>,
@@ -71,6 +77,10 @@ struct Config {
     pub metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     pub workers_per_process: usize,
+    /// Per-worker readers for storage timely logging events.
+    // TODO: Consider using the timely config's `process` and `workers` fields to
+    // deterministically assign readers to workers by local index, rather than pop().
+    pub storage_log_readers: Arc<Mutex<Vec<StorageTimelyLogReader>>>,
 }
 
 /// Initiates a timely dataflow computation, processing compute commands.
@@ -81,6 +91,7 @@ pub async fn serve(
     txns_ctx: TxnsContext,
     tracing_handle: Arc<TracingHandle>,
     context: ComputeInstanceContext,
+    storage_log_readers: Vec<StorageTimelyLogReader>,
 ) -> Result<impl Fn() -> Box<dyn ComputeClient> + use<>, Error> {
     let config = Config {
         persist_clients,
@@ -90,6 +101,7 @@ pub async fn serve(
         context,
         metrics_registry: metrics_registry.clone(),
         workers_per_process: timely_config.workers,
+        storage_log_readers: Arc::new(Mutex::new(storage_log_readers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
 
@@ -223,6 +235,8 @@ struct Worker<'w> {
     metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     workers_per_process: usize,
+    /// Reader for storage timely logging events.
+    storage_log_reader: Option<StorageTimelyLogReader>,
 }
 
 impl ClusterSpec for Config {
@@ -247,6 +261,9 @@ impl ClusterSpec for Config {
         let worker_id = timely_worker.index();
         let metrics = self.metrics.for_worker(worker_id);
 
+        // Take this worker's storage log reader.
+        let storage_log_reader = self.storage_log_readers.lock().unwrap().pop();
+
         // Create the command channel that broadcasts commands from worker 0 to other workers. We
         // reuse this channel between client connections, to avoid bugs where different workers end
         // up creating incompatible sides of the channel dataflow after reconnects.
@@ -268,6 +285,7 @@ impl ClusterSpec for Config {
             tracing_handle: Arc::clone(&self.tracing_handle),
             metrics_registry: self.metrics_registry.clone(),
             workers_per_process: self.workers_per_process,
+            storage_log_reader,
         }
         .run()
     }
@@ -396,21 +414,27 @@ impl<'w> Worker<'w> {
     }
 
     fn handle_command(&mut self, cmd: ComputeCommand) {
-        match &cmd {
-            ComputeCommand::CreateInstance(_) => {
-                self.compute_state = Some(ComputeState::new(
-                    Arc::clone(&self.persist_clients),
-                    self.txns_ctx.clone(),
-                    self.metrics.clone(),
-                    Arc::clone(&self.tracing_handle),
-                    self.context.clone(),
-                    self.metrics_registry.clone(),
-                    self.workers_per_process,
-                ));
-            }
-            _ => (),
+        let is_create_instance = matches!(&cmd, ComputeCommand::CreateInstance(_));
+        if is_create_instance {
+            self.compute_state = Some(ComputeState::new(
+                Arc::clone(&self.persist_clients),
+                self.txns_ctx.clone(),
+                self.metrics.clone(),
+                Arc::clone(&self.tracing_handle),
+                self.context.clone(),
+                self.metrics_registry.clone(),
+                self.workers_per_process,
+            ));
         }
-        self.activate_compute().unwrap().handle_compute_command(cmd);
+        // Take the storage log reader before borrowing self for activate_compute.
+        let storage_log_reader = if is_create_instance {
+            self.storage_log_reader.take()
+        } else {
+            None
+        };
+        let mut active = self.activate_compute().unwrap();
+        active.storage_log_reader = storage_log_reader;
+        active.handle_compute_command(cmd);
     }
 
     fn activate_compute(&mut self) -> Option<ActiveComputeState<'_>> {
@@ -419,6 +443,7 @@ impl<'w> Worker<'w> {
                 timely_worker: &mut *self.timely_worker,
                 compute_state,
                 response_tx: &mut self.response_tx,
+                storage_log_reader: None,
             })
         } else {
             None

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -424,8 +424,7 @@ impl<'w> Worker<'w> {
     }
 
     fn handle_command(&mut self, cmd: ComputeCommand) {
-        let is_create_instance = matches!(&cmd, ComputeCommand::CreateInstance(_));
-        if is_create_instance {
+        if matches!(&cmd, ComputeCommand::CreateInstance(_)) {
             self.compute_state = Some(ComputeState::new(
                 Arc::clone(&self.persist_clients),
                 self.txns_ctx.clone(),
@@ -434,17 +433,10 @@ impl<'w> Worker<'w> {
                 self.context.clone(),
                 self.metrics_registry.clone(),
                 self.workers_per_process,
+                self.storage_log_reader.take(),
             ));
         }
-        // Take the storage log reader before borrowing self for activate_compute.
-        let storage_log_reader = if is_create_instance {
-            self.storage_log_reader.take()
-        } else {
-            None
-        };
-        let mut active = self.activate_compute().unwrap();
-        active.storage_log_reader = storage_log_reader;
-        active.handle_compute_command(cmd);
+        self.activate_compute().unwrap().handle_compute_command(cmd);
     }
 
     fn activate_compute(&mut self) -> Option<ActiveComputeState<'_>> {
@@ -453,7 +445,6 @@ impl<'w> Worker<'w> {
                 timely_worker: &mut *self.timely_worker,
                 compute_state,
                 response_tx: &mut self.response_tx,
-                storage_log_reader: None,
             })
         } else {
             None

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -30,7 +30,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
 use mz_storage_types::connections::ConnectionContext;
-use mz_timely_util::capture::ArcEventLink;
+use mz_timely_util::capture::EventLink;
 use mz_txn_wal::operator::TxnsContext;
 use timely::logging::TimelyEvent;
 use timely::progress::Antichain;
@@ -58,7 +58,7 @@ pub struct ComputeInstanceContext {
 
 /// Type alias for the storage timely log reader.
 pub(crate) type StorageTimelyLogReader =
-    Arc<ArcEventLink<mz_repr::Timestamp, Vec<(Duration, TimelyEvent)>>>;
+    Arc<EventLink<mz_repr::Timestamp, Vec<(Duration, TimelyEvent)>>>;
 
 /// Configures the server with compute-specific metrics.
 #[derive(Clone)]

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -404,6 +404,7 @@ impl Controller {
         role: ClusterRole,
         config: ReplicaConfig,
         enable_worker_core_affinity: bool,
+        enable_storage_introspection_logs: bool,
     ) -> Result<(), anyhow::Error> {
         let storage_location: ClusterReplicaLocation;
         let compute_location: ClusterReplicaLocation;
@@ -431,6 +432,7 @@ impl Controller {
                     role,
                     m,
                     enable_worker_core_affinity,
+                    enable_storage_introspection_logs,
                 )?;
                 storage_location = ClusterReplicaLocation {
                     ctl_addrs: service.addresses("storagectl"),
@@ -624,6 +626,7 @@ impl Controller {
         role: ClusterRole,
         location: ManagedReplicaLocation,
         enable_worker_core_affinity: bool,
+        enable_storage_introspection_logs: bool,
     ) -> Result<(Box<dyn Service>, AbortOnDropHandle<()>), anyhow::Error> {
         let service_name = ReplicaServiceName {
             cluster_id,
@@ -737,6 +740,9 @@ impl Controller {
                     }
                     if location.allocation.cpu_exclusive && enable_worker_core_affinity {
                         args.push("--worker-core-affinity".into());
+                    }
+                    if enable_storage_introspection_logs {
+                        args.push("--enable-storage-introspection-logs".into());
                     }
                     if location.allocation.is_cc {
                         args.push("--is-cc".into());

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1221,11 +1221,13 @@ fn test_cancel_long_running_query() {
 
 fn test_cancellation_cancels_dataflows(query: &str) {
     // Query that returns how many dataflows are currently installed.
-    // Accounts for the presence of introspection subscribe dataflows by ignoring those.
+    // Ignores introspection subscribe dataflows.
+    // Ignores storage operators, whose IDs are offset by STORAGE_ID_OFFSET (1 << 48).
     const DATAFLOW_QUERY: &str = " \
         SELECT count(*) \
         FROM mz_introspection.mz_dataflows \
-        WHERE name NOT LIKE '%introspection-subscribe%'";
+        WHERE name NOT LIKE '%introspection-subscribe%' \
+        AND id < 281474976710656";
 
     let server = test_util::TestHarness::default()
         .unsafe_mode()
@@ -1300,11 +1302,13 @@ fn test_cancel_insert_select() {
 
 fn test_closing_connection_cancels_dataflows(query: String) {
     // Query that returns how many dataflows are currently installed.
-    // Accounts for the presence of introspection subscribe dataflows by ignoring those.
+    // Ignores introspection subscribe dataflows.
+    // Ignores storage operators, whose IDs are offset by STORAGE_ID_OFFSET (1 << 48).
     const DATAFLOW_QUERY: &str = " \
         SELECT count(*) \
         FROM mz_introspection.mz_dataflows \
-        WHERE name NOT LIKE '%introspection-subscribe%'";
+        WHERE name NOT LIKE '%introspection-subscribe%' \
+        AND id < 281474976710656";
 
     let server = test_util::TestHarness::default()
         .unsafe_mode()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2074,6 +2074,12 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
+        name: enable_storage_introspection_logs,
+        desc: "forward storage timely logging events into compute's introspection dataflow",
+        default: false,
+        enable_for_item_parsing: false,
+    },
+    {
         name: enable_copy_to_expr,
         desc: "COPY ... TO 's3://...'",
         default: true,

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -10,6 +10,7 @@
 //! An interactive dataflow server.
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use mz_cluster::client::{ClusterClient, ClusterSpec};
 use mz_cluster_client::client::TimelyConfig;
@@ -20,7 +21,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_storage_client::client::{StorageClient, StorageCommand, StorageResponse};
 use mz_storage_types::connections::ConnectionContext;
-use mz_timely_util::capture::ArcEventLink;
+use mz_timely_util::capture::EventLink;
 use mz_txn_wal::operator::TxnsContext;
 use timely::logging::TimelyEvent;
 use timely::worker::Worker as TimelyWorker;
@@ -54,16 +55,11 @@ struct Config {
     pub workers_per_process: usize,
     /// Per-worker writers for forwarding timely logging events to compute,
     /// indexed by local worker index.
-    pub timely_log_writers: Arc<
-        Mutex<
-            Vec<
-                Option<
-                    Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>,
-                >,
-            >,
-        >,
-    >,
+    pub timely_log_writers: Arc<Mutex<Vec<Option<TimelyLogWriter>>>>,
 }
+
+/// Per-worker writer handle for forwarding timely logging events to compute.
+pub(crate) type TimelyLogWriter = Arc<EventLink<mz_repr::Timestamp, Vec<(Duration, TimelyEvent)>>>;
 
 /// Initiates a timely dataflow computation, processing storage commands.
 pub async fn serve(
@@ -75,9 +71,7 @@ pub async fn serve(
     now: NowFn,
     connection_context: ConnectionContext,
     instance_context: StorageInstanceContext,
-    timely_log_writers: Vec<
-        Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>,
-    >,
+    timely_log_writers: Vec<TimelyLogWriter>,
 ) -> Result<impl Fn() -> Box<dyn StorageClient> + use<>, anyhow::Error> {
     let workers_per_process = timely_config.workers;
     // Normalize the log-writer vec to exactly one slot per worker in this process.

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -183,10 +183,9 @@ impl ClusterSpec for Config {
                 },
             );
 
-            let mut register = timely_worker
-                .log_register()
-                .expect("Logging must be enabled");
-            register.insert_logger("timely", logger);
+            if let Some(mut register) = timely_worker.log_register() {
+                register.insert_logger("timely", logger);
+            }
         }
 
         Worker::new(

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -23,7 +23,9 @@ use mz_storage_client::client::{StorageClient, StorageCommand, StorageResponse};
 use mz_storage_types::connections::ConnectionContext;
 use mz_timely_util::capture::EventLink;
 use mz_txn_wal::operator::TxnsContext;
-use timely::logging::TimelyEvent;
+use timely::logging::{
+    ChannelsEvent, MessagesEvent, OperatesEvent, ScheduleEvent, ShutdownEvent, TimelyEvent,
+};
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -151,7 +153,19 @@ impl ClusterSpec for Config {
                 start_offset,
                 move |time: &std::time::Duration,
                       data: &mut Option<Vec<(std::time::Duration, TimelyEvent)>>| {
-                    if let Some(data) = data.take() {
+                    if let Some(mut data) = data.take() {
+                        // Filter park/unpark events and remap IDs before handing events
+                        // off to compute. Compute's park tracking assumes a single
+                        // timely runtime; mixing in storage's park events would break
+                        // it. Remapping ensures storage operator/channel IDs don't
+                        // collide with compute's.
+                        data.retain_mut(|(_, event)| {
+                            if matches!(event, TimelyEvent::Park(_)) {
+                                return false;
+                            }
+                            remap_timely_event_ids(event);
+                            true
+                        });
                         event_pusher.push(Event::Messages(time_ms, data));
                     } else {
                         // Advance progress.
@@ -188,5 +202,57 @@ impl ClusterSpec for Config {
             self.shared_rocksdb_write_buffer_manager.clone(),
         )
         .run();
+    }
+}
+
+/// Offset added to storage operator/channel IDs to avoid collisions with compute IDs.
+///
+/// Large enough that compute IDs (which start from 0 and grow) will never reach it,
+/// but small enough to be representable as a `u64` with room for many storage operators.
+const STORAGE_ID_OFFSET: usize = 1 << 48;
+
+/// Remaps operator, channel, and address IDs in a `TimelyEvent` so that events
+/// forwarded to compute's logging dataflow don't collide with compute's IDs.
+fn remap_timely_event_ids(event: &mut TimelyEvent) {
+    match event {
+        TimelyEvent::Operates(OperatesEvent { id, addr, .. }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+            if let Some(first) = addr.first_mut() {
+                *first = first.wrapping_add(STORAGE_ID_OFFSET);
+            }
+        }
+        TimelyEvent::Channels(ChannelsEvent {
+            id,
+            scope_addr,
+            source,
+            target,
+            ..
+        }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+            if let Some(first) = scope_addr.first_mut() {
+                *first = first.wrapping_add(STORAGE_ID_OFFSET);
+            }
+            source.0 = source.0.wrapping_add(STORAGE_ID_OFFSET);
+            target.0 = target.0.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Shutdown(ShutdownEvent { id }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Schedule(ScheduleEvent { id, .. }) => {
+            *id = id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Messages(MessagesEvent { channel, .. }) => {
+            *channel = channel.wrapping_add(STORAGE_ID_OFFSET);
+            // source/target in Messages are worker IDs, not operator IDs.
+        }
+        TimelyEvent::PushProgress(e) => {
+            e.op_id = e.op_id.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::CommChannels(e) => {
+            e.identifier = e.identifier.wrapping_add(STORAGE_ID_OFFSET);
+        }
+        TimelyEvent::Park(_) | TimelyEvent::Text(_) => {
+            // No IDs to remap.
+        }
     }
 }

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -50,11 +50,18 @@ struct Config {
     pub metrics: StorageMetrics,
     /// Shared rocksdb write buffer manager
     pub shared_rocksdb_write_buffer_manager: SharedWriteBufferManager,
-    /// Per-worker writers for forwarding timely logging events to compute.
-    // TODO: Consider using the timely config's `process` and `workers` fields to
-    // deterministically assign writers to workers by local index, rather than pop().
+    /// Number of timely workers in this process, for local-index computation.
+    pub workers_per_process: usize,
+    /// Per-worker writers for forwarding timely logging events to compute,
+    /// indexed by local worker index.
     pub timely_log_writers: Arc<
-        Mutex<Vec<Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>>>,
+        Mutex<
+            Vec<
+                Option<
+                    Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>,
+                >,
+            >,
+        >,
     >,
 }
 
@@ -72,6 +79,16 @@ pub async fn serve(
         Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>,
     >,
 ) -> Result<impl Fn() -> Box<dyn StorageClient> + use<>, anyhow::Error> {
+    let workers_per_process = timely_config.workers;
+    // Normalize the log-writer vec to exactly one slot per worker in this process.
+    // Empty input means logging is disabled; pad with `None` so index-based access is
+    // always in bounds.
+    let timely_log_writers = if timely_log_writers.is_empty() {
+        (0..workers_per_process).map(|_| None).collect()
+    } else {
+        assert_eq!(timely_log_writers.len(), workers_per_process);
+        timely_log_writers.into_iter().map(Some).collect()
+    };
     let config = Config {
         persist_clients,
         txns_ctx,
@@ -84,6 +101,7 @@ pub async fn serve(
         // It protects (behind a shared mutex) a `Weak` that will be upgraded and shared when the
         // first worker attempts to initialize it.
         shared_rocksdb_write_buffer_manager: Default::default(),
+        workers_per_process,
         timely_log_writers: Arc::new(Mutex::new(timely_log_writers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
@@ -116,7 +134,9 @@ impl ClusterSpec for Config {
         )>,
     ) {
         // Register a timely logger that forwards events to the compute logging dataflow.
-        let writer = self.timely_log_writers.lock().unwrap().pop();
+        // Assign by local worker index so storage worker x matches compute worker x.
+        let local_index = timely_worker.index() % self.workers_per_process;
+        let writer = self.timely_log_writers.lock().unwrap()[local_index].take();
         if let Some(writer) = writer {
             use timely::dataflow::operators::capture::{Event, EventPusher};
             use timely::logging::TimelyEventBuilder;

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -20,7 +20,9 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_storage_client::client::{StorageClient, StorageCommand, StorageResponse};
 use mz_storage_types::connections::ConnectionContext;
+use mz_timely_util::capture::ArcEventLink;
 use mz_txn_wal::operator::TxnsContext;
+use timely::logging::TimelyEvent;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -48,6 +50,12 @@ struct Config {
     pub metrics: StorageMetrics,
     /// Shared rocksdb write buffer manager
     pub shared_rocksdb_write_buffer_manager: SharedWriteBufferManager,
+    /// Per-worker writers for forwarding timely logging events to compute.
+    // TODO: Consider using the timely config's `process` and `workers` fields to
+    // deterministically assign writers to workers by local index, rather than pop().
+    pub timely_log_writers: Arc<
+        Mutex<Vec<Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>>>,
+    >,
 }
 
 /// Initiates a timely dataflow computation, processing storage commands.
@@ -60,6 +68,9 @@ pub async fn serve(
     now: NowFn,
     connection_context: ConnectionContext,
     instance_context: StorageInstanceContext,
+    timely_log_writers: Vec<
+        Arc<ArcEventLink<mz_repr::Timestamp, Vec<(std::time::Duration, TimelyEvent)>>>,
+    >,
 ) -> Result<impl Fn() -> Box<dyn StorageClient> + use<>, anyhow::Error> {
     let config = Config {
         persist_clients,
@@ -73,6 +84,7 @@ pub async fn serve(
         // It protects (behind a shared mutex) a `Weak` that will be upgraded and shared when the
         // first worker attempts to initialize it.
         shared_rocksdb_write_buffer_manager: Default::default(),
+        timely_log_writers: Arc::new(Mutex::new(timely_log_writers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
 
@@ -103,6 +115,52 @@ impl ClusterSpec for Config {
             mpsc::UnboundedSender<StorageResponse>,
         )>,
     ) {
+        // Register a timely logger that forwards events to the compute logging dataflow.
+        let writer = self.timely_log_writers.lock().unwrap().pop();
+        if let Some(writer) = writer {
+            use timely::dataflow::operators::capture::{Event, EventPusher};
+            use timely::logging::TimelyEventBuilder;
+
+            // We use an approach similar to compute's logging: wrap the writer in
+            // a BatchLogger that translates Logger callbacks into Event pushes,
+            // then register the Logger with timely's log_register.
+            let interval_ms = 1000u128; // 1 second batching interval
+            let mut time_ms = mz_repr::Timestamp::from(0u64);
+            let mut event_pusher = writer;
+            let now = std::time::Instant::now();
+            let start_offset = std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("Failed to get duration since Unix epoch");
+
+            let logger = timely::logging_core::Logger::<TimelyEventBuilder>::new(
+                now,
+                start_offset,
+                move |time: &std::time::Duration,
+                      data: &mut Option<Vec<(std::time::Duration, TimelyEvent)>>| {
+                    if let Some(data) = data.take() {
+                        event_pusher.push(Event::Messages(time_ms, data));
+                    } else {
+                        // Advance progress.
+                        let new_time_ms: u64 = (((time.as_millis() / interval_ms) + 1)
+                            * interval_ms)
+                            .try_into()
+                            .expect("must fit");
+                        let new_time_ms = mz_repr::Timestamp::from(new_time_ms);
+                        if time_ms < new_time_ms {
+                            event_pusher
+                                .push(Event::Progress(vec![(new_time_ms, 1), (time_ms, -1)]));
+                            time_ms = new_time_ms;
+                        }
+                    }
+                },
+            );
+
+            let mut register = timely_worker
+                .log_register()
+                .expect("Logging must be enabled");
+            register.insert_logger("timely", logger);
+        }
+
         Worker::new(
             timely_worker,
             client_rx,

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -26,14 +26,15 @@ use timely::dataflow::operators::capture::{Event, EventPusher};
 /// (as opposed to the `Rc`/`RefCell`-based `EventLink` in `timely::capture`).
 ///
 /// Both writer and reader are `Arc<ArcEventLink<T, C>>`: the writer implements
-/// [`EventPusher`] and the reader implements [`EventIterator`].
+/// [`EventPusher`] and the reader implements
+/// [`EventIterator`](timely::dataflow::operators::capture::event::EventIterator).
 pub type ArcEventLink<T, C> = EventLink<T, C>;
 
 /// Creates a linked `(writer, reader)` pair for cross-thread event streaming.
 ///
 /// Both handles begin pointing at the same empty sentinel node. The writer
 /// appends events via [`EventPusher`]; the reader chases the list and yields
-/// them via [`EventIterator`].
+/// them via [`EventIterator`](timely::dataflow::operators::capture::event::EventIterator).
 pub fn arc_event_link<T, C>() -> (Arc<ArcEventLink<T, C>>, Arc<ArcEventLink<T, C>>) {
     let shared = Arc::new(ArcEventLink::new());
     (Arc::clone(&shared), shared)

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -13,9 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
 use timely::communication::Push;
+use timely::dataflow::operators::capture::event::link_sync::EventLink;
 use timely::dataflow::operators::capture::{Event, EventPusher};
+
+/// A thread-safe linked list for cross-thread event streaming.
+///
+/// This re-exports timely's `link_sync::EventLink`, which uses `Arc`/`Mutex`
+/// (as opposed to the `Rc`/`RefCell`-based `EventLink` in `timely::capture`).
+///
+/// Both writer and reader are `Arc<ArcEventLink<T, C>>`: the writer implements
+/// [`EventPusher`] and the reader implements [`EventIterator`].
+pub type ArcEventLink<T, C> = EventLink<T, C>;
+
+/// Creates a linked `(writer, reader)` pair for cross-thread event streaming.
+///
+/// Both handles begin pointing at the same empty sentinel node. The writer
+/// appends events via [`EventPusher`]; the reader chases the list and yields
+/// them via [`EventIterator`].
+pub fn arc_event_link<T, C>() -> (Arc<ArcEventLink<T, C>>, Arc<ArcEventLink<T, C>>) {
+    let shared = Arc::new(ArcEventLink::new());
+    (Arc::clone(&shared), shared)
+}
 
 pub struct UnboundedTokioCapture<T, C, M>(pub InstrumentedUnboundedSender<Event<T, C>, M>);
 

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -17,26 +17,23 @@ use std::sync::Arc;
 
 use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
 use timely::communication::Push;
-use timely::dataflow::operators::capture::event::link_sync::EventLink;
 use timely::dataflow::operators::capture::{Event, EventPusher};
 
 /// A thread-safe linked list for cross-thread event streaming.
 ///
-/// This re-exports timely's `link_sync::EventLink`, which uses `Arc`/`Mutex`
-/// (as opposed to the `Rc`/`RefCell`-based `EventLink` in `timely::capture`).
-///
-/// Both writer and reader are `Arc<ArcEventLink<T, C>>`: the writer implements
-/// [`EventPusher`] and the reader implements
+/// Uses `Arc`/`Mutex` internally, unlike the `Rc`/`RefCell`-based `EventLink`
+/// in `timely::capture`. Designed to be shared via `Arc<EventLink<T, C>>`:
+/// the writer side implements [`EventPusher`] and the reader side implements
 /// [`EventIterator`](timely::dataflow::operators::capture::event::EventIterator).
-pub type ArcEventLink<T, C> = EventLink<T, C>;
+pub use timely::dataflow::operators::capture::event::link_sync::EventLink;
 
 /// Creates a linked `(writer, reader)` pair for cross-thread event streaming.
 ///
 /// Both handles begin pointing at the same empty sentinel node. The writer
 /// appends events via [`EventPusher`]; the reader chases the list and yields
 /// them via [`EventIterator`](timely::dataflow::operators::capture::event::EventIterator).
-pub fn arc_event_link<T, C>() -> (Arc<ArcEventLink<T, C>>, Arc<ArcEventLink<T, C>>) {
-    let shared = Arc::new(ArcEventLink::new());
+pub fn arc_event_link<T, C>() -> (Arc<EventLink<T, C>>, Arc<EventLink<T, C>>) {
+    let shared = Arc::new(EventLink::new());
     (Arc::clone(&shared), shared)
 }
 

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -161,6 +161,7 @@ Compute␠Logging␠Demux  Arrange␠Compute(LirMapping)  mz_timely_util::column
 Compute␠Logging␠Demux  Arrange␠Compute(OperatorHydrationStatus)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  Arrange␠Compute(PeekCurrent)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Compute␠Logging␠Demux  Arrange␠Compute(PeekDuration)  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+Concatenate  Timely␠Logging␠Demux  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Consolidate␠Differential(ArrangementBatches)  ToRow␠Differential(ArrangementBatches)  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
 Consolidate␠Differential(ArrangementRecords)  ToRow␠Differential(ArrangementRecords)  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
 Consolidate␠Differential(BatcherAllocations)  ToRow␠Differential(BatcherAllocations)  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
@@ -185,12 +186,15 @@ Differential␠Logging␠Demux  Consolidate␠Differential(BatcherCapacity)  all
 Differential␠Logging␠Demux  Consolidate␠Differential(BatcherRecords)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Differential␠Logging␠Demux  Consolidate␠Differential(BatcherSize)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Differential␠Logging␠Demux  Consolidate␠Differential(Sharing)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+Filter  Remap␠Storage␠IDs  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 FlatMapReachability  Consolidate␠Timely(Reachability)  mz_timely_util::columnar::Column<(((bool,␠usize,␠usize,␠usize,␠mz_repr::timestamp::Timestamp),␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 PrometheusMetrics  Arrange␠PrometheusMetrics  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+Remap␠Storage␠IDs  Concatenate  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Replay␠compute␠logs  Compute␠Logging␠Demux  mz_timely_util::columnar::Column<(core::time::Duration,␠mz_compute::logging::compute::ComputeEvent)>
 Replay␠differential␠logs  Differential␠Logging␠Demux  alloc::vec::Vec<(core::time::Duration,␠differential_dataflow::logging::DifferentialEvent)>
 Replay␠reachability␠logs  FlatMapReachability  mz_timely_util::columnar::Column<(core::time::Duration,␠(usize,␠alloc::vec::Vec<(usize,␠usize,␠bool,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>))>
-Replay␠timely␠logs  Timely␠Logging␠Demux  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
+Replay␠storage␠timely␠logs  Filter  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
+Replay␠timely␠logs  Concatenate  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Timely␠Logging␠Demux  Consolidate␠Timely(Addresses)  alloc::vec::Vec<((usize,␠alloc::vec::Vec<usize>),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Timely␠Logging␠Demux  Consolidate␠Timely(BatchesReceived)  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Timely␠Logging␠Demux  Consolidate␠Timely(BatchesSent)  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
@@ -234,7 +238,6 @@ GROUP BY type;
 1  alloc::vec::Vec<((usize,␠alloc::string::String),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<((usize,␠alloc::vec::Vec<usize>),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<(core::time::Duration,␠differential_dataflow::logging::DifferentialEvent)>
-1  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 1  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<(((bool,␠usize,␠usize,␠usize,␠mz_repr::timestamp::Timestamp),␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
 1  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((mz_compute::logging::timely::ParkDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
 1  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((mz_compute::logging::timely::ScheduleHistogramDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
@@ -248,5 +251,6 @@ GROUP BY type;
 32  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 4  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 4  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
+5  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 8  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 8  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -186,14 +186,12 @@ Differential␠Logging␠Demux  Consolidate␠Differential(BatcherCapacity)  all
 Differential␠Logging␠Demux  Consolidate␠Differential(BatcherRecords)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Differential␠Logging␠Demux  Consolidate␠Differential(BatcherSize)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Differential␠Logging␠Demux  Consolidate␠Differential(Sharing)  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-Filter  Remap␠Storage␠IDs  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 FlatMapReachability  Consolidate␠Timely(Reachability)  mz_timely_util::columnar::Column<(((bool,␠usize,␠usize,␠usize,␠mz_repr::timestamp::Timestamp),␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 PrometheusMetrics  Arrange␠PrometheusMetrics  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-Remap␠Storage␠IDs  Concatenate  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Replay␠compute␠logs  Compute␠Logging␠Demux  mz_timely_util::columnar::Column<(core::time::Duration,␠mz_compute::logging::compute::ComputeEvent)>
 Replay␠differential␠logs  Differential␠Logging␠Demux  alloc::vec::Vec<(core::time::Duration,␠differential_dataflow::logging::DifferentialEvent)>
 Replay␠reachability␠logs  FlatMapReachability  mz_timely_util::columnar::Column<(core::time::Duration,␠(usize,␠alloc::vec::Vec<(usize,␠usize,␠bool,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>))>
-Replay␠storage␠timely␠logs  Filter  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
+Replay␠storage␠timely␠logs  Concatenate  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Replay␠timely␠logs  Concatenate  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 Timely␠Logging␠Demux  Consolidate␠Timely(Addresses)  alloc::vec::Vec<((usize,␠alloc::vec::Vec<usize>),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 Timely␠Logging␠Demux  Consolidate␠Timely(BatchesReceived)  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
@@ -247,10 +245,10 @@ GROUP BY type;
 1  mz_timely_util::columnar::Column<((mz_compute::logging::timely::ChannelDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  mz_timely_util::columnar::Column<(core::time::Duration,␠(usize,␠alloc::vec::Vec<(usize,␠usize,␠bool,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>))>
 1  mz_timely_util::columnar::Column<(core::time::Duration,␠mz_compute::logging::compute::ComputeEvent)>
+3  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 32  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 32  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 4  alloc::vec::Vec<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 4  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((mz_compute::logging::timely::MessageDatum,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>
-5  alloc::vec::Vec<(core::time::Duration,␠timely::logging::TimelyEvent)>
 8  alloc::vec::Vec<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 8  alloc::vec::Vec<alloc::vec::Vec<mz_timely_util::columnation::ColumnationStack<((usize,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -13,6 +13,10 @@
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 
+# Storage operator IDs are offset by STORAGE_ID_OFFSET (1 << 48).
+# Filter them out so test assertions only see compute operators.
+$ set storage-id-offset=281474976710656
+
 # Introspection subscribes add noise to the introspection sources, so disable them.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false
@@ -23,17 +27,17 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 > CREATE CLUSTER test REPLICAS (r1 (SIZE 'scale=1,workers=1', INTROSPECTION INTERVAL '10ms'))
 > SET cluster = test
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 
 # Verify that an index dataflow is cleaned up when the index is dropped.
 
 > CREATE TABLE t (a int)
 > CREATE INDEX test_index ON t (a)
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 true
 > DROP INDEX test_index
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 
 # Verify that an index dataflow is cleaned up when its input advances to the
@@ -47,19 +51,19 @@ false
 1000
 > SELECT mz_unsafe.mz_sleep(1)
 <null>
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 > DROP INDEX test_index
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 
 # Verify that an MV dataflow is cleaned up when the MV is dropped.
 
 > CREATE MATERIALIZED VIEW test_mv AS SELECT a FROM t
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 true
 > DROP MATERIALIZED VIEW test_mv
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 
 # Verify that an MV dataflow is cleaned up when its input advances to the
@@ -72,10 +76,10 @@ false
 1000
 > SELECT mz_unsafe.mz_sleep(1)
 <null>
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 > DROP MATERIALIZED VIEW test_mv
-> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 false
 
 # Regression test for https://github.com/MaterializeInc/database-issues/issues/4712
@@ -113,8 +117,8 @@ false
 true
 > SELECT mz_unsafe.mz_sleep(1)
 <null>
-> SELECT count(*) FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 0
 > DROP MATERIALIZED VIEW q14
-> SELECT count(*)  FROM mz_introspection.mz_dataflow_operators
+> SELECT count(*) FROM mz_introspection.mz_dataflow_operators WHERE id < ${storage-id-offset}
 0

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -14,6 +14,10 @@
 # sources. This also serves to verify that logging is correctly cleaned up under
 # active dataflow cancellation.
 
+# Storage operator IDs are offset by STORAGE_ID_OFFSET (1 << 48).
+# Filter them out so test assertions only see compute operators.
+$ set storage-id-offset=281474976710656
+
 # Introspection subscribes add noise to the introspection sources, so disable them.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false
@@ -86,14 +90,14 @@ contains: canceling statement due to statement timeout
 > SELECT *
   FROM mz_introspection.mz_compute_import_frontiers_per_worker
   WHERE export_id NOT LIKE 'si%'
-> SELECT * FROM mz_introspection.mz_compute_operator_durations_histogram_raw LIMIT 10
-> SELECT id, worker_id, address::text FROM mz_introspection.mz_dataflow_addresses_per_worker
-> SELECT * FROM mz_introspection.mz_dataflow_channels_per_worker
-> SELECT * FROM mz_introspection.mz_dataflow_operator_reachability_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_dataflow_operators_per_worker
-> SELECT * FROM mz_introspection.mz_message_counts_received_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_message_counts_sent_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_scheduling_elapsed_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_compute_operator_durations_histogram_raw WHERE id < ${storage-id-offset} LIMIT 10
+> SELECT id, worker_id, address::text FROM mz_introspection.mz_dataflow_addresses_per_worker WHERE id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_dataflow_channels_per_worker WHERE id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_dataflow_operator_reachability_raw WHERE id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_dataflow_operators_per_worker WHERE id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_message_counts_received_raw WHERE channel_id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_message_counts_sent_raw WHERE channel_id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_scheduling_elapsed_raw WHERE id < ${storage-id-offset} LIMIT 10
 
 # Cleanup.
 > DROP CLUSTER test CASCADE


### PR DESCRIPTION
Events from storage's timely infra are captured and replayed in the compute logging dataflows, with identifiers bumped up by 2^48. They are pretty large at that point, but shouldn't collide with the compute identifiers. The nudged identifiers should include Both the timely operator ids, and also the dataflow identifiers (the lead coordinate of addresses).

Not much testing, other than observing the information flowing after creating an auction leaden source.