### PR TITLE
Remove generic timestamp from `ReadHolds`

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -238,13 +238,13 @@ pub enum Command {
 
     GetTransactionReadHoldsBundle {
         conn_id: ConnectionId,
-        tx: oneshot::Sender<Option<ReadHolds<mz_repr::Timestamp>>>,
+        tx: oneshot::Sender<Option<ReadHolds>>,
     },
 
     /// _Merges_ the given read holds into the given connection's stored transaction read holds.
     StoreTransactionReadHolds {
         conn_id: ConnectionId,
-        read_holds: ReadHolds<mz_repr::Timestamp>,
+        read_holds: ReadHolds,
         tx: oneshot::Sender<()>,
     },
 
@@ -272,7 +272,7 @@ pub enum Command {
         replica_id: Option<ReplicaId>,
         conn_id: ConnectionId,
         session_uuid: Uuid,
-        read_holds: ReadHolds<mz_repr::Timestamp>,
+        read_holds: ReadHolds,
         plan: plan::SubscribePlan,
         statement_logging_id: Option<StatementLoggingId>,
         tx: oneshot::Sender<Result<ExecuteResponse, AdapterError>>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1020,7 +1020,7 @@ pub struct IntrospectionSubscribeTimestampOptimizeLir {
 pub struct IntrospectionSubscribeFinish {
     validity: PlanValidity,
     global_lir_plan: optimize::subscribe::GlobalLirPlan,
-    read_holds: ReadHolds<Timestamp>,
+    read_holds: ReadHolds,
     cluster_id: ComputeInstanceId,
     replica_id: ReplicaId,
 }
@@ -1855,7 +1855,7 @@ pub struct Coordinator {
     /// For each transaction, the read holds taken to support any performed reads.
     ///
     /// Upon completing a transaction, these read holds should be dropped.
-    txn_read_holds: BTreeMap<ConnectionId, read_policy::ReadHolds<Timestamp>>,
+    txn_read_holds: BTreeMap<ConnectionId, read_policy::ReadHolds>,
 
     /// Access to the peek fields should be restricted to methods in the [`peek`] API.
     /// A map from pending peek ids to the queue into which responses are sent, and
@@ -4960,7 +4960,7 @@ pub struct AlterSinkReadyContext {
     otel_ctx: OpenTelemetryContext,
     plan: AlterSinkPlan,
     plan_validity: PlanValidity,
-    read_hold: ReadHolds<Timestamp>,
+    read_hold: ReadHolds,
 }
 
 impl AlterSinkReadyContext {

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -27,7 +27,7 @@ use mz_repr::{CatalogItemId, GlobalId, Timestamp};
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use timely::progress::Antichain;
-use timely::progress::Timestamp as TimelyTimestamp;
+use timely::progress::Timestamp as _;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -40,13 +40,13 @@ use crate::util::ResultExt;
 /// that read frontiers cannot advance past the held time as long as they exist.
 /// Dropping a [`ReadHolds`] also drops the [`ReadHold`] tokens within and
 /// relinquishes the associated read capabilities.
-#[derive(Debug, Clone)]
-pub struct ReadHolds<T: TimelyTimestamp> {
-    pub storage_holds: BTreeMap<GlobalId, ReadHold<T>>,
-    pub compute_holds: BTreeMap<(ComputeInstanceId, GlobalId), ReadHold<T>>,
+#[derive(Debug, Default, Clone)]
+pub struct ReadHolds {
+    pub storage_holds: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+    pub compute_holds: BTreeMap<(ComputeInstanceId, GlobalId), ReadHold<Timestamp>>,
 }
 
-impl<T: TimelyTimestamp> ReadHolds<T> {
+impl ReadHolds {
     /// Return empty `ReadHolds`.
     pub fn new() -> Self {
         ReadHolds {
@@ -84,7 +84,7 @@ impl<T: TimelyTimestamp> ReadHolds<T> {
     }
 
     /// Downgrade the contained [`ReadHold`]s to the given time.
-    pub fn downgrade(&mut self, time: T) {
+    pub fn downgrade(&mut self, time: Timestamp) {
         let frontier = Antichain::from_elem(time);
         for hold in self.storage_holds.values_mut() {
             let _ = hold.try_downgrade(frontier.clone());
@@ -103,7 +103,7 @@ impl<T: TimelyTimestamp> ReadHolds<T> {
     }
 
     /// Returns a new ReadHolds containing only the holds for collections in `id_bundle`.
-    pub fn subset(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<T> {
+    pub fn subset(&self, id_bundle: &CollectionIdBundle) -> ReadHolds {
         let mut result = ReadHolds::new();
 
         for id in &id_bundle.storage_ids {
@@ -126,9 +126,9 @@ impl<T: TimelyTimestamp> ReadHolds<T> {
     }
 }
 
-impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
-    pub fn least_valid_read(&self) -> Antichain<T> {
-        let mut since = Antichain::from_elem(T::minimum());
+impl ReadHolds {
+    pub fn least_valid_read(&self) -> Antichain<Timestamp> {
+        let mut since = Antichain::from_elem(Timestamp::minimum());
         for hold in self.storage_holds.values() {
             since.join_assign(hold.since());
         }
@@ -146,7 +146,7 @@ impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
     /// _at least_ held back to the reported frontier by this read hold.
     ///
     /// This method is not meant to be fast, use wisely!
-    pub fn since(&self, desired_id: &GlobalId) -> Antichain<T> {
+    pub fn since(&self, desired_id: &GlobalId) -> Antichain<Timestamp> {
         let mut since = Antichain::new();
 
         if let Some(hold) = self.storage_holds.get(desired_id) {
@@ -205,12 +205,6 @@ impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
             let prev = self.compute_holds.insert(id, other_hold);
             assert!(prev.is_none(), "duplicate compute read hold: {id:?}");
         }
-    }
-}
-
-impl<T: TimelyTimestamp> Default for ReadHolds<T> {
-    fn default() -> Self {
-        ReadHolds::new()
     }
 }
 
@@ -375,10 +369,7 @@ impl crate::coord::Coordinator {
     ///
     /// Will panic if any of the referenced collections in `id_bundle` don't
     /// exist.
-    pub(crate) fn acquire_read_holds(
-        &self,
-        id_bundle: &CollectionIdBundle,
-    ) -> ReadHolds<Timestamp> {
+    pub(crate) fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds {
         let mut read_holds = ReadHolds::new();
 
         let desired_storage_holds = id_bundle.storage_ids.iter().map(|id| *id).collect_vec();
@@ -417,7 +408,7 @@ impl crate::coord::Coordinator {
     pub(crate) fn store_transaction_read_holds(
         &mut self,
         conn_id: ConnectionId,
-        read_holds: ReadHolds<Timestamp>,
+        read_holds: ReadHolds,
     ) {
         use std::collections::btree_map::Entry;
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2445,7 +2445,7 @@ impl Coordinator {
         ctx: ExecuteContext,
         as_of: Antichain<Timestamp>,
         mz_now: ResultSpec<'static>,
-        read_holds: Option<ReadHolds<Timestamp>>,
+        read_holds: Option<ReadHolds>,
         imports: impl IntoIterator<Item = (GlobalId, MapFilterProject)> + 'static,
     ) {
         let fut = self

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -793,7 +793,7 @@ impl Coordinator {
         &self,
         id_bundle: CollectionIdBundle,
         refresh_schedule: Option<&RefreshSchedule>,
-        read_holds: &ReadHolds<mz_repr::Timestamp>,
+        read_holds: &ReadHolds,
     ) -> Result<
         (
             Antichain<mz_repr::Timestamp>,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -478,7 +478,7 @@ impl Coordinator {
         replica_id: Option<ReplicaId>,
         conn_id: ConnectionId,
         session_uuid: Uuid,
-        read_holds: ReadHolds<mz_repr::Timestamp>,
+        read_holds: ReadHolds,
         plan: plan::SubscribePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let sink_id = df_desc.sink_id();

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -71,7 +71,7 @@ impl TimelineContext {
 /// guarantee that those read timestamps are valid.
 pub(crate) struct TimelineState {
     pub(crate) oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
-    pub(crate) read_holds: ReadHolds<Timestamp>,
+    pub(crate) read_holds: ReadHolds,
 }
 
 impl fmt::Debug for TimelineState {

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -168,7 +168,7 @@ impl TimestampProvider for Coordinator {
             .expect("missing collections")
     }
 
-    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
+    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds {
         self.acquire_read_holds(id_bundle)
     }
 
@@ -244,7 +244,7 @@ pub trait TimestampProvider {
     /// session_oracle_read_ts.
     fn determine_timestamp_via_constraints(
         session: &Session,
-        read_holds: &ReadHolds<Timestamp>,
+        read_holds: &ReadHolds,
         id_bundle: &CollectionIdBundle,
         when: &QueryWhen,
         oracle_read_ts: Option<Timestamp>,
@@ -443,7 +443,7 @@ pub trait TimestampProvider {
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<Timestamp>,
         isolation_level: &IsolationLevel,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds<Timestamp>), AdapterError> {
+    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
         // First, we acquire read holds that will ensure the queried collections
         // stay queryable at the chosen timestamp.
         let read_holds = self.acquire_read_holds(id_bundle);
@@ -472,9 +472,9 @@ pub trait TimestampProvider {
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<Timestamp>,
         isolation_level: &IsolationLevel,
-        read_holds: ReadHolds<Timestamp>,
+        read_holds: ReadHolds,
         upper: Antichain<Timestamp>,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds<Timestamp>), AdapterError> {
+    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
         let timeline = Self::get_timeline(timeline_context);
         let largest_not_in_advance_of_upper = Coordinator::largest_not_in_advance_of_upper(&upper);
         let since = read_holds.least_valid_read();
@@ -535,7 +535,7 @@ pub trait TimestampProvider {
 
     /// Acquires [ReadHolds], for the given `id_bundle` at the earliest possible
     /// times.
-    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<mz_repr::Timestamp>;
+    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds;
 
     /// The smallest common valid write frontier among the specified collections.
     ///
@@ -607,13 +607,7 @@ impl Coordinator {
         timeline_context: &TimelineContext,
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<mz_repr::Timestamp>,
-    ) -> Result<
-        (
-            TimestampDetermination<mz_repr::Timestamp>,
-            ReadHolds<mz_repr::Timestamp>,
-        ),
-        AdapterError,
-    > {
+    ) -> Result<(TimestampDetermination<mz_repr::Timestamp>, ReadHolds), AdapterError> {
         let isolation_level = session.vars().transaction_isolation();
         let (det, read_holds) = self.determine_timestamp_for(
             session,

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1502,7 +1502,7 @@ impl PeekClient {
         timeline_context: &TimelineContext,
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<Timestamp>,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds<Timestamp>), AdapterError> {
+    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
         // this is copy-pasted from Coordinator
 
         let isolation_level = session.vars().transaction_isolation();
@@ -1574,7 +1574,7 @@ impl PeekClient {
     }
 
     fn assert_read_holds_correct(
-        read_holds: &ReadHolds<Timestamp>,
+        read_holds: &ReadHolds,
         execution: &Execution,
         determination: &TimestampDetermination<Timestamp>,
         target_cluster_id: ClusterId,

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -166,7 +166,7 @@ impl PeekClient {
     pub async fn acquire_read_holds_and_least_valid_write(
         &mut self,
         id_bundle: &CollectionIdBundle,
-    ) -> Result<(ReadHolds<Timestamp>, Antichain<Timestamp>), CollectionLookupError> {
+    ) -> Result<(ReadHolds, Antichain<Timestamp>), CollectionLookupError> {
         let mut read_holds = ReadHolds::new();
         let mut upper = Antichain::new();
 
@@ -232,7 +232,7 @@ impl PeekClient {
         max_result_size: u64,
         max_returned_query_size: Option<u64>,
         row_set_finishing_seconds: Histogram,
-        input_read_holds: ReadHolds<Timestamp>,
+        input_read_holds: ReadHolds,
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
         conn_id: mz_adapter_types::connection::ConnectionId,

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -113,7 +113,7 @@ impl TimestampProvider for Frontiers {
             .collect()
     }
 
-    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
+    fn acquire_read_holds(&self, id_bundle: &CollectionIdBundle) -> ReadHolds {
         let mut read_holds = ReadHolds::new();
 
         let mock_read_hold = |id, frontier| {


### PR DESCRIPTION
This instantiates the `T: Timestamp` argument for `ReadHolds<T>` with `mz_repr::Timestamp`.

A next step could be to do the same for `ReadHold<T>`, but it is used by other types (e.g. `ExportState<T>`) which introduce a cascade of specialization. It's probably all good, but attempting to do this piecemeal.