### PR TITLE
De-genericize `Context`

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -690,7 +690,7 @@ where
 
 // This implementation block requires the scopes have the same timestamp as the trace manager.
 // That makes some sense, because we are hoping to deposit an arrangement in the trace manager.
-impl<'g, G> Context<Child<'g, G, G::Timestamp>, G::Timestamp>
+impl<'g, G> Context<Child<'g, G, G::Timestamp>>
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -64,7 +64,7 @@ use crate::typedefs::{
 /// of regions or iteration.
 pub struct Context<S: Scope>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// The scope within which all managed collections exist.
     ///
@@ -99,7 +99,7 @@ where
 
 impl<S: Scope> Context<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Creates a new empty Context.
     pub fn for_dataflow_in<Plan>(
@@ -145,7 +145,7 @@ where
 
 impl<S: Scope> Context<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Insert a collection bundle by an identifier.
     ///
@@ -193,7 +193,7 @@ where
 
 impl<S: Scope> Context<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
@@ -228,7 +228,7 @@ where
 #[derive(Clone)]
 pub enum ArrangementFlavor<S: Scope>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// A dataflow-local arrangement.
     Local(
@@ -248,7 +248,7 @@ where
 
 impl<S: Scope> ArrangementFlavor<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Presents `self` as a stream of updates.
     ///
@@ -336,7 +336,7 @@ where
 }
 impl<S: Scope> ArrangementFlavor<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> S {
@@ -366,7 +366,7 @@ where
 }
 impl<'a, S: Scope> ArrangementFlavor<Child<'a, S, S::Timestamp>>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Extracts the arrangement flavor from a region.
     pub fn leave_region(&self) -> ArrangementFlavor<S> {
@@ -390,7 +390,7 @@ where
 #[derive(Clone)]
 pub struct CollectionBundle<S: Scope>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     pub collection: Option<(
         VecCollection<S, Row, Diff>,
@@ -401,7 +401,7 @@ where
 
 impl<S: Scope> CollectionBundle<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
@@ -472,7 +472,7 @@ where
 
 impl<'a, S: Scope> CollectionBundle<Child<'a, S, S::Timestamp>>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Extracts the collection bundle from a region.
     pub fn leave_region(&self) -> CollectionBundle<S> {
@@ -492,7 +492,7 @@ where
 
 impl<S: Scope> CollectionBundle<S>
 where
-    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    S::Timestamp: RenderTimestamp,
 {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,
@@ -680,7 +680,7 @@ where
 impl<S> CollectionBundle<S>
 where
     S: Scope,
-    S::Timestamp: Refines<mz_repr::Timestamp> + RenderTimestamp,
+    S::Timestamp: RenderTimestamp,
 {
     /// Presents `self` as a stream of updates, having been subjected to `mfp`.
     ///

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -39,7 +39,6 @@ use timely::dataflow::operators::generic::{OutputBuilder, OutputBuilderSession};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, StreamVec};
 use timely::progress::operate::FrontierInterest;
-use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
@@ -48,8 +47,7 @@ use crate::render::errors::ErrorLogger;
 use crate::render::{LinearJoinSpec, RenderTimestamp};
 use crate::row_spine::{DatumSeq, RowRowBuilder};
 use crate::typedefs::{
-    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, MzTimestamp, RowRowAgent, RowRowEnter,
-    RowRowSpine,
+    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter, RowRowSpine,
 };
 
 /// Dataflow-local collections and arrangements.

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -58,14 +58,13 @@ use crate::typedefs::{
 /// These assets include dataflow-local collections and arrangements, as well as imported
 /// arrangements from outside the dataflow.
 ///
-/// Context has two timestamp types, one from `S::Timestamp` and one from `T`, where the
+/// Context has two timestamp types, one from `S::Timestamp` and `mz_repr::Timestamp`, where the
 /// former must refine the latter. The former is the timestamp used by the scope in question,
 /// and the latter is the timestamp of imported traces. The two may be different in the case
 /// of regions or iteration.
-pub struct Context<S: Scope, T = mz_repr::Timestamp>
+pub struct Context<S: Scope>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// The scope within which all managed collections exist.
     ///
@@ -81,19 +80,19 @@ where
     ///
     /// We *must* apply it to sinks, to ensure correct outputs.
     /// We *should* apply it to sources and imported traces, because it improves performance.
-    pub as_of_frontier: Antichain<T>,
+    pub as_of_frontier: Antichain<mz_repr::Timestamp>,
     /// Frontier after which updates should not be emitted.
     /// Used to limit the amount of work done when appropriate.
-    pub until: Antichain<T>,
+    pub until: Antichain<mz_repr::Timestamp>,
     /// Bindings of identifiers to collections.
-    pub bindings: BTreeMap<Id, CollectionBundle<S, T>>,
+    pub bindings: BTreeMap<Id, CollectionBundle<S>>,
     /// The logger, from Timely's logging framework, if logs are enabled.
     pub(super) compute_logger: Option<crate::logging::compute::Logger>,
     /// Specification for rendering linear joins.
     pub(super) linear_join_spec: LinearJoinSpec,
     /// The expiration time for dataflows in this context. The output's frontier should never advance
     /// past this frontier, except the empty frontier.
-    pub dataflow_expiration: Antichain<T>,
+    pub dataflow_expiration: Antichain<mz_repr::Timestamp>,
     /// The config set for this context.
     pub config_set: Rc<ConfigSet>,
 }
@@ -144,10 +143,9 @@ where
     }
 }
 
-impl<S: Scope, T> Context<S, T>
+impl<S: Scope> Context<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Insert a collection bundle by an identifier.
     ///
@@ -156,18 +154,18 @@ where
     pub fn insert_id(
         &mut self,
         id: Id,
-        collection: CollectionBundle<S, T>,
-    ) -> Option<CollectionBundle<S, T>> {
+        collection: CollectionBundle<S>,
+    ) -> Option<CollectionBundle<S>> {
         self.bindings.insert(id, collection)
     }
     /// Remove a collection bundle by an identifier.
     ///
     /// The primary use of this method is uninstalling `Let` bindings.
-    pub fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<S, T>> {
+    pub fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<S>> {
         self.bindings.remove(&id)
     }
     /// Melds a collection bundle to whatever exists.
-    pub fn update_id(&mut self, id: Id, collection: CollectionBundle<S, T>) {
+    pub fn update_id(&mut self, id: Id, collection: CollectionBundle<S>) {
         if !self.bindings.contains_key(&id) {
             self.bindings.insert(id, collection);
         } else {
@@ -184,7 +182,7 @@ where
         }
     }
     /// Look up a collection bundle by an identifier.
-    pub fn lookup_id(&self, id: Id) -> Option<CollectionBundle<S, T>> {
+    pub fn lookup_id(&self, id: Id) -> Option<CollectionBundle<S>> {
         self.bindings.get(&id).cloned()
     }
 
@@ -193,17 +191,16 @@ where
     }
 }
 
-impl<S: Scope, T> Context<S, T>
+impl<S: Scope> Context<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
         &self,
         region: &Child<'a, S, S::Timestamp>,
         bindings: Option<&std::collections::BTreeSet<Id>>,
-    ) -> Context<Child<'a, S, S::Timestamp>, T> {
+    ) -> Context<Child<'a, S, S::Timestamp>> {
         let bindings = self
             .bindings
             .iter()
@@ -229,10 +226,9 @@ where
 
 /// Describes flavor of arrangement: local or imported trace.
 #[derive(Clone)]
-pub enum ArrangementFlavor<S: Scope, T = mz_repr::Timestamp>
+pub enum ArrangementFlavor<S: Scope>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// A dataflow-local arrangement.
     Local(
@@ -245,15 +241,14 @@ where
     /// can refer back to and depend on the original instance.
     Trace(
         GlobalId,
-        Arranged<S, RowRowEnter<T, Diff, S::Timestamp>>,
-        Arranged<S, ErrEnter<T, S::Timestamp>>,
+        Arranged<S, RowRowEnter<mz_repr::Timestamp, Diff, S::Timestamp>>,
+        Arranged<S, ErrEnter<mz_repr::Timestamp, S::Timestamp>>,
     ),
 }
 
-impl<S: Scope, T> ArrangementFlavor<S, T>
+impl<S: Scope> ArrangementFlavor<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Presents `self` as a stream of updates.
     ///
@@ -327,22 +322,21 @@ where
 
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let oks = CollectionBundle::<S, T>::flat_map_core(oks.clone(), key, logic, refuel);
+                let oks = CollectionBundle::<S>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let oks = CollectionBundle::<S, T>::flat_map_core(oks.clone(), key, logic, refuel);
+                let oks = CollectionBundle::<S>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
         }
     }
 }
