### PR TITLE
adapter: Clean up secrets instead of leaking them on error

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -805,6 +805,18 @@ impl Coordinator {
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
                 kind: ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
             })) if plan.if_not_exists => {
+                // Clean up SSH key material if it was persisted, since the
+                // catalog item was not created.
+                if matches!(plan.connection.details, ConnectionDetails::Ssh { .. }) {
+                    if let Err(e) = self.secrets_controller.delete(connection_id).await {
+                        tracing::warn!(
+                            "Dropping SSH secret for existing connection has encountered an error: {}",
+                            e
+                        );
+                    } else {
+                        self.caching_secrets_reader.invalidate(connection_id);
+                    }
+                }
                 ctx.session()
                     .add_notice(AdapterNotice::ObjectAlreadyExists {
                         name: plan.name.item,
@@ -812,7 +824,21 @@ impl Coordinator {
                     });
                 Ok(ExecuteResponse::CreatedConnection)
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                // Clean up SSH key material if it was persisted, since the
+                // catalog item was not created.
+                if matches!(plan.connection.details, ConnectionDetails::Ssh { .. }) {
+                    if let Err(e) = self.secrets_controller.delete(connection_id).await {
+                        tracing::warn!(
+                            "Dropping SSH secret for failed connection has encountered an error: {}",
+                            e
+                        );
+                    } else {
+                        self.caching_secrets_reader.invalidate(connection_id);
+                    }
+                }
+                Err(err)
+            }
         }
     }
 

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -220,6 +220,16 @@ impl Coordinator {
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
                 kind: ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
             })) if if_not_exists => {
+                // Clean up the secret we already persisted, since the catalog
+                // item was not created.
+                if let Err(e) = self.secrets_controller.delete(item_id).await {
+                    warn!(
+                        "Dropping newly created secrets has encountered an error: {}",
+                        e
+                    );
+                } else {
+                    self.caching_secrets_reader.invalidate(item_id);
+                }
                 session.add_notice(AdapterNotice::ObjectAlreadyExists {
                     name: name.item,
                     ty: "secret",


### PR DESCRIPTION
Bugs introduced in #27545 and #23551, two refactorings