### PR TITLE
Convert `Scheduler` to `Activations`

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -31,7 +31,7 @@ use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::operator::empty;
 use timely::dataflow::{Scope, StreamVec};
-use timely::scheduling::Scheduler;
+use timely::scheduling::{Activations, Activator};
 use tracing::error;
 use uuid::Uuid;
 
@@ -300,9 +300,9 @@ pub(super) struct Return {
 /// * `event_queue`: The source to read compute log events from.
 /// * `compute_event_streams`: Additional compute event streams to absorb.
 /// * `shared_state`: Shared state between logging dataflow fragments.
-pub(super) fn construct<S: Scheduler + 'static, G: Scope<Timestamp = Timestamp>>(
+pub(super) fn construct<G: Scope<Timestamp = Timestamp>>(
     mut scope: G,
-    scheduler: S,
+    activations: Rc<RefCell<Activations>>,
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<Column<(Duration, ComputeEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
@@ -355,7 +355,7 @@ pub(super) fn construct<S: Scheduler + 'static, G: Scope<Timestamp = Timestamp>>
         let (dataflow_global_ids_out, dataflow_global_ids) = demux.new_output();
         let mut dataflow_global_ids_out = OutputBuilder::from(dataflow_global_ids_out);
 
-        let mut demux_state = DemuxState::new(scheduler, scope.index());
+        let mut demux_state = DemuxState::new(activations, scope.index());
         demux.build(move |_capability| {
             move |_frontiers| {
                 let mut export = export_out.activate();
@@ -467,9 +467,9 @@ where
 }
 
 /// State maintained by the demux operator.
-struct DemuxState<A> {
-    /// The timely scheduler.
-    scheduler: A,
+struct DemuxState {
+    /// Shared activations handle for obtaining activators.
+    activations: Rc<RefCell<Activations>>,
     /// The index of this worker.
     worker_id: usize,
     /// A reusable scratch string for formatting IDs.
@@ -514,10 +514,10 @@ struct DemuxState<A> {
     hydration_time_packer: PermutedRowPacker,
 }
 
-impl<A: Scheduler> DemuxState<A> {
-    fn new(scheduler: A, worker_id: usize) -> Self {
+impl DemuxState {
+    fn new(activations: Rc<RefCell<Activations>>, worker_id: usize) -> Self {
         Self {
-            scheduler,
+            activations,
             worker_id,
             scratch_string_a: String::new(),
             scratch_string_b: String::new(),
@@ -774,9 +774,9 @@ struct DemuxOutput<'a, 'b> {
 }
 
 /// Event handler of the demux operator.
-struct DemuxHandler<'a, 'b, 'c, A: Scheduler> {
+struct DemuxHandler<'a, 'b, 'c> {
     /// State kept by the demux operator.
-    state: &'a mut DemuxState<A>,
+    state: &'a mut DemuxState,
     /// State shared across log receivers.
     shared_state: &'a mut SharedLoggingState,
     /// Demux output sessions.
@@ -787,7 +787,7 @@ struct DemuxHandler<'a, 'b, 'c, A: Scheduler> {
     time: Duration,
 }
 
-impl<A: Scheduler> DemuxHandler<'_, '_, '_, A> {
+impl DemuxHandler<'_, '_, '_> {
     /// Return the timestamp associated with the current event, based on the event time and the
     /// logging interval.
     fn ts(&self) -> Timestamp {
@@ -1186,10 +1186,10 @@ impl<A: Scheduler> DemuxHandler<'_, '_, '_, A> {
             address,
         }: Ref<'_, ArrangementHeapSizeOperator>,
     ) {
-        let activator = self
-            .state
-            .scheduler
-            .activator_for(address.into_iter().collect());
+        let activator = Activator::new(
+            address.into_iter().collect(),
+            Rc::clone(&self.state.activations),
+        );
         let existing = self
             .state
             .arrangement_size

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -31,6 +31,7 @@ use timely::logging::{TimelyEvent, TimelyEventBuilder};
 use timely::logging_core::{Logger, Registry};
 use timely::order::Product;
 use timely::progress::reachability::logging::{TrackerEvent, TrackerEventBuilder};
+use timely::scheduling::Scheduler;
 use timely::worker::AsWorker;
 
 use crate::arrangement::manager::TraceBundle;
@@ -163,7 +164,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
                 collections: compute_collections,
             } = super::compute::construct(
                 scope.clone(),
-                scope.parent().clone(),
+                scope.activations(),
                 self.config,
                 self.c_event_queue.clone(),
                 Rc::clone(&self.shared_state),


### PR DESCRIPTION
Our compute logging uses `S: Scheduler` when it only needs `Activations`. This PR simplifies it and removes the dependence on the more complex trait (which will be harder to access in future TD).