### PR TITLE
Use vendored `Columnation` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6531,6 +6531,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "chrono-tz",
+ "columnation",
  "crc32fast",
  "criterion",
  "csv",
@@ -12091,15 +12092,15 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ae21fb064a79d9010f8108429745fa91b92b694fa4df218ba84d7f3b2dbd60"
+checksum = "18f23a0d67d58c5e33b1d2e1405f153302eaed97b03b019eaadc506078b0d9b3"
 
 [[package]]
 name = "timely_communication"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c086160017fb45428d907e2abfe102a75c4563ef93db5b34bd66bc85d4c140"
+checksum = "7dfca21d938082bdd981b2e68dbbcc84c5d1a3540b9cb186f70e3280f75f5366"
 dependencies = [
  "byteorder",
  "columnar",
@@ -12112,15 +12113,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb11577da6f9af245617074f52c1327ff670f940cbd44fad5c3cbd99c1b1ee1"
+checksum = "59d871973712d029dc403809a06bd33134f4e91c2da9d86b7476b946d64db1e7"
 
 [[package]]
 name = "timely_logging"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15dae737805a73889faeff9446b18e17dbeebb3941c9d8861d4c19a14074f543"
+checksum = "7071ee1e8c0e4d0e97041819a114ca037f197616691039845973b88138fa0b78"
 dependencies = [
  "timely_container",
 ]

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use columnar::{Columnar, Index};
-use differential_dataflow::containers::{Columnation, CopyRegion};
+use columnation::{Columnation, CopyRegion};
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, Timestamp};

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -14,11 +14,11 @@
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
+use columnation::{Columnation, CopyRegion};
 use dec::OrderedDecimal;
 use differential_dataflow::Diff as _;
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use differential_dataflow::containers::{Columnation, CopyRegion};
 use differential_dataflow::difference::{IsZero, Multiply, Semigroup};
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
@@ -2146,7 +2146,7 @@ mod monoids {
     // add a new enum variant here), because other code (e.g., `HierarchicalOneByOneAggr`)
     // assumes this.
 
-    use differential_dataflow::containers::{Columnation, Region};
+    use columnation::{Columnation, Region};
     use differential_dataflow::difference::{IsZero, Multiply, Semigroup};
     use mz_expr::AggregateFunc;
     use mz_ore::soft_panic_or_log;

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -864,7 +864,7 @@ pub mod monoids {
     use std::hash::{Hash, Hasher};
     use std::rc::Rc;
 
-    use differential_dataflow::containers::{Columnation, Region};
+    use columnation::{Columnation, Region};
     use differential_dataflow::difference::{IsZero, Multiply, Semigroup};
     use mz_expr::ColumnOrder;
     use mz_repr::{DatumVec, Diff, Row};

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -27,6 +27,7 @@ anyhow.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
 chrono.workspace = true
+columnation.workspace = true
 chrono-tz.workspace = true
 crc32fast.workspace = true
 csv.workspace = true

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroU64;
 use std::time::Instant;
 
 use bytesize::ByteSize;
-use differential_dataflow::containers::{Columnation, CopyRegion};
+use columnation::{Columnation, CopyRegion};
 use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::{CastFrom, CastInto};

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -493,8 +493,8 @@ impl Error for DataflowError {}
 
 mod boxed_str {
 
-    use differential_dataflow::containers::Region;
-    use differential_dataflow::containers::StableRegion;
+    use columnation::Region;
+    use columnation::StableRegion;
 
     /// Region allocation for `String` data.
     ///
@@ -546,7 +546,7 @@ mod boxed_str {
 mod columnation {
     use std::iter::once;
 
-    use differential_dataflow::containers::{Columnation, Region, StableRegion};
+    use columnation::{Columnation, Region, StableRegion};
     use mz_expr::EvalError;
     use mz_repr::Row;
     use mz_repr::adt::range::InvalidRangeError;

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, Waker, ready};
 
-use differential_dataflow::containers::Columnation;
+use columnation::Columnation;
 use futures_util::Stream;
 use futures_util::task::ArcWake;
 use timely::communication::{Pull, Push};

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -18,8 +18,8 @@
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::marker::PhantomData;
 
+use columnation::Columnation;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use differential_dataflow::containers::Columnation;
 use differential_dataflow::difference::{Multiply, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::{Batcher, Builder, Description};

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-use differential_dataflow::containers::CopyRegion;
+use columnation::CopyRegion;
 use serde::{Deserialize, Serialize};
 use timely::order::Product;
 use timely::progress::Antichain;


### PR DESCRIPTION
When we introduced the vendored `Columnation` container types, we didn't fully re-orient to target them vs the ones exported by differential. That will be a break when it happens, so we fix it here.