### PR TITLE
compute: diagnostic log when dropping per-replica read holds

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1164,7 +1164,35 @@ where
     /// Remove an existing instance replica, by ID.
     #[mz_ore::instrument(level = "debug")]
     pub fn remove_replica(&mut self, id: ReplicaId) -> Result<(), ReplicaMissing> {
-        self.replicas.remove(&id).ok_or(ReplicaMissing(id))?;
+        let replica = self.replicas.remove(&id).ok_or(ReplicaMissing(id))?;
+
+        // Before dropping the replica state (and the contained input read holds), log read holds
+        // that are the last line of defense against compaction of a dataflow's storage inputs. If
+        // the corresponding global read hold has already been released, dropping the per-replica
+        // read hold will allow compaction, which can cause the replica to panic trying to install
+        // the dataflow.
+        //
+        // This exists primarily to help diagnose incidents-and-escalations#39.
+        for (collection_id, replica_collection) in &replica.collections {
+            let collection = self.collections.get(collection_id);
+            for replica_hold in &replica_collection.input_read_holds {
+                let input_id = replica_hold.id();
+                let global_hold = collection.and_then(|c| c.storage_dependencies.get(&input_id));
+                let unprotected = global_hold
+                    .is_none_or(|h| PartialOrder::less_than(replica_hold.since(), h.since()));
+                if unprotected {
+                    tracing::warn!(
+                        replica_id = %id,
+                        %collection_id,
+                        %input_id,
+                        replica_hold_since = ?replica_hold.since(),
+                        global_hold_since = ?global_hold.map(|h| h.since()),
+                        "dropping per-replica read hold without equivalent global read hold",
+                    );
+                }
+            }
+        }
+        drop(replica);
 
         // Subscribes targeting this replica either won't be served anymore (if the replica is
         // dropped) or might produce inconsistent output (if the target collection is an


### PR DESCRIPTION
When a replica is removed, we drop its per-replica input read holds. If the corresponding global read holds have already been released/downgraded (e.g. because the dataflow was dropped by a user), the per-replica holds are the last line of defense against compaction. The dataflow might still be in flight at the replica, and dropping its input read holds can allow the storage inputs to compact past a its as_of, causing the replica to panic when it tries to render the dataflow.

We believe that this is the cause for "cannot serve requested as_of" panics observed in the wild. This commit adds a warning log to help validate that theory.

### Motivation

Part of diagnosing https://github.com/MaterializeInc/incidents-and-escalations/issues/39