### PR TITLE
compute: insert temporal bucketing before ArrangeBy nodes

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/temporal.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/temporal.py
@@ -20,7 +20,7 @@ class TemporalFilter(Scenario):
 
 
 class TemporalFilterIndexed(TemporalFilter):
-    """Measure the time to create an index on a view with a temporal filter over 1M rows.
+    """Measure the time to create an index on a view with a temporal filter over 10M rows.
 
     The view applies a temporal filter (mz_now() range) on top of a materialized
     view joined with a table, ensuring the collection has future updates that
@@ -47,11 +47,11 @@ class TemporalFilterIndexed(TemporalFilter):
 
             > CREATE MATERIALIZED VIEW mv_temporal AS
               SELECT x, a
-              FROM generate_series(1, 1000000) AS x
+              FROM generate_series(1, 10000000) AS x
               CROSS JOIN anchor;
 
             > SELECT COUNT(*) FROM mv_temporal;
-            1000000
+            10000000
 
             > SELECT 1
               /* A */
@@ -66,5 +66,5 @@ class TemporalFilterIndexed(TemporalFilter):
 
             > SELECT COUNT(*) FROM v_temporal
               /* B */
-            1000000
+            10000000
         """))

--- a/misc/python/materialize/feature_benchmark/scenarios/temporal.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/temporal.py
@@ -1,0 +1,70 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from datetime import date, timedelta
+from textwrap import dedent
+
+from materialize.feature_benchmark.action import Action, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
+from materialize.feature_benchmark.scenario import Scenario
+
+
+class TemporalFilter(Scenario):
+    """Feature benchmarks related to temporal filters using mz_now()."""
+
+
+class TemporalFilterIndexed(TemporalFilter):
+    """Measure the time to create an index on a view with a temporal filter over 1M rows.
+
+    The view applies a temporal filter (mz_now() range) on top of a materialized
+    view joined with a table, ensuring the collection has future updates that
+    require temporal bucketing before arrangement.
+    """
+
+    FIXED_SCALE = True
+
+    def init(self) -> list[Action]:
+        return [
+            TdAction(dedent("""
+                > DROP TABLE IF EXISTS anchor CASCADE;
+                > CREATE TABLE anchor (a int);
+                > INSERT INTO anchor VALUES (1);
+            """)),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        today = date.today()
+        next_week = today + timedelta(days=7)
+        return Td(dedent(f"""
+            > DROP VIEW IF EXISTS v_temporal CASCADE;
+            > DROP MATERIALIZED VIEW IF EXISTS mv_temporal CASCADE;
+
+            > CREATE MATERIALIZED VIEW mv_temporal AS
+              SELECT x, a
+              FROM generate_series(1, 1000000) AS x
+              CROSS JOIN anchor;
+
+            > SELECT COUNT(*) FROM mv_temporal;
+            1000000
+
+            > SELECT 1
+              /* A */
+            1
+
+            > CREATE VIEW v_temporal AS
+              SELECT x, a FROM mv_temporal
+              WHERE mz_now() >= extract(epoch from timestamp '{today}')::uint8 * 1000
+                AND mz_now() < extract(epoch from timestamp '{next_week}')::uint8 * 1000;
+
+            > CREATE INDEX idx_temporal ON v_temporal (x);
+
+            > SELECT COUNT(*) FROM v_temporal
+              /* B */
+            1000000
+        """))

--- a/misc/python/materialize/feature_benchmark/scenarios/temporal.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/temporal.py
@@ -68,3 +68,55 @@ class TemporalFilterIndexed(TemporalFilter):
               /* B */
             10000000
         """))
+
+
+class TemporalFilterSustainedInsert(TemporalFilter):
+    """Measure ingestion latency through a temporal-filtered indexed view.
+
+    Pre-loads 10M rows into a table that's filtered by a temporal predicate,
+    with the filtered view indexed. Then drives several small inserts and
+    times how long it takes for the index to reflect them.
+
+    Each input row produces an insert at today + a retract at next-week
+    through the temporal MFP. Without bucketing both updates land in the
+    index's merge batcher, growing the arrangement spine; with bucketing,
+    only today's update lands in the spine while future retractions
+    accumulate in the BucketChain. The smaller spine keeps per-insert
+    incremental merge work cheaper and that work is on the critical path
+    of the trailing SELECT.
+    """
+
+    FIXED_SCALE = True
+
+    def benchmark(self) -> MeasurementSource:
+        today = date.today()
+        next_week = today + timedelta(days=7)
+        return Td(dedent(f"""
+            > DROP TABLE IF EXISTS t_temporal CASCADE;
+            > CREATE TABLE t_temporal (x int);
+            > INSERT INTO t_temporal SELECT generate_series(1, 10000000);
+
+            > CREATE VIEW v_temporal AS
+              SELECT x FROM t_temporal
+              WHERE mz_now() >= extract(epoch from timestamp '{today}')::uint8 * 1000
+                AND mz_now() < extract(epoch from timestamp '{next_week}')::uint8 * 1000;
+
+            > CREATE INDEX idx_temporal ON v_temporal (x);
+
+            > SELECT COUNT(*) FROM v_temporal;
+            10000000
+
+            > SELECT 1
+              /* A */
+            1
+
+            > INSERT INTO t_temporal SELECT generate_series(10000001, 10100000);
+            > INSERT INTO t_temporal SELECT generate_series(10100001, 10200000);
+            > INSERT INTO t_temporal SELECT generate_series(10200001, 10300000);
+            > INSERT INTO t_temporal SELECT generate_series(10300001, 10400000);
+            > INSERT INTO t_temporal SELECT generate_series(10400001, 10500000);
+
+            > SELECT COUNT(*) FROM v_temporal
+              /* B */
+            10500000
+        """))

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -60,7 +60,7 @@ pub const CORRECTION_V2_CHUNK_SIZE: Config<usize> = Config::new(
 );
 
 /// Whether to enable temporal bucketing in compute.
-pub const ENABLE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
+pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
     "enable_compute_temporal_bucketing",
     false,
     "Whether to enable temporal bucketing in compute.",
