### PR TITLE
Move source/sink dataflow restart into storage controller

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -106,6 +106,12 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// [`CancelOneshotIngestion`]: crate::client::StorageCommand::CancelOneshotIngestion
     /// [`RunOneshotIngestion`]: crate::client::StorageCommand::RunOneshotIngestion
     CancelOneshotIngestion(Uuid),
+    /// Instructs the replica to restart the dataflow identified by the given `GlobalId`.
+    ///
+    /// This is sent by the controller in response to a `HaltRequest` from the worker,
+    /// after applying backoff logic. The worker should tear down the existing dataflow
+    /// and re-render it with fresh frontiers from persist.
+    RestartDataflow(GlobalId),
 }
 
 impl<T> StorageCommand<T> {
@@ -118,7 +124,8 @@ impl<T> StorageCommand<T> {
             | AllowWrites
             | UpdateConfiguration(_)
             | AllowCompaction(_, _)
-            | CancelOneshotIngestion { .. } => false,
+            | CancelOneshotIngestion { .. }
+            | RestartDataflow(_) => false,
             // TODO(cf2): multi-replica oneshot ingestions. At the moment returning
             // true here means we can't run `COPY FROM` on multi-replica clusters, this
             // should be easy enough to support though.
@@ -344,6 +351,17 @@ pub enum StorageResponse<T = mz_repr::Timestamp> {
     /// A status update for a source or a sink. Periodically sent from
     /// storage workers to convey the latest status information about an object.
     StatusUpdate(StatusUpdate),
+    /// A request from the worker that the identified dataflow should be restarted.
+    ///
+    /// The worker has detected a transient error and is requesting the controller
+    /// to schedule a restart (with appropriate backoff). The worker does not
+    /// self-restart; it waits for the controller to send a `RestartDataflow` command.
+    HaltRequest {
+        /// The id of the dataflow that should be restarted.
+        id: GlobalId,
+        /// The reason for the restart request.
+        reason: String,
+    },
 }
 
 /// Maintained state for partitioned storage clients.
@@ -402,7 +420,8 @@ where
             | StorageCommand::UpdateConfiguration(_)
             | StorageCommand::AllowCompaction(_, _)
             | StorageCommand::RunOneshotIngestion(_)
-            | StorageCommand::CancelOneshotIngestion { .. } => {}
+            | StorageCommand::CancelOneshotIngestion { .. }
+            | StorageCommand::RestartDataflow(_) => {}
         }
     }
 
@@ -496,6 +515,11 @@ where
             }
             StorageResponse::StatusUpdate(updates) => {
                 Some(Ok(StorageResponse::StatusUpdate(updates)))
+            }
+            StorageResponse::HaltRequest { id, reason } => {
+                // Forward halt requests directly; only one worker should emit them
+                // (the health operator's chosen worker), so no deduplication needed.
+                Some(Ok(StorageResponse::HaltRequest { id, reason }))
             }
             StorageResponse::StagedBatches(batches) => {
                 let mut finished_batches = BTreeMap::new();

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -274,6 +274,8 @@ pub struct CommandMetrics<M> {
     pub run_oneshot_ingestion: M,
     /// Metrics for `CancelOneshotIngestion`.
     pub cancel_oneshot_ingestion: M,
+    /// Metrics for `RestartDataflow`.
+    pub restart_dataflow: M,
 }
 
 impl<M> CommandMetrics<M> {
@@ -291,6 +293,7 @@ impl<M> CommandMetrics<M> {
             run_sink: build_metric("run_sink"),
             run_oneshot_ingestion: build_metric("run_oneshot_ingestion"),
             cancel_oneshot_ingestion: build_metric("cancel_oneshot_ingestion"),
+            restart_dataflow: build_metric("restart_dataflow"),
         }
     }
 
@@ -307,6 +310,7 @@ impl<M> CommandMetrics<M> {
         f(&self.run_sink);
         f(&self.run_oneshot_ingestion);
         f(&self.cancel_oneshot_ingestion);
+        f(&self.restart_dataflow);
     }
 
     pub fn for_command<T>(&self, command: &StorageCommand<T>) -> &M {
@@ -322,6 +326,7 @@ impl<M> CommandMetrics<M> {
             RunSink(..) => &self.run_sink,
             RunOneshotIngestion(..) => &self.run_oneshot_ingestion,
             CancelOneshotIngestion(..) => &self.cancel_oneshot_ingestion,
+            RestartDataflow(..) => &self.restart_dataflow,
         }
     }
 }
