### PR TITLE
[SS-103] Fix COPY FROM PARQUET unsorted map keys

### DIFF
--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -25,6 +25,7 @@ use arrow::buffer::{NullBuffer, OffsetBuffer};
 use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
 use chrono::{DateTime, NaiveTime};
 use dec::OrderedDecimal;
+use itertools::Itertools;
 use mz_ore::cast::CastFrom;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
@@ -831,10 +832,13 @@ impl ColReader {
                 let start: usize = offsets[idx].try_into().context("map start offset")?;
                 let end: usize = offsets[idx + 1].try_into().context("map end offset")?;
 
+                let kv_sorted = (start..end)
+                    .map(|i| (keys.value(i), i))
+                    .sorted_by_key(|(k, _)| *k);
                 packer
                     .push_dict_with(|packer| {
-                        for i in start..end {
-                            packer.push(Datum::String(keys.value(i)));
+                        for (key, i) in kv_sorted {
+                            packer.push(Datum::String(key));
                             values.read(i, packer)?;
                         }
                         Ok::<_, anyhow::Error>(())

--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -832,6 +832,9 @@ impl ColReader {
                 let start: usize = offsets[idx].try_into().context("map start offset")?;
                 let end: usize = offsets[idx + 1].try_into().context("map end offset")?;
 
+                // Arrow's MapArray doesn't guarantee that keys are in sorted order, but Materialize's
+                // Datum::Map does, so we need to sort the keys here before packing them, or else
+                // many assumptions will break.
                 let kv_sorted = (start..end)
                     .map(|i| (keys.value(i), i))
                     .sorted_by_key(|(k, _)| *k);

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -883,6 +883,9 @@ impl Run for PosCommand {
                     "s3-file-upload" => s3::run_upload(builtin, state).await,
                     "s3-set-presigned-url" => s3::run_set_presigned_url(builtin, state).await,
                     "s3-upload-parquet-types" => s3::run_upload_parquet_types(builtin, state).await,
+                    "s3-upload-parquet-unsorted-map" => {
+                        s3::run_upload_parquet_unsorted_map(builtin, state).await
+                    }
                     "schema-registry-publish" => schema_registry::run_publish(builtin, state).await,
                     "schema-registry-verify" => schema_registry::run_verify(builtin, state).await,
                     "schema-registry-wait" => schema_registry::run_wait(builtin, state).await,

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -711,10 +711,7 @@ fn build_parquet_unsorted_map_batch() -> Result<RecordBatch, anyhow::Error> {
 
     let batch = RecordBatch::try_new(
         schema,
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
-            map_array,
-        ],
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4])), map_array],
     )
     .context("building record batch")?;
 

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -611,3 +611,112 @@ fn build_parquet_types_batch() -> Result<RecordBatch, anyhow::Error> {
 
     Ok(batch)
 }
+
+/// Upload a parquet file with map columns whose keys are deliberately unsorted.
+/// This is used to test that COPY FROM correctly handles unsorted map keys.
+pub async fn run_upload_parquet_unsorted_map(
+    mut cmd: BuiltinCommand,
+    state: &State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let bucket = cmd.args.string("bucket")?;
+    let key = cmd.args.string("key")?;
+    cmd.args.done()?;
+
+    let batch =
+        build_parquet_unsorted_map_batch().context("building parquet unsorted map batch")?;
+
+    let client = mz_aws_util::s3::new_client(&state.aws_config);
+
+    println!("Uploading parquet unsorted-map file to S3 bucket {bucket}/{key}");
+
+    let props = WriterProperties::builder().build();
+    let mut buf = Vec::new();
+    {
+        let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), Some(props))
+            .context("creating parquet writer")?;
+        writer.write(&batch).context("writing parquet batch")?;
+        writer.close().context("closing parquet writer")?;
+    }
+
+    client
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .body(buf.into())
+        .send()
+        .await
+        .context("s3 put")?;
+
+    Ok(ControlFlow::Continue)
+}
+
+/// Build a parquet record batch with map columns whose keys are deliberately
+/// unsorted, to test that the COPY FROM reader sorts them correctly.
+#[allow(clippy::as_conversions, clippy::disallowed_types)]
+fn build_parquet_unsorted_map_batch() -> Result<RecordBatch, anyhow::Error> {
+    // Row 0: id=1, map keys in reverse order: {"z": "val_z", "a": "val_a", "m": "val_m"}
+    // Row 1: id=2, map keys unsorted: {"b": "val_b", "a": "val_a"}
+    // Row 2: id=3, single key (trivially sorted): {"x": "val_x"}
+    // Row 3: id=4, empty map: {}
+
+    let mut map_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+
+    // Row 0: keys deliberately in reverse order
+    map_builder.keys().append_value("z");
+    map_builder.values().append_value("val_z");
+    map_builder.keys().append_value("a");
+    map_builder.values().append_value("val_a");
+    map_builder.keys().append_value("m");
+    map_builder.values().append_value("val_m");
+    map_builder.append(true).context("appending map row 0")?;
+
+    // Row 1: keys unsorted
+    map_builder.keys().append_value("b");
+    map_builder.values().append_value("val_b");
+    map_builder.keys().append_value("a");
+    map_builder.values().append_value("val_a");
+    map_builder.append(true).context("appending map row 1")?;
+
+    // Row 2: single key (trivially sorted)
+    map_builder.keys().append_value("x");
+    map_builder.values().append_value("val_x");
+    map_builder.append(true).context("appending map row 2")?;
+
+    // Row 3: empty map
+    map_builder.append(true).context("appending map row 3")?;
+
+    let map_array = Arc::new(map_builder.finish());
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new(
+            "map_col",
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(
+                        vec![
+                            Field::new("keys", DataType::Utf8, false),
+                            Field::new("values", DataType::Utf8, true),
+                        ]
+                        .into(),
+                    ),
+                    false,
+                )),
+                false, // keys_sorted = false
+            ),
+            true,
+        ),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            map_array,
+        ],
+    )
+    .context("building record batch")?;
+
+    Ok(batch)
+}