@@ -385,7 +385,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)
-        .add(&ENABLE_TEMPORAL_BUCKETING)
+        .add(&ENABLE_COMPUTE_TEMPORAL_BUCKETING)
         .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -488,6 +488,7 @@ impl Plan {
                 input,
                 input_mfp,
                 forms,
+                input_has_future_updates: _,
             } => {
                 ctx.indent.set();
                 if forms.raw && forms.arranged.is_empty() {
@@ -897,6 +898,7 @@ impl Plan {
                 input,
                 input_mfp,
                 forms,
+                input_has_future_updates: _,
             } => {
                 writeln!(f, "{}ArrangeBy{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| {

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -898,7 +898,7 @@ impl Plan {
                 input,
                 input_mfp,
                 forms,
-                input_has_future_updates: _,
+                input_has_future_updates,
             } => {
                 writeln!(f, "{}ArrangeBy{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| {
@@ -906,6 +906,9 @@ impl Plan {
                         let key = mode.seq(key, None);
                         let key = CompactScalars(key);
                         writeln!(f, "{}input_key=[{}]", ctx.indent, key)?;
+                    }
+                    if *input_has_future_updates {
+                        writeln!(f, "{}input_has_future_updates=true", ctx.indent)?;
                     }
                     mode.expr(input_mfp, None).fmt_text(f, ctx)?;
                     forms.fmt_text(f, ctx)?;

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -40,7 +40,7 @@ use crate::plan::reduce::{
     AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, MonotonicPlan, SingleBasicPlan,
 };
 use crate::plan::threshold::ThresholdPlan;
-use crate::plan::{AvailableCollections, LirId, Plan, PlanNode};
+use crate::plan::{ArrangementStrategy, AvailableCollections, LirId, Plan, PlanNode};
 
 impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
     fn fmt_text(
@@ -488,7 +488,7 @@ impl Plan {
                 input,
                 input_mfp,
                 forms,
-                input_has_future_updates: _,
+                strategy: _,
             } => {
                 ctx.indent.set();
                 if forms.raw && forms.arranged.is_empty() {
@@ -898,7 +898,7 @@ impl Plan {
                 input,
                 input_mfp,
                 forms,
-                input_has_future_updates,
+                strategy,
             } => {
                 writeln!(f, "{}ArrangeBy{}", ctx.indent, annotations)?;
                 ctx.indented(|ctx| {
@@ -907,8 +907,8 @@ impl Plan {
                         let key = CompactScalars(key);
                         writeln!(f, "{}input_key=[{}]", ctx.indent, key)?;
                     }
-                    if *input_has_future_updates {
-                        writeln!(f, "{}input_has_future_updates=true", ctx.indent)?;
+                    if !matches!(strategy, ArrangementStrategy::Direct) {
+                        writeln!(f, "{}strategy={:?}", ctx.indent, strategy)?;
                     }
                     mode.expr(input_mfp, None).fmt_text(f, ctx)?;
                     forms.fmt_text(f, ctx)?;

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -343,6 +343,10 @@ pub enum PlanNode {
         /// that will be added to those of the input. Does not include
         /// any other existing arrangements.
         forms: AvailableCollections,
+        /// Whether the input collection may contain updates with future timestamps,
+        /// e.g., from a temporal MFP using `mz_now()`. When true, the renderer
+        /// inserts temporal bucketing before forming arrangements.
+        input_has_future_updates: bool,
     },
 }
 
@@ -770,6 +774,7 @@ impl CollectionPlan for PlanNode {
                 input,
                 input_mfp: _,
                 forms: _,
+                input_has_future_updates: _,
             }
             | PlanNode::Reduce {
                 input_key: _,

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -125,7 +125,7 @@ pub enum ArrangementStrategy {
     Direct,
     /// Insert temporal bucketing in front of the arrangement, to delay future-stamped
     /// updates (e.g., from `mz_now()` MFPs) until their bucket boundary releases them.
-    /// Honoured only when `ENABLE_TEMPORAL_BUCKETING` is set; otherwise behaves like
+    /// Honoured only when `ENABLE_COMPUTE_TEMPORAL_BUCKETING` is set; otherwise behaves like
     /// `Direct`.
     TemporalBucketing,
 }

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -105,6 +105,31 @@ impl AvailableCollections {
     }
 }
 
+/// How to render the arrangements requested by an `ArrangeBy`.
+///
+/// Decided during LIR lowering and consumed by the renderer. The variant says what the
+/// renderer will do, not what it knows about the input.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize
+)]
+pub enum ArrangementStrategy {
+    /// Form arrangements directly from the input collection.
+    Direct,
+    /// Insert temporal bucketing in front of the arrangement, to delay future-stamped
+    /// updates (e.g., from `mz_now()` MFPs) until their bucket boundary releases them.
+    /// Honoured only when `ENABLE_TEMPORAL_BUCKETING` is set; otherwise behaves like
+    /// `Direct`.
+    TemporalBucketing,
+}
+
 /// An identifier for an LIR node.
 #[derive(
     Clone,
@@ -343,10 +368,8 @@ pub enum PlanNode {
         /// that will be added to those of the input. Does not include
         /// any other existing arrangements.
         forms: AvailableCollections,
-        /// Whether the input collection may contain updates with future timestamps,
-        /// e.g., from a temporal MFP using `mz_now()`. When true, the renderer
-        /// inserts temporal bucketing before forming arrangements.
-        input_has_future_updates: bool,
+        /// How the renderer should form the arrangements requested by `forms`.
+        strategy: ArrangementStrategy,
     },
 }
 
@@ -774,7 +797,7 @@ impl CollectionPlan for PlanNode {
                 input,
                 input_mfp: _,
                 forms: _,
-                input_has_future_updates: _,
+                strategy: _,
             }
             | PlanNode::Reduce {
                 input_key: _,

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -444,6 +444,7 @@ where
                     input,
                     input_mfp,
                     forms,
+                    input_has_future_updates: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -750,6 +751,7 @@ where
                     input,
                     input_mfp,
                     forms,
+                    input_has_future_updates: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -444,7 +444,7 @@ where
                     input,
                     input_mfp,
                     forms,
-                    input_has_future_updates: _,
+                    strategy: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -751,7 +751,7 @@ where
                     input,
                     input_mfp,
                     forms,
-                    input_has_future_updates: _,
+                    strategy: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -346,6 +346,7 @@ impl Context {
                                             input: body,
                                             input_mfp,
                                             forms,
+                                            input_has_future_updates: false,
                                         }
                                         .as_plan(inner_lir_id),
                                     ),
@@ -359,6 +360,7 @@ impl Context {
                                     input: Box::new(lir_value),
                                     input_mfp,
                                     forms,
+                                    input_has_future_updates: false,
                                 }
                                 .as_plan(lir_id)
                             }
@@ -876,6 +878,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             input: Box::new(input),
                             input_mfp,
                             forms,
+                            input_has_future_updates: false,
                         }
                         .as_plan(lir_id),
                         input_keys,
@@ -1058,6 +1061,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     input,
                     input_mfp,
                     mut forms,
+                    input_has_future_updates,
                 },
             lir_id,
         } = plan
@@ -1071,6 +1075,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 input,
                 input_mfp,
                 forms,
+                input_has_future_updates,
             }
             .as_plan(lir_id)
         } else {
@@ -1090,6 +1095,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 input: Box::new(plan),
                 input_mfp,
                 forms: collections,
+                input_has_future_updates: false,
             }
             .as_plan(lir_id)
         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -29,6 +29,17 @@ use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
 use crate::plan::{AvailableCollections, GetPlan, LirId, Plan, PlanNode};
 
+/// The result of lowering a [`MirRelationExpr`] to a [`Plan`].
+struct LoweredExpr {
+    /// The lowered plan.
+    plan: Plan,
+    /// The arrangement keys that the plan is certain to produce.
+    keys: AvailableCollections,
+    /// Whether the plan's output may contain updates at future timestamps,
+    /// e.g., from a temporal MFP using `mz_now()`.
+    has_future_updates: bool,
+}
+
 pub(super) struct Context {
     /// Known bindings to (possibly arranged) collections.
     arrangements: BTreeMap<Id, AvailableCollections>,
@@ -106,7 +117,11 @@ impl Context {
         let mut objects_to_build = Vec::with_capacity(desc.objects_to_build.len());
         for build in desc.objects_to_build {
             self.debug_info.id = build.id;
-            let (plan, keys, has_future_updates) = self.lower_mir_expr(&build.plan)?;
+            let LoweredExpr {
+                plan,
+                keys,
+                has_future_updates,
+            } = self.lower_mir_expr(&build.plan)?;
 
             self.arrangements.insert(Id::Global(build.id), keys);
             if has_future_updates {
@@ -147,10 +162,7 @@ impl Context {
     ///
     /// An empty list of arrangement keys indicates that only a `Collection` stream can
     /// be assumed to exist.
-    fn lower_mir_expr(
-        &mut self,
-        expr: &MirRelationExpr,
-    ) -> Result<(Plan, AvailableCollections, bool), String> {
+    fn lower_mir_expr(&mut self, expr: &MirRelationExpr) -> Result<LoweredExpr, String> {
         // This function is recursive and can overflow its stack, so grow it if
         // needed. The growth here is unbounded. Our general solution for this problem
         // is to use [`ore::stack::RecursionGuard`] to additionally limit the stack
@@ -163,10 +175,7 @@ impl Context {
         mz_ore::stack::maybe_grow(|| self.lower_mir_expr_stack_safe(expr))
     }
 
-    fn lower_mir_expr_stack_safe(
-        &mut self,
-        expr: &MirRelationExpr,
-    ) -> Result<(Plan, AvailableCollections, bool), String> {
+    fn lower_mir_expr_stack_safe(&mut self, expr: &MirRelationExpr) -> Result<LoweredExpr, String> {
         // Extract a maximally large MapFilterProject from `expr`.
         // We will then try and push this in to the resulting expression.
         //
@@ -176,7 +185,11 @@ impl Context {
         let (mut mfp, expr) = MapFilterProject::extract_from_expression(expr);
         // We attempt to plan what we have remaining, in the context of `mfp`.
         // We may not be able to do this, and must wrap some operators with a `Mfp` stage.
-        let (mut plan, mut keys, mut has_future_updates) = match expr {
+        let LoweredExpr {
+            mut plan,
+            mut keys,
+            mut has_future_updates,
+        } = match expr {
             // These operators should have been extracted from the expression.
             MirRelationExpr::Map { .. } => {
                 panic!("This operator should have been extracted");
@@ -198,7 +211,11 @@ impl Context {
                     }),
                 };
                 // The plan, not arranged in any way.
-                (node.as_plan(lir_id), AvailableCollections::new_raw(), false)
+                LoweredExpr {
+                    plan: node.as_plan(lir_id),
+                    keys: AvailableCollections::new_raw(),
+                    has_future_updates: false,
+                }
             }
             MirRelationExpr::Get { id, typ: _, .. } => {
                 // This stage can absorb arbitrary MFP operators.
@@ -282,7 +299,11 @@ impl Context {
                     plan,
                 };
                 // Return the plan, and any keys if an identity `mfp`.
-                (node.as_plan(lir_id), out_keys, has_future_updates)
+                LoweredExpr {
+                    plan: node.as_plan(lir_id),
+                    keys: out_keys,
+                    has_future_updates,
+                }
             }
             MirRelationExpr::Let { id, value, body } => {
                 // It would be unfortunate to have a non-trivial `mfp` here, as we hope
@@ -291,7 +312,11 @@ impl Context {
 
                 // Plan the value using only the initial arrangements, but
                 // introduce any resulting arrangements bound to `id`.
-                let (value, v_keys, v_future) = self.lower_mir_expr(value)?;
+                let LoweredExpr {
+                    plan: value,
+                    keys: v_keys,
+                    has_future_updates: v_future,
+                } = self.lower_mir_expr(value)?;
                 let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
                 assert_none!(pre_existing);
                 if v_future {
@@ -299,21 +324,25 @@ impl Context {
                 }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
-                let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
+                let LoweredExpr {
+                    plan: body,
+                    keys: b_keys,
+                    has_future_updates: b_future,
+                } = self.lower_mir_expr(body)?;
                 self.arrangements.remove(&Id::Local(*id));
                 self.has_future_updates.remove(&Id::Local(*id));
                 // Return the plan, and any `body` arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::Let {
+                LoweredExpr {
+                    plan: PlanNode::Let {
                         id: id.clone(),
                         value: Box::new(value),
                         body: Box::new(body),
                     }
                     .as_plan(lir_id),
-                    b_keys,
-                    b_future,
-                )
+                    keys: b_keys,
+                    has_future_updates: b_future,
+                }
             }
             MirRelationExpr::LetRec {
                 ids,
@@ -329,7 +358,11 @@ impl Context {
                 // as we cannot circulate an arrangement through a `Variable` yet.
                 let mut lir_values = Vec::with_capacity(values.len());
                 for (id, value) in ids.iter().zip_eq(values) {
-                    let (mut lir_value, mut v_keys, v_future) = self.lower_mir_expr(value)?;
+                    let LoweredExpr {
+                        plan: mut lir_value,
+                        keys: mut v_keys,
+                        has_future_updates: v_future,
+                    } = self.lower_mir_expr(value)?;
                     // If `v_keys` does not contain an unarranged collection, we must form it.
                     if !v_keys.raw {
                         // Choose an "arbitrary" arrangement; TODO: prefer a specific one.
@@ -405,24 +438,28 @@ impl Context {
                 }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
-                let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
+                let LoweredExpr {
+                    plan: body,
+                    keys: b_keys,
+                    has_future_updates: b_future,
+                } = self.lower_mir_expr(body)?;
                 for id in ids.iter() {
                     self.arrangements.remove(&Id::Local(*id));
                     self.has_future_updates.remove(&Id::Local(*id));
                 }
                 // Return the plan, and any `body` arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::LetRec {
+                LoweredExpr {
+                    plan: PlanNode::LetRec {
                         ids: ids.clone(),
                         values: lir_values,
                         limits: limits.clone(),
                         body: Box::new(body),
                     }
                     .as_plan(lir_id),
-                    b_keys,
-                    b_future,
-                )
+                    keys: b_keys,
+                    has_future_updates: b_future,
+                }
             }
             MirRelationExpr::FlatMap {
                 input: flat_map_input,
@@ -534,7 +571,11 @@ impl Context {
                     fused_with_reduce
                 } else {
                     // Couldn't fuse it with a `Reduce`, so lower as a normal `FlatMap`.
-                    let (input, keys, input_future) = self.lower_mir_expr(flat_map_input)?;
+                    let LoweredExpr {
+                        plan: input,
+                        keys,
+                        has_future_updates: input_future,
+                    } = self.lower_mir_expr(flat_map_input)?;
                     // This stage can absorb arbitrary MFP instances.
                     let mfp = mfp.take();
                     let mut exprs = exprs.clone();
@@ -557,8 +598,8 @@ impl Context {
 
                     let lir_id = self.allocate_lir_id();
                     // Return the plan, and no arrangements.
-                    (
-                        PlanNode::FlatMap {
+                    LoweredExpr {
+                        plan: PlanNode::FlatMap {
                             input_key,
                             input: Box::new(input),
                             exprs: exprs.clone(),
@@ -566,9 +607,9 @@ impl Context {
                             mfp_after: mfp,
                         }
                         .as_plan(lir_id),
-                        AvailableCollections::new_raw(),
-                        input_future,
-                    )
+                        keys: AvailableCollections::new_raw(),
+                        has_future_updates: input_future,
+                    }
                 }
             }
             MirRelationExpr::Join {
@@ -585,7 +626,11 @@ impl Context {
                 let mut input_arities = Vec::new();
                 let mut input_futures = Vec::new();
                 for input in inputs.iter() {
-                    let (plan, keys, input_future) = self.lower_mir_expr(input)?;
+                    let LoweredExpr {
+                        plan,
+                        keys,
+                        has_future_updates: input_future,
+                    } = self.lower_mir_expr(input)?;
                     input_arities.push(input.arity());
                     plans.push(plan);
                     input_keys.push(keys);
@@ -704,15 +749,15 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 }
                 // Return the plan, and no arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::Join {
+                LoweredExpr {
+                    plan: PlanNode::Join {
                         inputs: plans,
                         plan,
                     }
                     .as_plan(lir_id),
-                    AvailableCollections::new_raw(),
-                    any_input_future,
-                )
+                    keys: AvailableCollections::new_raw(),
+                    has_future_updates: any_input_future,
+                }
             }
             MirRelationExpr::Reduce {
                 input,
@@ -752,7 +797,11 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 expected_group_size,
             } => {
                 let arity = input.arity();
-                let (input, keys, input_future) = self.lower_mir_expr(input)?;
+                let LoweredExpr {
+                    plan: input,
+                    keys,
+                    has_future_updates: input_future,
+                } = self.lower_mir_expr(input)?;
 
                 let top_k_plan = TopKPlan::create_from(
                     group_key.clone(),
@@ -779,19 +828,23 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 };
                 // Return the plan, and no arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::TopK {
+                LoweredExpr {
+                    plan: PlanNode::TopK {
                         input: Box::new(input),
                         top_k_plan,
                     }
                     .as_plan(lir_id),
-                    AvailableCollections::new_raw(),
-                    input_future,
-                )
+                    keys: AvailableCollections::new_raw(),
+                    has_future_updates: input_future,
+                }
             }
             MirRelationExpr::Negate { input } => {
                 let arity = input.arity();
-                let (input, keys, input_future) = self.lower_mir_expr(input)?;
+                let LoweredExpr {
+                    plan: input,
+                    keys,
+                    has_future_updates: input_future,
+                } = self.lower_mir_expr(input)?;
 
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
@@ -808,17 +861,21 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 };
                 // Return the plan, and no arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::Negate {
+                LoweredExpr {
+                    plan: PlanNode::Negate {
                         input: Box::new(input),
                     }
                     .as_plan(lir_id),
-                    AvailableCollections::new_raw(),
-                    input_future,
-                )
+                    keys: AvailableCollections::new_raw(),
+                    has_future_updates: input_future,
+                }
             }
             MirRelationExpr::Threshold { input } => {
-                let (plan, keys, input_future) = self.lower_mir_expr(input)?;
+                let LoweredExpr {
+                    plan,
+                    keys,
+                    has_future_updates: input_future,
+                } = self.lower_mir_expr(input)?;
                 let arity = input.arity();
                 let (threshold_plan, required_arrangement) = ThresholdPlan::create_from(arity);
                 let plan = if !keys
@@ -840,59 +897,67 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 let output_keys = threshold_plan.keys();
                 // Return the plan, and any produced keys.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::Threshold {
+                LoweredExpr {
+                    plan: PlanNode::Threshold {
                         input: Box::new(plan),
                         threshold_plan,
                     }
                     .as_plan(lir_id),
-                    output_keys,
-                    input_future,
-                )
+                    keys: output_keys,
+                    has_future_updates: input_future,
+                }
             }
             MirRelationExpr::Union { base, inputs } => {
                 let arity = base.arity();
-                let mut plans_keys_futures = Vec::with_capacity(1 + inputs.len());
-                let (plan, keys, future) = self.lower_mir_expr(base)?;
-                plans_keys_futures.push((plan, keys, future));
+                let mut lowered_inputs = Vec::with_capacity(1 + inputs.len());
+                lowered_inputs.push(self.lower_mir_expr(base)?);
                 for input in inputs.iter() {
-                    let (plan, keys, future) = self.lower_mir_expr(input)?;
-                    plans_keys_futures.push((plan, keys, future));
+                    lowered_inputs.push(self.lower_mir_expr(input)?);
                 }
-                let any_future = plans_keys_futures.iter().any(|(_, _, f)| *f);
-                let plans = plans_keys_futures
+                let any_future = lowered_inputs.iter().any(|l| l.has_future_updates);
+                let plans = lowered_inputs
                     .into_iter()
-                    .map(|(plan, keys, future)| {
-                        // We don't have an MFP here -- install an operator to permute the
-                        // input, if necessary.
-                        if !keys.raw {
-                            self.arrange_by(
-                                plan,
-                                AvailableCollections::new_raw(),
-                                &keys,
-                                arity,
-                                future,
-                            )
-                        } else {
-                            plan
-                        }
-                    })
+                    .map(
+                        |LoweredExpr {
+                             plan,
+                             keys,
+                             has_future_updates: future,
+                         }| {
+                            // We don't have an MFP here -- install an operator to permute the
+                            // input, if necessary.
+                            if !keys.raw {
+                                self.arrange_by(
+                                    plan,
+                                    AvailableCollections::new_raw(),
+                                    &keys,
+                                    arity,
+                                    future,
+                                )
+                            } else {
+                                plan
+                            }
+                        },
+                    )
                     .collect();
                 // Return the plan and no arrangements.
                 let lir_id = self.allocate_lir_id();
-                (
-                    PlanNode::Union {
+                LoweredExpr {
+                    plan: PlanNode::Union {
                         inputs: plans,
                         consolidate_output: false,
                     }
                     .as_plan(lir_id),
-                    AvailableCollections::new_raw(),
-                    any_future,
-                )
+                    keys: AvailableCollections::new_raw(),
+                    has_future_updates: any_future,
+                }
             }
             MirRelationExpr::ArrangeBy { input, keys } => {
                 let input_mir = input;
-                let (input, mut input_keys, future) = self.lower_mir_expr(input)?;
+                let LoweredExpr {
+                    plan: input,
+                    keys: mut input_keys,
+                    has_future_updates: future,
+                } = self.lower_mir_expr(input)?;
                 // Fill the `types` in `input_keys` if not already present.
                 let arity = input_mir.arity();
 
@@ -903,7 +968,11 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     .cloned()
                     .collect::<Vec<_>>();
                 if new_keys.is_empty() {
-                    (input, input_keys, future)
+                    LoweredExpr {
+                        plan: input,
+                        keys: input_keys,
+                        has_future_updates: future,
+                    }
                 } else {
                     let mut new_keys = new_keys
                         .iter()
@@ -931,8 +1000,8 @@ This is not expected to cause incorrect results, but could indicate a performanc
 
                     // Return the plan and extended keys.
                     let lir_id = self.allocate_lir_id();
-                    (
-                        PlanNode::ArrangeBy {
+                    LoweredExpr {
+                        plan: PlanNode::ArrangeBy {
                             input_key,
                             input: Box::new(input),
                             input_mfp,
@@ -940,9 +1009,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             input_has_future_updates: future,
                         }
                         .as_plan(lir_id),
-                        input_keys,
-                        future,
-                    )
+                        keys: input_keys,
+                        has_future_updates: future,
+                    }
                 }
             }
         };
@@ -1036,7 +1105,11 @@ This is not expected to cause incorrect results, but could indicate a performanc
             }
         }
 
-        Ok((plan, keys, has_future_updates))
+        Ok(LoweredExpr {
+            plan,
+            keys,
+            has_future_updates,
+        })
     }
 
     /// Lowers a `Reduce` with the given fields and an `mfp_on_top`, which is the MFP that is
@@ -1052,9 +1125,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
         expected_group_size: &Option<u64>,
         mfp_on_top: &mut MapFilterProject,
         fused_unnest_list: bool,
-    ) -> Result<(Plan, AvailableCollections, bool), String> {
+    ) -> Result<LoweredExpr, String> {
         let input_arity = input.arity();
-        let (input, keys, input_future) = self.lower_mir_expr(input)?;
+        let LoweredExpr {
+            plan: input,
+            keys,
+            has_future_updates: input_future,
+        } = self.lower_mir_expr(input)?;
         let (input_key, permutation_and_new_arity) =
             if let Some((input_key, permutation, thinning)) = keys.arbitrary_arrangement() {
                 (
@@ -1095,8 +1172,8 @@ This is not expected to cause incorrect results, but could indicate a performanc
         );
         let output_keys = reduce_plan.keys(group_key.len(), output_arity);
         let lir_id = self.allocate_lir_id();
-        Ok((
-            PlanNode::Reduce {
+        Ok(LoweredExpr {
+            plan: PlanNode::Reduce {
                 input_key,
                 input: Box::new(input),
                 key_val_plan,
@@ -1104,9 +1181,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 mfp_after,
             }
             .as_plan(lir_id),
-            output_keys,
-            input_future,
-        ))
+            keys: output_keys,
+            has_future_updates: input_future,
+        })
     }
 
     /// Replace the plan with another one

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -766,7 +766,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
                 let input = if !keys.raw {
-                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity, input_future)
+                    self.arrange_by(
+                        input,
+                        AvailableCollections::new_raw(),
+                        &keys,
+                        arity,
+                        input_future,
+                    )
                 } else {
                     input
                 };
@@ -830,7 +836,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         // We don't have an MFP here -- install an operator to permute the
                         // input, if necessary.
                         if !keys.raw {
-                            self.arrange_by(plan, AvailableCollections::new_raw(), &keys, arity, future)
+                            self.arrange_by(
+                                plan,
+                                AvailableCollections::new_raw(),
+                                &keys,
+                                arity,
+                                future,
+                            )
                         } else {
                             plan
                         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -357,12 +357,14 @@ impl Context {
                 // Arrangements made available cannot be used by prior bindings,
                 // as we cannot circulate an arrangement through a `Variable` yet.
                 let mut lir_values = Vec::with_capacity(values.len());
+                let mut any_v_future = false;
                 for (id, value) in ids.iter().zip_eq(values) {
                     let LoweredExpr {
                         plan: mut lir_value,
                         keys: mut v_keys,
                         has_future_updates: v_future,
                     } = self.lower_mir_expr(value)?;
+                    any_v_future |= v_future;
                     // If `v_keys` does not contain an unarranged collection, we must form it.
                     if !v_keys.raw {
                         // Choose an "arbitrary" arrangement; TODO: prefer a specific one.
@@ -380,6 +382,9 @@ impl Context {
                         // anything between two `LetRec`s. So if `lir_value` is itself a `LetRec`,
                         // then we insert the `ArrangeBy` on the `body` of the inner `LetRec`,
                         // instead of on top of the inner `LetRec`.
+                        //
+                        // We forward `v_future` for honesty; bucketing has no observable effect
+                        // inside an iterative scope, but the field should reflect reality.
                         lir_value = match lir_value {
                             Plan {
                                 node:
@@ -402,7 +407,7 @@ impl Context {
                                             input: body,
                                             input_mfp,
                                             forms,
-                                            input_has_future_updates: false,
+                                            input_has_future_updates: v_future,
                                         }
                                         .as_plan(inner_lir_id),
                                     ),
@@ -416,7 +421,7 @@ impl Context {
                                     input: Box::new(lir_value),
                                     input_mfp,
                                     forms,
-                                    input_has_future_updates: false,
+                                    input_has_future_updates: v_future,
                                 }
                                 .as_plan(lir_id)
                             }
@@ -448,6 +453,15 @@ impl Context {
                     self.has_future_updates.remove(&Id::Local(*id));
                 }
                 // Return the plan, and any `body` arrangements.
+                //
+                // The body's `b_future` alone can under-report: an earlier binding may only
+                // inherit `has_future_updates` via a Variable to a *later* binding, which the
+                // sequential sweep can't observe at the time the earlier binding is lowered.
+                // A precise fix would require a fixpoint (or the MIR `Analysis` framework with
+                // a `true ⊑ false` lattice). As a cheap correct alternative, OR with the
+                // bindings' future flags: any cross-binding propagation must originate from a
+                // local temporal predicate inside *some* binding, so the OR captures it
+                // without forcing bucketing on a fully non-temporal LetRec.
                 let lir_id = self.allocate_lir_id();
                 LoweredExpr {
                     plan: PlanNode::LetRec {
@@ -458,7 +472,7 @@ impl Context {
                     }
                     .as_plan(lir_id),
                     keys: b_keys,
-                    has_future_updates: b_future,
+                    has_future_updates: b_future || any_v_future,
                 }
             }
             MirRelationExpr::FlatMap {
@@ -597,6 +611,9 @@ impl Context {
                     };
 
                     let lir_id = self.allocate_lir_id();
+                    // The absorbed `mfp` may contain temporal predicates, which can
+                    // introduce future-stamped updates that aren't present on the input.
+                    let has_future_updates = input_future || mfp.has_temporal_predicates();
                     // Return the plan, and no arrangements.
                     LoweredExpr {
                         plan: PlanNode::FlatMap {
@@ -608,7 +625,7 @@ impl Context {
                         }
                         .as_plan(lir_id),
                         keys: AvailableCollections::new_raw(),
-                        has_future_updates: input_future,
+                        has_future_updates,
                     }
                 }
             }
@@ -748,6 +765,10 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                 }
                 // Return the plan, and no arrangements.
+                // Both linear and delta join planning extract temporal predicates back into the
+                // residual `mfp` (see `LinearJoinPlan::create_from` / `DeltaJoinPlan::create_from`),
+                // so the absorbed MFP cannot introduce future updates — the join's output future
+                // flag is just the OR of its inputs.
                 let lir_id = self.allocate_lir_id();
                 LoweredExpr {
                     plan: PlanNode::Join {
@@ -1172,6 +1193,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
         );
         let output_keys = reduce_plan.keys(group_key.len(), output_arity);
         let lir_id = self.allocate_lir_id();
+        // `extract_mfp_after` strips temporal predicates back into `*mfp_on_top` (the residual
+        // MFP installed above the reduce), so `mfp_after` is non-temporal and cannot introduce
+        // future updates. The output's future flag is just whatever the input had.
         Ok(LoweredExpr {
             plan: PlanNode::Reduce {
                 input_key,

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -9,7 +9,7 @@
 
 //! Lowering [`DataflowDescription`]s from MIR ([`MirRelationExpr`]) to LIR ([`Plan`]).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use columnar::Len;
 use itertools::Itertools;
@@ -32,6 +32,9 @@ use crate::plan::{AvailableCollections, GetPlan, LirId, Plan, PlanNode};
 pub(super) struct Context {
     /// Known bindings to (possibly arranged) collections.
     arrangements: BTreeMap<Id, AvailableCollections>,
+    /// Ids whose collections may contain updates at future timestamps,
+    /// e.g., from a temporal MFP using `mz_now()`.
+    has_future_updates: BTreeSet<Id>,
     /// Tracks the next available `LirId`.
     next_lir_id: LirId,
     /// Information to print along with error messages.
@@ -44,6 +47,7 @@ impl Context {
     pub fn new(debug_name: String, features: &OptimizerFeatures) -> Self {
         Self {
             arrangements: Default::default(),
+            has_future_updates: Default::default(),
             next_lir_id: LirId(1),
             debug_info: LirDebugInfo {
                 debug_name,
@@ -102,9 +106,12 @@ impl Context {
         let mut objects_to_build = Vec::with_capacity(desc.objects_to_build.len());
         for build in desc.objects_to_build {
             self.debug_info.id = build.id;
-            let (plan, keys, _has_future_updates) = self.lower_mir_expr(&build.plan)?;
+            let (plan, keys, has_future_updates) = self.lower_mir_expr(&build.plan)?;
 
             self.arrangements.insert(Id::Global(build.id), keys);
+            if has_future_updates {
+                self.has_future_updates.insert(Id::Global(build.id));
+            }
             objects_to_build.push(BuildDesc { id: build.id, plan });
         }
 
@@ -261,7 +268,7 @@ impl Context {
                     GetPlan::Arrangement(_, _, mfp) | GetPlan::Collection(mfp) => {
                         mfp.has_temporal_predicates()
                     }
-                    GetPlan::PassArrangements => false,
+                    GetPlan::PassArrangements => self.has_future_updates.contains(id),
                 };
 
                 let lir_id = self.allocate_lir_id();
@@ -280,13 +287,17 @@ impl Context {
 
                 // Plan the value using only the initial arrangements, but
                 // introduce any resulting arrangements bound to `id`.
-                let (value, v_keys, _v_future) = self.lower_mir_expr(value)?;
+                let (value, v_keys, v_future) = self.lower_mir_expr(value)?;
                 let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
                 assert_none!(pre_existing);
+                if v_future {
+                    self.has_future_updates.insert(Id::Local(*id));
+                }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
                 let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
                 self.arrangements.remove(&Id::Local(*id));
+                self.has_future_updates.remove(&Id::Local(*id));
                 // Return the plan, and any `body` arrangements.
                 let lir_id = self.allocate_lir_id();
                 (
@@ -314,7 +325,7 @@ impl Context {
                 // as we cannot circulate an arrangement through a `Variable` yet.
                 let mut lir_values = Vec::with_capacity(values.len());
                 for (id, value) in ids.iter().zip_eq(values) {
-                    let (mut lir_value, mut v_keys, _v_future) = self.lower_mir_expr(value)?;
+                    let (mut lir_value, mut v_keys, v_future) = self.lower_mir_expr(value)?;
                     // If `v_keys` does not contain an unarranged collection, we must form it.
                     if !v_keys.raw {
                         // Choose an "arbitrary" arrangement; TODO: prefer a specific one.
@@ -377,6 +388,9 @@ impl Context {
                     }
                     let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
                     assert_none!(pre_existing);
+                    if v_future {
+                        self.has_future_updates.insert(Id::Local(*id));
+                    }
                     lir_values.push(lir_value);
                 }
                 // As we exit the iterative scope, we must leave all arrangements behind,
@@ -390,6 +404,7 @@ impl Context {
                 let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
                 for id in ids.iter() {
                     self.arrangements.remove(&Id::Local(*id));
+                    self.has_future_updates.remove(&Id::Local(*id));
                 }
                 // Return the plan, and any `body` arrangements.
                 let lir_id = self.allocate_lir_id();

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -102,7 +102,7 @@ impl Context {
         let mut objects_to_build = Vec::with_capacity(desc.objects_to_build.len());
         for build in desc.objects_to_build {
             self.debug_info.id = build.id;
-            let (plan, keys) = self.lower_mir_expr(&build.plan)?;
+            let (plan, keys, _has_future_updates) = self.lower_mir_expr(&build.plan)?;
 
             self.arrangements.insert(Id::Global(build.id), keys);
             objects_to_build.push(BuildDesc { id: build.id, plan });
@@ -143,7 +143,7 @@ impl Context {
     fn lower_mir_expr(
         &mut self,
         expr: &MirRelationExpr,
-    ) -> Result<(Plan, AvailableCollections), String> {
+    ) -> Result<(Plan, AvailableCollections, bool), String> {
         // This function is recursive and can overflow its stack, so grow it if
         // needed. The growth here is unbounded. Our general solution for this problem
         // is to use [`ore::stack::RecursionGuard`] to additionally limit the stack
@@ -159,7 +159,7 @@ impl Context {
     fn lower_mir_expr_stack_safe(
         &mut self,
         expr: &MirRelationExpr,
-    ) -> Result<(Plan, AvailableCollections), String> {
+    ) -> Result<(Plan, AvailableCollections, bool), String> {
         // Extract a maximally large MapFilterProject from `expr`.
         // We will then try and push this in to the resulting expression.
         //
@@ -169,7 +169,7 @@ impl Context {
         let (mut mfp, expr) = MapFilterProject::extract_from_expression(expr);
         // We attempt to plan what we have remaining, in the context of `mfp`.
         // We may not be able to do this, and must wrap some operators with a `Mfp` stage.
-        let (mut plan, mut keys) = match expr {
+        let (mut plan, mut keys, mut has_future_updates) = match expr {
             // These operators should have been extracted from the expression.
             MirRelationExpr::Map { .. } => {
                 panic!("This operator should have been extracted");
@@ -191,7 +191,7 @@ impl Context {
                     }),
                 };
                 // The plan, not arranged in any way.
-                (node.as_plan(lir_id), AvailableCollections::new_raw())
+                (node.as_plan(lir_id), AvailableCollections::new_raw(), false)
             }
             MirRelationExpr::Get { id, typ: _, .. } => {
                 // This stage can absorb arbitrary MFP operators.
@@ -257,6 +257,13 @@ impl Context {
                     AvailableCollections::new_raw()
                 };
 
+                let has_future_updates = match &plan {
+                    GetPlan::Arrangement(_, _, mfp) | GetPlan::Collection(mfp) => {
+                        mfp.has_temporal_predicates()
+                    }
+                    GetPlan::PassArrangements => false,
+                };
+
                 let lir_id = self.allocate_lir_id();
                 let node = PlanNode::Get {
                     id: id.clone(),
@@ -264,7 +271,7 @@ impl Context {
                     plan,
                 };
                 // Return the plan, and any keys if an identity `mfp`.
-                (node.as_plan(lir_id), out_keys)
+                (node.as_plan(lir_id), out_keys, has_future_updates)
             }
             MirRelationExpr::Let { id, value, body } => {
                 // It would be unfortunate to have a non-trivial `mfp` here, as we hope
@@ -273,12 +280,12 @@ impl Context {
 
                 // Plan the value using only the initial arrangements, but
                 // introduce any resulting arrangements bound to `id`.
-                let (value, v_keys) = self.lower_mir_expr(value)?;
+                let (value, v_keys, _v_future) = self.lower_mir_expr(value)?;
                 let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
                 assert_none!(pre_existing);
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
-                let (body, b_keys) = self.lower_mir_expr(body)?;
+                let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
                 self.arrangements.remove(&Id::Local(*id));
                 // Return the plan, and any `body` arrangements.
                 let lir_id = self.allocate_lir_id();
@@ -290,6 +297,7 @@ impl Context {
                     }
                     .as_plan(lir_id),
                     b_keys,
+                    b_future,
                 )
             }
             MirRelationExpr::LetRec {
@@ -306,7 +314,7 @@ impl Context {
                 // as we cannot circulate an arrangement through a `Variable` yet.
                 let mut lir_values = Vec::with_capacity(values.len());
                 for (id, value) in ids.iter().zip_eq(values) {
-                    let (mut lir_value, mut v_keys) = self.lower_mir_expr(value)?;
+                    let (mut lir_value, mut v_keys, _v_future) = self.lower_mir_expr(value)?;
                     // If `v_keys` does not contain an unarranged collection, we must form it.
                     if !v_keys.raw {
                         // Choose an "arbitrary" arrangement; TODO: prefer a specific one.
@@ -379,7 +387,7 @@ impl Context {
                 }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
-                let (body, b_keys) = self.lower_mir_expr(body)?;
+                let (body, b_keys, b_future) = self.lower_mir_expr(body)?;
                 for id in ids.iter() {
                     self.arrangements.remove(&Id::Local(*id));
                 }
@@ -394,6 +402,7 @@ impl Context {
                     }
                     .as_plan(lir_id),
                     b_keys,
+                    b_future,
                 )
             }
             MirRelationExpr::FlatMap {
@@ -506,7 +515,7 @@ impl Context {
                     fused_with_reduce
                 } else {
                     // Couldn't fuse it with a `Reduce`, so lower as a normal `FlatMap`.
-                    let (input, keys) = self.lower_mir_expr(flat_map_input)?;
+                    let (input, keys, input_future) = self.lower_mir_expr(flat_map_input)?;
                     // This stage can absorb arbitrary MFP instances.
                     let mfp = mfp.take();
                     let mut exprs = exprs.clone();
@@ -539,6 +548,7 @@ impl Context {
                         }
                         .as_plan(lir_id),
                         AvailableCollections::new_raw(),
+                        input_future,
                     )
                 }
             }
@@ -555,7 +565,7 @@ impl Context {
                 let mut input_keys = Vec::new();
                 let mut input_arities = Vec::new();
                 for input in inputs.iter() {
-                    let (plan, keys) = self.lower_mir_expr(input)?;
+                    let (plan, keys, _input_future) = self.lower_mir_expr(input)?;
                     input_arities.push(input.arity());
                     plans.push(plan);
                     input_keys.push(keys);
@@ -665,7 +675,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             }
                             .as_plan(lir_id),
                         );
-                        *input_plan = self.arrange_by(raw_plan, missing, input_keys, arity);
+                        *input_plan = self.arrange_by(raw_plan, missing, input_keys, arity, false);
                     }
                 }
                 // Return the plan, and no arrangements.
@@ -677,6 +687,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
+                    false,
                 )
             }
             MirRelationExpr::Reduce {
@@ -717,7 +728,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 expected_group_size,
             } => {
                 let arity = input.arity();
-                let (input, keys) = self.lower_mir_expr(input)?;
+                let (input, keys, _input_future) = self.lower_mir_expr(input)?;
 
                 let top_k_plan = TopKPlan::create_from(
                     group_key.clone(),
@@ -732,7 +743,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
                 let input = if !keys.raw {
-                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity)
+                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity, false)
                 } else {
                     input
                 };
@@ -745,16 +756,17 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
+                    false,
                 )
             }
             MirRelationExpr::Negate { input } => {
                 let arity = input.arity();
-                let (input, keys) = self.lower_mir_expr(input)?;
+                let (input, keys, input_future) = self.lower_mir_expr(input)?;
 
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
                 let input = if !keys.raw {
-                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity)
+                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity, input_future)
                 } else {
                     input
                 };
@@ -766,10 +778,11 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
+                    input_future,
                 )
             }
             MirRelationExpr::Threshold { input } => {
-                let (plan, keys) = self.lower_mir_expr(input)?;
+                let (plan, keys, _input_future) = self.lower_mir_expr(input)?;
                 let arity = input.arity();
                 let (threshold_plan, required_arrangement) = ThresholdPlan::create_from(arity);
                 let plan = if !keys
@@ -782,6 +795,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         AvailableCollections::new_arranged(vec![required_arrangement]),
                         &keys,
                         arity,
+                        false,
                     )
                 } else {
                     plan
@@ -797,24 +811,26 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     output_keys,
+                    false,
                 )
             }
             MirRelationExpr::Union { base, inputs } => {
                 let arity = base.arity();
-                let mut plans_keys = Vec::with_capacity(1 + inputs.len());
-                let (plan, keys) = self.lower_mir_expr(base)?;
-                plans_keys.push((plan, keys));
+                let mut plans_keys_futures = Vec::with_capacity(1 + inputs.len());
+                let (plan, keys, future) = self.lower_mir_expr(base)?;
+                plans_keys_futures.push((plan, keys, future));
                 for input in inputs.iter() {
-                    let (plan, keys) = self.lower_mir_expr(input)?;
-                    plans_keys.push((plan, keys));
+                    let (plan, keys, future) = self.lower_mir_expr(input)?;
+                    plans_keys_futures.push((plan, keys, future));
                 }
-                let plans = plans_keys
+                let any_future = plans_keys_futures.iter().any(|(_, _, f)| *f);
+                let plans = plans_keys_futures
                     .into_iter()
-                    .map(|(plan, keys)| {
+                    .map(|(plan, keys, future)| {
                         // We don't have an MFP here -- install an operator to permute the
                         // input, if necessary.
                         if !keys.raw {
-                            self.arrange_by(plan, AvailableCollections::new_raw(), &keys, arity)
+                            self.arrange_by(plan, AvailableCollections::new_raw(), &keys, arity, future)
                         } else {
                             plan
                         }
@@ -829,11 +845,12 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
+                    any_future,
                 )
             }
             MirRelationExpr::ArrangeBy { input, keys } => {
                 let input_mir = input;
-                let (input, mut input_keys) = self.lower_mir_expr(input)?;
+                let (input, mut input_keys, future) = self.lower_mir_expr(input)?;
                 // Fill the `types` in `input_keys` if not already present.
                 let arity = input_mir.arity();
 
@@ -844,7 +861,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     .cloned()
                     .collect::<Vec<_>>();
                 if new_keys.is_empty() {
-                    (input, input_keys)
+                    (input, input_keys, future)
                 } else {
                     let mut new_keys = new_keys
                         .iter()
@@ -878,10 +895,11 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             input: Box::new(input),
                             input_mfp,
                             forms,
-                            input_has_future_updates: false,
+                            input_has_future_updates: future,
                         }
                         .as_plan(lir_id),
                         input_keys,
+                        future,
                     )
                 }
             }
@@ -889,6 +907,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
 
         // If the plan stage did not absorb all linear operators, introduce a new stage to implement them.
         if !mfp.is_identity() {
+            // Check if this MFP introduces future updates.
+            let mfp_is_temporal = mfp.has_temporal_predicates();
+            has_future_updates = has_future_updates || mfp_is_temporal;
             // Seek out an arrangement key that might be constrained to a literal.
             // TODO: Improve key selection heuristic.
             let key_val = keys
@@ -973,7 +994,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             }
         }
 
-        Ok((plan, keys))
+        Ok((plan, keys, has_future_updates))
     }
 
     /// Lowers a `Reduce` with the given fields and an `mfp_on_top`, which is the MFP that is
@@ -989,9 +1010,9 @@ This is not expected to cause incorrect results, but could indicate a performanc
         expected_group_size: &Option<u64>,
         mfp_on_top: &mut MapFilterProject,
         fused_unnest_list: bool,
-    ) -> Result<(Plan, AvailableCollections), String> {
+    ) -> Result<(Plan, AvailableCollections, bool), String> {
         let input_arity = input.arity();
-        let (input, keys) = self.lower_mir_expr(input)?;
+        let (input, keys, _input_future) = self.lower_mir_expr(input)?;
         let (input_key, permutation_and_new_arity) =
             if let Some((input_key, permutation, thinning)) = keys.arbitrary_arrangement() {
                 (
@@ -1042,6 +1063,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             }
             .as_plan(lir_id),
             output_keys,
+            false,
         ))
     }
 
@@ -1053,6 +1075,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
         collections: AvailableCollections,
         old_collections: &AvailableCollections,
         arity: usize,
+        has_future_updates: bool,
     ) -> Plan {
         if let Plan {
             node:
@@ -1095,7 +1118,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 input: Box::new(plan),
                 input_mfp,
                 forms: collections,
-                input_has_future_updates: false,
+                input_has_future_updates: has_future_updates,
             }
             .as_plan(lir_id)
         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -27,7 +27,17 @@ use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
 use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
-use crate::plan::{AvailableCollections, GetPlan, LirId, Plan, PlanNode};
+use crate::plan::{ArrangementStrategy, AvailableCollections, GetPlan, LirId, Plan, PlanNode};
+
+/// Pick an [`ArrangementStrategy`] based on whether the input may contain future-stamped
+/// updates. Future updates are the only case where temporal bucketing pays off.
+fn strategy_from_future(has_future_updates: bool) -> ArrangementStrategy {
+    if has_future_updates {
+        ArrangementStrategy::TemporalBucketing
+    } else {
+        ArrangementStrategy::Direct
+    }
+}
 
 /// The result of lowering a [`MirRelationExpr`] to a [`Plan`].
 struct LoweredExpr {
@@ -407,7 +417,7 @@ impl Context {
                                             input: body,
                                             input_mfp,
                                             forms,
-                                            input_has_future_updates: v_future,
+                                            strategy: strategy_from_future(v_future),
                                         }
                                         .as_plan(inner_lir_id),
                                     ),
@@ -421,7 +431,7 @@ impl Context {
                                     input: Box::new(lir_value),
                                     input_mfp,
                                     forms,
-                                    input_has_future_updates: v_future,
+                                    strategy: strategy_from_future(v_future),
                                 }
                                 .as_plan(lir_id)
                             }
@@ -1027,7 +1037,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             input: Box::new(input),
                             input_mfp,
                             forms,
-                            input_has_future_updates: future,
+                            strategy: strategy_from_future(future),
                         }
                         .as_plan(lir_id),
                         keys: input_keys,
@@ -1227,7 +1237,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     input,
                     input_mfp,
                     mut forms,
-                    input_has_future_updates,
+                    strategy,
                 },
             lir_id,
         } = plan
@@ -1241,7 +1251,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 input,
                 input_mfp,
                 forms,
-                input_has_future_updates,
+                strategy,
             }
             .as_plan(lir_id)
         } else {
@@ -1261,7 +1271,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 input: Box::new(plan),
                 input_mfp,
                 forms: collections,
-                input_has_future_updates: has_future_updates,
+                strategy: strategy_from_future(has_future_updates),
             }
             .as_plan(lir_id)
         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -264,12 +264,16 @@ impl Context {
                     AvailableCollections::new_raw()
                 };
 
-                let has_future_updates = match &plan {
-                    GetPlan::Arrangement(_, _, mfp) | GetPlan::Collection(mfp) => {
-                        mfp.has_temporal_predicates()
-                    }
-                    GetPlan::PassArrangements => self.has_future_updates.contains(id),
-                };
+                // Even with a non-temporal MFP, we must propagate `has_future_updates`
+                // from the underlying binding — applying an MFP doesn't drop future-
+                // timestamped updates that already exist on the input.
+                let has_future_updates = self.has_future_updates.contains(id)
+                    || match &plan {
+                        GetPlan::Arrangement(_, _, mfp) | GetPlan::Collection(mfp) => {
+                            mfp.has_temporal_predicates()
+                        }
+                        GetPlan::PassArrangements => false,
+                    };
 
                 let lir_id = self.allocate_lir_id();
                 let node = PlanNode::Get {
@@ -579,12 +583,15 @@ impl Context {
                 let mut plans = Vec::new();
                 let mut input_keys = Vec::new();
                 let mut input_arities = Vec::new();
+                let mut input_futures = Vec::new();
                 for input in inputs.iter() {
-                    let (plan, keys, _input_future) = self.lower_mir_expr(input)?;
+                    let (plan, keys, input_future) = self.lower_mir_expr(input)?;
                     input_arities.push(input.arity());
                     plans.push(plan);
                     input_keys.push(keys);
+                    input_futures.push(input_future);
                 }
+                let any_input_future = input_futures.iter().any(|&f| f);
 
                 let input_mapper =
                     JoinInputMapper::new_from_input_arities(input_arities.iter().copied());
@@ -650,11 +657,12 @@ impl Context {
                 // The renderer will expect certain arrangements to exist; if any of those are not available, the join planning functions above should have returned them in
                 // `missing`. We thus need to plan them here so they'll exist.
                 let is_delta = matches!(plan, JoinPlan::Delta(_));
-                for (((input_plan, input_keys), missing), arity) in plans
+                for ((((input_plan, input_keys), missing), arity), input_future) in plans
                     .iter_mut()
                     .zip_eq(input_keys.iter())
                     .zip_eq(missing)
                     .zip_eq(input_arities.iter().cloned())
+                    .zip_eq(input_futures.iter().copied())
                 {
                     if missing != Default::default() {
                         if is_delta {
@@ -690,7 +698,8 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             }
                             .as_plan(lir_id),
                         );
-                        *input_plan = self.arrange_by(raw_plan, missing, input_keys, arity, false);
+                        *input_plan =
+                            self.arrange_by(raw_plan, missing, input_keys, arity, input_future);
                     }
                 }
                 // Return the plan, and no arrangements.
@@ -702,7 +711,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
-                    false,
+                    any_input_future,
                 )
             }
             MirRelationExpr::Reduce {
@@ -743,7 +752,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 expected_group_size,
             } => {
                 let arity = input.arity();
-                let (input, keys, _input_future) = self.lower_mir_expr(input)?;
+                let (input, keys, input_future) = self.lower_mir_expr(input)?;
 
                 let top_k_plan = TopKPlan::create_from(
                     group_key.clone(),
@@ -758,7 +767,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
                 let input = if !keys.raw {
-                    self.arrange_by(input, AvailableCollections::new_raw(), &keys, arity, false)
+                    self.arrange_by(
+                        input,
+                        AvailableCollections::new_raw(),
+                        &keys,
+                        arity,
+                        input_future,
+                    )
                 } else {
                     input
                 };
@@ -771,7 +786,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     AvailableCollections::new_raw(),
-                    false,
+                    input_future,
                 )
             }
             MirRelationExpr::Negate { input } => {
@@ -803,7 +818,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 )
             }
             MirRelationExpr::Threshold { input } => {
-                let (plan, keys, _input_future) = self.lower_mir_expr(input)?;
+                let (plan, keys, input_future) = self.lower_mir_expr(input)?;
                 let arity = input.arity();
                 let (threshold_plan, required_arrangement) = ThresholdPlan::create_from(arity);
                 let plan = if !keys
@@ -816,7 +831,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         AvailableCollections::new_arranged(vec![required_arrangement]),
                         &keys,
                         arity,
-                        false,
+                        input_future,
                     )
                 } else {
                     plan
@@ -832,7 +847,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     }
                     .as_plan(lir_id),
                     output_keys,
-                    false,
+                    input_future,
                 )
             }
             MirRelationExpr::Union { base, inputs } => {
@@ -1039,7 +1054,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
         fused_unnest_list: bool,
     ) -> Result<(Plan, AvailableCollections, bool), String> {
         let input_arity = input.arity();
-        let (input, keys, _input_future) = self.lower_mir_expr(input)?;
+        let (input, keys, input_future) = self.lower_mir_expr(input)?;
         let (input_key, permutation_and_new_arity) =
             if let Some((input_key, permutation, thinning)) = keys.arbitrary_arrangement() {
                 (
@@ -1090,7 +1105,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             }
             .as_plan(lir_id),
             output_keys,
-            false,
+            input_future,
         ))
     }
 

--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -273,6 +273,10 @@ pub enum Expr {
         /// A list of arrangement keys, and possibly a raw collection, that will be added to those
         /// of the input. Does not include any other existing arrangements.
         forms: AvailableCollections,
+        /// Whether the input collection may contain updates with future timestamps,
+        /// e.g., from a temporal MFP using `mz_now()`. When true, the renderer
+        /// inserts temporal bucketing before forming arrangements.
+        input_has_future_updates: bool,
     },
 }
 
@@ -498,12 +502,14 @@ impl TryFrom<Plan> for LetFreePlan {
                     input,
                     input_mfp,
                     forms,
+                    input_has_future_updates,
                 } => {
                     let expr = ArrangeBy {
                         input_key,
                         input: input.lir_id,
                         input_mfp,
                         forms,
+                        input_has_future_updates,
                     };
                     insert_node(lir_id, parent, expr, nesting);
 
@@ -975,6 +981,7 @@ impl<'a> std::fmt::Display for RenderPlanExprHumanizer<'a> {
                 input: _,
                 input_mfp: _,
                 forms,
+                input_has_future_updates: _,
             } => {
                 if forms.arranged.is_empty() {
                     soft_assert_or_log!(forms.raw, "raw stream with no arrangements");

--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -26,7 +26,7 @@ use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
 use crate::plan::reduce::{BucketedPlan, HierarchicalPlan, KeyValPlan, MonotonicPlan, ReducePlan};
 use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::{MonotonicTopKPlan, TopKPlan};
-use crate::plan::{AvailableCollections, GetPlan, LirId, Plan, PlanNode};
+use crate::plan::{ArrangementStrategy, AvailableCollections, GetPlan, LirId, Plan, PlanNode};
 
 /// A representation of LIR plans used for rendering.
 ///
@@ -273,10 +273,8 @@ pub enum Expr {
         /// A list of arrangement keys, and possibly a raw collection, that will be added to those
         /// of the input. Does not include any other existing arrangements.
         forms: AvailableCollections,
-        /// Whether the input collection may contain updates with future timestamps,
-        /// e.g., from a temporal MFP using `mz_now()`. When true, the renderer
-        /// inserts temporal bucketing before forming arrangements.
-        input_has_future_updates: bool,
+        /// How the renderer should form the arrangements requested by `forms`.
+        strategy: ArrangementStrategy,
     },
 }
 
@@ -502,14 +500,14 @@ impl TryFrom<Plan> for LetFreePlan {
                     input,
                     input_mfp,
                     forms,
-                    input_has_future_updates,
+                    strategy,
                 } => {
                     let expr = ArrangeBy {
                         input_key,
                         input: input.lir_id,
                         input_mfp,
                         forms,
-                        input_has_future_updates,
+                        strategy,
                     };
                     insert_node(lir_id, parent, expr, nesting);
 
@@ -981,7 +979,7 @@ impl<'a> std::fmt::Display for RenderPlanExprHumanizer<'a> {
                 input: _,
                 input_mfp: _,
                 forms,
-                input_has_future_updates: _,
+                strategy: _,
             } => {
                 if forms.arranged.is_empty() {
                     soft_assert_or_log!(forms.raw, "raw stream with no arrangements");

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -138,6 +138,7 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::vec::ToStream;
 use timely::dataflow::operators::vec::{BranchWhen, Filter};
@@ -153,6 +154,7 @@ use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
+use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
@@ -1505,9 +1507,6 @@ impl RenderTimestamp for mz_repr::Timestamp {
         as_of: Antichain<mz_repr::Timestamp>,
         summary: mz_repr::Timestamp,
     ) -> VecCollection<'scope, Self, Row, Diff> {
-        use crate::extensions::temporal_bucket::TemporalBucketing;
-        use differential_dataflow::AsCollection;
-        use timely::container::CapacityContainerBuilder;
         stream
             .bucket::<CapacityContainerBuilder<_>>(as_of, summary)
             .as_collection()
@@ -1546,7 +1545,6 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
         _as_of: Antichain<mz_repr::Timestamp>,
         _summary: mz_repr::Timestamp,
     ) -> VecCollection<'scope, Self, Row, Diff> {
-        use differential_dataflow::AsCollection;
         // TODO: Implement bucketing on outer timestamp for iterative scopes.
         stream.as_collection()
     }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1324,6 +1324,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 input,
                 input_mfp,
                 forms: keys,
+                input_has_future_updates: _input_has_future_updates,
             } => {
                 let input = expect_input(input);
                 input.ensure_collections(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -138,7 +138,6 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
-use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::vec::ToStream;
 use timely::dataflow::operators::vec::{BranchWhen, Filter};
@@ -1318,10 +1317,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     keys,
                     input_key,
                     input_mfp,
+                    self.as_of_frontier.clone(),
                     self.until.clone(),
                     &self.config_set,
                     input_has_future_updates,
-                    self.as_of_frontier.clone(),
                 )
             }
         }
@@ -1475,13 +1474,11 @@ pub trait RenderTimestamp: MzTimestamp + Refines<mz_repr::Timestamp> {
     ///
     /// Temporal bucketing requires a total order on timestamps. For timestamp
     /// types without a total order (e.g., in iterative scopes), this is a no-op.
-    fn maybe_apply_temporal_bucketing<G>(
-        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+    fn maybe_apply_temporal_bucketing<'scope>(
+        stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         as_of: Antichain<mz_repr::Timestamp>,
         summary: mz_repr::Timestamp,
-    ) -> VecCollection<G, Row, Diff>
-    where
-        G: Scope<Timestamp = Self>;
+    ) -> VecCollection<'scope, Self, Row, Diff>;
 }
 
 impl RenderTimestamp for mz_repr::Timestamp {
@@ -1503,14 +1500,11 @@ impl RenderTimestamp for mz_repr::Timestamp {
     fn step_back(&self) -> Self {
         self.saturating_sub(1)
     }
-    fn maybe_apply_temporal_bucketing<G>(
-        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+    fn maybe_apply_temporal_bucketing<'scope>(
+        stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         as_of: Antichain<mz_repr::Timestamp>,
         summary: mz_repr::Timestamp,
-    ) -> VecCollection<G, Row, Diff>
-    where
-        G: Scope<Timestamp = Self>,
-    {
+    ) -> VecCollection<'scope, Self, Row, Diff> {
         use crate::extensions::temporal_bucket::TemporalBucketing;
         use differential_dataflow::AsCollection;
         use timely::container::CapacityContainerBuilder;
@@ -1547,14 +1541,11 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
         }
         Product::new(self.outer.saturating_sub(1), PointStamp::new(vec))
     }
-    fn maybe_apply_temporal_bucketing<G>(
-        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+    fn maybe_apply_temporal_bucketing<'scope>(
+        stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         _as_of: Antichain<mz_repr::Timestamp>,
         _summary: mz_repr::Timestamp,
-    ) -> VecCollection<G, Row, Diff>
-    where
-        G: Scope<Timestamp = Self>,
-    {
+    ) -> VecCollection<'scope, Self, Row, Diff> {
         use differential_dataflow::AsCollection;
         // TODO: Implement bucketing on outer timestamp for iterative scopes.
         stream.as_collection()

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1324,7 +1324,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 input,
                 input_mfp,
                 forms: keys,
-                input_has_future_updates: _input_has_future_updates,
+                input_has_future_updates,
             } => {
                 let input = expect_input(input);
                 input.ensure_collections(
@@ -1333,6 +1333,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     input_mfp,
                     self.until.clone(),
                     &self.config_set,
+                    input_has_future_updates,
+                    self.as_of_frontier.clone(),
                 )
             }
         }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -122,7 +122,7 @@ use mz_compute_types::dataflows::{DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::{
     COMPUTE_APPLY_COLUMN_DEMANDS, COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK,
     COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES, ENABLE_COMPUTE_LOGICAL_BACKPRESSURE,
-    ENABLE_TEMPORAL_BUCKETING, SUBSCRIBE_SNAPSHOT_OPTIMIZATION, TEMPORAL_BUCKETING_SUMMARY,
+    SUBSCRIBE_SNAPSHOT_OPTIMIZATION,
 };
 use mz_compute_types::plan::LirId;
 use mz_compute_types::plan::render_plan::{
@@ -154,7 +154,6 @@ use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
-use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
@@ -453,18 +452,6 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let oks = if ENABLE_TEMPORAL_BUCKETING.get(&compute_state.worker_config) {
-                        let as_of = context.as_of_frontier.clone();
-                        let summary = TEMPORAL_BUCKETING_SUMMARY
-                            .get(&compute_state.worker_config)
-                            .try_into()
-                            .expect("must fit");
-                        oks.inner
-                            .bucket::<CapacityContainerBuilder<_>>(as_of, summary)
-                            .as_collection()
-                    } else {
-                        oks
-                    };
                     let bundle = crate::render::CollectionBundle::from_collections(
                         oks.enter_region(region),
                         errs.enter_region(region),

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1482,6 +1482,17 @@ pub trait RenderTimestamp: MzTimestamp + Refines<mz_repr::Timestamp> {
     /// Steps the timestamp back so that logical compaction to the output will
     /// not conflate `self` with any historical times.
     fn step_back(&self) -> Self;
+    /// Apply temporal bucketing to a stream if the timestamp type supports it.
+    ///
+    /// Temporal bucketing requires a total order on timestamps. For timestamp
+    /// types without a total order (e.g., in iterative scopes), this is a no-op.
+    fn maybe_apply_temporal_bucketing<G>(
+        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+        as_of: Antichain<mz_repr::Timestamp>,
+        summary: mz_repr::Timestamp,
+    ) -> VecCollection<G, Row, Diff>
+    where
+        G: Scope<Timestamp = Self>;
 }
 
 impl RenderTimestamp for mz_repr::Timestamp {
@@ -1502,6 +1513,21 @@ impl RenderTimestamp for mz_repr::Timestamp {
     }
     fn step_back(&self) -> Self {
         self.saturating_sub(1)
+    }
+    fn maybe_apply_temporal_bucketing<G>(
+        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+        as_of: Antichain<mz_repr::Timestamp>,
+        summary: mz_repr::Timestamp,
+    ) -> VecCollection<G, Row, Diff>
+    where
+        G: Scope<Timestamp = Self>,
+    {
+        use crate::extensions::temporal_bucket::TemporalBucketing;
+        use differential_dataflow::AsCollection;
+        use timely::container::CapacityContainerBuilder;
+        stream
+            .bucket::<CapacityContainerBuilder<_>>(as_of, summary)
+            .as_collection()
     }
 }
 
@@ -1531,6 +1557,18 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
             *item = item.saturating_sub(1);
         }
         Product::new(self.outer.saturating_sub(1), PointStamp::new(vec))
+    }
+    fn maybe_apply_temporal_bucketing<G>(
+        stream: StreamVec<G, (Row, G::Timestamp, Diff)>,
+        _as_of: Antichain<mz_repr::Timestamp>,
+        _summary: mz_repr::Timestamp,
+    ) -> VecCollection<G, Row, Diff>
+    where
+        G: Scope<Timestamp = Self>,
+    {
+        use differential_dataflow::AsCollection;
+        // TODO: Implement bucketing on outer timestamp for iterative scopes.
+        stream.as_collection()
     }
 }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1312,7 +1312,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 input,
                 input_mfp,
                 forms: keys,
-                input_has_future_updates,
+                strategy,
             } => {
                 let input = expect_input(input);
                 input.ensure_collections(
@@ -1322,7 +1322,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     self.as_of_frontier.clone(),
                     self.until.clone(),
                     &self.config_set,
-                    input_has_future_updates,
+                    strategy,
                 )
             }
         }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -976,7 +976,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
     }
 }
 
-impl<'scope, T: RenderTimestamp> Context<'scope, T> {
+impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
     /// Renders a non-recursive plan to a differential dataflow, producing the collection of
     /// results.
     ///
@@ -1472,10 +1472,15 @@ pub trait RenderTimestamp: MzTimestamp + Refines<mz_repr::Timestamp> {
     /// Steps the timestamp back so that logical compaction to the output will
     /// not conflate `self` with any historical times.
     fn step_back(&self) -> Self;
-    /// Apply temporal bucketing to a stream if the timestamp type supports it.
-    ///
-    /// Temporal bucketing requires a total order on timestamps. For timestamp
-    /// types without a total order (e.g., in iterative scopes), this is a no-op.
+}
+
+/// Apply temporal bucketing to a stream when the timestamp type supports it.
+///
+/// Sibling to [`RenderTimestamp`]: bucketing is an arrangement-time concern, not a
+/// general property of a render timestamp, so the dispatch lives in its own trait.
+/// Total-ordered timestamps perform real bucketing; partially-ordered timestamps
+/// (e.g. `Product<…>` in iterative scopes) implement this as a no-op.
+pub trait MaybeBucketByTime: Timestamp {
     fn maybe_apply_temporal_bucketing<'scope>(
         stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         as_of: Antichain<mz_repr::Timestamp>,
@@ -1502,6 +1507,9 @@ impl RenderTimestamp for mz_repr::Timestamp {
     fn step_back(&self) -> Self {
         self.saturating_sub(1)
     }
+}
+
+impl MaybeBucketByTime for mz_repr::Timestamp {
     fn maybe_apply_temporal_bucketing<'scope>(
         stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         as_of: Antichain<mz_repr::Timestamp>,
@@ -1540,6 +1548,9 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
         }
         Product::new(self.outer.saturating_sub(1), PointStamp::new(vec))
     }
+}
+
+impl MaybeBucketByTime for Product<mz_repr::Timestamp, PointStamp<u64>> {
     fn maybe_apply_temporal_bucketing<'scope>(
         stream: StreamVec<'scope, Self, (Row, Self, Diff)>,
         _as_of: Antichain<mz_repr::Timestamp>,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -765,19 +765,26 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         // Track whether we applied temporal bucketing, to avoid double-bucketing.
         let mut bucketed = false;
 
+        // True iff at least one new arrangement will actually be built below. Bucketing only
+        // pays off when something downstream merges/compacts the future-stamped updates; on a
+        // pure raw collection (no new arrangement) the work is wasted.
+        let will_create_arrangement = collections
+            .arranged
+            .iter()
+            .any(|(key, _, _)| !self.arranged.contains_key(key));
+
         // We need the collection if either (1) it is explicitly demanded, or (2) we are going to render any arrangement
-        let form_raw_collection = collections.raw
-            || collections
-                .arranged
-                .iter()
-                .any(|(key, _, _)| !self.arranged.contains_key(key));
+        let form_raw_collection = collections.raw || will_create_arrangement;
         if form_raw_collection && self.collection.is_none() {
             let (oks, errs) =
                 self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until, config_set);
-            // Apply temporal bucketing if the input may contain future updates.
-            // This path fires when the collection must be formed from scratch
-            // (e.g., from an arrangement via as_collection_core).
-            let oks = if input_has_future_updates && ENABLE_TEMPORAL_BUCKETING.get(config_set) {
+            // Apply temporal bucketing if the input may contain future updates and we are
+            // going to build at least one arrangement. This path fires when the collection
+            // must be formed from scratch (e.g., from an arrangement via as_collection_core).
+            let oks = if will_create_arrangement
+                && input_has_future_updates
+                && ENABLE_TEMPORAL_BUCKETING.get(config_set)
+            {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                     .get(config_set)
                     .try_into()

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -739,10 +739,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         collections: AvailableCollections,
         input_key: Option<Vec<MirScalarExpr>>,
         input_mfp: MapFilterProject,
+        as_of: Antichain<mz_repr::Timestamp>,
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
         input_has_future_updates: bool,
-        as_of: Antichain<mz_repr::Timestamp>,
     ) -> Self {
         if collections == Default::default() {
             return self;
@@ -783,11 +783,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .try_into()
                     .expect("must fit");
                 bucketed = true;
-                <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
-                    oks.inner,
-                    as_of.clone(),
-                    summary,
-                )
+                T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
             } else {
                 oks
             };
@@ -815,11 +811,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                         .try_into()
                         .expect("must fit");
                     bucketed = true;
-                    <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
-                        oks.inner,
-                        as_of.clone(),
-                        summary,
-                    )
+                    T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
                 } else {
                     oks
                 };

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -762,6 +762,9 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             );
         }
 
+        // Track whether we applied temporal bucketing, to avoid double-bucketing.
+        let mut bucketed = false;
+
         // We need the collection if either (1) it is explicitly demanded, or (2) we are going to render any arrangement
         let form_raw_collection = collections.raw
             || collections
@@ -772,13 +775,18 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             let (oks, errs) =
                 self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until, config_set);
             // Apply temporal bucketing if the input may contain future updates.
+            // This path fires when the collection must be formed from scratch
+            // (e.g., from an arrangement via as_collection_core).
             let oks = if input_has_future_updates && ENABLE_TEMPORAL_BUCKETING.get(config_set) {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                     .get(config_set)
                     .try_into()
                     .expect("must fit");
+                bucketed = true;
                 <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
-                    oks.inner, as_of, summary,
+                    oks.inner,
+                    as_of.clone(),
+                    summary,
                 )
             } else {
                 oks
@@ -794,6 +802,27 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .take()
                     .expect("Collection constructed above");
+                // Apply temporal bucketing if the collection already existed on
+                // the bundle (e.g., from an upstream temporal Mfp or Get) and we
+                // haven't bucketed yet. This is the common path for temporal-MFP
+                // → ArrangeBy flows.
+                let oks = if !bucketed
+                    && input_has_future_updates
+                    && ENABLE_TEMPORAL_BUCKETING.get(config_set)
+                {
+                    let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
+                        .get(config_set)
+                        .try_into()
+                        .expect("must fit");
+                    bucketed = true;
+                    <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
+                        oks.inner,
+                        as_of.clone(),
+                        summary,
+                    )
+                } else {
+                    oks
+                };
                 let (oks, errs_keyed, passthrough) =
                     Self::arrange_collection(&name, oks, key.clone(), thinning.clone());
                 let errs_concat: KeyCollection<_, _, _> = errs.clone().concat(errs_keyed).into();

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -769,12 +769,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 .iter()
                 .any(|(key, _, _)| !self.arranged.contains_key(key));
         if form_raw_collection && self.collection.is_none() {
-            let (oks, errs) = self.as_collection_core(
-                input_mfp,
-                input_key.map(|k| (k, None)),
-                until,
-                config_set,
-            );
+            let (oks, errs) =
+                self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until, config_set);
             // Apply temporal bucketing if the input may contain future updates.
             let oks = if input_has_future_updates && ENABLE_TEMPORAL_BUCKETING.get(config_set) {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
@@ -782,9 +778,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .try_into()
                     .expect("must fit");
                 <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
-                    oks.inner,
-                    as_of,
-                    summary,
+                    oks.inner, as_of, summary,
                 )
             } else {
                 oks

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -19,7 +19,10 @@ use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, Data, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
-use mz_compute_types::dyncfgs::ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION;
+use mz_compute_types::dyncfgs::{
+    ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_TEMPORAL_BUCKETING,
+    TEMPORAL_BUCKETING_SUMMARY,
+};
 use mz_compute_types::plan::AvailableCollections;
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
@@ -738,6 +741,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         input_mfp: MapFilterProject,
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
+        input_has_future_updates: bool,
+        as_of: Antichain<mz_repr::Timestamp>,
     ) -> Self {
         if collections == Default::default() {
             return self;
@@ -764,12 +769,27 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 .iter()
                 .any(|(key, _, _)| !self.arranged.contains_key(key));
         if form_raw_collection && self.collection.is_none() {
-            self.collection = Some(self.as_collection_core(
+            let (oks, errs) = self.as_collection_core(
                 input_mfp,
                 input_key.map(|k| (k, None)),
                 until,
                 config_set,
-            ));
+            );
+            // Apply temporal bucketing if the input may contain future updates.
+            let oks = if input_has_future_updates && ENABLE_TEMPORAL_BUCKETING.get(config_set) {
+                let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
+                    .get(config_set)
+                    .try_into()
+                    .expect("must fit");
+                <S::Timestamp as RenderTimestamp>::maybe_apply_temporal_bucketing(
+                    oks.inner,
+                    as_of,
+                    summary,
+                )
+            } else {
+                oks
+            };
+            self.collection = Some((oks, errs));
         }
         for (key, _, thinning) in collections.arranged {
             if !self.arranged.contains_key(&key) {

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -20,7 +20,7 @@ use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, Data, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
-    ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_TEMPORAL_BUCKETING,
+    ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_COMPUTE_TEMPORAL_BUCKETING,
     TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
@@ -786,7 +786,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             // must be formed from scratch (e.g., from an arrangement via as_collection_core).
             let oks = if will_create_arrangement
                 && matches!(strategy, ArrangementStrategy::TemporalBucketing)
-                && ENABLE_TEMPORAL_BUCKETING.get(config_set)
+                && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
             {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                     .get(config_set)
@@ -814,7 +814,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 // → ArrangeBy flows.
                 let oks = if !bucketed
                     && matches!(strategy, ArrangementStrategy::TemporalBucketing)
-                    && ENABLE_TEMPORAL_BUCKETING.get(config_set)
+                    && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
                 {
                     let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                         .get(config_set)

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -45,7 +45,7 @@ use timely::progress::{Antichain, Timestamp};
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
 use crate::render::errors::{DataflowErrorSer, ErrorLogger};
-use crate::render::{LinearJoinSpec, RenderTimestamp};
+use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
 use crate::row_spine::{DatumSeq, RowRowBuilder};
 use crate::typedefs::{
     ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter, RowRowSpine,
@@ -743,7 +743,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
         strategy: ArrangementStrategy,
-    ) -> Self {
+    ) -> Self
+    where
+        T: MaybeBucketByTime,
+    {
         if collections == Default::default() {
             return self;
         }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -23,7 +23,7 @@ use mz_compute_types::dyncfgs::{
     ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_TEMPORAL_BUCKETING,
     TEMPORAL_BUCKETING_SUMMARY,
 };
-use mz_compute_types::plan::AvailableCollections;
+use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
 use mz_ore::soft_assert_or_log;
@@ -742,7 +742,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         as_of: Antichain<mz_repr::Timestamp>,
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
-        input_has_future_updates: bool,
+        strategy: ArrangementStrategy,
     ) -> Self {
         if collections == Default::default() {
             return self;
@@ -778,11 +778,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         if form_raw_collection && self.collection.is_none() {
             let (oks, errs) =
                 self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until, config_set);
-            // Apply temporal bucketing if the input may contain future updates and we are
-            // going to build at least one arrangement. This path fires when the collection
+            // Apply temporal bucketing when the lowering selected `TemporalBucketing` and
+            // we will build at least one arrangement. This path fires when the collection
             // must be formed from scratch (e.g., from an arrangement via as_collection_core).
             let oks = if will_create_arrangement
-                && input_has_future_updates
+                && matches!(strategy, ArrangementStrategy::TemporalBucketing)
                 && ENABLE_TEMPORAL_BUCKETING.get(config_set)
             {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
@@ -810,7 +810,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 // haven't bucketed yet. This is the common path for temporal-MFP
                 // → ArrangeBy flows.
                 let oks = if !bucketed
-                    && input_has_future_updates
+                    && matches!(strategy, ArrangementStrategy::TemporalBucketing)
                     && ENABLE_TEMPORAL_BUCKETING.get(config_set)
                 {
                     let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -394,6 +394,13 @@ impl MapFilterProject {
         }
     }
 
+    /// Returns `true` if any predicate in this MFP contains a temporal expression (`mz_now()`).
+    pub fn has_temporal_predicates(&self) -> bool {
+        self.predicates
+            .iter()
+            .any(|(_, predicate)| predicate.contains_temporal())
+    }
+
     /// Extracts temporal predicates into their own `Self`.
     ///
     /// Expressions that are used by the temporal predicates are exposed by `self.projection`,

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -81,6 +81,7 @@ from materialize.feature_benchmark.scenarios.optbench import *  # noqa: F401 F40
 from materialize.feature_benchmark.scenarios.scale import *  # noqa: F401 F403
 from materialize.feature_benchmark.scenarios.skew import *  # noqa: F401 F403
 from materialize.feature_benchmark.scenarios.subscribe import *  # noqa: F401 F403
+from materialize.feature_benchmark.scenarios.temporal import *  # noqa: F401 F403
 from materialize.feature_benchmark.termination import (
     NormalDistributionOverlap,
     ProbForMin,

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -538,7 +538,8 @@ SELECT * FROM ov
                   "forms": {
                     "raw": true,
                     "arranged": []
-                  }
+                  },
+                  "input_has_future_updates": false
                 }
               }
             },
@@ -728,7 +729,8 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                         []
                       ]
                     ]
-                  }
+                  },
+                  "input_has_future_updates": false
                 }
               }
             },
@@ -844,7 +846,8 @@ SELECT * FROM ov
                   "forms": {
                     "raw": true,
                     "arranged": []
-                  }
+                  },
+                  "input_has_future_updates": false
                 }
               }
             },