@@ -334,6 +339,7 @@ struct ResponseMetrics<M> {
     staged_batches: M,
     statistics_updates: M,
     status_update: M,
+    halt_request: M,
 }
 
 impl<M> ResponseMetrics<M> {
@@ -347,6 +353,7 @@ impl<M> ResponseMetrics<M> {
             staged_batches: build_metric("staged_batches"),
             statistics_updates: build_metric("statistics_updates"),
             status_update: build_metric("status_update"),
+            halt_request: build_metric("halt_request"),
         }
     }
 
@@ -359,6 +366,7 @@ impl<M> ResponseMetrics<M> {
             StagedBatches(..) => &self.staged_batches,
             StatisticsUpdates(..) => &self.statistics_updates,
             StatusUpdate(..) => &self.status_update,
+            HaltRequest { .. } => &self.halt_request,
         }
     }
 }

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -110,6 +110,10 @@ impl<T: timely::progress::Timestamp + TotalOrder> CommandHistory<T> {
                 CancelOneshotIngestion(uuid) => {
                     final_oneshot_ingestions.remove(&uuid);
                 }
+                RestartDataflow(_) => {
+                    // RestartDataflow is a transient command; don't replay
+                    // it during reconciliation.
+                }
             }
         }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::collection_mgmt::{
     AppendOnlyIntrospectionConfig, CollectionManagerKind, DifferentialIntrospectionConfig,
@@ -125,6 +125,39 @@ impl PendingOneshotIngestion {
     }
 }
 
+/// Tracks the state of a pending dataflow restart requested by a worker.
+#[derive(Debug)]
+struct RestartState {
+    /// When the halt request was received.
+    requested_at: Instant,
+    /// Number of restart attempts so far for this dataflow.
+    attempt_count: u32,
+    /// How long to wait before the next restart attempt.
+    next_backoff: Duration,
+}
+
+impl RestartState {
+    fn new() -> Self {
+        Self {
+            requested_at: Instant::now(),
+            attempt_count: 0,
+            next_backoff: Duration::from_secs(1),
+        }
+    }
+
+    /// Returns true if enough time has elapsed to attempt a restart.
+    fn ready(&self) -> bool {
+        self.requested_at.elapsed() >= self.next_backoff
+    }
+
+    /// Advance the backoff for the next attempt (exponential, capped at 60s).
+    fn advance_backoff(&mut self) {
+        self.attempt_count += 1;
+        self.requested_at = Instant::now();
+        self.next_backoff = Duration::min(self.next_backoff * 2, Duration::from_secs(60));
+    }
+}
+
 /// A storage controller for a storage instance.
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -164,6 +197,9 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     txns_read: TxnsRead<T>,
     txns_metrics: Arc<TxnMetrics>,
     stashed_responses: Vec<(Option<ReplicaId>, StorageResponse<T>)>,
+    /// Dataflows that have requested a restart due to transient errors.
+    /// The controller applies backoff before issuing `RestartDataflow` commands.
+    pending_restarts: BTreeMap<GlobalId, RestartState>,
     /// Channel for sending table handle drops.
     #[derivative(Debug = "ignore")]
     pending_table_handle_drops_tx: mpsc::UnboundedSender<GlobalId>,