-impl<S: Scope, T> ArrangementFlavor<S, T>
+impl<S: Scope> ArrangementFlavor<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> S {
@@ -356,7 +350,7 @@ where
     pub fn enter_region<'a>(
         &self,
         region: &Child<'a, S, S::Timestamp>,
-    ) -> ArrangementFlavor<Child<'a, S, S::Timestamp>, T> {
+    ) -> ArrangementFlavor<Child<'a, S, S::Timestamp>> {
         match self {
             ArrangementFlavor::Local(oks, errs) => ArrangementFlavor::Local(
                 oks.clone().enter_region(region),
@@ -370,13 +364,12 @@ where
         }
     }
 }
-impl<'a, S: Scope, T> ArrangementFlavor<Child<'a, S, S::Timestamp>, T>
+impl<'a, S: Scope> ArrangementFlavor<Child<'a, S, S::Timestamp>>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Extracts the arrangement flavor from a region.
-    pub fn leave_region(&self) -> ArrangementFlavor<S, T> {
+    pub fn leave_region(&self) -> ArrangementFlavor<S> {
         match self {
             ArrangementFlavor::Local(oks, errs) => {
                 ArrangementFlavor::Local(oks.clone().leave_region(), errs.clone().leave_region())
@@ -395,22 +388,20 @@ where
 /// This type maintains the invariant that it does contain at least one valid
 /// source of data, either a collection or at least one arrangement.
 #[derive(Clone)]
-pub struct CollectionBundle<S: Scope, T = mz_repr::Timestamp>
+pub struct CollectionBundle<S: Scope>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     pub collection: Option<(
         VecCollection<S, Row, Diff>,
         VecCollection<S, DataflowError, Diff>,
     )>,
-    pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<S, T>>,
+    pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<S>>,
 }
 
-impl<S: Scope, T> CollectionBundle<S, T>
+impl<S: Scope> CollectionBundle<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
@@ -424,10 +415,7 @@ where
     }
 
     /// Inserts arrangements by the expressions on which they are keyed.
-    pub fn from_expressions(
-        exprs: Vec<MirScalarExpr>,
-        arrangements: ArrangementFlavor<S, T>,
-    ) -> Self {
+    pub fn from_expressions(exprs: Vec<MirScalarExpr>, arrangements: ArrangementFlavor<S>) -> Self {
         let mut arranged = BTreeMap::new();
         arranged.insert(exprs, arrangements);
         Self {
@@ -439,7 +427,7 @@ where
     /// Inserts arrangements by the columns on which they are keyed.
     pub fn from_columns<I: IntoIterator<Item = usize>>(
         columns: I,
-        arrangements: ArrangementFlavor<S, T>,
+        arrangements: ArrangementFlavor<S>,
     ) -> Self {
         let mut keys = Vec::new();
         for column in columns {
@@ -465,7 +453,7 @@ where
     pub fn enter_region<'a>(
         &self,
         region: &Child<'a, S, S::Timestamp>,
-    ) -> CollectionBundle<Child<'a, S, S::Timestamp>, T> {
+    ) -> CollectionBundle<Child<'a, S, S::Timestamp>> {
         CollectionBundle {
             collection: self.collection.as_ref().map(|(oks, errs)| {
                 (
@@ -482,13 +470,12 @@ where
     }
 }
 
-impl<'a, S: Scope, T> CollectionBundle<Child<'a, S, S::Timestamp>, T>
+impl<'a, S: Scope> CollectionBundle<Child<'a, S, S::Timestamp>>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Extracts the collection bundle from a region.
-    pub fn leave_region(&self) -> CollectionBundle<S, T> {
+    pub fn leave_region(&self) -> CollectionBundle<S> {
         CollectionBundle {
             collection: self
                 .collection
@@ -503,10 +490,9 @@ where
     }
 }
 
-impl<S: Scope, T> CollectionBundle<S, T>
+impl<S: Scope> CollectionBundle<S>
 where
-    T: MzTimestamp,
-    S::Timestamp: MzTimestamp + Refines<T>,
+    S::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,
@@ -686,16 +672,15 @@ where
     ///
     /// The result may be `None` if no such arrangement exists, or it may be one of many
     /// "arrangement flavors" that represent the types of arranged data we might have.
-    pub fn arrangement(&self, key: &[MirScalarExpr]) -> Option<ArrangementFlavor<S, T>> {
+    pub fn arrangement(&self, key: &[MirScalarExpr]) -> Option<ArrangementFlavor<S>> {
         self.arranged.get(key).map(|x| x.clone())
     }
 }
 
-impl<S, T> CollectionBundle<S, T>
+impl<S> CollectionBundle<S>
 where
-    T: MzTimestamp,
     S: Scope,
-    S::Timestamp: Refines<T> + RenderTimestamp,
+    S::Timestamp: Refines<mz_repr::Timestamp> + RenderTimestamp,
 {
     /// Presents `self` as a stream of updates, having been subjected to `mfp`.
     ///

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -32,14 +32,13 @@ use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, ScopeParent};
-use timely::progress::timestamp::Refines;
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::row_spine::{RowRowBuilder, RowRowSpine};
-use crate::typedefs::{MzTimestamp, RowRowAgent, RowRowEnter};
+use crate::typedefs::{RowRowAgent, RowRowEnter};
 
 /// Available linear join implementations.
 ///

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -189,7 +189,7 @@ impl YieldSpec {
 enum JoinedFlavor<G>
 where
     G: Scope,
-    G::Timestamp: Refines<mz_repr::Timestamp> + MzTimestamp,
+    G::Timestamp: RenderTimestamp,
 {
     /// Streamed data as a collection.
     Collection(VecCollection<G, Row, Diff>),

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -186,31 +186,29 @@ impl YieldSpec {
 }
 
 /// Different forms the streamed data might take.
-enum JoinedFlavor<G, T>
+enum JoinedFlavor<G>
 where
     G: Scope,
-    G::Timestamp: Refines<T> + MzTimestamp,
-    T: MzTimestamp,
+    G::Timestamp: Refines<mz_repr::Timestamp> + MzTimestamp,
 {
     /// Streamed data as a collection.
     Collection(VecCollection<G, Row, Diff>),
     /// A dataflow-local arrangement.
     Local(Arranged<G, RowRowAgent<G::Timestamp, Diff>>),
     /// An imported arrangement.
-    Trace(Arranged<G, RowRowEnter<T, Diff, G::Timestamp>>),
+    Trace(Arranged<G, RowRowEnter<mz_repr::Timestamp, Diff, G::Timestamp>>),
 }
 
-impl<G, T> Context<G, T>
+impl<G> Context<G>
 where
     G: Scope,
-    G::Timestamp: Lattice + Refines<T> + RenderTimestamp,
-    T: MzTimestamp,
+    G::Timestamp: Lattice + RenderTimestamp,
 {
     pub(crate) fn render_join(
         &self,
-        inputs: Vec<CollectionBundle<G, T>>,
+        inputs: Vec<CollectionBundle<G>>,
         linear_plan: LinearJoinPlan,
-    ) -> CollectionBundle<G, T> {
+    ) -> CollectionBundle<G> {
         self.scope.clone().region_named("Join(Linear)", |inner| {
             self.render_join_inner(inputs, linear_plan, inner)
         })
@@ -218,10 +216,10 @@ where
 
     fn render_join_inner(
         &self,
-        inputs: Vec<CollectionBundle<G, T>>,
+        inputs: Vec<CollectionBundle<G>>,
         linear_plan: LinearJoinPlan,
         inner: &mut Child<G, <G as ScopeParent>::Timestamp>,
-    ) -> CollectionBundle<G, T> {
+    ) -> CollectionBundle<G> {
         // Collect all error streams, and concatenate them at the end.
         let mut errors = Vec::new();
 
@@ -338,8 +336,8 @@ where
     /// version of the join of previous inputs.
     fn differential_join<S>(
         &self,
-        mut joined: JoinedFlavor<S, T>,
-        lookup_relation: CollectionBundle<S, T>,
+        mut joined: JoinedFlavor<S>,
+        lookup_relation: CollectionBundle<S>,
         LinearStagePlan {
             stream_key,
             stream_thinning,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -59,22 +59,21 @@ use crate::typedefs::{
     RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
 };
 
-impl<G, T> Context<G, T>
+impl<G> Context<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<T>,
-    T: MzTimestamp,
+    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.
     pub fn render_reduce(
         &self,
         input_key: Option<Vec<MirScalarExpr>>,
-        input: CollectionBundle<G, T>,
+        input: CollectionBundle<G>,
         key_val_plan: KeyValPlan,
         reduce_plan: ReducePlan,
         mfp_after: Option<MapFilterProject>,
-    ) -> CollectionBundle<G, T> {
+    ) -> CollectionBundle<G> {
         // Convert `mfp_after` to an actionable plan.
         let mfp_after = mfp_after.map(|m| {
             m.into_plan()
@@ -177,7 +176,7 @@ where
         err_input: VecCollection<S, DataflowError, Diff>,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
-    ) -> CollectionBundle<S, T>
+    ) -> CollectionBundle<S>
     where
         S: Scope<Timestamp = G::Timestamp>,
     {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -42,7 +42,6 @@ use serde::{Deserialize, Serialize};
 use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
 use timely::dataflow::Scope;
-use timely::progress::timestamp::Refines;
 use tracing::warn;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
@@ -55,8 +54,8 @@ use crate::row_spine::{
     DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBatcher, RowValBuilder,
 };
 use crate::typedefs::{
-    ErrBatcher, ErrBuilder, KeyBatcher, MzTimestamp, RowErrBuilder, RowErrSpine, RowRowAgent,
-    RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
+    ErrBatcher, ErrBuilder, KeyBatcher, RowErrBuilder, RowErrSpine, RowRowAgent, RowRowArrangement,
+    RowRowSpine, RowSpine, RowValSpine,
 };
 
 impl<G> Context<G>

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -50,7 +50,7 @@ use crate::extensions::reduce::MzReduce;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{ReductionMonoid, get_monoid};
-use crate::render::{ArrangementFlavor, Pairer};
+use crate::render::{ArrangementFlavor, Pairer, RenderTimestamp};
 use crate::row_spine::{
     DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBatcher, RowValBuilder,
 };
@@ -62,7 +62,7 @@ use crate::typedefs::{
 impl<G> Context<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    G::Timestamp: RenderTimestamp,
 {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -25,6 +25,7 @@ use timely::progress::timestamp::Refines;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
+use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::row_spine::RowRowBuilder;
 use crate::typedefs::{ErrBatcher, ErrBuilder, MzData, MzTimestamp};
@@ -78,7 +79,7 @@ pub fn build_threshold_basic<G>(
 ) -> CollectionBundle<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    G::Timestamp: RenderTimestamp,
 {
     let arrangement = input
         .arrangement(&key)
@@ -109,7 +110,7 @@ where
 impl<G> Context<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
+    G::Timestamp: RenderTimestamp,
 {
     pub(crate) fn render_threshold(
         &self,

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -21,7 +21,6 @@ use mz_repr::Diff;
 use timely::Container;
 use timely::container::PushInto;
 use timely::dataflow::Scope;
-use timely::progress::timestamp::Refines;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -72,14 +72,13 @@ where
 ///
 /// This implementation maintains rows in the output, i.e. all rows that have a count greater than
 /// zero. It returns a [CollectionBundle] populated from a local arrangement.
-pub fn build_threshold_basic<G, T>(
-    input: CollectionBundle<G, T>,
+pub fn build_threshold_basic<G>(
+    input: CollectionBundle<G>,
     key: Vec<MirScalarExpr>,
-) -> CollectionBundle<G, T>
+) -> CollectionBundle<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<T>,
-    T: MzTimestamp,
+    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     let arrangement = input
         .arrangement(&key)
@@ -107,17 +106,16 @@ where
     }
 }
 
-impl<G, T> Context<G, T>
+impl<G> Context<G>
 where
     G: Scope,
-    G::Timestamp: MzTimestamp + Refines<T>,
-    T: MzTimestamp,
+    G::Timestamp: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     pub(crate) fn render_threshold(
         &self,
-        input: CollectionBundle<G, T>,
+        input: CollectionBundle<G>,
         threshold_plan: ThresholdPlan,
-    ) -> CollectionBundle<G, T> {
+    ) -> CollectionBundle<G> {
         match threshold_plan {
             ThresholdPlan::Basic(BasicThresholdPlan {
                 ensure_arrangement: (key, _, _),


### PR DESCRIPTION
Compute's `Context` type has a generic timestamp parameter, and a second one that corresponds to the "root" timestamp type. That type is always `mz_repr::Timestamp`. The genericity existed to signal the relationship, but .. it's arguably not carrying its weight. This PR removes it and simplifies things.