@@ -1040,7 +1043,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                               []
                             ]
                           ]
-                        }
+                        },
+                        "input_has_future_updates": false
                       }
                     }
                   },
@@ -1378,7 +1382,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                     []
                                                   ]
                                                 ]
-                                              }
+                                              },
+                                              "input_has_future_updates": false
                                             }
                                           }
                                         }
@@ -1500,7 +1505,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                               []
                             ]
                           ]
-                        }
+                        },
+                        "input_has_future_updates": false
                       }
                     }
                   },
@@ -2191,7 +2197,8 @@ FROM t
                           "forms": {
                             "raw": true,
                             "arranged": []
-                          }
+                          },
+                          "input_has_future_updates": false
                         }
                       }
                     },
@@ -2614,7 +2621,8 @@ MATERIALIZED VIEW hierarchical_global_mv
                           "forms": {
                             "raw": true,
                             "arranged": []
-                          }
+                          },
+                          "input_has_future_updates": false
                         }
                       }
                     },
@@ -2920,7 +2928,8 @@ SELECT * FROM hierarchical_global
                           "forms": {
                             "raw": true,
                             "arranged": []
-                          }
+                          },
+                          "input_has_future_updates": false
                         }
                       }
                     },
@@ -10046,7 +10055,8 @@ WHERE a = c AND d = e AND b + d > 42
                           ]
                         ]
                       ]
