### PR TITLE
ccsr: Fix error code for subject not found

### DIFF
--- a/src/ccsr/src/client.rs
+++ b/src/ccsr/src/client.rs
@@ -546,7 +546,7 @@ impl From<UnhandledError> for GetSubjectConfigError {
         match err {
             UnhandledError::Transport(err) => GetSubjectConfigError::Transport(err),
             UnhandledError::Api { code, message } => match code {
-                404 => GetSubjectConfigError::SubjectNotFound,
+                40401 => GetSubjectConfigError::SubjectNotFound,
                 40408 => GetSubjectConfigError::SubjectCompatibilityLevelNotSet,
                 _ => GetSubjectConfigError::Server { code, message },
             },


### PR DESCRIPTION
See https://docs.confluent.io/platform/current/schema-registry/develop/api.html#errors for error codes

Caused by https://github.com/MaterializeInc/materialize/pull/27641

Nikhil noted this correctly in the original review: https://github.com/MaterializeInc/materialize/pull/27641#discussion_r1640358246