### PR TITLE
Remove genericity over `Allocate` trait

### DIFF
--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -21,9 +21,8 @@ use mz_cluster_client::client::{TimelyConfig, TryIntoProtocolNonce};
 use mz_service::client::{GenericClient, Partitionable, Partitioned};
 use mz_service::local::LocalClient;
 use timely::WorkerConfig;
-use timely::communication::Allocate;
-use timely::communication::allocator::GenericBuilder;
 use timely::communication::allocator::zero_copy::bytes_slab::BytesRefill;
+use timely::communication::allocator::{Generic, GenericBuilder};
 use timely::communication::initialize::WorkerGuards;
 use timely::execute::execute_from;
 use timely::worker::Worker as TimelyWorker;
@@ -170,9 +169,9 @@ pub trait ClusterSpec: Clone + Send + Sync + 'static {
     const NAME: &str;
 
     /// Run the given Timely worker.
-    fn run_worker<A: Allocate + 'static>(
+    fn run_worker(
         &self,
-        timely_worker: &mut TimelyWorker<A>,
+        timely_worker: &mut TimelyWorker<Generic>,
         client_rx: mpsc::UnboundedReceiver<(
             Uuid,
             mpsc::UnboundedReceiver<Self::Command>,

--- a/src/compute/src/command_channel.rs
+++ b/src/compute/src/command_channel.rs
@@ -30,7 +30,7 @@ use mz_compute_client::protocol::command::ComputeCommand;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
 use mz_ore::cast::CastFrom;
 use mz_timely_util::scope_label::ScopeExt;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::operators::generic::source;
@@ -81,7 +81,7 @@ impl Receiver {
 }
 
 /// Render the command channel dataflow.
-pub fn render<A: Allocate>(timely_worker: &mut TimelyWorker<A>) -> (Sender, Receiver) {
+pub fn render(timely_worker: &mut TimelyWorker<Generic>) -> (Sender, Receiver) {
     let (input_tx, input_rx) = mpsc::channel();
     let (output_tx, output_rx) = mpsc::channel();
     let activator = Arc::new(Mutex::new(None));

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -58,7 +58,7 @@ use mz_storage_types::sources::SourceData;
 use mz_storage_types::time_dependence::TimeDependence;
 use mz_txn_wal::operator::TxnsContext;
 use mz_txn_wal::txn_cache::TxnsCache;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::dataflow::operators::probe;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
@@ -355,9 +355,9 @@ impl ComputeState {
 }
 
 /// A wrapper around [ComputeState] with a live timely worker and response channel.
-pub(crate) struct ActiveComputeState<'a, A: Allocate> {
+pub(crate) struct ActiveComputeState<'a> {
     /// The underlying Timely worker.
-    pub timely_worker: &'a mut TimelyWorker<A>,
+    pub timely_worker: &'a mut TimelyWorker<Generic>,
     /// The compute state itself.
     pub compute_state: &'a mut ComputeState,
     /// The channel over which frontier information is reported.
@@ -374,7 +374,7 @@ impl SinkToken {
     }
 }
 
-impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
+impl<'a> ActiveComputeState<'a> {
     /// Entrypoint for applying a compute command.
     #[mz_ore::instrument(level = "debug")]
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
@@ -1160,12 +1160,12 @@ impl PendingPeek {
         })
     }
 
-    fn persist<A: Allocate>(
+    fn persist(
         peek: Peek,
         persist_clients: Arc<PersistClientCache>,
         metadata: CollectionMetadata,
         max_result_size: usize,
-        timely_worker: &TimelyWorker<A>,
+        timely_worker: &TimelyWorker<Generic>,
     ) -> Self {
         let active_worker = {
             // Choose the worker that does the actual peek arbitrarily but consistently.

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -24,7 +24,7 @@ use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::operator::CollectionExt;
 use mz_timely_util::scope_label::ScopeExt;
 use timely::ContainerBuilder;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::container::{ContainerBuilder as _, PushInto};
 use timely::dataflow::Scope;
 use timely::logging::{TimelyEvent, TimelyEventBuilder};
@@ -43,8 +43,8 @@ use crate::typedefs::{ErrBatcher, ErrBuilder};
 ///
 /// Returns a logger for compute events, and for each `LogVariant` a trace bundle usable for
 /// retrieving logged records as well as the index of the exporting dataflow.
-pub fn initialize<A: Allocate + 'static>(
-    worker: &mut timely::worker::Worker<A>,
+pub fn initialize(
+    worker: &mut timely::worker::Worker<Generic>,
     config: &LoggingConfig,
     metrics_registry: MetricsRegistry,
     worker_config: Rc<ConfigSet>,
@@ -98,8 +98,8 @@ pub fn initialize<A: Allocate + 'static>(
 
 pub(super) type ReachabilityEvent = (usize, Vec<(usize, usize, bool, Timestamp, Diff)>);
 
-struct LoggingContext<'a, A: Allocate> {
-    worker: &'a mut timely::worker::Worker<A>,
+struct LoggingContext<'a> {
+    worker: &'a mut timely::worker::Worker<Generic>,
     config: &'a LoggingConfig,
     interval_ms: u128,
     now: Instant,
@@ -123,7 +123,7 @@ pub(crate) struct LoggingTraces {
     pub compute_logger: super::compute::Logger,
 }
 
-impl<A: Allocate + 'static> LoggingContext<'_, A> {
+impl LoggingContext<'_> {
     fn construct_dataflow(&mut self) -> BTreeMap<LogVariant, TraceBundle> {
         self.worker.dataflow_named("Dataflow: logging", |scope| {
             let scope = &mut scope.with_label();

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -139,7 +139,7 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::vec::ToStream;
@@ -184,8 +184,8 @@ pub use join::LinearJoinSpec;
 /// This method imports sources from provided assets, and then builds the remaining
 /// dataflow using "compute-local" assets like shared arrangements, and producing
 /// both arrangements and sinks.
-pub fn build_compute_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
+pub fn build_compute_dataflow(
+    timely_worker: &mut TimelyWorker<Generic>,
     compute_state: &mut ComputeState,
     dataflow: DataflowDescription<RenderPlan, CollectionMetadata>,
     start_signal: StartSignal,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -31,7 +31,7 @@ use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
 use mz_storage_types::connections::ConnectionContext;
 use mz_txn_wal::operator::TxnsContext;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
@@ -202,9 +202,9 @@ impl ResponseSender {
 ///
 /// Much of this state can be viewed as local variables for the worker thread,
 /// holding state that persists across function calls.
-struct Worker<'w, A: Allocate> {
+struct Worker<'w> {
     /// The underlying Timely worker.
-    timely_worker: &'w mut TimelyWorker<A>,
+    timely_worker: &'w mut TimelyWorker<Generic>,
     /// The channel over which commands are received.
     command_rx: CommandReceiver,
     /// The channel over which responses are sent.
@@ -232,9 +232,9 @@ impl ClusterSpec for Config {
 
     const NAME: &str = "compute";
 
-    fn run_worker<A: Allocate + 'static>(
+    fn run_worker(
         &self,
-        timely_worker: &mut TimelyWorker<A>,
+        timely_worker: &mut TimelyWorker<Generic>,
         client_rx: mpsc::UnboundedReceiver<(
             Uuid,
             mpsc::UnboundedReceiver<ComputeCommand>,
@@ -318,7 +318,7 @@ fn set_core_affinity(_worker_id: usize) {
     info!("setting core affinity is not supported on macOS");
 }
 
-impl<'w, A: Allocate + 'static> Worker<'w, A> {
+impl<'w> Worker<'w> {
     /// Runs a compute worker.
     pub fn run(&mut self) {
         // The command receiver is initialized without an nonce, so receiving the first command
@@ -414,7 +414,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         self.activate_compute().unwrap().handle_compute_command(cmd);
     }
 
-    fn activate_compute(&mut self) -> Option<ActiveComputeState<'_, A>> {
+    fn activate_compute(&mut self) -> Option<ActiveComputeState<'_>> {
         if let Some(compute_state) = &mut self.compute_state {
             Some(ActiveComputeState {
                 timely_worker: &mut *self.timely_worker,

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -20,7 +20,7 @@ use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::IngestionDescription;
 use mz_timely_util::scope_label::ScopeExt;
 use serde::{Deserialize, Serialize};
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::Operator;
 use timely::dataflow::operators::generic::source;
@@ -166,8 +166,8 @@ impl InternalCommandReceiver {
     }
 }
 
-pub(crate) fn setup_command_sequencer<'w, A: Allocate>(
-    timely_worker: &'w mut TimelyWorker<A>,
+pub(crate) fn setup_command_sequencer<'w>(
+    timely_worker: &'w mut TimelyWorker<Generic>,
 ) -> (InternalCommandSender, InternalCommandReceiver) {
     let (input_tx, input_rx) = mpsc::channel();
     let (output_tx, output_rx) = mpsc::channel();

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -210,7 +210,7 @@ use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::{GenericSourceConnection, IngestionDescription, SourceConnection};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::scope_label::ScopeExt;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::dataflow::Scope;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::operators::{Concatenate, ConnectLoop, Feedback, Leave};
@@ -231,8 +231,8 @@ pub mod sources;
 ///
 /// This method creates a new dataflow to host the implementations of sources for the `dataflow`
 /// argument, and returns assets for each source that can import the results into a new dataflow.
-pub fn build_ingestion_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
+pub fn build_ingestion_dataflow(
+    timely_worker: &mut TimelyWorker<Generic>,
     storage_state: &mut StorageState,
     primary_source_id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
@@ -435,8 +435,8 @@ pub fn build_ingestion_dataflow<A: Allocate>(
 }
 
 /// do the export dataflow thing
-pub fn build_export_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
+pub fn build_export_dataflow(
+    timely_worker: &mut TimelyWorker<Generic>,
     storage_state: &mut StorageState,
     id: GlobalId,
     description: StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
@@ -478,8 +478,8 @@ pub fn build_export_dataflow<A: Allocate>(
     });
 }
 
-pub(crate) fn build_oneshot_ingestion_dataflow<A: Allocate>(
-    timely_worker: &mut TimelyWorker<A>,
+pub(crate) fn build_oneshot_ingestion_dataflow(
+    timely_worker: &mut TimelyWorker<Generic>,
     storage_state: &mut StorageState,
     ingestion_id: uuid::Uuid,
     collection_id: GlobalId,

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -21,7 +21,7 @@ use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_storage_client::client::{StorageClient, StorageCommand, StorageResponse};
 use mz_storage_types::connections::ConnectionContext;
 use mz_txn_wal::operator::TxnsContext;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -95,9 +95,9 @@ impl ClusterSpec for Config {
 
     const NAME: &str = "storage";
 
-    fn run_worker<A: Allocate + 'static>(
+    fn run_worker(
         &self,
-        timely_worker: &mut TimelyWorker<A>,
+        timely_worker: &mut TimelyWorker<Generic>,
         client_rx: mpsc::UnboundedReceiver<(
             Uuid,
             mpsc::UnboundedReceiver<StorageCommand>,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -103,7 +103,7 @@ use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::IngestionDescription;
 use mz_timely_util::builder_async::PressOnDropButton;
 use mz_txn_wal::operator::TxnsContext;
-use timely::communication::Allocate;
+use timely::communication::allocator::Generic;
 use timely::order::PartialOrder;
 use timely::progress::Timestamp as _;
 use timely::progress::frontier::Antichain;
@@ -131,11 +131,11 @@ type ResponseSender = mpsc::UnboundedSender<StorageResponse>;
 ///
 /// Much of this state can be viewed as local variables for the worker thread,
 /// holding state that persists across function calls.
-pub struct Worker<'w, A: Allocate> {
+pub struct Worker<'w> {
     /// The underlying Timely worker.
     ///
     /// NOTE: This is `pub` for testing.
-    pub timely_worker: &'w mut TimelyWorker<A>,
+    pub timely_worker: &'w mut TimelyWorker<Generic>,
     /// The channel over which communication handles for newly connected clients
     /// are delivered.
     pub client_rx: mpsc::UnboundedReceiver<(Uuid, CommandReceiver, ResponseSender)>,
@@ -143,10 +143,10 @@ pub struct Worker<'w, A: Allocate> {
     pub storage_state: StorageState,
 }
 
-impl<'w, A: Allocate> Worker<'w, A> {
+impl<'w> Worker<'w> {
     /// Creates new `Worker` state from the given components.
     pub fn new(
-        timely_worker: &'w mut TimelyWorker<A>,
+        timely_worker: &'w mut TimelyWorker<Generic>,
         client_rx: mpsc::UnboundedReceiver<(Uuid, CommandReceiver, ResponseSender)>,
         metrics: StorageMetrics,
         now: NowFn,
@@ -413,7 +413,7 @@ impl StorageInstanceContext {
     }
 }
 
-impl<'w, A: Allocate> Worker<'w, A> {
+impl<'w> Worker<'w> {
     /// Waits for client connections and runs them to completion.
     pub fn run(&mut self) {
         while let Some((_nonce, rx, tx)) = self.client_rx.blocking_recv() {


### PR DESCRIPTION
Some amount of code is generic over `A: Allocate`, which allows swapping the timely channel allocator. We only instantiate this with the most general form, `Generic`. We can remove the false generality and cut out our use of this trait.