-                    }
+                    },
+                    "input_has_future_updates": false
                   }
                 }
               },
@@ -10107,7 +10117,8 @@ WHERE a = c AND d = e AND b + d > 42
                           []
                         ]
                       ]
-                    }
+                    },
+                    "input_has_future_updates": false
                   }
                 }
               }
@@ -11006,7 +11017,8 @@ WHERE a = c AND d = e AND f = a
                           []
                         ]
                       ]
-                    }
+                    },
+                    "input_has_future_updates": false
                   }
                 }
               },
@@ -11152,7 +11164,8 @@ WHERE a = c AND d = e AND f = a
                           []
                         ]
                       ]
-                    }
+                    },
+                    "input_has_future_updates": false
                   }
                 }
               }

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -539,7 +539,7 @@ SELECT * FROM ov
                     "raw": true,
                     "arranged": []
                   },
-                  "input_has_future_updates": false
+                  "strategy": "Direct"
                 }
               }
             },
@@ -730,7 +730,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                       ]
                     ]
                   },
-                  "input_has_future_updates": false
+                  "strategy": "Direct"
                 }
               }
             },
@@ -847,7 +847,7 @@ SELECT * FROM ov
                     "raw": true,
                     "arranged": []
                   },
-                  "input_has_future_updates": false
+                  "strategy": "Direct"
                 }
               }
             },