@@ -2334,6 +2370,10 @@ where
                     // find something better.
                     match status_update.status {
                         Status::Running => {
+                            // Dataflow is running successfully — clear any
+                            // pending restart state.
+                            self.pending_restarts.remove(&status_update.id);
+
                             let collection = self.collections.get_mut(&status_update.id);
                             match collection {
                                 Some(collection) => {
@@ -2398,6 +2438,18 @@ where
                     }
                     status_updates.push(status_update);
                 }
+                (_replica_id, StorageResponse::HaltRequest { id, reason }) => {
+                    info!(
+                        %id,
+                        %reason,
+                        "Received halt request from worker, scheduling restart with backoff"
+                    );
+                    // Only insert if not already pending — avoid resetting backoff
+                    // on duplicate halt requests for the same dataflow.
+                    self.pending_restarts
+                        .entry(id)
+                        .or_insert_with(RestartState::new);
+                }
                 (_replica_id, StorageResponse::StagedBatches(batches)) => {
                     for (ingestion_id, batches) in batches {
                         match self.pending_oneshot_ingestions.remove(&ingestion_id) {
@@ -2423,6 +2475,38 @@ where
         }
 
         self.record_status_updates(status_updates);
+
+        // Process pending restarts: issue RestartDataflow commands for
+        // dataflows whose backoff has elapsed.
+        let ready_restarts: Vec<GlobalId> = self
+            .pending_restarts
+            .iter()
+            .filter_map(|(id, state)| state.ready().then_some(*id))
+            .collect();
+        for id in ready_restarts {
+            let state = self.pending_restarts.get_mut(&id).expect("known to exist");
+            state.advance_backoff();
+
+            // Find the instance that owns this dataflow and send the restart command.
+            let instance_id = self.collections.get(&id).and_then(|c| match &c.extra_state {
+                CollectionStateExtra::Ingestion(ingestion) => Some(ingestion.instance_id),
+                CollectionStateExtra::Export(export) => Some(export.cluster_id()),
+                CollectionStateExtra::None => None,
+            });
+            if let Some(instance_id) = instance_id {
+                if let Some(instance) = self.instances.get_mut(&instance_id) {
+                    info!(
+                        %id,
+                        attempt = state.attempt_count,
+                        "Issuing RestartDataflow command to worker"
+                    );
+                    instance.send(StorageCommand::RestartDataflow(id));
+                }
+            } else {
+                // Collection no longer tracked; clean up the pending restart.
+                self.pending_restarts.remove(&id);
+            }
+        }
 
         // Process dropped tables in a single batch.
         let mut dropped_table_ids = Vec::new();
@@ -2664,6 +2748,7 @@ where
             instance_response_tx: _,
             instance_response_rx: _,
             persist_warm_task: _,
+            pending_restarts: _,
         } = self;
 
         let collections: BTreeMap<_, _> = collections
@@ -2843,6 +2928,7 @@ where
             txns_read,
             txns_metrics,
             stashed_responses: vec![],
+            pending_restarts: BTreeMap::new(),
             pending_table_handle_drops_tx,
             pending_table_handle_drops_rx,
             pending_oneshot_ingestions: BTreeMap::default(),

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -15,7 +15,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Debug;
 use std::rc::Rc;
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use differential_dataflow::Hashable;
@@ -31,8 +30,6 @@ use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::{Scope, StreamVec};
 use tracing::{error, info};
-
-use crate::internal_control::{InternalCommandSender, InternalStorageCommand};
 
 /// The namespace of the update. The `Ord` impl matter here, later variants are
 /// displayed over earlier ones.
@@ -270,10 +267,19 @@ pub trait HealthOperator {
     }
 }
 
+/// A halt request from the health operator, indicating a dataflow should be restarted.
+#[derive(Clone, Debug)]
+pub struct HaltRequest {
+    /// The id of the dataflow that should be restarted.
+    pub id: GlobalId,
+    /// The reason for the restart request.
+    pub reason: String,
+}
+
 /// A default `HealthOperator` for use in normal cases.
 pub struct DefaultWriter {
-    pub command_tx: InternalCommandSender,
     pub updates: Rc<RefCell<Vec<StatusUpdate>>>,
+    pub halt_requests: Rc<RefCell<Vec<HaltRequest>>>,
 }
 
 impl HealthOperator for DefaultWriter {
@@ -306,13 +312,10 @@ impl HealthOperator for DefaultWriter {
     }
 
     fn send_halt(&self, id: GlobalId, error: Option<(StatusNamespace, HealthStatusUpdate)>) {
-        self.command_tx
-            .send(InternalStorageCommand::SuspendAndRestart {
-                // Suspend and restart is expected to operate on the primary object and
-                // not any of the sub-objects
-                id,
-                reason: format!("{:?}", error),
-            });
+        self.halt_requests.borrow_mut().push(HaltRequest {
+            id,
+            reason: format!("{:?}", error),
+        });
     }
 }
 
@@ -351,9 +354,6 @@ pub(crate) fn health_operator<G, P>(
     health_operator_impl: P,
     // Whether or not we should actually write namespaced errors in the `details` column.
     write_namespaced_map: bool,
-    // How long to wait before initiating a `SuspendAndRestart` command, to
-    // prevent hot restart loops.
-    suspend_and_restart_delay: Duration,
 ) -> PressOnDropButton
 where
     G: Scope,
@@ -490,10 +490,6 @@ where
                     }
                 }
 
