### PR TITLE
sql: Fix `SWAP` with `IF EXISTS`

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2797,6 +2797,7 @@ impl_display_t!(AlterRetainHistoryStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterObjectSwapStatement {
     pub object_type: ObjectType,
+    pub if_exists: bool,
     pub name_a: UnresolvedObjectName,
     pub name_b: Ident,
 }
@@ -2807,6 +2808,9 @@ impl AstDisplay for AlterObjectSwapStatement {
 
         f.write_node(&self.object_type);
         f.write_str(" ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
         f.write_node(&self.name_a);
 
         f.write_str(" SWAP WITH ");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5872,6 +5872,7 @@ impl<'a> Parser<'a> {
 
                 Ok(Statement::AlterObjectSwap(AlterObjectSwapStatement {
                     object_type,
+                    if_exists,
                     name_a: UnresolvedObjectName::Cluster(name),
                     name_b,
                 }))
@@ -6700,6 +6701,7 @@ impl<'a> Parser<'a> {
 
                 Ok(Statement::AlterObjectSwap(AlterObjectSwapStatement {
                     object_type,
+                    if_exists,
                     name_a: name,
                     name_b,
                 }))

--- a/src/sql-parser/tests/testdata/alter
+++ b/src/sql-parser/tests/testdata/alter
@@ -74,14 +74,21 @@ ALTER SCHEMA blue SWAP WITH green
 ----
 ALTER SCHEMA blue SWAP WITH green
 =>
-AlterObjectSwap(AlterObjectSwapStatement { object_type: Schema, name_a: Schema(UnresolvedSchemaName([Ident("blue")])), name_b: Ident("green") })
+AlterObjectSwap(AlterObjectSwapStatement { object_type: Schema, if_exists: false, name_a: Schema(UnresolvedSchemaName([Ident("blue")])), name_b: Ident("green") })
+
+parse-statement
+ALTER SCHEMA IF EXISTS blue SWAP WITH green
+----
+ALTER SCHEMA IF EXISTS blue SWAP WITH green
+=>
+AlterObjectSwap(AlterObjectSwapStatement { object_type: Schema, if_exists: true, name_a: Schema(UnresolvedSchemaName([Ident("blue")])), name_b: Ident("green") })
 
 parse-statement
 ALTER SCHEMA materialize.blue SWAP WITH green
 ----
 ALTER SCHEMA materialize.blue SWAP WITH green
 =>
-AlterObjectSwap(AlterObjectSwapStatement { object_type: Schema, name_a: Schema(UnresolvedSchemaName([Ident("materialize"), Ident("blue")])), name_b: Ident("green") })
+AlterObjectSwap(AlterObjectSwapStatement { object_type: Schema, if_exists: false, name_a: Schema(UnresolvedSchemaName([Ident("materialize"), Ident("blue")])), name_b: Ident("green") })
 
 parse-statement
 ALTER SCHEMA materialize.blue SWAP WITH other.green
@@ -95,7 +102,14 @@ ALTER CLUSTER foo SWAP WITH bar
 ----
 ALTER CLUSTER foo SWAP WITH bar
 =>
-AlterObjectSwap(AlterObjectSwapStatement { object_type: Cluster, name_a: Cluster(Ident("foo")), name_b: Ident("bar") })
+AlterObjectSwap(AlterObjectSwapStatement { object_type: Cluster, if_exists: false, name_a: Cluster(Ident("foo")), name_b: Ident("bar") })
+
+parse-statement
+ALTER CLUSTER IF EXISTS foo SWAP WITH bar
+----
+ALTER CLUSTER IF EXISTS foo SWAP WITH bar
+=>
+AlterObjectSwap(AlterObjectSwapStatement { object_type: Cluster, if_exists: true, name_a: Cluster(Ident("foo")), name_b: Ident("bar") })
 
 parse-statement
 ALTER CLUSTER cluster.too_many SWAP WITH cluster.this_wont_work

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6768,6 +6768,7 @@ pub fn plan_alter_schema_swap<F>(
     scx: &mut StatementContext,
     name_a: UnresolvedSchemaName,
     name_b: Ident,
+    if_exists: bool,
     gen_temp_suffix: F,
 ) -> Result<Plan, PlanError>
 where
@@ -6787,7 +6788,19 @@ where
         sql_bail!("cannot swap schemas that are in the ambient database");
     }
 
-    let schema_a = scx.resolve_schema(name_a.clone())?;
+    let schema_a = match scx.resolve_schema(name_a.clone()) {
+        Ok(schema) => schema,
+        Err(_) if if_exists => {
+            scx.catalog.add_notice(PlanNotice::ObjectDoesNotExist {
+                name: name_a.to_ast_string_simple(),
+                object_type: ObjectType::Schema,
+            });
+            return Ok(Plan::AlterNoop(AlterNoopPlan {
+                object_type: ObjectType::Schema,
+            }));
+        }
+        Err(e) => return Err(e),
+    };
 
     let db_spec = schema_a.database().clone();
     if matches!(db_spec, ResolvedDatabaseSpecifier::Ambient) {
@@ -6918,12 +6931,25 @@ pub fn plan_alter_cluster_swap<F>(
     scx: &mut StatementContext,
     name_a: Ident,
     name_b: Ident,
+    if_exists: bool,
     gen_temp_suffix: F,
 ) -> Result<Plan, PlanError>
 where
     F: Fn(&dyn Fn(&str) -> bool) -> Result<String, PlanError>,
 {
-    let cluster_a = scx.resolve_cluster(Some(&name_a))?;
+    let cluster_a = match scx.resolve_cluster(Some(&name_a)) {
+        Ok(cluster) => cluster,
+        Err(_) if if_exists => {
+            scx.catalog.add_notice(PlanNotice::ObjectDoesNotExist {
+                name: name_a.to_ast_string_simple(),
+                object_type: ObjectType::Cluster,
+            });
+            return Ok(Plan::AlterNoop(AlterNoopPlan {
+                object_type: ObjectType::Cluster,
+            }));
+        }
+        Err(e) => return Err(e),
+    };
     let cluster_b = scx.resolve_cluster(Some(&name_b))?;
 
     let check = |temp_suffix: &str| {
@@ -6996,6 +7022,7 @@ pub fn plan_alter_object_swap(
 
     let AlterObjectSwapStatement {
         object_type,
+        if_exists,
         name_a,
         name_b,
     } = stmt;
@@ -7023,10 +7050,10 @@ pub fn plan_alter_object_swap(
 
     match (object_type, name_a, name_b) {
         (ObjectType::Schema, UnresolvedObjectName::Schema(name_a), name_b) => {
-            plan_alter_schema_swap(scx, name_a, name_b, gen_temp_suffix)
+            plan_alter_schema_swap(scx, name_a, name_b, if_exists, gen_temp_suffix)
         }
         (ObjectType::Cluster, UnresolvedObjectName::Cluster(name_a), name_b) => {
-            plan_alter_cluster_swap(scx, name_a, name_b, gen_temp_suffix)
+            plan_alter_cluster_swap(scx, name_a, name_b, if_exists, gen_temp_suffix)
         }
         (ObjectType::Schema | ObjectType::Cluster, _, _) => {
             unreachable!("parser ensures name type matches object type")

--- a/test/sqllogictest/swap.slt
+++ b/test/sqllogictest/swap.slt
@@ -176,6 +176,55 @@ statement ok
 ALTER SCHEMA blue SWAP WITH green;
 
 
+# Test IF EXISTS with SWAP.
+# IF EXISTS should be a no-op when the named object doesn't exist.
+
+# Cluster: IF EXISTS with non-existent cluster should succeed as a no-op.
+statement ok
+ALTER CLUSTER IF EXISTS nonexistent SWAP WITH bar;
+
+# Verify bar still exists and wasn't affected.
+query T
+SELECT name FROM mz_clusters WHERE name = 'bar';
+----
+bar
+
+# Cluster: IF EXISTS with existing cluster should still work normally.
+statement ok
+CREATE CLUSTER swap_test_a SIZE = 'scale=1,workers=1';
+
+statement ok
+CREATE CLUSTER swap_test_b SIZE = 'scale=1,workers=1';
+
+statement ok
+ALTER CLUSTER IF EXISTS swap_test_a SWAP WITH swap_test_b;
+
+statement ok
+DROP CLUSTER swap_test_a CASCADE;
+
+statement ok
+DROP CLUSTER swap_test_b CASCADE;
+
+# Schema: IF EXISTS with non-existent schema should succeed as a no-op.
+statement ok
+ALTER SCHEMA IF EXISTS nonexistent SWAP WITH green;
+
+# Schema: IF EXISTS with existing schema should still work normally.
+statement ok
+CREATE SCHEMA swap_s1;
+
+statement ok
+CREATE SCHEMA swap_s2;
+
+statement ok
+ALTER SCHEMA IF EXISTS swap_s1 SWAP WITH swap_s2;
+
+statement ok
+DROP SCHEMA swap_s1 CASCADE;
+
+statement ok
+DROP SCHEMA swap_s2 CASCADE;
+
 # Disable the feature.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_alter_swap TO false;


### PR DESCRIPTION
Bug introduced in https://github.com/MaterializeInc/materialize/pull/21979

We parsed `IF EXISTS` but then just ignored it.