@@ -1044,7 +1044,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                             ]
                           ]
                         },
-                        "input_has_future_updates": false
+                        "strategy": "Direct"
                       }
                     }
                   },
@@ -1383,7 +1383,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                   ]
                                                 ]
                                               },
-                                              "input_has_future_updates": false
+                                              "strategy": "Direct"
                                             }
                                           }
                                         }
@@ -1506,7 +1506,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                             ]
                           ]
                         },
-                        "input_has_future_updates": false
+                        "strategy": "Direct"
                       }
                     }
                   },
@@ -2198,7 +2198,7 @@ FROM t
                             "raw": true,
                             "arranged": []
                           },
-                          "input_has_future_updates": false
+                          "strategy": "Direct"
                         }
                       }
                     },
@@ -2622,7 +2622,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                             "raw": true,
                             "arranged": []
                           },
-                          "input_has_future_updates": false
+                          "strategy": "Direct"
                         }
                       }
                     },
@@ -2929,7 +2929,7 @@ SELECT * FROM hierarchical_global
                             "raw": true,
                             "arranged": []
                           },
-                          "input_has_future_updates": false
+                          "strategy": "Direct"
                         }
                       }
                     },
@@ -10056,7 +10056,7 @@ WHERE a = c AND d = e AND b + d > 42
                         ]
                       ]
                     },
