### PR TITLE
sql: escape object names in EXPLAIN ANALYZE generated SQL

### DIFF
--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -41,7 +41,7 @@ use mz_storage_types::sinks::{
     MIN_S3_SINK_FILE_SIZE, S3SinkFormat, StorageSinkConnection,
 };
 
-use crate::ast::display::AstDisplay;
+use crate::ast::display::{AstDisplay, escaped_string_literal};
 use crate::ast::{
     AstInfo, CopyDirection, CopyOption, CopyOptionName, CopyRelation, CopyStatement, CopyTarget,
     DeleteStatement, ExplainPlanStatement, ExplainStage, Explainee, Ident, InsertStatement, Query,
@@ -917,14 +917,17 @@ pub fn plan_explain_analyze_object(
              JOIN {from} USING (lir_id)
              JOIN mz_introspection.mz_mappable_objects mo
                ON (mlm.global_id = mo.global_id)
-       WHERE     mo.name = '{plan.explainee_name}'
+       WHERE     mo.name = {escaped explainee_name}
              AND {predicates}
        ORDER BY lir_id DESC
     */
     let mut ctes = Vec::with_capacity(4); // max 2 per ExplainAnalyzeComputationProperty
     let mut columns = vec!["REPEAT(' ', nesting * 2) || operator AS operator"];
     let mut from = vec!["mz_introspection.mz_lir_mapping mlm"];
-    let mut predicates = vec![format!("mo.name = '{}'", explainee_name)];
+    let mut predicates = vec![format!(
+        "mo.name = {}",
+        escaped_string_literal(&explainee_name)
+    )];
     let mut order_by = vec!["mlm.lir_id DESC"];
 
     match statement.properties {

--- a/test/testdrive/explain-analyze.td
+++ b/test/testdrive/explain-analyze.td
@@ -171,3 +171,18 @@ operator                     total_elapsed
 "    Arranged l0"  <null>  <null>
 "With l0 = Accumulable GroupAggregate"  <XXX>  2
 "  Stream <XXX>"  <null>  <null>
+
+# regression test for https://github.com/MaterializeInc/database-issues/issues/11293
+> CREATE MATERIALIZED VIEW "it's" AS SELECT SUM(x) FROM t;
+
+> EXPLAIN ANALYZE MEMORY FOR MATERIALIZED VIEW "it's";
+"Returning Union"  <null>  <null>
+"  Unarranged Raw Stream"  <null>  <null>
+"  Map/Filter/Project"  <null>  <null>
+"    Consolidating Union"  <null>  <null>
+"      Constant (1 rows)"  <null>  <null>
+"      Negate Diffs"  <null>  <null>
+"        Arranged l0"  <null>  <null>
+"    Arranged l0"  <null>  <null>
+"With l0 = Accumulable GroupAggregate"  <XXX>  2
+"  Stream <XXX>"  <null>  <null>


### PR DESCRIPTION
Object names containing single quotes (e.g., `"it's"`) cause a parse error when interpolated into the generated SQL query for `EXPLAIN ANALYZE ... FOR MATERIALIZED VIEW`.
Uses `escaped_string_literal` to properly escape the name, preventing a panic in `ShowSelect::new` with "unterminated quoted string".

Reproduces with:
```sql
CREATE MATERIALIZED VIEW "it's" AS SELECT * FROM t;
EXPLAIN ANALYZE MEMORY FOR MATERIALIZED VIEW "it's";
```

Regression from #32555.

Fixes https://github.com/MaterializeInc/database-issues/issues/11293