### PR TITLE
license: allow CDLA-Permissive-2.0

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -4,6 +4,7 @@ accepted = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "0BSD",
     "BSD-2-Clause",
     "BSD-3-Clause",

--- a/deny.toml
+++ b/deny.toml
@@ -268,6 +268,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "0BSD",
     "BSD-2-Clause",
     "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Add `CDLA-Permissive-2.0` to the accepted license lists in `about.toml` and `deny.toml`
- Pre-requisite for the crypto migration to rustls/aws-lc-rs, which introduces dependencies licensed under this permissive license

## Test plan
- [ ] `cargo deny check licenses` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)