-                    "input_has_future_updates": false
+                    "strategy": "Direct"
                   }
                 }
               },
@@ -10118,7 +10118,7 @@ WHERE a = c AND d = e AND b + d > 42
                         ]
                       ]
                     },
-                    "input_has_future_updates": false
+                    "strategy": "Direct"
                   }
                 }
               }
@@ -11018,7 +11018,7 @@ WHERE a = c AND d = e AND f = a
                         ]
                       ]
                     },
-                    "input_has_future_updates": false
+                    "strategy": "Direct"
                   }
                 }
               },
@@ -11165,7 +11165,7 @@ WHERE a = c AND d = e AND f = a
                         ]
                       ]
                     },
-                    "input_has_future_updates": false
+                    "strategy": "Direct"
                   }
                 }
               }

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -62,13 +62,12 @@ FlatMap  Exchange  alloc::vec::Vec<(u64,␠mz_txn_wal::txn_read::DataRemapEntry<
 FlatMap  txns_progress_frontiers(u1)  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 FormArrangementKey  ArrangeBy[[Column(0,␠"a"),␠Column(1,␠"b")]]  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 FormArrangementKey  Concatenate  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-InputRegion:␠materialize.public.test_primary_idx  Temporal␠delay  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LogOperatorHydration␠(1)  FormArrangementKey  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 OkErr  SuppressEarlyProgress  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-Temporal␠delay  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
@@ -94,7 +93,6 @@ GROUP BY type;
 1  alloc::vec::Vec<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 1  alloc::vec::Vec<mz_persist_client::fetch::FetchedBlob<mz_storage_types::sources::SourceData,␠(),␠mz_repr::timestamp::Timestamp,␠i64>>
 1  mz_timely_util::columnar::Column<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-10  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 2  alloc::vec::Vec<(u64,␠mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
@@ -103,6 +101,7 @@ GROUP BY type;
 5  alloc::vec::Vec<core::convert::Infallible>
 6  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 6  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_compute::row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
+9  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 
 query TTT rowsort
 SELECT mdod_from.name AS from_name,


### PR DESCRIPTION
Temporal MFPs (e.g. `WHERE mz_now() > ts`) emit updates with future timestamps. When those land in an arrangement merge batcher, the batcher does work merging data that won't be read for a long time. Bucketing buffers the future updates in a logarithmic `BucketChain` and releases them as the frontier advances.

The previous source-level bucketing applied to all imports regardless of whether the source actually produced future updates. This change targets bucketing precisely at `ArrangeBy` nodes that receive future updates from upstream temporal MFPs.

### Description

* Adds `MapFilterProject::has_temporal_predicates()` to detect MFPs containing `mz_now()`.
* Threads a `has_future_updates` analysis bit through LIR plan lowering. Every node knows whether its output may carry future-stamped updates.
* On `PlanNode::ArrangeBy` / `Expr::ArrangeBy`, stores the rendering decision as `strategy: ArrangementStrategy` (`Direct` or `TemporalBucketing`) — action-named, picked by the lowering and consumed by the renderer.
* In `ensure_collections`, when the strategy is `TemporalBucketing` and `ENABLE_COMPUTE_TEMPORAL_BUCKETING` is on, inserts bucketing in front of the arrangement. Both the collection-from-scratch path (via `as_collection_core`) and the pre-existing-collection path are covered, with a guard against double-bucketing.
* Removes the old source-level bucketing operator.
* Adds a `MaybeBucketByTime` trait sibling to `RenderTimestamp` that dispatches bucketing per timestamp type: real work for `mz_repr::Timestamp`, no-op for `Product<…>` in iterative scopes (follow-up). Bucketing is an arrangement-time concern, so the dispatch lives outside `RenderTimestamp`.
* Adds a feature-benchmark scenario exercising a temporal filter.

Bucketing is gated on `ENABLE_COMPUTE_TEMPORAL_BUCKETING` (default false).