--- a/test/testdrive/copy-from-parquet-unsorted-map-keys.td
+++ b/test/testdrive/copy-from-parquet-unsorted-map-keys.td
@@ -67,7 +67,7 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
 
 # Verify equality: maps from COPY FROM should equal maps inserted via SQL.
 # If unsorted, these will NOT match, demonstrating silent data corruption.
-> SELECT p.id, p.map_col = s.map_col AS maps_equal
+> SELECT p.id, p.map_col::text = s.map_col::text AS maps_equal
   FROM from_parquet p
   JOIN from_sql s ON p.id = s.id
   ORDER BY p.id;
@@ -80,7 +80,7 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
 # If keys are unsorted, hash/equality is broken and this join will miss rows.
 > SELECT p.id
   FROM from_parquet p
-  JOIN from_sql s ON p.map_col = s.map_col
+  JOIN from_sql s ON p.map_col::text = s.map_col::text
   ORDER BY p.id;
 1
 2

--- a/test/testdrive/copy-from-parquet-unsorted-map-keys.td
+++ b/test/testdrive/copy-from-parquet-unsorted-map-keys.td
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for BUG #41: COPY FROM Parquet Map keys not sorted.
+#
+# Materialize's Datum::Map requires keys to be in ascending sorted order.
+# The COPY FROM parquet reader pushes map entries in their original order
+# without sorting. If a parquet file has unsorted map keys, this produces
+# silent data corruption: map equality, hashing, and comparisons all depend
+# on sorted keys.
+#
+# This test creates a parquet file with deliberately unsorted map keys,
+# COPY FROMs it, and verifies that the resulting maps are correctly sorted
+# and compare equal to maps inserted via SQL (which are always sorted).
+
+$ set-max-tries max-tries=1
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_copy_from_remote = true;
+
+> CREATE SECRET aws_secret AS '${arg.aws-secret-access-key}'
+
+> CREATE CONNECTION aws_conn
+  TO AWS (
+    ACCESS KEY ID = '${arg.aws-access-key-id}',
+    SECRET ACCESS KEY = SECRET aws_secret,
+    ENDPOINT = '${arg.aws-endpoint}',
+    REGION = 'us-east-1'
+  );
+
+# Upload parquet file with deliberately unsorted map keys.
+# Row 0: id=1, keys in reverse order: {"z": "val_z", "a": "val_a", "m": "val_m"}
+# Row 1: id=2, keys unsorted: {"b": "val_b", "a": "val_a"}
+# Row 2: id=3, single key (trivially sorted): {"x": "val_x"}
+# Row 3: id=4, empty map: {}
+$ s3-upload-parquet-unsorted-map bucket=copyfroms3 key=parquet/unsorted_map.parquet
+
+> CREATE TABLE from_parquet (id int, map_col map[text => text]);
+
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-name=unsorted_map_url
+
+> COPY INTO from_parquet FROM '${unsorted_map_url}' (FORMAT PARQUET);
+
+# Insert equivalent maps via SQL. SQL insertion always sorts keys correctly.
+> CREATE TABLE from_sql (id int, map_col map[text => text]);
+
+> INSERT INTO from_sql VALUES
+  (1, '{a=>val_a,m=>val_m,z=>val_z}'),
+  (2, '{a=>val_a,b=>val_b}'),
+  (3, '{x=>val_x}'),
+  (4, '{}');
+
+# Verify that COPY FROM'd maps have keys in sorted order.
+# If the bug is present, keys will be in their original unsorted order
+# (e.g., {z=>val_z,a=>val_a,m=>val_m} instead of {a=>val_a,m=>val_m,z=>val_z}).
+> SELECT id, map_col::text FROM from_parquet ORDER BY id;
+1 {a=>val_a,m=>val_m,z=>val_z}
+2 {a=>val_a,b=>val_b}
+3 {x=>val_x}
+4 {}
+
+# Verify equality: maps from COPY FROM should equal maps inserted via SQL.
+# If unsorted, these will NOT match, demonstrating silent data corruption.
+> SELECT p.id, p.map_col = s.map_col AS maps_equal
+  FROM from_parquet p
+  JOIN from_sql s ON p.id = s.id
+  ORDER BY p.id;
+1 true
+2 true
+3 true
+4 true
+
+# Verify that a join on map_col works correctly.
+# If keys are unsorted, hash/equality is broken and this join will miss rows.
+> SELECT p.id
+  FROM from_parquet p
+  JOIN from_sql s ON p.map_col = s.map_col
+  ORDER BY p.id;
+1
+2
+3
+4


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/11290 
Updates `ColReader::Map` logic to sort keys when reading in data.