### PR TITLE
console: show row count for queries that return rows with no columns

### DIFF
--- a/console/src/platform/shell/SqlSelectTable.tsx
+++ b/console/src/platform/shell/SqlSelectTable.tsx
@@ -181,6 +181,7 @@ const SqlSelectTable = ({
   const hasResults = paginatedRows.length > 0;
 
   if (colNames.length === 0) {
+    const rowCount = rows?.length ?? 0;
     return (
       <Flex
         px="4"
@@ -189,7 +190,11 @@ const SqlSelectTable = ({
         borderColor={colors.border.secondary}
         borderRadius="lg"
       >
-        <Text textStyle="monospace">No results</Text>
+        <Text textStyle="monospace">
+          {rowCount > 0
+            ? `(${rowCount} ${rowCount === 1 ? "row" : "rows"})`
+            : "No results"}
+        </Text>
       </Flex>
     );
   }


### PR DESCRIPTION
Queries like `SELECT FROM (SELECT 1)` return rows with zero columns. Previously the shell displayed "No results" because it checked `colNames.length === 0`. Now it checks whether rows exist and displays the row count (e.g. "(1 row)") instead, matching psql behavior.

Remove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