-                // TODO(aljoscha): Instead of threading through the
-                // `should_halt` bit, we can give an internal command sender
-                // directly to the places where `should_halt = true` originates.
-                // We should definitely do that, but this is okay for a PoC.
                 if let Some((id, halt_with)) = halt_with_outer {
                     mz_ore::soft_assert_or_log!(
                         id == halting_id,
@@ -505,11 +501,12 @@ where
                     );
 
                     info!(
-                        "Broadcasting suspend-and-restart \
-                        command because of {:?} after {:?} delay",
-                        halt_with, suspend_and_restart_delay
+                        "Sending halt request to controller for \
+                        {object_type} {id} because of {:?}",
+                        halt_with
                     );
-                    tokio::time::sleep(suspend_and_restart_delay).await;
+                    // Send halt request to the controller which will decide
+                    // when to restart with appropriate backoff.
                     health_operator_impl.send_halt(id, halt_with);
                 }
             }
@@ -1107,7 +1104,6 @@ mod tests {
                                     input_mapping: inputs,
                                 },
                                 write_namespaced_map,
-                                Duration::from_secs(5),
                             )));
                         });
                 });

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -67,13 +67,6 @@ impl DataflowParameters {
 /// on them.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum InternalStorageCommand {
-    /// Suspend and restart the dataflow identified by the `GlobalId`.
-    SuspendAndRestart {
-        /// The id of the dataflow that should be restarted.
-        id: GlobalId,
-        /// The reason for the restart request.
-        reason: String,
-    },
     /// Render an ingestion dataflow at the given resumption frontier.
     CreateIngestionDataflow {
         /// ID of the ingestion/sourve.

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -218,6 +218,7 @@ use timely::dataflow::scopes::Child;
 use timely::progress::Antichain;
 use timely::worker::{AsWorker, Worker as TimelyWorker};
 use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::RawSourceCreationConfig;
@@ -300,6 +301,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 config: storage_state.storage_configuration.clone(),
                 remap_collection_id: description.remap_collection_id,
                 busy_signal: Arc::clone(&busy_signal),
+                transient_error_token: CancellationToken::new(),
             };
 
             let (outputs, source_health, source_tokens) = match connection {
@@ -415,15 +417,13 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 "source",
                 health_stream,
                 crate::healthcheck::DefaultWriter {
-                    command_tx: storage_state.internal_cmd_tx.clone(),
                     updates: Rc::clone(&storage_state.shared_status_updates),
+                    halt_requests: Rc::clone(&storage_state.shared_halt_requests),
                 },
                 storage_state
                     .storage_configuration
                     .parameters
                     .record_namespaced_errors,
-                dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
-                    .get(storage_state.storage_configuration.config_set()),
             );
             tokens.push(health_token);
 
@@ -462,15 +462,13 @@ pub fn build_export_dataflow<A: Allocate>(
             "sink",
             health_stream,
             crate::healthcheck::DefaultWriter {
-                command_tx: storage_state.internal_cmd_tx.clone(),
                 updates: Rc::clone(&storage_state.shared_status_updates),
+                halt_requests: Rc::clone(&storage_state.shared_halt_requests),
             },
             storage_state
                 .storage_configuration
                 .parameters
                 .record_namespaced_errors,
-            dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
-                .get(storage_state.storage_configuration.config_set()),
         );
         tokens.push(health_token);
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -416,6 +416,11 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
             let consumer = match consumer {
                 Ok(consumer) => Arc::new(consumer),
                 Err(e) => {
+                    // Signal transient error before emitting the halting health
+                    // status. This ensures the remap operator will not seal the
+                    // remap shard when the probe channel closes.
+                    config.transient_error_token.cancel();
+
                     let update = HealthStatusUpdate::halting(
                         format!(
                             "failed creating kafka reader consumer: {}",
@@ -449,11 +454,9 @@ fn render_reader<G: Scope<Timestamp = KafkaTimestamp>>(
                             },
                         );
                     }
-                    // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
-                    // Returning would incorrectly present to the remap operator as progress to the
-                    // empty frontier which would be incorrectly recorded to the remap shard.
-                    std::future::pending::<()>().await;
-                    unreachable!("pending future never returns");
+                    // The transient error token is set, so the remap operator
+                    // will not seal the remap shard when this operator exits.
+                    return;
                 }
             };
 
@@ -1615,6 +1618,11 @@ fn render_metadata_fetcher<G: Scope<Timestamp = KafkaTimestamp>>(
         let consumer = match consumer {
             Ok(consumer) => consumer,
             Err(e) => {
+                // Signal transient error before emitting the halting health
+                // status. This ensures the remap operator will not seal the
+                // remap shard when the probe channel closes.
+                config.transient_error_token.cancel();
+
                 let msg = format!(
                     "failed creating kafka metadata consumer: {}",
                     e.display_with_causes()
@@ -1628,11 +1636,9 @@ fn render_metadata_fetcher<G: Scope<Timestamp = KafkaTimestamp>>(
                 let timestamp = (config.now_fn)().into();
                 metadata_output.give(&metadata_cap, (timestamp, error));
 
-                // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
-                // Returning would incorrectly present to the remap operator as progress to the
-                // empty frontier which would be incorrectly recorded to the remap shard.
-                std::future::pending::<()>().await;
-                unreachable!("pending future never returns");
+                // The transient error token is set, so the remap operator
+                // will not seal the remap shard when this operator exits.
+                return;
             }
         };
 

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -211,11 +211,16 @@ impl SourceRender for MySqlSourceConnection {
             .collect::<Vec<_>>()
             .to_stream(scope);
 
+        let transient_error_token = config.transient_error_token.clone();
         let health_errs = snapshot_err
             .concat(repl_err)
             .concat(stats_err)
             .map(move |err| {
-                // This update will cause the dataflow to restart
+                // Signal transient error before emitting the halting health status.
+                // This ensures the remap operator will not seal the remap shard when
+                // the probe channel closes.
+                transient_error_token.cancel();
+
                 let err_string = err.display_with_causes().to_string();
                 let update = HealthStatusUpdate::halting(err_string.clone(), None);
 

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -230,8 +230,13 @@ impl SourceRender for PostgresSourceConnection {
         // N.B. Note that we don't check ssh tunnel statuses here. We could, but immediately on
         // restart we are going to set the status to an ssh error correctly, so we don't do this
         // extra work.
+        let transient_error_token = config.transient_error_token.clone();
         let errs = snapshot_err.concat(repl_err).map(move |err| {
-            // This update will cause the dataflow to restart
+            // Signal transient error before emitting the halting health status.
+            // This ensures the remap operator will not seal the remap shard when
+            // the probe channel closes.
+            transient_error_token.cancel();
+
             let err_string = err.display_with_causes().to_string();
             let update = HealthStatusUpdate::halting(err_string.clone(), None);
 

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -63,6 +63,7 @@ use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use tokio::sync::{Semaphore, watch};
 use tokio_stream::wrappers::WatchStream;
+use tokio_util::sync::CancellationToken;
 use tracing::trace;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate};
@@ -120,6 +121,11 @@ pub struct RawSourceCreationConfig {
     // A semaphore that should be acquired by async operators in order to signal that upstream
     // operators should slow down.
     pub busy_signal: Arc<Semaphore>,
+    /// A cancellation token that upstream source operators should set when they encounter a
+    /// transient error and are about to exit. This prevents the remap operator from minting
+    /// an empty-frontier binding (which would permanently seal the remap shard) when the
+    /// probe channel closes due to the error.
+    pub transient_error_token: CancellationToken,
 }
 
 /// Reduced version of [`RawSourceCreationConfig`] that is used when rendering
@@ -202,6 +208,7 @@ where
         config.clone(),
         probed_upper_rx,
         timestamp_desc,
+        config.transient_error_token.clone(),
     );
     // Need to broadcast the remap changes to all workers.
     let remap_collection = remap_collection.inner.broadcast().as_collection();
@@ -404,6 +411,7 @@ fn remap_operator<G, FromTime>(
     config: RawSourceCreationConfig,
     mut probed_upper: watch::Receiver<Option<Probe<FromTime>>>,
     remap_relation_desc: RelationDesc,
+    transient_error_token: CancellationToken,
 ) -> (VecCollection<G, FromTime, Diff>, PressOnDropButton)
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -428,6 +436,7 @@ where
         config: _,
         remap_collection_id,
         busy_signal: _,
+        transient_error_token: _,
     } = config;
 
     let read_only_rx = storage_state.read_only_rx.clone();
@@ -503,13 +512,29 @@ where
                 .await
                 .map(|probe| (*probe).clone())
                 .unwrap_or_else(|_| {
-                    Some(Probe {
-                        probe_ts: now_fn().into(),
-                        upstream_frontier: Antichain::new(),
-                    })
+                    // The probe channel closed. Check whether this is due to a transient
+                    // error (token is cancelled) or normal source completion.
+                    if transient_error_token.is_cancelled() {
+                        // A transient error caused the upstream operators to exit.
+                        // We must NOT mint a binding for the empty frontier, as that
+                        // would permanently seal the remap shard. Instead, exit the
+                        // minting loop and drop capabilities at the current position.
+                        // The controller will restart the dataflow.
+                        None
+                    } else {
+                        // Normal completion: the source is done. Mint a final binding
+                        // at the empty frontier to seal the remap shard.
+                        Some(Probe {
+                            probe_ts: now_fn().into(),
+                            upstream_frontier: Antichain::new(),
+                        })
+                    }
                 });
 
-            let probe = new_probe.expect("known to be Some");
+            // If the probe is None, a transient error occurred. Exit without sealing.
+            let Some(probe) = new_probe else {
+                return;
+            };
             prev_probe_ts = Some(probe.probe_ts);
 
             let binding_ts = probe.probe_ts;

--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -205,8 +205,13 @@ impl SourceRender for SqlServerSourceConnection {
             .collect::<Vec<_>>()
             .to_stream(scope);
 
+        let transient_error_token = config.transient_error_token.clone();
         let health_errs = repl_errs.concat(progress_errs).map(move |err| {
-            // This update will cause the dataflow to restart
+            // Signal transient error before emitting the halting health status.
+            // This ensures the remap operator will not seal the remap shard when
+            // the probe channel closes.
+            transient_error_token.cancel();
+
             let err_string = err.display_with_causes().to_string();
             let update = HealthStatusUpdate::halting(err_string, None);
             // TODO(sql_server2): If the error has anything to do with SSH

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -226,6 +226,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 timely_worker.peers(),
             ),
             shared_status_updates: Default::default(),
+            shared_halt_requests: Default::default(),
             latest_status_updates: Default::default(),
             initial_status_reported: Default::default(),
             internal_cmd_tx,
@@ -313,6 +314,11 @@ pub struct StorageState {
     /// status updates if the status of the ingestion/export in question has _changed_.
     pub shared_status_updates: Rc<RefCell<Vec<StatusUpdate>>>,
 
+    /// A place shared with running dataflows, so that health operators can
+    /// report halt requests (transient errors requiring restart) back to us.
+    /// These are forwarded to the controller, which decides when to restart.
+    pub shared_halt_requests: Rc<RefCell<Vec<crate::healthcheck::HaltRequest>>>,
+
     /// The latest status update for each object.
     pub latest_status_updates: BTreeMap<GlobalId, StatusUpdate>,
 
@@ -363,15 +369,17 @@ pub struct StorageState {
 }
 
 impl StorageState {
-    /// Return an error handler that triggers a suspend and restart of the corresponding storage
-    /// dataflow.
+    /// Return an error handler that requests a restart of the corresponding storage
+    /// dataflow via the controller.
     pub fn error_handler(&self, context: &'static str, id: GlobalId) -> ErrorHandler {
-        let tx = self.internal_cmd_tx.clone();
+        let halt_requests = Rc::clone(&self.shared_halt_requests);
         ErrorHandler::signal(move |e| {
-            tx.send(InternalStorageCommand::SuspendAndRestart {
-                id,
-                reason: format!("{context}: {e:#}"),
-            })
+            halt_requests
+                .borrow_mut()
+                .push(crate::healthcheck::HaltRequest {
+                    id,
+                    reason: format!("{context}: {e:#}"),
+                })
         })
     }
 }
@@ -569,96 +577,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
     /// Entry point for applying an internal storage command.
     pub fn handle_internal_storage_command(&mut self, internal_cmd: InternalStorageCommand) {
         match internal_cmd {
-            InternalStorageCommand::SuspendAndRestart { id, reason } => {
-                info!(
-                    "worker {}/{} initiating suspend-and-restart for {id} because of: {reason}",
-                    self.timely_worker.index(),
-                    self.timely_worker.peers(),
-                );
-
-                let maybe_ingestion = self.storage_state.ingestions.get(&id).cloned();
-                if let Some(ingestion_description) = maybe_ingestion {
-                    // Yank the token of the previously existing source dataflow.Note that this
-                    // token also includes any source exports/subsources.
-                    let maybe_token = self.storage_state.source_tokens.remove(&id);
-                    if maybe_token.is_none() {
-                        // Something has dropped the source. Make sure we don't
-                        // accidentally re-create it.
-                        return;
-                    }
-
-                    // This needs to be done by one worker, which will
-                    // broadcasts a `CreateIngestionDataflow` command to all
-                    // workers based on the response that contains the
-                    // resumption upper.
-                    //
-                    // Doing this separately on each worker could lead to
-                    // differing resume_uppers which might lead to all kinds of
-                    // mayhem.
-                    //
-                    // TODO(aljoscha): If we ever become worried that this is
-                    // putting undue pressure on worker 0 we can pick the
-                    // designated worker for a source/sink based on `id.hash()`.
-                    if self.timely_worker.index() == 0 {
-                        for (id, _) in ingestion_description.source_exports.iter() {
-                            self.storage_state
-                                .aggregated_statistics
-                                .advance_global_epoch(*id);
-                        }
-                        self.storage_state
-                            .async_worker
-                            .update_ingestion_frontiers(id, ingestion_description);
-                    }
-
-                    // Continue with other commands.
-                    return;
-                }
-
-                let maybe_sink = self.storage_state.exports.get(&id).cloned();
-                if let Some(sink_description) = maybe_sink {
-                    // Yank the token of the previously existing sink
-                    // dataflow.
-                    let maybe_token = self.storage_state.sink_tokens.remove(&id);
-
-                    if maybe_token.is_none() {
-                        // Something has dropped the sink. Make sure we don't
-                        // accidentally re-create it.
-                        return;
-                    }
-
-                    // This needs to be broadcast by one worker and go through
-                    // the internal command fabric, to ensure consistent
-                    // ordering of dataflow rendering across all workers.
-                    if self.timely_worker.index() == 0 {
-                        self.storage_state
-                            .aggregated_statistics
-                            .advance_global_epoch(id);
-                        self.storage_state
-                            .async_worker
-                            .update_sink_frontiers(id, sink_description);
-                    }
-
-                    // Continue with other commands.
-                    return;
-                }
-
-                if !self
-                    .storage_state
-                    .ingestions
-                    .values()
-                    .any(|v| v.source_exports.contains_key(&id))
-                {
-                    // Our current approach to dropping a source results in a race between shard
-                    // finalization (which happens in the controller) and dataflow shutdown (which
-                    // happens in clusterd). If a source is created and dropped fast enough -or the
-                    // two commands get sufficiently delayed- then it's possible to receive a
-                    // SuspendAndRestart command for an unknown source. We cannot assert that this
-                    // never happens but we log an error here to track how often this happens.
-                    warn!(
-                        "got InternalStorageCommand::SuspendAndRestart for something that is not a source or sink: {id}"
-                    );
-                }
-            }
             InternalStorageCommand::CreateIngestionDataflow {
                 id: ingestion_id,
                 mut ingestion_description,
@@ -931,6 +849,17 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 .latest_status_updates
                 .insert(shared_update.id, shared_update);
         }
+
+        // Pump halt requests from the health operators and forward to the controller.
+        for halt_request in self.storage_state.shared_halt_requests.take() {
+            self.send_storage_response(
+                response_tx,
+                StorageResponse::HaltRequest {
+                    id: halt_request.id,
+                    reason: halt_request.reason,
+                },
+            );
+        }
     }
 
     /// Report source statistics back to the controller.
@@ -1067,7 +996,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::InitializationComplete
                 | StorageCommand::AllowWrites
-                | StorageCommand::UpdateConfiguration(_) => (),
+                | StorageCommand::UpdateConfiguration(_)
+                | StorageCommand::RestartDataflow(_) => (),
             }
         }
 
@@ -1187,7 +1117,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 StorageCommand::InitializationComplete
                 | StorageCommand::AllowWrites
                 | StorageCommand::UpdateConfiguration(_)
-                | StorageCommand::AllowCompaction(_, _) => (),
+                | StorageCommand::AllowCompaction(_, _)
+                | StorageCommand::RestartDataflow(_) => (),
             }
             if should_keep {
                 filtered_commands.push_front(command);
@@ -1397,6 +1328,60 @@ impl StorageState {
                     // Indicates that we may drop `id`, as there are no more valid times to read.
                     self.drop_collection(id);
                 }
+            }
+            StorageCommand::RestartDataflow(id) => {
+                info!(
+                    "worker {}/{} received controller-initiated restart for {id}",
+                    self.timely_worker_index, self.timely_worker_peers,
+                );
+
+                let maybe_ingestion = self.ingestions.get(&id).cloned();
+                if let Some(ingestion_description) = maybe_ingestion {
+                    // Yank the token of the previously existing source dataflow.
+                    // This also includes any source exports/subsources.
+                    let maybe_token = self.source_tokens.remove(&id);
+                    if maybe_token.is_none() {
+                        // Something has dropped the source. Make sure we don't
+                        // accidentally re-create it.
+                        return;
+                    }
+
+                    // This needs to be done by one worker, which will broadcast a
+                    // `CreateIngestionDataflow` command to all workers based on the
+                    // response that contains the resumption upper.
+                    if self.timely_worker_index == 0 {
+                        for (export_id, _) in ingestion_description.source_exports.iter() {
+                            self.aggregated_statistics.advance_global_epoch(*export_id);
+                        }
+                        self.async_worker
+                            .update_ingestion_frontiers(id, ingestion_description);
+                    }
+
+                    return;
+                }
+
+                let maybe_sink = self.exports.get(&id).cloned();
+                if let Some(sink_description) = maybe_sink {
+                    let maybe_token = self.sink_tokens.remove(&id);
+                    if maybe_token.is_none() {
+                        // Something has dropped the sink. Make sure we don't
+                        // accidentally re-create it.
+                        return;
+                    }
+
+                    if self.timely_worker_index == 0 {
+                        self.aggregated_statistics.advance_global_epoch(id);
+                        self.async_worker
+                            .update_sink_frontiers(id, sink_description);
+                    }
+
+                    return;
+                }
+
+                warn!(
+                    "got StorageCommand::RestartDataflow for something that is \
+                    not a source or sink: {id}"
+                );
             }
         }
     }


### PR DESCRIPTION
This just moves the restart logic to controller, the health stream continues to exist. Additionally, this takes a stab at addressing operator exit and remap binding the empty frontier.