### PR TITLE
Fix cast inversion for integer-to-numeric casts

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6314,6 +6314,7 @@ pub static MZ_DATAFLOW_ADDRESSES: LazyLock<BuiltinView> = LazyLock::new(|| Built
             }
             .nullable(false),
         )
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (
@@ -6343,6 +6344,7 @@ pub static MZ_DATAFLOW_CHANNELS: LazyLock<BuiltinView> = LazyLock::new(|| Builti
         .with_column("to_index", SqlScalarType::UInt64.nullable(false))
         .with_column("to_port", SqlScalarType::UInt64.nullable(false))
         .with_column("type", SqlScalarType::String.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the channel."),
@@ -6372,6 +6374,7 @@ pub static MZ_DATAFLOW_OPERATORS: LazyLock<BuiltinView> = LazyLock::new(|| Built
     desc: RelationDesc::builder()
         .with_column("id", SqlScalarType::UInt64.nullable(false))
         .with_column("name", SqlScalarType::String.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the operator."),
@@ -6391,6 +6394,7 @@ pub static MZ_DATAFLOW_GLOBAL_IDS: LazyLock<BuiltinView> = LazyLock::new(|| Buil
     desc: RelationDesc::builder()
         .with_column("id", SqlScalarType::UInt64.nullable(false))
         .with_column("global_id", SqlScalarType::String.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The dataflow ID."),
@@ -6440,6 +6444,7 @@ pub static MZ_LIR_MAPPING: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView 
         .with_column("nesting", SqlScalarType::UInt16.nullable(false))
         .with_column("operator_id_start", SqlScalarType::UInt64.nullable(false))
         .with_column("operator_id_end", SqlScalarType::UInt64.nullable(false))
+        .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("global_id", "The global ID."),
@@ -6574,6 +6579,7 @@ pub static MZ_COMPUTE_EXPORTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
     desc: RelationDesc::builder()
         .with_column("export_id", SqlScalarType::String.nullable(false))
         .with_column("dataflow_id", SqlScalarType::UInt64.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (
@@ -8745,6 +8751,7 @@ pub static MZ_ACTIVE_PEEKS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView
         .with_column("object_id", SqlScalarType::String.nullable(false))
         .with_column("type", SqlScalarType::String.nullable(false))
         .with_column("time", SqlScalarType::MzTimestamp.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the peek request."),
@@ -9068,6 +9075,7 @@ pub static MZ_ARRANGEMENT_SHARING: LazyLock<BuiltinView> = LazyLock::new(|| Buil
     desc: RelationDesc::builder()
         .with_column("operator_id", SqlScalarType::UInt64.nullable(false))
         .with_column("count", SqlScalarType::Int64.nullable(false))
+        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6314,7 +6314,6 @@ pub static MZ_DATAFLOW_ADDRESSES: LazyLock<BuiltinView> = LazyLock::new(|| Built
             }
             .nullable(false),
         )
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (
@@ -6344,7 +6343,6 @@ pub static MZ_DATAFLOW_CHANNELS: LazyLock<BuiltinView> = LazyLock::new(|| Builti
         .with_column("to_index", SqlScalarType::UInt64.nullable(false))
         .with_column("to_port", SqlScalarType::UInt64.nullable(false))
         .with_column("type", SqlScalarType::String.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the channel."),
@@ -6374,7 +6372,6 @@ pub static MZ_DATAFLOW_OPERATORS: LazyLock<BuiltinView> = LazyLock::new(|| Built
     desc: RelationDesc::builder()
         .with_column("id", SqlScalarType::UInt64.nullable(false))
         .with_column("name", SqlScalarType::String.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the operator."),
@@ -6394,7 +6391,6 @@ pub static MZ_DATAFLOW_GLOBAL_IDS: LazyLock<BuiltinView> = LazyLock::new(|| Buil
     desc: RelationDesc::builder()
         .with_column("id", SqlScalarType::UInt64.nullable(false))
         .with_column("global_id", SqlScalarType::String.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The dataflow ID."),
@@ -6444,7 +6440,6 @@ pub static MZ_LIR_MAPPING: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView 
         .with_column("nesting", SqlScalarType::UInt16.nullable(false))
         .with_column("operator_id_start", SqlScalarType::UInt64.nullable(false))
         .with_column("operator_id_end", SqlScalarType::UInt64.nullable(false))
-        .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("global_id", "The global ID."),
@@ -6579,7 +6574,6 @@ pub static MZ_COMPUTE_EXPORTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
     desc: RelationDesc::builder()
         .with_column("export_id", SqlScalarType::String.nullable(false))
         .with_column("dataflow_id", SqlScalarType::UInt64.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (
@@ -8751,7 +8745,6 @@ pub static MZ_ACTIVE_PEEKS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView
         .with_column("object_id", SqlScalarType::String.nullable(false))
         .with_column("type", SqlScalarType::String.nullable(false))
         .with_column("time", SqlScalarType::MzTimestamp.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The ID of the peek request."),
@@ -9075,7 +9068,6 @@ pub static MZ_ARRANGEMENT_SHARING: LazyLock<BuiltinView> = LazyLock::new(|| Buil
     desc: RelationDesc::builder()
         .with_column("operator_id", SqlScalarType::UInt64.nullable(false))
         .with_column("count", SqlScalarType::Int64.nullable(false))
-        .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
         (

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1215,24 +1215,6 @@ impl MirScalarExpr {
                                     .map(|(a, b)| a.clone().call_binary(b.clone(), func::Eq))
                                     .collect(),
                             )
-                        } else if matches!(*func, BinaryFunc::Eq(_))
-                            && (matches!(**expr1, MirScalarExpr::CallUnary { .. })
-                                || matches!(**expr2, MirScalarExpr::CallUnary { .. }))
-                        {
-                            // For equality predicates like `Cast(col) = literal`,
-                            // try to invert the cast to `col = inverse_cast(literal)`.
-                            // This enables index usage and key inference.
-                            // We only attempt this when at least one side is a function
-                            // call (potential cast), to avoid an infinite loop: without
-                            // this guard, `invert_casts_on_expr_eq_literal` can flip the
-                            // operand order even when no inversion occurs, which fights
-                            // with the canonical ordering above and prevents convergence.
-                            let rewritten = e.invert_casts_on_expr_eq_literal();
-                            if rewritten != *e {
-                                *e = rewritten;
-                            } else if e.impossible_literal_equality_because_types() {
-                                *e = MirScalarExpr::literal_false();
-                            }
                         }
                     }
                     MirScalarExpr::CallVariadic { .. } => {

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1215,10 +1215,18 @@ impl MirScalarExpr {
                                     .map(|(a, b)| a.clone().call_binary(b.clone(), func::Eq))
                                     .collect(),
                             )
-                        } else if matches!(*func, BinaryFunc::Eq(_)) {
+                        } else if matches!(*func, BinaryFunc::Eq(_))
+                            && (matches!(**expr1, MirScalarExpr::CallUnary { .. })
+                                || matches!(**expr2, MirScalarExpr::CallUnary { .. }))
+                        {
                             // For equality predicates like `Cast(col) = literal`,
                             // try to invert the cast to `col = inverse_cast(literal)`.
                             // This enables index usage and key inference.
+                            // We only attempt this when at least one side is a function
+                            // call (potential cast), to avoid an infinite loop: without
+                            // this guard, `invert_casts_on_expr_eq_literal` can flip the
+                            // operand order even when no inversion occurs, which fights
+                            // with the canonical ordering above and prevents convergence.
                             let rewritten = e.invert_casts_on_expr_eq_literal();
                             if rewritten != *e {
                                 *e = rewritten;

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -378,7 +378,8 @@ impl MirScalarExpr {
                 // Also, we don't want to insert a function call that doesn't preserve
                 // uniqueness. E.g., if `a` has an integer type, we don't want to do
                 // a surprise rounding for `WHERE a = 3.14`.
-                if func.preserves_uniqueness() && inverse_func.preserves_uniqueness() {
+                if func.preserves_uniqueness() {
+                    let inverse_preserves = inverse_func.preserves_uniqueness();
                     let lit_inv = eval(&MirScalarExpr::CallUnary {
                         func: inverse_func,
                         expr: Box::new(literal.clone()),
@@ -386,7 +387,20 @@ impl MirScalarExpr {
                     // The evaluation can error out, e.g., when casting a too large int32 to int16.
                     // This case is handled by `impossible_literal_equality_because_types`.
                     if !lit_inv.is_literal_err() {
-                        return (*inner_expr.clone(), lit_inv);
+                        if inverse_preserves {
+                            return (*inner_expr.clone(), lit_inv);
+                        }
+                        // When the inverse doesn't preserve uniqueness (e.g.,
+                        // numeric-to-uint64 rounds), verify with a round-trip:
+                        // func(inverse(literal)) must equal the original literal.
+                        // This ensures the inverse produced the exact pre-image.
+                        let round_trip = eval(&MirScalarExpr::CallUnary {
+                            func: func.clone(),
+                            expr: Box::new(lit_inv.clone()),
+                        });
+                        if !round_trip.is_literal_err() && round_trip == *literal {
+                            return (*inner_expr.clone(), lit_inv);
+                        }
                     }
                 }
             }
@@ -429,14 +443,28 @@ impl MirScalarExpr {
 
         if let MirScalarExpr::CallUnary { func, .. } = other_side {
             if let Some(inverse_func) = func.inverse() {
-                if inverse_func.preserves_uniqueness()
-                    && eval(&MirScalarExpr::CallUnary {
-                        func: inverse_func,
-                        expr: Box::new(literal.clone()),
-                    })
-                    .is_literal_err()
-                {
+                let lit_inv = eval(&MirScalarExpr::CallUnary {
+                    func: inverse_func.clone(),
+                    expr: Box::new(literal.clone()),
+                });
+                if inverse_func.preserves_uniqueness() && lit_inv.is_literal_err() {
                     return true;
+                }
+                // When the inverse doesn't preserve uniqueness but func does
+                // (e.g., uint64-to-numeric with numeric-to-uint64 inverse),
+                // the equality is impossible if the inverse errors OR if a
+                // round-trip check fails (the literal has no pre-image under func).
+                if func.preserves_uniqueness() && !inverse_func.preserves_uniqueness() {
+                    if lit_inv.is_literal_err() {
+                        return true;
+                    }
+                    let round_trip = eval(&MirScalarExpr::CallUnary {
+                        func: func.clone(),
+                        expr: Box::new(lit_inv),
+                    });
+                    if round_trip.is_literal_err() || round_trip != *literal {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1215,6 +1215,16 @@ impl MirScalarExpr {
                                     .map(|(a, b)| a.clone().call_binary(b.clone(), func::Eq))
                                     .collect(),
                             )
+                        } else if matches!(*func, BinaryFunc::Eq(_)) {
+                            // For equality predicates like `Cast(col) = literal`,
+                            // try to invert the cast to `col = inverse_cast(literal)`.
+                            // This enables index usage and key inference.
+                            let rewritten = e.invert_casts_on_expr_eq_literal();
+                            if rewritten != *e {
+                                *e = rewritten;
+                            } else if e.impossible_literal_equality_because_types() {
+                                *e = MirScalarExpr::literal_false();
+                            }
                         }
                     }
                     MirScalarExpr::CallVariadic { .. } => {

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -161,6 +161,10 @@ impl EagerUnaryFunc for CastInt16ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt16)
     }

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -177,6 +177,10 @@ impl EagerUnaryFunc for CastInt32ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt32)
     }

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -154,6 +154,10 @@ impl EagerUnaryFunc for CastInt64ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt64)
     }

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -143,6 +143,10 @@ impl EagerUnaryFunc for CastUint16ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint16)
     }

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -149,6 +149,10 @@ impl EagerUnaryFunc for CastUint32ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint32)
     }

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -153,6 +153,10 @@ impl EagerUnaryFunc for CastUint64ToNumeric {
         self.0.is_some()
     }
 
+    fn preserves_uniqueness(&self) -> bool {
+        true
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint64)
     }

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1416,3 +1416,99 @@ LIMIT 3 OFFSET 1;
 2  l2
 1  a
 1  l1
+
+# -------------------------------------------------------
+# Tests for cast inversion with unsigned integer types.
+# When a uint column is compared to an integer literal, the planner resolves to
+# (Numeric, Numeric) equality because there's no implicit cast from int4 to uint8.
+# The cast inversion in `invert_casts_on_expr_eq_literal` should move the cast from
+# the column to the literal, enabling index lookups.
+# -------------------------------------------------------
+
+statement ok
+CREATE TABLE t_uint(a uint8);
+
+statement ok
+CREATE INDEX idx_t_uint_a ON t_uint(a);
+
+statement ok
+INSERT INTO t_uint VALUES (0), (5), (42);
+
+# Integer literal comparison should use index lookup via cast inversion
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
+SELECT a FROM t_uint WHERE a = 5;
+----
+Explained Query (fast path):
+  Project (#0{a})
+    ReadIndex on=materialize.public.t_uint idx_t_uint_a=[lookup value=(5)]
+
+Used Indexes:
+  - materialize.public.idx_t_uint_a (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+query I
+SELECT a FROM t_uint WHERE a = 5;
+----
+5
+
+# IN list should also use index lookup
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
+SELECT a FROM t_uint WHERE a IN (0, 42);
+----
+Explained Query (fast path):
+  Project (#0{a})
+    ReadIndex on=materialize.public.t_uint idx_t_uint_a=[lookup values=[(0); (42)]]
+
+Used Indexes:
+  - materialize.public.idx_t_uint_a (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+query I rowsort
+SELECT a FROM t_uint WHERE a IN (0, 42);
+----
+0
+42
+
+# Negative literal: impossible equality (uint8 can't hold negative values)
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
+SELECT a FROM t_uint WHERE a = -1;
+----
+Explained Query (fast path):
+  Constant <empty>
+
+Target cluster: quickstart
+
+EOF
+
+query I
+SELECT a FROM t_uint WHERE a = -1;
+----
+
+# Fractional numeric literal: round-trip check should detect this as impossible
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, arity, join implementations) AS VERBOSE TEXT FOR
+SELECT a FROM t_uint WHERE a = 3.14;
+----
+Explained Query (fast path):
+  Constant <empty>
+
+Target cluster: quickstart
+
+EOF
+
+query I
+SELECT a FROM t_uint WHERE a = 3.14;
+----


### PR DESCRIPTION
## Summary

Fixes the optimizer so that filters like `uint_col = 0` can use indexes, instead of casting both sides to Numeric.

When a `UInt64` column is compared to an integer literal, the planner resolves to `(Numeric, Numeric)` equality (since there's no implicit cast from `Int32` to `UInt64`). This inserts `CastUint64ToNumeric` on the column side, preventing index usage. The existing `invert_casts_on_expr_eq_literal` mechanism should move the cast from the column to the literal, but it wasn't firing because:

1. The 6 `CastIntNToNumeric` / `CastUintNToNumeric` `EagerUnaryFunc` impls didn't override `preserves_uniqueness` (defaulting to `false`), even though integer-to-numeric is injective.
2. The inverse (`CastNumericToIntN`) doesn't preserve uniqueness (it rounds), and the old condition required **both** func and inverse to preserve uniqueness.

### Changes

- **Add `preserves_uniqueness() -> true`** to all 6 integer-to-numeric cast impls (`CastInt16ToNumeric`, `CastInt32ToNumeric`, `CastInt64ToNumeric`, `CastUint16ToNumeric`, `CastUint32ToNumeric`, `CastUint64ToNumeric`).
- **Add round-trip verification** to `invert_casts_on_expr_eq_literal_inner`: when the inverse doesn't preserve uniqueness, check that `func(inverse(literal)) == literal`. This safely confirms the inverse produced the exact pre-image without lossy rounding.
- **Apply same logic to `impossible_literal_equality_because_types`** so predicates like `uint_col = -1` or `uint_col = 3.14` are detected as impossible and constant-folded to empty.

### Motivation

This particularly affects introspection views like `mz_dataflow_addresses` that filter on `worker_id = 0` where `worker_id` is `uint8`. Without this fix, the Numeric cast prevents index usage. With this fix, the optimizer inverts the cast and produces `worker_id = 0::uint8`, enabling index lookups.

## Test plan

- [x] `cargo test -p mz-expr` — unit tests pass
- [ ] SLT tests added in `test/sqllogictest/transform/literal_constraints.slt` covering:
  - Index lookup on `uint8` column with integer literal
  - `IN` list with integer literals
  - Negative literal detected as impossible (`Constant <empty>`)
  - Fractional literal detected as impossible via round-trip check

https://claude.ai/code/session_01GH1nqb2vmcQTRhXQ1c8FY8