### PR TITLE
Show some notices if pod metrics are not enabled

### DIFF
--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -47,7 +47,10 @@ import {
   UtilizationGraph,
 } from "./ClusterOverview/UtilizationGraph";
 import { ClusterParams } from "./ClusterRoutes";
-import { CLUSTERS_FETCH_ERROR_MESSAGE } from "./constants";
+import {
+  CLUSTER_METRICS_UNAVAILABLE_MESSAGE,
+  CLUSTERS_FETCH_ERROR_MESSAGE,
+} from "./constants";
 import LargestMaintainedQueries from "./LargestMaintainedQueries";
 import { useReplicaUtilizationHistory } from "./queries";
 
@@ -126,6 +129,24 @@ const ClusterOverview = () => {
   const graphContainerHeight = clusterHasDisk
     ? TOTAL_GRAPH_HEIGHT_PX * 2 + GRAPH_SPACING
     : TOTAL_GRAPH_HEIGHT_PX;
+
+  // If there are no metrics at all (rows are all zeros/nulls),
+  // the cluster may be misconfigured (issue with metrics collection),
+  // so we show an error message in that case.
+  const clusterHasNoMetrics =
+    (graphData ?? []).length &&
+    graphData?.every((d) =>
+      d.data.every(
+        (point) =>
+          (point.cpuPercent === 0 || point.cpuPercent === null) &&
+          (point.memoryPercent === 0 || point.memoryPercent === null) &&
+          (point.diskPercent === 0 || point.diskPercent === null),
+      ),
+    );
+
+  if (clusterHasNoMetrics) {
+    return <ErrorBox message={CLUSTER_METRICS_UNAVAILABLE_MESSAGE} />;
+  }
 
   return (
     <MainContentContainer mt="10">

--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -138,15 +138,9 @@ const ClusterOverview = () => {
     graphData?.every((d) =>
       d.data.every(
         (point) =>
-          (point.cpuPercent === 0 || point.cpuPercent === null) &&
-          (point.memoryPercent === 0 || point.memoryPercent === null) &&
-          (point.diskPercent === 0 || point.diskPercent === null),
+          !point.cpuPercent && !point.memoryPercent && !point.diskPercent,
       ),
     );
-
-  if (clusterHasNoMetrics) {
-    return <ErrorBox message={CLUSTER_METRICS_UNAVAILABLE_MESSAGE} />;
-  }
 
   return (
     <MainContentContainer mt="10">
@@ -201,6 +195,8 @@ const ClusterOverview = () => {
             >
               <Spinner data-testid="loading-spinner" />
             </Flex>
+          ) : clusterHasNoMetrics ? (
+            <ErrorBox message={CLUSTER_METRICS_UNAVAILABLE_MESSAGE} />
           ) : data ? (
             <Grid
               gridTemplateColumns={{

--- a/console/src/platform/clusters/constants.ts
+++ b/console/src/platform/clusters/constants.ts
@@ -9,3 +9,7 @@
 
 export const CLUSTERS_FETCH_ERROR_MESSAGE =
   "An error occurred loading cluster data";
+
+export const CLUSTER_METRICS_UNAVAILABLE_MESSAGE = `Cluster metrics are unavailable.
+  This may be due to a temporary issue with the cluster or because pod metrics collection is disabled.
+  If you are the administrator of this cluster, please ensure that pod metrics collection is enabled and that metrics-server is installed.`;

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -238,6 +238,9 @@ pub struct Args {
     #[clap(long, env = "ORCHESTRATOR_KUBERNETES_NAME_PREFIX")]
     orchestrator_kubernetes_name_prefix: Option<String>,
     /// Whether to enable pod metrics collection.
+    ///
+    /// Required for resource usage graphs in the console.
+    /// Requires metrics-server to be installed.
     #[clap(long, env = "ORCHESTRATOR_KUBERNETES_DISABLE_POD_METRICS_COLLECTION")]
     orchestrator_kubernetes_disable_pod_metrics_collection: bool,
     /// Whether to annotate pods for prometheus service discovery.

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -1367,6 +1367,12 @@ impl OrchestratorWorker {
             self.owner_references
                 .extend(orchestrator_pod.owner_references().into_iter().cloned());
 
+            if !self.collect_pod_metrics {
+                info!(
+                    "pod metrics collection is disabled; resource usage graphs in the console will not be available"
+                );
+            }
+
             info!(
                 "Kubernetes orchestrator worker initialized in {:?}",
                 start.elapsed()


### PR DESCRIPTION
### Motivation

We currently default observability.podMetrics.enabled to false in our operator helm chart.
This is also the default in our environmentd CLI.

The unfortunate side effect of this is that resource utilization graphs come up entirely empty
unless this is turned on.

### Description

This adds a log message (once at startup) indicating that metrics are disabled and their implication.
In the case of our resource utilization graph, this attempts to show an error message.

### Verification

Need to figure out how to run a console with a port-forwarded cluster...

This is my first console PR... sorry in advance!

<details><summary>Details</summary>
<p>

Working fine with metrics (existing behavior)
<img width="1648" height="730" alt="image" src="https://github.com/user-attachments/assets/60aa7e40-d27b-4c7d-98ad-d4dc6edcff7c" />

When there are no metrics
<img width="1647" height="721" alt="image" src="https://github.com/user-attachments/assets/bae58bda-76f6-4912-be09-9023b5bc6503" />


</p>
</details> 