### PR TITLE
compute-client: stop being generic over the timestamp type

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -701,8 +701,7 @@ impl Catalog {
         config: mz_controller::ControllerConfig,
         envd_epoch: core::num::NonZeroI64,
         read_only: bool,
-    ) -> Result<mz_controller::Controller<mz_repr::Timestamp>, mz_catalog::durable::CatalogError>
-    {
+    ) -> Result<mz_controller::Controller, mz_catalog::durable::CatalogError> {
         let controller_start = Instant::now();
         info!("startup: controller init: beginning");
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -217,7 +217,7 @@ pub enum Command {
         instance_id: ComputeInstanceId,
         tx: oneshot::Sender<
             Result<
-                mz_compute_client::controller::instance_client::InstanceClient<mz_repr::Timestamp>,
+                mz_compute_client::controller::instance_client::InstanceClient,
                 mz_compute_client::controller::error::InstanceMissing,
             >,
         >,

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -58,7 +58,7 @@ pub struct PeekClient {
     /// Note that these are never cleaned up. In theory, this could lead to a very slow memory leak
     /// if a long-running user session keeps peeking on clusters that are being created and dropped
     /// in a hot loop. Hopefully this won't occur any time soon.
-    compute_instances: BTreeMap<ComputeInstanceId, InstanceClient<Timestamp>>,
+    compute_instances: BTreeMap<ComputeInstanceId, InstanceClient>,
     /// Handle to storage collections for reading frontiers and policies.
     pub storage_collections: StorageCollectionsHandle,
     /// A generator for transient `GlobalId`s, shared with Coordinator.
@@ -96,7 +96,7 @@ impl PeekClient {
     pub async fn ensure_compute_instance_client(
         &mut self,
         compute_instance: ComputeInstanceId,
-    ) -> Result<InstanceClient<Timestamp>, InstanceMissing> {
+    ) -> Result<InstanceClient, InstanceMissing> {
         if !self.compute_instances.contains_key(&compute_instance) {
             let client = self
                 .call_coordinator(|tx| Command::GetComputeInstanceClient {

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -85,12 +85,12 @@ use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_panic_or_log;
-use mz_repr::{GlobalId, TimestampManipulation};
+use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::storage_collections::StorageCollections;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use timely::PartialOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tracing::{info, warn};
 
 /// Runs as-of selection for the given dataflows.
@@ -98,13 +98,13 @@ use tracing::{info, warn};
 /// Assigns the selected as-of to the provided dataflow descriptions and returns a set of
 /// `ReadHold`s that must not be dropped nor downgraded until the dataflows have been installed
 /// with the compute controller.
-pub fn run<T: TimestampManipulation>(
-    dataflows: &mut [DataflowDescription<Plan<T>, (), T>],
-    read_policies: &BTreeMap<GlobalId, ReadPolicy<T>>,
-    storage_collections: &dyn StorageCollections<Timestamp = T>,
-    current_time: T,
+pub fn run(
+    dataflows: &mut [DataflowDescription<Plan, ()>],
+    read_policies: &BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
+    storage_collections: &dyn StorageCollections<Timestamp = Timestamp>,
+    current_time: Timestamp,
     read_only_mode: bool,
-) -> BTreeMap<GlobalId, ReadHold<T>> {
+) -> BTreeMap<GlobalId, ReadHold<Timestamp>> {
     // Get read holds for the storage inputs of the dataflows.
     // This ensures that storage frontiers don't advance past the selected as-ofs.
     let mut storage_read_holds = BTreeMap::new();
@@ -177,16 +177,16 @@ pub fn run<T: TimestampManipulation>(
 
 /// Bounds for possible as-of values of a dataflow.
 #[derive(Debug)]
-struct AsOfBounds<T> {
-    lower: Antichain<T>,
-    upper: Antichain<T>,
+struct AsOfBounds {
+    lower: Antichain<Timestamp>,
+    upper: Antichain<Timestamp>,
     /// Whether these bounds can still change.
     sealed: bool,
 }
 
-impl<T: Clone> AsOfBounds<T> {
+impl AsOfBounds {
     /// Creates an `AsOfBounds` that only allows the given `frontier`.
-    fn single(frontier: Antichain<T>) -> Self {
+    fn single(frontier: Antichain<Timestamp>) -> Self {
         Self {
             lower: frontier.clone(),
             upper: frontier,
@@ -195,7 +195,7 @@ impl<T: Clone> AsOfBounds<T> {
     }
 
     /// Get the bound of the given type.
-    fn get(&self, type_: BoundType) -> &Antichain<T> {
+    fn get(&self, type_: BoundType) -> &Antichain<Timestamp> {
         match type_ {
             BoundType::Lower => &self.lower,
             BoundType::Upper => &self.upper,
@@ -203,17 +203,17 @@ impl<T: Clone> AsOfBounds<T> {
     }
 }
 
-impl<T: Timestamp> Default for AsOfBounds<T> {
+impl Default for AsOfBounds {
     fn default() -> Self {
         Self {
-            lower: Antichain::from_elem(T::minimum()),
+            lower: Antichain::from_elem(Timestamp::MIN),
             upper: Antichain::new(),
             sealed: false,
         }
     }
 }
 
-impl<T: fmt::Debug> fmt::Display for AsOfBounds<T> {
+impl fmt::Display for AsOfBounds {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -253,19 +253,19 @@ enum ConstraintType {
 
 /// A constraint that can be applied to the `AsOfBounds` of a collection.
 #[derive(Debug)]
-struct Constraint<'a, T> {
+struct Constraint<'a> {
     type_: ConstraintType,
     /// Which bound this constraint applies to.
     bound_type: BoundType,
     /// The frontier by which the bound should be constrained.
-    frontier: &'a Antichain<T>,
+    frontier: &'a Antichain<Timestamp>,
     /// A short description of the reason for applying this constraint.
     ///
     /// Used only for logging.
     reason: &'a str,
 }
 
-impl<T: Timestamp> Constraint<'_, T> {
+impl Constraint<'_> {
     /// Applies this constraint to the given bounds.
     ///
     /// Returns a bool indicating whether the given bounds were changed as a result.
@@ -275,7 +275,7 @@ impl<T: Timestamp> Constraint<'_, T> {
     /// the bounds up/down to the other, depending on the `bound_type`.
     ///
     /// Applying a constraint to sealed bounds is a no-op.
-    fn apply(&self, bounds: &mut AsOfBounds<T>) -> Result<bool, bool> {
+    fn apply(&self, bounds: &mut AsOfBounds) -> Result<bool, bool> {
         if bounds.sealed {
             return Ok(false);
         }
@@ -318,32 +318,32 @@ impl<T: Timestamp> Constraint<'_, T> {
 }
 
 /// State tracked for a compute collection during as-of selection.
-struct Collection<'a, T> {
+struct Collection<'a> {
     storage_inputs: Vec<GlobalId>,
     compute_inputs: Vec<GlobalId>,
-    read_policy: Option<&'a ReadPolicy<T>>,
+    read_policy: Option<&'a ReadPolicy<Timestamp>>,
     /// The currently known as-of bounds.
     ///
     /// Shared between collections exported by the same dataflow.
-    bounds: Rc<RefCell<AsOfBounds<T>>>,
+    bounds: Rc<RefCell<AsOfBounds>>,
     /// Whether this collection is an index.
     is_index: bool,
 }
 
 /// The as-of selection context.
-struct Context<'a, T> {
-    collections: BTreeMap<GlobalId, Collection<'a, T>>,
-    storage_collections: &'a dyn StorageCollections<Timestamp = T>,
-    current_time: T,
+struct Context<'a> {
+    collections: BTreeMap<GlobalId, Collection<'a>>,
+    storage_collections: &'a dyn StorageCollections<Timestamp = Timestamp>,
+    current_time: Timestamp,
 }
 
-impl<'a, T: TimestampManipulation> Context<'a, T> {
+impl<'a> Context<'a> {
     /// Initializes an as-of selection context for the given `dataflows`.
     fn new(
-        dataflows: &[DataflowDescription<Plan<T>, (), T>],
-        storage_collections: &'a dyn StorageCollections<Timestamp = T>,
-        read_policies: &'a BTreeMap<GlobalId, ReadPolicy<T>>,
-        current_time: T,
+        dataflows: &[DataflowDescription<Plan, ()>],
+        storage_collections: &'a dyn StorageCollections<Timestamp = Timestamp>,
+        read_policies: &'a BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
+        current_time: Timestamp,
     ) -> Self {
         // Construct initial collection state for each dataflow export. Dataflows might have their
         // as-ofs already fixed, which we need to take into account when constructing `AsOfBounds`.
@@ -382,7 +382,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
     /// # Panics
     ///
     /// Panics if the identified collection doesn't exist.
-    fn expect_collection(&self, id: GlobalId) -> &Collection<'_, T> {
+    fn expect_collection(&self, id: GlobalId) -> &Collection<'_> {
         self.collections
             .get(&id)
             .unwrap_or_else(|| panic!("collection missing: {id}"))
@@ -391,7 +391,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
     /// Applies the given as-of constraint to the identified collection.
     ///
     /// Returns whether the collection's as-of bounds where changed as a result.
-    fn apply_constraint(&self, id: GlobalId, constraint: Constraint<T>) -> bool {
+    fn apply_constraint(&self, id: GlobalId, constraint: Constraint) -> bool {
         let collection = self.expect_collection(id);
         let mut bounds = collection.bounds.borrow_mut();
         match constraint.apply(&mut bounds) {
@@ -427,7 +427,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
     /// not be able to hydrate successfully.
     fn apply_upstream_storage_constraints(
         &self,
-        storage_read_holds: &BTreeMap<GlobalId, ReadHold<T>>,
+        storage_read_holds: &BTreeMap<GlobalId, ReadHold<Timestamp>>,
     ) {
         // Apply direct constraints from storage inputs.
         for (id, collection) in &self.collections {
@@ -484,12 +484,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
             let upper = if collection_empty {
                 frontiers.read_capabilities
             } else {
-                Antichain::from_iter(
-                    frontiers
-                        .write_frontier
-                        .iter()
-                        .map(|t| t.step_back().unwrap_or_else(T::minimum)),
-                )
+                step_back_frontier(&frontiers.write_frontier)
             };
 
             let constraint = Constraint {
@@ -753,7 +748,7 @@ impl<'a, T: TimestampManipulation> Context<'a, T> {
     /// We simply use the upper bound here, to maximize the chances of compute reconciliation
     /// succeeding. Choosing the latest possible as-of also minimizes the amount of work the
     /// dataflow has to spend processing historical data from its sources.
-    fn best_as_of(&self, id: GlobalId) -> Antichain<T> {
+    fn best_as_of(&self, id: GlobalId) -> Antichain<Timestamp> {
         if let Some(collection) = self.collections.get(&id) {
             let bounds = collection.bounds.borrow();
             bounds.upper.clone()
@@ -838,10 +833,10 @@ fn fixpoint(mut step: impl FnMut(&mut bool)) {
 ///
 /// This method is saturating: If the frontier contains `T::minimum()` times, these are kept
 /// unchanged.
-fn step_back_frontier<T: TimestampManipulation>(frontier: &Antichain<T>) -> Antichain<T> {
+fn step_back_frontier(frontier: &Antichain<Timestamp>) -> Antichain<Timestamp> {
     frontier
         .iter()
-        .map(|t| t.step_back().unwrap_or_else(T::minimum))
+        .map(|t| t.step_back().unwrap_or(Timestamp::MIN))
         .collect()
 }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -53,7 +53,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_types::PersistLocation;
-use mz_repr::{Datum, GlobalId, RelationDesc, Row, TimestampManipulation};
+use mz_repr::{GlobalId, RelationDesc, Row, Timestamp};
 use mz_storage_client::controller::StorageController;
 use mz_storage_types::dyncfgs::ORE_OVERFLOWING_BEHAVIOR;
 use mz_storage_types::read_holds::ReadHold;
@@ -62,7 +62,7 @@ use mz_storage_types::time_dependence::{TimeDependence, TimeDependenceError};
 use prometheus::proto::LabelPair;
 use serde::{Deserialize, Serialize};
 use timely::PartialOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, MissedTickBehavior};
 use uuid::Uuid;
@@ -89,23 +89,19 @@ pub mod error;
 pub mod instance_client;
 pub use instance_client::InstanceClient;
 
-pub(crate) type StorageCollections<T> = Arc<
-    dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = T> + Send + Sync,
+pub(crate) type StorageCollections = Arc<
+    dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = Timestamp>
+        + Send
+        + Sync,
 >;
-
-/// A composite trait for types that serve as timestamps in the Compute Controller.
-/// `Into<Datum<'a>>` is needed for writing timestamps to introspection collections.
-pub trait ComputeControllerTimestamp: TimestampManipulation + Into<Datum<'static>> + Sync {}
-
-impl ComputeControllerTimestamp for mz_repr::Timestamp {}
 
 /// Responses from the compute controller.
 #[derive(Debug)]
-pub enum ComputeControllerResponse<T> {
+pub enum ComputeControllerResponse {
     /// See [`PeekNotification`].
     PeekNotification(Uuid, PeekNotification, OpenTelemetryContext),
     /// See [`crate::protocol::response::ComputeResponse::SubscribeResponse`].
-    SubscribeResponse(GlobalId, SubscribeBatch<T>),
+    SubscribeResponse(GlobalId, SubscribeBatch),
     /// The response from a dataflow containing an `CopyToS3Oneshot` sink.
     ///
     /// The `GlobalId` identifies the sink. The `Result` is the response from
@@ -125,7 +121,7 @@ pub enum ComputeControllerResponse<T> {
         /// The ID of a compute collection.
         id: GlobalId,
         /// The new upper frontier of the identified compute collection.
-        upper: Antichain<T>,
+        upper: Antichain<Timestamp>,
     },
 }
 
@@ -183,15 +179,15 @@ impl PeekNotification {
 }
 
 /// A controller for the compute layer.
-pub struct ComputeController<T: ComputeControllerTimestamp> {
-    instances: BTreeMap<ComputeInstanceId, InstanceState<T>>,
+pub struct ComputeController {
+    instances: BTreeMap<ComputeInstanceId, InstanceState>,
     /// A map from an instance ID to an arbitrary string that describes the
     /// class of the workload that compute instance is running (e.g.,
     /// `production` or `staging`).
     instance_workload_classes: Arc<Mutex<BTreeMap<ComputeInstanceId, Option<String>>>>,
     build_info: &'static BuildInfo,
     /// A handle providing access to storage collections.
-    storage_collections: StorageCollections<T>,
+    storage_collections: StorageCollections,
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
     /// Whether or not this controller is in read-only mode.
@@ -205,13 +201,13 @@ pub struct ComputeController<T: ComputeControllerTimestamp> {
     /// The persist location where we can stash large peek results.
     peek_stash_persist_location: PersistLocation,
     /// A controller response to be returned on the next call to [`ComputeController::process`].
-    stashed_response: Option<ComputeControllerResponse<T>>,
+    stashed_response: Option<ComputeControllerResponse>,
     /// The compute controller metrics.
     metrics: ComputeControllerMetrics,
     /// A function that produces the current wallclock time.
     now: NowFn,
     /// A function that computes the lag between the given time and wallclock time.
-    wallclock_lag: WallclockLagFn<T>,
+    wallclock_lag: WallclockLagFn<Timestamp>,
     /// Dynamic system configuration.
     ///
     /// Updated through `ComputeController::update_configuration` calls and shared with all
@@ -219,9 +215,9 @@ pub struct ComputeController<T: ComputeControllerTimestamp> {
     dyncfg: Arc<ConfigSet>,
 
     /// Receiver for responses produced by `Instance`s.
-    response_rx: mpsc::UnboundedReceiver<ComputeControllerResponse<T>>,
+    response_rx: mpsc::UnboundedReceiver<ComputeControllerResponse>,
     /// Response sender that's passed to new `Instance`s.
-    response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
+    response_tx: mpsc::UnboundedSender<ComputeControllerResponse>,
     /// Receiver for introspection updates produced by `Instance`s.
     ///
     /// When [`ComputeController::start_introspection_sink`] is first called, this receiver is
@@ -236,17 +232,17 @@ pub struct ComputeController<T: ComputeControllerTimestamp> {
     maintenance_scheduled: bool,
 }
 
-impl<T: ComputeControllerTimestamp> ComputeController<T> {
+impl ComputeController {
     /// Construct a new [`ComputeController`].
     pub fn new(
         build_info: &'static BuildInfo,
-        storage_collections: StorageCollections<T>,
+        storage_collections: StorageCollections,
         read_only: bool,
         metrics_registry: &MetricsRegistry,
         peek_stash_persist_location: PersistLocation,
         controller_metrics: ControllerMetrics,
         now: NowFn,
-        wallclock_lag: WallclockLagFn<T>,
+        wallclock_lag: WallclockLagFn<Timestamp>,
     ) -> Self {
         let (response_tx, response_rx) = mpsc::unbounded_channel();
         let (introspection_tx, introspection_rx) = mpsc::unbounded_channel();
@@ -327,7 +323,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     /// the storage controller. It will panic if invoked earlier than that.
     pub fn start_introspection_sink(
         &mut self,
-        storage_controller: &dyn StorageController<Timestamp = T>,
+        storage_controller: &dyn StorageController<Timestamp = Timestamp>,
     ) {
         if let Some(rx) = self.introspection_rx.take() {
             spawn_introspection_sink(rx, storage_controller);
@@ -340,7 +336,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     }
 
     /// Return a reference to the indicated compute instance.
-    fn instance(&self, id: ComputeInstanceId) -> Result<&InstanceState<T>, InstanceMissing> {
+    fn instance(&self, id: ComputeInstanceId) -> Result<&InstanceState, InstanceMissing> {
         self.instances.get(&id).ok_or(InstanceMissing(id))
     }
 
@@ -348,7 +344,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     pub fn instance_client(
         &self,
         id: ComputeInstanceId,
-    ) -> Result<InstanceClient<T>, InstanceMissing> {
+    ) -> Result<InstanceClient, InstanceMissing> {
         self.instance(id).map(|instance| instance.client.clone())
     }
 
@@ -356,7 +352,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     fn instance_mut(
         &mut self,
         id: ComputeInstanceId,
-    ) -> Result<&mut InstanceState<T>, InstanceMissing> {
+    ) -> Result<&mut InstanceState, InstanceMissing> {
         self.instances.get_mut(&id).ok_or(InstanceMissing(id))
     }
 
@@ -378,7 +374,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         &self,
         collection_id: GlobalId,
         instance_id: Option<ComputeInstanceId>,
-    ) -> Result<CollectionFrontiers<T>, CollectionLookupError> {
+    ) -> Result<CollectionFrontiers, CollectionLookupError> {
         let collection = match instance_id {
             Some(id) => self.instance(id)?.collection(collection_id)?,
             None => self
@@ -510,10 +506,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     }
 }
 
-impl<T> ComputeController<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl ComputeController {
     /// Create a compute instance.
     pub fn create_instance(
         &mut self,
@@ -762,7 +755,7 @@ where
     pub fn create_dataflow(
         &mut self,
         instance_id: ComputeInstanceId,
-        mut dataflow: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
+        mut dataflow: DataflowDescription<mz_compute_types::plan::Plan, ()>,
         target_replica: Option<ReplicaId>,
     ) -> Result<(), DataflowCreationError> {
         use DataflowCreationError::*;
@@ -872,7 +865,7 @@ where
         peek_target: PeekTarget,
         literal_constraints: Option<Vec<Row>>,
         uuid: Uuid,
-        timestamp: T,
+        timestamp: Timestamp,
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
@@ -955,7 +948,7 @@ where
     pub fn set_read_policy(
         &self,
         instance_id: ComputeInstanceId,
-        policies: Vec<(GlobalId, ReadPolicy<T>)>,
+        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
     ) -> Result<(), ReadPolicyError> {
         use ReadPolicyError::*;
 
@@ -980,7 +973,7 @@ where
         &self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
-    ) -> Result<ReadHold<T>, CollectionUpdateError> {
+    ) -> Result<ReadHold<Timestamp>, CollectionUpdateError> {
         let read_hold = self
             .instance(instance_id)?
             .acquire_read_hold(collection_id)?;
@@ -991,7 +984,7 @@ where
     fn determine_time_dependence(
         &self,
         instance_id: ComputeInstanceId,
-        dataflow: &DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
+        dataflow: &DataflowDescription<mz_compute_types::plan::Plan, ()>,
     ) -> Result<Option<TimeDependence>, TimeDependenceError> {
         // TODO(ct3): Continual tasks don't support replica expiration
         let is_continual_task = dataflow.continual_task_ids().next().is_some();
@@ -1034,7 +1027,7 @@ where
 
     /// Processes the work queued by [`ComputeController::ready`].
     #[mz_ore::instrument(level = "debug")]
-    pub fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
+    pub fn process(&mut self) -> Option<ComputeControllerResponse> {
         // Perform periodic maintenance work.
         if self.maintenance_scheduled {
             self.maintain();
@@ -1078,14 +1071,14 @@ where
 }
 
 #[derive(Debug)]
-struct InstanceState<T: ComputeControllerTimestamp> {
-    client: InstanceClient<T>,
+struct InstanceState {
+    client: InstanceClient,
     replicas: BTreeSet<ReplicaId>,
-    collections: BTreeMap<GlobalId, Collection<T>>,
+    collections: BTreeMap<GlobalId, Collection>,
 }
 
-impl<T: ComputeControllerTimestamp> InstanceState<T> {
-    fn new(client: InstanceClient<T>, collections: BTreeMap<GlobalId, Collection<T>>) -> Self {
+impl InstanceState {
+    fn new(client: InstanceClient, collections: BTreeMap<GlobalId, Collection>) -> Self {
         Self {
             client,
             replicas: Default::default(),
@@ -1093,7 +1086,7 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
         }
     }
 
-    fn collection(&self, id: GlobalId) -> Result<&Collection<T>, CollectionMissing> {
+    fn collection(&self, id: GlobalId) -> Result<&Collection, CollectionMissing> {
         self.collections.get(&id).ok_or(CollectionMissing(id))
     }
 
@@ -1104,7 +1097,7 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
     /// Panics if the instance corresponding to `self` does not exist.
     fn call<F>(&self, f: F)
     where
-        F: FnOnce(&mut Instance<T>) + Send + 'static,
+        F: FnOnce(&mut Instance) + Send + 'static,
     {
         self.client.call(f).expect("instance not dropped")
     }
@@ -1116,7 +1109,7 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
     /// Panics if the instance corresponding to `self` does not exist.
     async fn call_sync<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&mut Instance<T>) -> R + Send + 'static,
+        F: FnOnce(&mut Instance) -> R + Send + 'static,
         R: Send + 'static,
     {
         self.client
@@ -1126,7 +1119,10 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
     }
 
     /// Acquires a [`ReadHold`] for the identified compute collection.
-    pub fn acquire_read_hold(&self, id: GlobalId) -> Result<ReadHold<T>, CollectionMissing> {
+    pub fn acquire_read_hold(
+        &self,
+        id: GlobalId,
+    ) -> Result<ReadHold<Timestamp>, CollectionMissing> {
         // We acquire read holds at the earliest possible time rather than returning a copy
         // of the implied read hold. This is so that in `create_dataflow` we can acquire read holds
         // on compute dependencies at frontiers that are held back by other read holds the caller
@@ -1180,19 +1176,19 @@ impl<T: ComputeControllerTimestamp> InstanceState<T> {
 }
 
 #[derive(Debug)]
-struct Collection<T> {
+struct Collection {
     /// Whether a collection is write-only, i.e., we cannot read it directly like an index.
     write_only: bool,
     compute_dependencies: BTreeSet<GlobalId>,
-    shared: SharedCollectionState<T>,
+    shared: SharedCollectionState,
     /// The computed time dependence for this collection. None indicates no specific information,
     /// a value describes how the collection relates to wall-clock time.
     time_dependence: Option<TimeDependence>,
 }
 
-impl<T: Timestamp> Collection<T> {
+impl Collection {
     fn new_log() -> Self {
-        let as_of = Antichain::from_elem(T::minimum());
+        let as_of = Antichain::from_elem(Timestamp::MIN);
         Self {
             write_only: false,
             compute_dependencies: Default::default(),
@@ -1201,7 +1197,7 @@ impl<T: Timestamp> Collection<T> {
         }
     }
 
-    fn frontiers(&self) -> CollectionFrontiers<T> {
+    fn frontiers(&self) -> CollectionFrontiers {
         let read_frontier = self
             .shared
             .lock_read_capabilities(|c| c.frontier().to_owned());
@@ -1215,18 +1211,18 @@ impl<T: Timestamp> Collection<T> {
 
 /// The frontiers of a compute collection.
 #[derive(Clone, Debug)]
-pub struct CollectionFrontiers<T> {
+pub struct CollectionFrontiers {
     /// The read frontier.
-    pub read_frontier: Antichain<T>,
+    pub read_frontier: Antichain<Timestamp>,
     /// The write frontier.
-    pub write_frontier: Antichain<T>,
+    pub write_frontier: Antichain<Timestamp>,
 }
 
-impl<T: Timestamp> Default for CollectionFrontiers<T> {
+impl Default for CollectionFrontiers {
     fn default() -> Self {
         Self {
-            read_frontier: Antichain::from_elem(T::minimum()),
-            write_frontier: Antichain::from_elem(T::minimum()),
+            read_frontier: Antichain::from_elem(Timestamp::MIN),
+            write_frontier: Antichain::from_elem(Timestamp::MIN),
         }
     }
 }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -36,14 +36,14 @@ use mz_ore::{soft_assert_or_log, soft_panic_or_log};
 use mz_persist_types::PersistLocation;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::refresh_schedule::RefreshSchedule;
-use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row};
+use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, Timestamp};
 use mz_storage_client::controller::{IntrospectionType, WallclockLag, WallclockLagHistogramPeriod};
 use mz_storage_types::read_holds::{self, ReadHold};
 use mz_storage_types::read_policy::ReadPolicy;
 use thiserror::Error;
 use timely::PartialOrder;
 use timely::progress::frontier::MutableAntichain;
-use timely::progress::{Antichain, ChangeBatch, Timestamp};
+use timely::progress::{Antichain, ChangeBatch};
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
@@ -53,8 +53,8 @@ use crate::controller::error::{
 use crate::controller::instance_client::PeekError;
 use crate::controller::replica::{ReplicaClient, ReplicaConfig};
 use crate::controller::{
-    ComputeControllerResponse, ComputeControllerTimestamp, IntrospectionUpdates, PeekNotification,
-    ReplicaId, StorageCollections,
+    ComputeControllerResponse, IntrospectionUpdates, PeekNotification, ReplicaId,
+    StorageCollections,
 };
 use crate::logging::LogVariant;
 use crate::metrics::IntCounter;
@@ -115,18 +115,18 @@ impl From<CollectionMissing> for ReadPolicyError {
 }
 
 /// A command sent to an [`Instance`] task.
-pub(super) type Command<T> = Box<dyn FnOnce(&mut Instance<T>) + Send>;
+pub(super) type Command = Box<dyn FnOnce(&mut Instance) + Send>;
 
 /// A response from a replica, composed of a replica ID, the replica's current epoch, and the
 /// compute response itself.
-pub(super) type ReplicaResponse<T> = (ReplicaId, u64, ComputeResponse<T>);
+pub(super) type ReplicaResponse = (ReplicaId, u64, ComputeResponse);
 
 /// The state we keep for a compute instance.
-pub(super) struct Instance<T: ComputeControllerTimestamp> {
+pub(super) struct Instance {
     /// Build info for spawning replicas
     build_info: &'static BuildInfo,
     /// A handle providing access to storage collections.
-    storage_collections: StorageCollections<T>,
+    storage_collections: StorageCollections,
     /// Whether instance initialization has been completed.
     initialized: bool,
     /// Whether this instance is in read-only mode.
@@ -139,7 +139,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     /// This is currently only used to annotate metrics.
     workload_class: Option<String>,
     /// The replicas of this compute instance.
-    replicas: BTreeMap<ReplicaId, ReplicaState<T>>,
+    replicas: BTreeMap<ReplicaId, ReplicaState>,
     /// Currently installed compute collections.
     ///
     /// New entries are added for all collections exported from dataflows created through
@@ -147,7 +147,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     ///
     /// Entries are removed by [`Instance::cleanup_collections`]. See that method's documentation
     /// about the conditions for removing collection state.
-    collections: BTreeMap<GlobalId, CollectionState<T>>,
+    collections: BTreeMap<GlobalId, CollectionState>,
     /// IDs of log sources maintained by this compute instance.
     log_sources: BTreeMap<LogVariant, GlobalId>,
     /// Currently outstanding peeks.
@@ -158,7 +158,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     /// currently required to ensure all replicas have stopped reading from the peeked collection's
     /// inputs before we allow them to compact. database-issues#4822 tracks changing this so we only have to wait
     /// for the first peek response.
-    peeks: BTreeMap<Uuid, PendingPeek<T>>,
+    peeks: BTreeMap<Uuid, PendingPeek>,
     /// Currently in-progress subscribes.
     ///
     /// New entries are added for all subscribes exported from dataflows created through
@@ -172,7 +172,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     /// keeps track of the subscribe's upper and since frontiers and ensures appropriate read holds
     /// on the subscribe's input. `subscribes` is only used to track which updates have been
     /// emitted, to decide if new ones should be emitted or suppressed.
-    subscribes: BTreeMap<GlobalId, ActiveSubscribe<T>>,
+    subscribes: BTreeMap<GlobalId, ActiveSubscribe>,
     /// Tracks all in-progress COPY TOs.
     ///
     /// New entries are added for all s3 oneshot sinks (corresponding to a COPY TO) exported from
@@ -182,11 +182,11 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     /// or the exporting collection is dropped.
     copy_tos: BTreeSet<GlobalId>,
     /// The command history, used when introducing new replicas or restarting existing replicas.
-    history: ComputeCommandHistory<UIntGauge, T>,
+    history: ComputeCommandHistory<UIntGauge>,
     /// Receiver for commands to be executed.
-    command_rx: mpsc::UnboundedReceiver<Command<T>>,
+    command_rx: mpsc::UnboundedReceiver<Command>,
     /// Sender for responses to be delivered.
-    response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
+    response_tx: mpsc::UnboundedSender<ComputeControllerResponse>,
     /// Sender for introspection updates to be recorded.
     introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
     /// The registry the controller uses to report metrics.
@@ -200,7 +200,7 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     /// A function that produces the current wallclock time.
     now: NowFn,
     /// A function that computes the lag between the given time and wallclock time.
-    wallclock_lag: WallclockLagFn<T>,
+    wallclock_lag: WallclockLagFn<Timestamp>,
     /// The last time wallclock lag introspection was recorded.
     wallclock_lag_last_recorded: DateTime<Utc>,
 
@@ -208,24 +208,21 @@ pub(super) struct Instance<T: ComputeControllerTimestamp> {
     ///
     /// Copies of this sender are given to [`ReadHold`]s that are created in
     /// [`CollectionState::new`].
-    read_hold_tx: read_holds::ChangeTx<T>,
+    read_hold_tx: read_holds::ChangeTx<Timestamp>,
     /// A sender for responses from replicas.
-    replica_tx: mz_ore::channel::InstrumentedUnboundedSender<ReplicaResponse<T>, IntCounter>,
+    replica_tx: mz_ore::channel::InstrumentedUnboundedSender<ReplicaResponse, IntCounter>,
     /// A receiver for responses from replicas.
-    replica_rx: mz_ore::channel::InstrumentedUnboundedReceiver<ReplicaResponse<T>, IntCounter>,
+    replica_rx: mz_ore::channel::InstrumentedUnboundedReceiver<ReplicaResponse, IntCounter>,
 }
 
-impl<T: ComputeControllerTimestamp> Instance<T> {
+impl Instance {
     /// Acquire a handle to the collection state associated with `id`.
-    fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, CollectionMissing> {
+    fn collection(&self, id: GlobalId) -> Result<&CollectionState, CollectionMissing> {
         self.collections.get(&id).ok_or(CollectionMissing(id))
     }
 
     /// Acquire a mutable handle to the collection state associated with `id`.
-    fn collection_mut(
-        &mut self,
-        id: GlobalId,
-    ) -> Result<&mut CollectionState<T>, CollectionMissing> {
+    fn collection_mut(&mut self, id: GlobalId) -> Result<&mut CollectionState, CollectionMissing> {
         self.collections.get_mut(&id).ok_or(CollectionMissing(id))
     }
 
@@ -234,7 +231,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     /// # Panics
     ///
     /// Panics if the identified collection does not exist.
-    fn expect_collection(&self, id: GlobalId) -> &CollectionState<T> {
+    fn expect_collection(&self, id: GlobalId) -> &CollectionState {
         self.collections.get(&id).expect("collection must exist")
     }
 
@@ -243,13 +240,13 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     /// # Panics
     ///
     /// Panics if the identified collection does not exist.
-    fn expect_collection_mut(&mut self, id: GlobalId) -> &mut CollectionState<T> {
+    fn expect_collection_mut(&mut self, id: GlobalId) -> &mut CollectionState {
         self.collections
             .get_mut(&id)
             .expect("collection must exist")
     }
 
-    fn collections_iter(&self) -> impl Iterator<Item = (GlobalId, &CollectionState<T>)> {
+    fn collections_iter(&self) -> impl Iterator<Item = (GlobalId, &CollectionState)> {
         self.collections.iter().map(|(id, coll)| (*id, coll))
     }
 
@@ -262,7 +259,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     fn replicas_hosting(
         &self,
         id: GlobalId,
-    ) -> Result<impl Iterator<Item = &ReplicaState<T>>, CollectionMissing> {
+    ) -> Result<impl Iterator<Item = &ReplicaState>, CollectionMissing> {
         let target = self.collection(id)?.target_replica;
         Ok(self
             .replicas
@@ -278,14 +275,14 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     fn add_collection(
         &mut self,
         id: GlobalId,
-        as_of: Antichain<T>,
-        shared: SharedCollectionState<T>,
-        storage_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        compute_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        replica_input_read_holds: Vec<ReadHold<T>>,
+        as_of: Antichain<Timestamp>,
+        shared: SharedCollectionState,
+        storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+        compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+        replica_input_read_holds: Vec<ReadHold<Timestamp>>,
         write_only: bool,
         storage_sink: bool,
-        initial_as_of: Option<Antichain<T>>,
+        initial_as_of: Option<Antichain<Timestamp>>,
         refresh_schedule: Option<RefreshSchedule>,
         target_replica: Option<ReplicaId>,
     ) {
@@ -345,7 +342,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     fn add_replica_state(
         &mut self,
         id: ReplicaId,
-        client: ReplicaClient<T>,
+        client: ReplicaClient,
         config: ReplicaConfig,
         epoch: u64,
     ) {
@@ -376,7 +373,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                 // it doesn't know which as-of the controler chose and defaults to the minimum
                 // frontier instead. We need to initialize the controller-side tracking with the
                 // same frontier, to avoid observing regressions in the reported frontiers.
-                Antichain::from_elem(T::minimum())
+                Antichain::from_elem(Timestamp::MIN)
             } else {
                 collection.read_frontier().to_owned()
             };
@@ -389,7 +386,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     }
 
     /// Enqueue the given response for delivery to the controller clients.
-    fn deliver_response(&self, response: ComputeControllerResponse<T>) {
+    fn deliver_response(&self, response: ComputeControllerResponse) {
         // Failure to send means the `ComputeController` has been dropped and doesn't care about
         // responses anymore.
         let _ = self.response_tx.send(response);
@@ -408,10 +405,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     }
 
     /// Return the IDs of pending peeks targeting the specified replica.
-    fn peeks_targeting(
-        &self,
-        replica_id: ReplicaId,
-    ) -> impl Iterator<Item = (Uuid, &PendingPeek<T>)> {
+    fn peeks_targeting(&self, replica_id: ReplicaId) -> impl Iterator<Item = (Uuid, &PendingPeek)> {
         self.peeks.iter().filter_map(move |(uuid, peek)| {
             if peek.target_replica == Some(replica_id) {
                 Some((*uuid, peek))
@@ -512,7 +506,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     /// This method is invoked by `ComputeController::maintain`, which we expect to be called once
     /// per second during normal operation.
     fn refresh_wallclock_lag(&mut self) {
-        let frontier_lag = |frontier: &Antichain<T>| match frontier.as_option() {
+        let frontier_lag = |frontier: &Antichain<Timestamp>| match frontier.as_option() {
             Some(ts) => (self.wallclock_lag)(ts.clone()),
             None => Duration::ZERO,
         };
@@ -874,27 +868,24 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     pub(super) fn collection_write_frontier(
         &self,
         id: GlobalId,
-    ) -> Result<Antichain<T>, CollectionMissing> {
+    ) -> Result<Antichain<Timestamp>, CollectionMissing> {
         Ok(self.collection(id)?.write_frontier())
     }
 }
 
-impl<T> Instance<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl Instance {
     pub(super) fn new(
         build_info: &'static BuildInfo,
-        storage: StorageCollections<T>,
+        storage: StorageCollections,
         peek_stash_persist_location: PersistLocation,
-        arranged_logs: Vec<(LogVariant, GlobalId, SharedCollectionState<T>)>,
+        arranged_logs: Vec<(LogVariant, GlobalId, SharedCollectionState)>,
         metrics: InstanceMetrics,
         now: NowFn,
-        wallclock_lag: WallclockLagFn<T>,
+        wallclock_lag: WallclockLagFn<Timestamp>,
         dyncfg: Arc<ConfigSet>,
-        command_rx: mpsc::UnboundedReceiver<Command<T>>,
-        response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
-        read_hold_tx: read_holds::ChangeTx<T>,
+        command_rx: mpsc::UnboundedReceiver<Command>,
+        response_tx: mpsc::UnboundedSender<ComputeControllerResponse>,
+        read_hold_tx: read_holds::ChangeTx<Timestamp>,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
         read_only: bool,
     ) -> Self {
@@ -1053,7 +1044,7 @@ where
 
     /// Sends a command to replicas of this instance.
     #[mz_ore::instrument(level = "debug")]
-    fn send(&mut self, cmd: ComputeCommand<T>) {
+    fn send(&mut self, cmd: ComputeCommand) {
         // Record the command so that new replicas can be brought up to speed.
         self.history.push(cmd.clone());
 
@@ -1077,7 +1068,7 @@ where
     /// Panics if a create-dataflow command names collections that have different
     /// target replicas. It is an error to construct such an object and would
     /// indicate a bug in [`Self::create_dataflow`].
-    fn target_replica(&self, cmd: &ComputeCommand<T>) -> Option<ReplicaId> {
+    fn target_replica(&self, cmd: &ComputeCommand) -> Option<ReplicaId> {
         match &cmd {
             ComputeCommand::Schedule(id)
             | ComputeCommand::AllowWrites(id)
@@ -1249,9 +1240,9 @@ where
     #[mz_ore::instrument(level = "debug")]
     pub fn create_dataflow(
         &mut self,
-        dataflow: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
-        import_read_holds: Vec<ReadHold<T>>,
-        mut shared_collection_state: BTreeMap<GlobalId, SharedCollectionState<T>>,
+        dataflow: DataflowDescription<mz_compute_types::plan::Plan, ()>,
+        import_read_holds: Vec<ReadHold<Timestamp>>,
+        mut shared_collection_state: BTreeMap<GlobalId, SharedCollectionState>,
         target_replica: Option<ReplicaId>,
     ) -> Result<(), DataflowCreationError> {
         use DataflowCreationError::*;
@@ -1605,11 +1596,11 @@ where
         peek_target: PeekTarget,
         literal_constraints: Option<Vec<Row>>,
         uuid: Uuid,
-        timestamp: T,
+        timestamp: Timestamp,
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
-        mut read_hold: ReadHold<T>,
+        mut read_hold: ReadHold<Timestamp>,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
     ) -> Result<(), PeekError> {
@@ -1705,7 +1696,7 @@ where
     #[mz_ore::instrument(level = "debug")]
     pub fn set_read_policy(
         &mut self,
-        policies: Vec<(GlobalId, ReadPolicy<T>)>,
+        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
     ) -> Result<(), ReadPolicyError> {
         // Do error checking upfront, to avoid introducing inconsistencies between a collection's
         // `implied_capability` and `read_capabilities`.
@@ -1734,7 +1725,11 @@ where
     ///
     /// Panics if the identified collection does not exist.
     #[mz_ore::instrument(level = "debug")]
-    fn maybe_update_global_write_frontier(&mut self, id: GlobalId, new_frontier: Antichain<T>) {
+    fn maybe_update_global_write_frontier(
+        &mut self,
+        id: GlobalId,
+        new_frontier: Antichain<Timestamp>,
+    ) {
         let collection = self.expect_collection_mut(id);
 
         let advanced = collection.shared.lock_write_frontier(|f| {
@@ -1768,7 +1763,7 @@ where
                 Antichain::from_iter(
                     new_frontier
                         .iter()
-                        .map(|t| t.step_back().unwrap_or_else(T::minimum)),
+                        .map(|t| t.step_back().unwrap_or(Timestamp::MIN)),
                 )
             }
         };
@@ -1782,7 +1777,11 @@ where
     }
 
     /// Apply a collection read hold change.
-    pub(super) fn apply_read_hold_change(&mut self, id: GlobalId, mut update: ChangeBatch<T>) {
+    pub(super) fn apply_read_hold_change(
+        &mut self,
+        id: GlobalId,
+        mut update: ChangeBatch<Timestamp>,
+    ) {
         let Some(collection) = self.collections.get_mut(&id) else {
             soft_panic_or_log!(
                 "read hold change for absent collection (id={id}, changes={update:?})"
@@ -1864,7 +1863,7 @@ where
 
     /// Handles a response from a replica. Replica IDs are re-used across replica restarts, so we
     /// use the replica epoch to drop stale responses.
-    fn handle_response(&mut self, (replica_id, epoch, response): ReplicaResponse<T>) {
+    fn handle_response(&mut self, (replica_id, epoch, response): ReplicaResponse) {
         // Filter responses from non-existing or stale replicas.
         if self
             .replicas
@@ -1901,7 +1900,7 @@ where
     fn handle_frontiers_response(
         &mut self,
         id: GlobalId,
-        frontiers: FrontiersResponse<T>,
+        frontiers: FrontiersResponse,
         replica_id: ReplicaId,
     ) {
         if !self.collections.contains_key(&id) {
@@ -2035,7 +2034,7 @@ where
     fn handle_subscribe_response(
         &mut self,
         subscribe_id: GlobalId,
-        response: SubscribeResponse<T>,
+        response: SubscribeResponse,
         replica_id: ReplicaId,
     ) {
         if !self.collections.contains_key(&subscribe_id) {
@@ -2151,8 +2150,8 @@ where
     /// Return the write frontiers of the dependencies of the given collection.
     fn dependency_write_frontiers<'b>(
         &'b self,
-        collection: &'b CollectionState<T>,
-    ) -> impl Iterator<Item = Antichain<T>> + 'b {
+        collection: &'b CollectionState,
+    ) -> impl Iterator<Item = Antichain<Timestamp>> + 'b {
         let compute_frontiers = collection.compute_dependency_ids().filter_map(|dep_id| {
             let collection = self.collections.get(&dep_id);
             collection.map(|c| c.write_frontier())
@@ -2168,8 +2167,8 @@ where
     /// Return the write frontiers of transitive storage dependencies of the given collection.
     fn transitive_storage_dependency_write_frontiers<'b>(
         &'b self,
-        collection: &'b CollectionState<T>,
-    ) -> impl Iterator<Item = Antichain<T>> + 'b {
+        collection: &'b CollectionState,
+    ) -> impl Iterator<Item = Antichain<Timestamp>> + 'b {
         let mut storage_ids: BTreeSet<_> = collection.storage_dependency_ids().collect();
         let mut todo: Vec<_> = collection.compute_dependency_ids().collect();
         let mut done = BTreeSet::new();
@@ -2300,7 +2299,10 @@ where
     ///
     /// This mirrors the logic used by the controller-side `InstanceState::acquire_read_hold`,
     /// but executes on the instance task itself.
-    pub(super) fn acquire_read_hold(&self, id: GlobalId) -> Result<ReadHold<T>, CollectionMissing> {
+    pub(super) fn acquire_read_hold(
+        &self,
+        id: GlobalId,
+    ) -> Result<ReadHold<Timestamp>, CollectionMissing> {
         // Similarly to InstanceState::acquire_read_hold and StorageCollections::acquire_read_holds,
         // we acquire read holds at the earliest possible time rather than returning a copy
         // of the implied read hold. This is so that dependents can acquire read holds on
@@ -2339,7 +2341,7 @@ where
 /// A compute collection is either an index, or a storage sink, or a subscribe, exported by a
 /// compute dataflow.
 #[derive(Debug)]
-struct CollectionState<T: ComputeControllerTimestamp> {
+struct CollectionState {
     /// If set, this collection is only maintained by the specified replica.
     target_replica: Option<ReplicaId>,
     /// Whether this collection is a log collection.
@@ -2362,7 +2364,7 @@ struct CollectionState<T: ComputeControllerTimestamp> {
     read_only: bool,
 
     /// State shared with the `ComputeController`.
-    shared: SharedCollectionState<T>,
+    shared: SharedCollectionState,
 
     /// A read hold maintaining the implicit capability of the collection.
     ///
@@ -2370,7 +2372,7 @@ struct CollectionState<T: ComputeControllerTimestamp> {
     /// `read_policy`. It also ensures that read holds on the collection's dependencies are kept at
     /// some time not greater than the collection's `write_frontier`, guaranteeing that the
     /// collection's next outputs can always be computed without skipping times.
-    implied_read_hold: ReadHold<T>,
+    implied_read_hold: ReadHold<Timestamp>,
     /// A read hold held to enable dataflow warmup.
     ///
     /// Dataflow warmup is an optimization that allows dataflows to immediately start hydrating
@@ -2378,23 +2380,23 @@ struct CollectionState<T: ComputeControllerTimestamp> {
     /// By installing a read capability derived from the write frontiers of the collection's
     /// inputs, we ensure that the as-of of new dataflows installed for the collection is at a time
     /// that is immediately available, so hydration can begin immediately too.
-    warmup_read_hold: ReadHold<T>,
+    warmup_read_hold: ReadHold<Timestamp>,
     /// The policy to use to downgrade `self.implied_read_hold`.
     ///
     /// If `None`, the collection is a write-only collection (i.e. a sink). For write-only
     /// collections, the `implied_read_hold` is only required for maintaining read holds on the
     /// inputs, so we can immediately downgrade it to the `write_frontier`.
-    read_policy: Option<ReadPolicy<T>>,
+    read_policy: Option<ReadPolicy<Timestamp>>,
 
     /// Storage identifiers on which this collection depends, and read holds this collection
     /// requires on them.
-    storage_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
+    storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
     /// Compute identifiers on which this collection depends, and read holds this collection
     /// requires on them.
-    compute_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
+    compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
 
     /// Introspection state associated with this collection.
-    introspection: CollectionIntrospection<T>,
+    introspection: CollectionIntrospection,
 
     /// Frontier wallclock lag measurements stashed until the next `WallclockLagHistogram`
     /// introspection update.
@@ -2414,16 +2416,16 @@ struct CollectionState<T: ComputeControllerTimestamp> {
     >,
 }
 
-impl<T: ComputeControllerTimestamp> CollectionState<T> {
+impl CollectionState {
     /// Creates a new collection state, with an initial read policy valid from `since`.
     fn new(
         collection_id: GlobalId,
-        as_of: Antichain<T>,
-        shared: SharedCollectionState<T>,
-        storage_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        compute_dependencies: BTreeMap<GlobalId, ReadHold<T>>,
-        read_hold_tx: read_holds::ChangeTx<T>,
-        introspection: CollectionIntrospection<T>,
+        as_of: Antichain<Timestamp>,
+        shared: SharedCollectionState,
+        storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+        compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+        read_hold_tx: read_holds::ChangeTx<Timestamp>,
+        introspection: CollectionIntrospection,
     ) -> Self {
         // A collection is not readable before the `as_of`.
         let since = as_of.clone();
@@ -2474,11 +2476,11 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
     /// Creates a new collection state for a log collection.
     fn new_log_collection(
         id: GlobalId,
-        shared: SharedCollectionState<T>,
-        read_hold_tx: read_holds::ChangeTx<T>,
+        shared: SharedCollectionState,
+        read_hold_tx: read_holds::ChangeTx<Timestamp>,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
     ) -> Self {
-        let since = Antichain::from_elem(T::minimum());
+        let since = Antichain::from_elem(Timestamp::MIN);
         let introspection = CollectionIntrospection::new(
             id,
             introspection_tx,
@@ -2504,13 +2506,13 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
     }
 
     /// Reports the current read frontier.
-    fn read_frontier(&self) -> Antichain<T> {
+    fn read_frontier(&self) -> Antichain<Timestamp> {
         self.shared
             .lock_read_capabilities(|c| c.frontier().to_owned())
     }
 
     /// Reports the current write frontier.
-    fn write_frontier(&self) -> Antichain<T> {
+    fn write_frontier(&self) -> Antichain<Timestamp> {
         self.shared.lock_write_frontier(|f| f.clone())
     }
 
@@ -2534,7 +2536,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
 /// collection's creation in the [`Instance`]. This is to allow compute clients to query frontiers
 /// and take new read holds immediately, without having to wait for the [`Instance`] to update.
 #[derive(Clone, Debug)]
-pub(super) struct SharedCollectionState<T> {
+pub(super) struct SharedCollectionState {
     /// Accumulation of read capabilities for the collection.
     ///
     /// This accumulation contains the capabilities held by all [`ReadHold`]s given out for the
@@ -2547,13 +2549,13 @@ pub(super) struct SharedCollectionState<T> {
     /// `ComputeController::acquire_read_hold`.
     ///
     /// TODO(teskje): Restructure the code to enforce the above in the type system.
-    read_capabilities: Arc<Mutex<MutableAntichain<T>>>,
+    read_capabilities: Arc<Mutex<MutableAntichain<Timestamp>>>,
     /// The write frontier of this collection.
-    write_frontier: Arc<Mutex<Antichain<T>>>,
+    write_frontier: Arc<Mutex<Antichain<Timestamp>>>,
 }
 
-impl<T: Timestamp> SharedCollectionState<T> {
-    pub fn new(as_of: Antichain<T>) -> Self {
+impl SharedCollectionState {
+    pub fn new(as_of: Antichain<Timestamp>) -> Self {
         // A collection is not readable before the `as_of`.
         let since = as_of.clone();
         // A collection won't produce updates for times before the `as_of`.
@@ -2573,7 +2575,7 @@ impl<T: Timestamp> SharedCollectionState<T> {
 
     pub fn lock_read_capabilities<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&mut MutableAntichain<T>) -> R,
+        F: FnOnce(&mut MutableAntichain<Timestamp>) -> R,
     {
         let mut caps = self.read_capabilities.lock().expect("poisoned");
         f(&mut *caps)
@@ -2581,7 +2583,7 @@ impl<T: Timestamp> SharedCollectionState<T> {
 
     pub fn lock_write_frontier<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&mut Antichain<T>) -> R,
+        F: FnOnce(&mut Antichain<Timestamp>) -> R,
     {
         let mut frontier = self.write_frontier.lock().expect("poisoned");
         f(&mut *frontier)
@@ -2591,7 +2593,7 @@ impl<T: Timestamp> SharedCollectionState<T> {
 /// Manages certain introspection relations associated with a collection. Upon creation, it adds
 /// rows to introspection relations. When dropped, it retracts its managed rows.
 #[derive(Debug)]
-struct CollectionIntrospection<T: ComputeControllerTimestamp> {
+struct CollectionIntrospection {
     /// The ID of the compute collection.
     collection_id: GlobalId,
     /// A channel through which introspection updates are delivered.
@@ -2600,22 +2602,22 @@ struct CollectionIntrospection<T: ComputeControllerTimestamp> {
     ///
     /// `Some` if the collection does _not_ sink into a storage collection (i.e. is not an MV). If
     /// the collection sinks into storage, the storage controller reports its frontiers instead.
-    frontiers: Option<FrontiersIntrospectionState<T>>,
+    frontiers: Option<FrontiersIntrospectionState>,
     /// Introspection state for `IntrospectionType::ComputeMaterializedViewRefreshes`.
     ///
     /// `Some` if the collection is a REFRESH MV.
-    refresh: Option<RefreshIntrospectionState<T>>,
+    refresh: Option<RefreshIntrospectionState>,
     /// The IDs of the collection's dependencies, for `IntrospectionType::ComputeDependencies`.
     dependency_ids: Vec<GlobalId>,
 }
 
-impl<T: ComputeControllerTimestamp> CollectionIntrospection<T> {
+impl CollectionIntrospection {
     fn new(
         collection_id: GlobalId,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
-        as_of: Antichain<T>,
+        as_of: Antichain<Timestamp>,
         storage_sink: bool,
-        initial_as_of: Option<Antichain<T>>,
+        initial_as_of: Option<Antichain<Timestamp>>,
         refresh_schedule: Option<RefreshSchedule>,
         dependency_ids: Vec<GlobalId>,
     ) -> Self {
@@ -2684,15 +2686,19 @@ impl<T: ComputeControllerTimestamp> CollectionIntrospection<T> {
 
     /// Observe the given current collection frontiers and update the introspection state as
     /// necessary.
-    fn observe_frontiers(&mut self, read_frontier: &Antichain<T>, write_frontier: &Antichain<T>) {
+    fn observe_frontiers(
+        &mut self,
+        read_frontier: &Antichain<Timestamp>,
+        write_frontier: &Antichain<Timestamp>,
+    ) {
         self.update_frontier_introspection(read_frontier, write_frontier);
         self.update_refresh_introspection(write_frontier);
     }
 
     fn update_frontier_introspection(
         &mut self,
-        read_frontier: &Antichain<T>,
-        write_frontier: &Antichain<T>,
+        read_frontier: &Antichain<Timestamp>,
+        write_frontier: &Antichain<Timestamp>,
     ) {
         let Some(frontiers) = &mut self.frontiers else {
             return;
@@ -2710,7 +2716,7 @@ impl<T: ComputeControllerTimestamp> CollectionIntrospection<T> {
         self.send(IntrospectionType::Frontiers, updates);
     }
 
-    fn update_refresh_introspection(&mut self, write_frontier: &Antichain<T>) {
+    fn update_refresh_introspection(&mut self, write_frontier: &Antichain<Timestamp>) {
         let Some(refresh) = &mut self.refresh else {
             return;
         };
@@ -2734,7 +2740,7 @@ impl<T: ComputeControllerTimestamp> CollectionIntrospection<T> {
     }
 }
 
-impl<T: ComputeControllerTimestamp> Drop for CollectionIntrospection<T> {
+impl Drop for CollectionIntrospection {
     fn drop(&mut self) {
         // Retract collection frontiers.
         if let Some(frontiers) = &self.frontiers {
@@ -2759,13 +2765,13 @@ impl<T: ComputeControllerTimestamp> Drop for CollectionIntrospection<T> {
 }
 
 #[derive(Debug)]
-struct FrontiersIntrospectionState<T> {
-    read_frontier: Antichain<T>,
-    write_frontier: Antichain<T>,
+struct FrontiersIntrospectionState {
+    read_frontier: Antichain<Timestamp>,
+    write_frontier: Antichain<Timestamp>,
 }
 
-impl<T: ComputeControllerTimestamp> FrontiersIntrospectionState<T> {
-    fn new(as_of: Antichain<T>) -> Self {
+impl FrontiersIntrospectionState {
+    fn new(as_of: Antichain<Timestamp>) -> Self {
         Self {
             read_frontier: as_of.clone(),
             write_frontier: as_of,
@@ -2790,7 +2796,11 @@ impl<T: ComputeControllerTimestamp> FrontiersIntrospectionState<T> {
     }
 
     /// Update the introspection state with the given new frontiers.
-    fn update(&mut self, read_frontier: &Antichain<T>, write_frontier: &Antichain<T>) {
+    fn update(
+        &mut self,
+        read_frontier: &Antichain<Timestamp>,
+        write_frontier: &Antichain<Timestamp>,
+    ) {
         if read_frontier != &self.read_frontier {
             self.read_frontier.clone_from(read_frontier);
         }
@@ -2803,16 +2813,16 @@ impl<T: ComputeControllerTimestamp> FrontiersIntrospectionState<T> {
 /// Information needed to compute introspection updates for a REFRESH materialized view when the
 /// write frontier advances.
 #[derive(Debug)]
-struct RefreshIntrospectionState<T> {
+struct RefreshIntrospectionState {
     // Immutable properties of the MV
     refresh_schedule: RefreshSchedule,
-    initial_as_of: Antichain<T>,
+    initial_as_of: Antichain<Timestamp>,
     // Refresh state
     next_refresh: Datum<'static>,           // Null or an MzTimestamp
     last_completed_refresh: Datum<'static>, // Null or an MzTimestamp
 }
 
-impl<T> RefreshIntrospectionState<T> {
+impl RefreshIntrospectionState {
     /// Return a `Row` reflecting the current refresh introspection state.
     fn row_for_collection(&self, collection_id: GlobalId) -> Row {
         Row::pack_slice(&[
@@ -2823,13 +2833,13 @@ impl<T> RefreshIntrospectionState<T> {
     }
 }
 
-impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
+impl RefreshIntrospectionState {
     /// Construct a new [`RefreshIntrospectionState`], and apply an initial `frontier_update()` at
     /// the `upper`.
     fn new(
         refresh_schedule: RefreshSchedule,
-        initial_as_of: Antichain<T>,
-        upper: &Antichain<T>,
+        initial_as_of: Antichain<Timestamp>,
+        upper: &Antichain<Timestamp>,
     ) -> Self {
         let mut self_ = Self {
             refresh_schedule: refresh_schedule.clone(),
@@ -2843,7 +2853,7 @@ impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
 
     /// Should be called whenever the write frontier of the collection advances. It updates the
     /// state that should be recorded in introspection relations, but doesn't send the updates yet.
-    fn frontier_update(&mut self, write_frontier: &Antichain<T>) {
+    fn frontier_update(&mut self, write_frontier: &Antichain<Timestamp>) {
         if write_frontier.is_empty() {
             self.last_completed_refresh =
                 if let Some(last_refresh) = self.refresh_schedule.last_refresh() {
@@ -2851,7 +2861,7 @@ impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
                 } else {
                     // If there is no last refresh, then we have a `REFRESH EVERY`, in which case
                     // the saturating roundup puts a refresh at the maximum possible timestamp.
-                    T::maximum().into()
+                    Timestamp::MAX.into()
                 };
             self.next_refresh = Datum::Null;
         } else {
@@ -2861,8 +2871,9 @@ impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
                 let initial_as_of = self.initial_as_of.as_option().expect(
                     "initial_as_of can't be [], because then there would be no refreshes at all",
                 );
-                let first_refresh = initial_as_of
-                    .round_up(&self.refresh_schedule)
+                let first_refresh = self
+                    .refresh_schedule
+                    .round_up_timestamp(*initial_as_of)
                     .expect("sequencing makes sure that REFRESH MVs always have a first refresh");
                 soft_assert_or_log!(
                     first_refresh == *initial_as_of,
@@ -2872,8 +2883,9 @@ impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
             } else {
                 // The first refresh has already happened.
                 let write_frontier = write_frontier.as_option().expect("checked above");
-                self.last_completed_refresh = write_frontier
-                    .round_down_minus_1(&self.refresh_schedule)
+                self.last_completed_refresh = self
+                    .refresh_schedule
+                    .round_down_timestamp_m1(*write_frontier)
                     .map_or_else(
                         || {
                             soft_panic_or_log!(
@@ -2891,7 +2903,7 @@ impl<T: ComputeControllerTimestamp> RefreshIntrospectionState<T> {
 
 /// A note of an outstanding peek response.
 #[derive(Debug)]
-struct PendingPeek<T: Timestamp> {
+struct PendingPeek {
     /// For replica-targeted peeks, this specifies the replica whose response we should pass on.
     ///
     /// If this value is `None`, we pass on the first response.
@@ -2903,7 +2915,7 @@ struct PendingPeek<T: Timestamp> {
     /// Used to track peek durations.
     requested_at: Instant,
     /// The read hold installed to serve this peek.
-    read_hold: ReadHold<T>,
+    read_hold: ReadHold<Timestamp>,
     /// The channel to send peek results.
     peek_response_tx: oneshot::Sender<PeekResponse>,
     /// An optional limit of the peek's result size.
@@ -2913,26 +2925,26 @@ struct PendingPeek<T: Timestamp> {
 }
 
 #[derive(Debug, Clone)]
-struct ActiveSubscribe<T> {
+struct ActiveSubscribe {
     /// Current upper frontier of this subscribe.
-    frontier: Antichain<T>,
+    frontier: Antichain<Timestamp>,
 }
 
-impl<T: ComputeControllerTimestamp> Default for ActiveSubscribe<T> {
+impl Default for ActiveSubscribe {
     fn default() -> Self {
         Self {
-            frontier: Antichain::from_elem(T::minimum()),
+            frontier: Antichain::from_elem(Timestamp::MIN),
         }
     }
 }
 
 /// State maintained about individual replicas.
 #[derive(Debug)]
-struct ReplicaState<T: ComputeControllerTimestamp> {
+struct ReplicaState {
     /// The ID of the replica.
     id: ReplicaId,
     /// Client for the running replica task.
-    client: ReplicaClient<T>,
+    client: ReplicaClient,
     /// The replica configuration.
     config: ReplicaConfig,
     /// Replica metrics.
@@ -2940,15 +2952,15 @@ struct ReplicaState<T: ComputeControllerTimestamp> {
     /// A channel through which introspection updates are delivered.
     introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
     /// Per-replica collection state.
-    collections: BTreeMap<GlobalId, ReplicaCollectionState<T>>,
+    collections: BTreeMap<GlobalId, ReplicaCollectionState>,
     /// The epoch of the replica.
     epoch: u64,
 }
 
-impl<T: ComputeControllerTimestamp> ReplicaState<T> {
+impl ReplicaState {
     fn new(
         id: ReplicaId,
-        client: ReplicaClient<T>,
+        client: ReplicaClient,
         config: ReplicaConfig,
         metrics: ReplicaMetrics,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
@@ -2973,8 +2985,8 @@ impl<T: ComputeControllerTimestamp> ReplicaState<T> {
     fn add_collection(
         &mut self,
         id: GlobalId,
-        as_of: Antichain<T>,
-        input_read_holds: Vec<ReadHold<T>>,
+        as_of: Antichain<Timestamp>,
+        input_read_holds: Vec<ReadHold<Timestamp>>,
     ) {
         let metrics = self.metrics.for_collection(id);
         let introspection = ReplicaCollectionIntrospection::new(
@@ -2999,7 +3011,7 @@ impl<T: ComputeControllerTimestamp> ReplicaState<T> {
     }
 
     /// Remove state for a collection.
-    fn remove_collection(&mut self, id: GlobalId) -> Option<ReplicaCollectionState<T>> {
+    fn remove_collection(&mut self, id: GlobalId) -> Option<ReplicaCollectionState> {
         self.collections.remove(&id)
     }
 
@@ -3047,34 +3059,34 @@ impl<T: ComputeControllerTimestamp> ReplicaState<T> {
 }
 
 #[derive(Debug)]
-struct ReplicaCollectionState<T: ComputeControllerTimestamp> {
+struct ReplicaCollectionState {
     /// The replica write frontier of this collection.
     ///
     /// See [`FrontiersResponse::write_frontier`].
-    write_frontier: Antichain<T>,
+    write_frontier: Antichain<Timestamp>,
     /// The replica input frontier of this collection.
     ///
     /// See [`FrontiersResponse::input_frontier`].
-    input_frontier: Antichain<T>,
+    input_frontier: Antichain<Timestamp>,
     /// The replica output frontier of this collection.
     ///
     /// See [`FrontiersResponse::output_frontier`].
-    output_frontier: Antichain<T>,
+    output_frontier: Antichain<Timestamp>,
 
     /// Metrics tracked for this collection.
     ///
     /// If this is `None`, no metrics are collected.
     metrics: Option<ReplicaCollectionMetrics>,
     /// As-of frontier with which this collection was installed on the replica.
-    as_of: Antichain<T>,
+    as_of: Antichain<Timestamp>,
     /// Tracks introspection state for this collection.
-    introspection: ReplicaCollectionIntrospection<T>,
+    introspection: ReplicaCollectionIntrospection,
     /// Read holds on storage inputs to this collection.
     ///
     /// These read holds are kept to ensure that the replica is able to read from storage inputs at
     /// all times it hasn't read yet. We only need to install read holds for storage inputs since
     /// compaction of compute inputs is implicitly held back by Timely/DD.
-    input_read_holds: Vec<ReadHold<T>>,
+    input_read_holds: Vec<ReadHold<Timestamp>>,
 
     /// Maximum frontier wallclock lag since the last `WallclockLagHistory` introspection update.
     ///
@@ -3082,12 +3094,12 @@ struct ReplicaCollectionState<T: ComputeControllerTimestamp> {
     wallclock_lag_max: Option<WallclockLag>,
 }
 
-impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
+impl ReplicaCollectionState {
     fn new(
         metrics: Option<ReplicaCollectionMetrics>,
-        as_of: Antichain<T>,
-        introspection: ReplicaCollectionIntrospection<T>,
-        input_read_holds: Vec<ReadHold<T>>,
+        as_of: Antichain<Timestamp>,
+        introspection: ReplicaCollectionIntrospection,
+        input_read_holds: Vec<ReadHold<Timestamp>>,
     ) -> Self {
         Self {
             write_frontier: as_of.clone(),
@@ -3122,7 +3134,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
     }
 
     /// Updates the replica write frontier of this collection.
-    fn update_write_frontier(&mut self, new_frontier: Antichain<T>) {
+    fn update_write_frontier(&mut self, new_frontier: Antichain<Timestamp>) {
         if PartialOrder::less_than(&new_frontier, &self.write_frontier) {
             soft_panic_or_log!(
                 "replica collection write frontier regression (old={:?}, new={new_frontier:?})",
@@ -3137,7 +3149,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
     }
 
     /// Updates the replica input frontier of this collection.
-    fn update_input_frontier(&mut self, new_frontier: Antichain<T>) {
+    fn update_input_frontier(&mut self, new_frontier: Antichain<Timestamp>) {
         if PartialOrder::less_than(&new_frontier, &self.input_frontier) {
             soft_panic_or_log!(
                 "replica collection input frontier regression (old={:?}, new={new_frontier:?})",
@@ -3162,7 +3174,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
     }
 
     /// Updates the replica output frontier of this collection.
-    fn update_output_frontier(&mut self, new_frontier: Antichain<T>) {
+    fn update_output_frontier(&mut self, new_frontier: Antichain<Timestamp>) {
         if PartialOrder::less_than(&new_frontier, &self.output_frontier) {
             soft_panic_or_log!(
                 "replica collection output frontier regression (old={:?}, new={new_frontier:?})",
@@ -3180,24 +3192,24 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionState<T> {
 /// Maintains the introspection state for a given replica and collection, and ensures that reported
 /// introspection data is retracted when the collection is dropped.
 #[derive(Debug)]
-struct ReplicaCollectionIntrospection<T: ComputeControllerTimestamp> {
+struct ReplicaCollectionIntrospection {
     /// The ID of the replica.
     replica_id: ReplicaId,
     /// The ID of the compute collection.
     collection_id: GlobalId,
     /// The collection's reported replica write frontier.
-    write_frontier: Antichain<T>,
+    write_frontier: Antichain<Timestamp>,
     /// A channel through which introspection updates are delivered.
     introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
 }
 
-impl<T: ComputeControllerTimestamp> ReplicaCollectionIntrospection<T> {
+impl ReplicaCollectionIntrospection {
     /// Create a new `HydrationState` and initialize introspection.
     fn new(
         replica_id: ReplicaId,
         collection_id: GlobalId,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
-        as_of: Antichain<T>,
+        as_of: Antichain<Timestamp>,
     ) -> Self {
         let self_ = Self {
             replica_id,
@@ -3218,7 +3230,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionIntrospection<T> {
     }
 
     /// Observe the given current write frontier and update the introspection state as necessary.
-    fn observe_frontier(&mut self, write_frontier: &Antichain<T>) {
+    fn observe_frontier(&mut self, write_frontier: &Antichain<Timestamp>) {
         if self.write_frontier == *write_frontier {
             return; // no change
         }
@@ -3251,7 +3263,7 @@ impl<T: ComputeControllerTimestamp> ReplicaCollectionIntrospection<T> {
     }
 }
 
-impl<T: ComputeControllerTimestamp> Drop for ReplicaCollectionIntrospection<T> {
+impl Drop for ReplicaCollectionIntrospection {
     fn drop(&mut self) {
         // Retract the write frontier.
         let row = self.write_frontier_row();

--- a/src/compute-client/src/controller/instance_client.rs
+++ b/src/compute-client/src/controller/instance_client.rs
@@ -23,7 +23,7 @@ use mz_expr::RowSetFinishing;
 use mz_ore::now::NowFn;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_types::PersistLocation;
-use mz_repr::{GlobalId, RelationDesc, Row};
+use mz_repr::{GlobalId, RelationDesc, Row, Timestamp};
 use mz_storage_types::read_holds::{self, ReadHold};
 use thiserror::Error;
 use timely::progress::{Antichain, ChangeBatch};
@@ -35,8 +35,7 @@ use uuid::Uuid;
 use crate::controller::error::CollectionMissing;
 use crate::controller::instance::{Command, Instance, SharedCollectionState};
 use crate::controller::{
-    ComputeControllerResponse, ComputeControllerTimestamp, IntrospectionUpdates, ReplicaId,
-    StorageCollections,
+    ComputeControllerResponse, IntrospectionUpdates, ReplicaId, StorageCollections,
 };
 use crate::logging::LogVariant;
 use crate::metrics::InstanceMetrics;
@@ -97,16 +96,16 @@ impl From<InstanceShutDown> for AcquireReadHoldsError {
 /// A client for an `Instance` task.
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug)]
-pub struct InstanceClient<T: ComputeControllerTimestamp> {
+pub struct InstanceClient {
     /// A sender for commands for the instance.
-    command_tx: mpsc::UnboundedSender<Command<T>>,
+    command_tx: mpsc::UnboundedSender<Command>,
     /// A sender for read hold changes for collections installed on the instance.
     #[derivative(Debug = "ignore")]
-    read_hold_tx: read_holds::ChangeTx<T>,
+    read_hold_tx: read_holds::ChangeTx<Timestamp>,
 }
 
-impl<T: ComputeControllerTimestamp> InstanceClient<T> {
-    pub(super) fn read_hold_tx(&self) -> read_holds::ChangeTx<T> {
+impl InstanceClient {
+    pub(super) fn read_hold_tx(&self) -> read_holds::ChangeTx<Timestamp> {
         Arc::clone(&self.read_hold_tx)
     }
 
@@ -114,7 +113,7 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
     /// Does not wait for a response message.
     pub(super) fn call<F>(&self, f: F) -> Result<(), InstanceShutDown>
     where
-        F: FnOnce(&mut Instance<T>) + Send + 'static,
+        F: FnOnce(&mut Instance) + Send + 'static,
     {
         let otel_ctx = OpenTelemetryContext::obtain();
         self.command_tx
@@ -131,7 +130,7 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
     /// waiting for a response message.
     pub(super) async fn call_sync<F, R>(&self, f: F) -> Result<R, InstanceShutDown>
     where
-        F: FnOnce(&mut Instance<T>) -> R + Send + 'static,
+        F: FnOnce(&mut Instance) -> R + Send + 'static,
         R: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();
@@ -151,14 +150,14 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
     pub(super) fn spawn(
         id: ComputeInstanceId,
         build_info: &'static BuildInfo,
-        storage: StorageCollections<T>,
+        storage: StorageCollections,
         peek_stash_persist_location: PersistLocation,
-        arranged_logs: Vec<(LogVariant, GlobalId, SharedCollectionState<T>)>,
+        arranged_logs: Vec<(LogVariant, GlobalId, SharedCollectionState)>,
         metrics: InstanceMetrics,
         now: NowFn,
-        wallclock_lag: WallclockLagFn<T>,
+        wallclock_lag: WallclockLagFn<Timestamp>,
         dyncfg: Arc<ConfigSet>,
-        response_tx: mpsc::UnboundedSender<ComputeControllerResponse<T>>,
+        response_tx: mpsc::UnboundedSender<ComputeControllerResponse>,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
         read_only: bool,
     ) -> Self {
@@ -167,7 +166,7 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
         let read_hold_tx: read_holds::ChangeTx<_> = {
             let command_tx = command_tx.clone();
             Arc::new(move |id, change: ChangeBatch<_>| {
-                let cmd: Command<_> = {
+                let cmd: Command = {
                     let change = change.clone();
                     Box::new(move |i| i.apply_read_hold_change(id, change))
                 };
@@ -206,7 +205,8 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
     pub async fn acquire_read_holds_and_collection_write_frontiers(
         &self,
         ids: Vec<GlobalId>,
-    ) -> Result<Vec<(GlobalId, ReadHold<T>, Antichain<T>)>, AcquireReadHoldsError> {
+    ) -> Result<Vec<(GlobalId, ReadHold<Timestamp>, Antichain<Timestamp>)>, AcquireReadHoldsError>
+    {
         self.call_sync(move |i| {
             let mut result = Vec::new();
             for id in ids.into_iter() {
@@ -229,11 +229,11 @@ impl<T: ComputeControllerTimestamp> InstanceClient<T> {
         peek_target: PeekTarget,
         literal_constraints: Option<Vec<Row>>,
         uuid: Uuid,
-        timestamp: T,
+        timestamp: Timestamp,
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
-        target_read_hold: ReadHold<T>,
+        target_read_hold: ReadHold<Timestamp>,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
     ) -> Result<(), PeekError> {

--- a/src/compute-client/src/controller/introspection.rs
+++ b/src/compute-client/src/controller/introspection.rs
@@ -7,20 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_repr::{Diff, Row};
+use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_client::client::AppendOnlyUpdate;
 use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
 use mz_storage_types::controller::StorageError;
-use timely::progress::Timestamp;
 use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 
 pub type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
 
 /// Spawn a task sinking introspection updates produced by the compute controller to storage.
-pub fn spawn_introspection_sink<T: Timestamp>(
+pub fn spawn_introspection_sink(
     mut rx: mpsc::UnboundedReceiver<IntrospectionUpdates>,
-    storage_controller: &dyn StorageController<Timestamp = T>,
+    storage_controller: &dyn StorageController<Timestamp = Timestamp>,
 ) {
     let sink = IntrospectionSink::new(storage_controller);
 
@@ -35,33 +34,33 @@ pub fn spawn_introspection_sink<T: Timestamp>(
     });
 }
 
-type Notifier<T> = oneshot::Sender<Result<(), StorageError<T>>>;
-type AppendOnlySender<T> = mpsc::UnboundedSender<(Vec<AppendOnlyUpdate>, Notifier<T>)>;
-type DifferentialSender<T> = mpsc::UnboundedSender<(StorageWriteOp, Notifier<T>)>;
+type Notifier = oneshot::Sender<Result<(), StorageError<Timestamp>>>;
+type AppendOnlySender = mpsc::UnboundedSender<(Vec<AppendOnlyUpdate>, Notifier)>;
+type DifferentialSender = mpsc::UnboundedSender<(StorageWriteOp, Notifier)>;
 
 /// A sink for introspection updates produced by the compute controller.
 ///
 /// The sender is connected to the storage controller's CollectionManager, which writes received
 /// updates to persist.
 #[derive(Debug)]
-struct IntrospectionSink<T> {
+struct IntrospectionSink {
     /// Sender for [`IntrospectionType::Frontiers`] updates.
-    frontiers_tx: DifferentialSender<T>,
+    frontiers_tx: DifferentialSender,
     /// Sender for [`IntrospectionType::ReplicaFrontiers`] updates.
-    replica_frontiers_tx: DifferentialSender<T>,
+    replica_frontiers_tx: DifferentialSender,
     /// Sender for [`IntrospectionType::ComputeDependencies`] updates.
-    compute_dependencies_tx: DifferentialSender<T>,
+    compute_dependencies_tx: DifferentialSender,
     /// Sender for [`IntrospectionType::ComputeMaterializedViewRefreshes`] updates.
-    compute_materialized_view_refreshes_tx: DifferentialSender<T>,
+    compute_materialized_view_refreshes_tx: DifferentialSender,
     /// Sender for [`IntrospectionType::WallclockLagHistory`] updates.
-    wallclock_lag_history_tx: AppendOnlySender<T>,
+    wallclock_lag_history_tx: AppendOnlySender,
     /// Sender for [`IntrospectionType::WallclockLagHistogram`] updates.
-    wallclock_lag_histogram_tx: AppendOnlySender<T>,
+    wallclock_lag_histogram_tx: AppendOnlySender,
 }
 
-impl<T: Timestamp> IntrospectionSink<T> {
+impl IntrospectionSink {
     /// Create a new `IntrospectionSink`.
-    pub fn new(storage_controller: &dyn StorageController<Timestamp = T>) -> Self {
+    pub fn new(storage_controller: &dyn StorageController<Timestamp = Timestamp>) -> Self {
         use IntrospectionType::*;
         Self {
             frontiers_tx: storage_controller.differential_introspection_tx(Frontiers),
@@ -80,12 +79,12 @@ impl<T: Timestamp> IntrospectionSink<T> {
 
     /// Send a batch of updates of the given introspection type.
     pub fn send(&self, type_: IntrospectionType, updates: Vec<(Row, Diff)>) {
-        let send_append_only = |tx: &AppendOnlySender<_>, updates: Vec<_>| {
+        let send_append_only = |tx: &AppendOnlySender, updates: Vec<_>| {
             let updates = updates.into_iter().map(AppendOnlyUpdate::Row).collect();
             let (notifier, _) = oneshot::channel();
             let _ = tx.send((updates, notifier));
         };
-        let send_differential = |tx: &DifferentialSender<_>, updates: Vec<_>| {
+        let send_differential = |tx: &DifferentialSender, updates: Vec<_>| {
             let op = StorageWriteOp::Append { updates };
             let (notifier, _) = oneshot::channel();
             let _ = tx.send((op, notifier));

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -30,16 +30,16 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tracing::{debug, info, trace, warn};
 use uuid::Uuid;
 
+use crate::controller::ReplicaId;
 use crate::controller::instance::ReplicaResponse;
 use crate::controller::sequential_hydration::SequentialHydration;
-use crate::controller::{ComputeControllerTimestamp, ReplicaId};
 use crate::logging::LoggingConfig;
 use crate::metrics::IntCounter;
 use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::ComputeResponse;
 
-type Client<T> = SequentialHydration<T>;
+type Client = SequentialHydration;
 
 /// Replica-specific configuration.
 #[derive(Clone, Debug)]
@@ -53,9 +53,9 @@ pub(super) struct ReplicaConfig {
 
 /// A client for a replica task.
 #[derive(Debug)]
-pub(super) struct ReplicaClient<T> {
+pub(super) struct ReplicaClient {
     /// A sender for commands for the replica.
-    command_tx: UnboundedSender<ComputeCommand<T>>,
+    command_tx: UnboundedSender<ComputeCommand>,
     /// A handle to the task that aborts it when the replica is dropped.
     ///
     /// If the task is finished, the replica has failed and needs rehydration.
@@ -66,10 +66,7 @@ pub(super) struct ReplicaClient<T> {
     connected: Arc<AtomicBool>,
 }
 
-impl<T> ReplicaClient<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl ReplicaClient {
     pub(super) fn spawn(
         id: ReplicaId,
         build_info: &'static BuildInfo,
@@ -77,7 +74,7 @@ where
         epoch: u64,
         metrics: ReplicaMetrics,
         dyncfg: Arc<ConfigSet>,
-        response_tx: InstrumentedUnboundedSender<ReplicaResponse<T>, IntCounter>,
+        response_tx: InstrumentedUnboundedSender<ReplicaResponse, IntCounter>,
     ) -> Self {
         // Launch a task to handle communication with the replica
         // asynchronously. This isolates the main controller thread from
@@ -110,12 +107,9 @@ where
     }
 }
 
-impl<T> ReplicaClient<T> {
+impl ReplicaClient {
     /// Sends a command to this replica.
-    pub(super) fn send(
-        &self,
-        command: ComputeCommand<T>,
-    ) -> Result<(), SendError<ComputeCommand<T>>> {
+    pub(super) fn send(&self, command: ComputeCommand) -> Result<(), SendError<ComputeCommand>> {
         self.command_tx.send(command).map(|r| {
             self.metrics.inner.command_queue_size.inc();
             r
@@ -133,10 +127,10 @@ impl<T> ReplicaClient<T> {
     }
 }
 
-type ComputeCtpClient<T> = transport::Client<ComputeCommand<T>, ComputeResponse<T>>;
+type ComputeCtpClient = transport::Client<ComputeCommand, ComputeResponse>;
 
 /// Configuration for `replica_task`.
-struct ReplicaTask<T> {
+struct ReplicaTask {
     /// The ID of the replica.
     replica_id: ReplicaId,
     /// Replica configuration.
@@ -144,9 +138,9 @@ struct ReplicaTask<T> {
     /// The build information for this process.
     build_info: &'static BuildInfo,
     /// A channel upon which commands intended for the replica are delivered.
-    command_rx: UnboundedReceiver<ComputeCommand<T>>,
+    command_rx: UnboundedReceiver<ComputeCommand>,
     /// A channel upon which responses from the replica are delivered.
-    response_tx: InstrumentedUnboundedSender<ReplicaResponse<T>, IntCounter>,
+    response_tx: InstrumentedUnboundedSender<ReplicaResponse, IntCounter>,
     /// A number identifying this incarnation of the replica.
     /// The semantics of this don't matter, except that it must strictly increase.
     epoch: u64,
@@ -158,10 +152,7 @@ struct ReplicaTask<T> {
     dyncfg: Arc<ConfigSet>,
 }
 
-impl<T> ReplicaTask<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl ReplicaTask {
     /// Asynchronously forwards commands to and responses from a single replica.
     async fn run(self) {
         let replica_id = self.replica_id;
@@ -178,7 +169,7 @@ where
     ///
     /// The connection is retried forever (with backoff) and this method returns only after
     /// a connection was successfully established.
-    async fn connect(&self) -> Client<T> {
+    async fn connect(&self) -> Client {
         let try_connect = async |retry: RetryState| {
             let version = self.build_info.semver_version();
             let client_params = &self.config.grpc_client;
@@ -188,7 +179,7 @@ where
                 .unwrap_or(Duration::MAX);
 
             let connect_start = Instant::now();
-            let connect_result = ComputeCtpClient::<T>::connect_partitioned(
+            let connect_result = ComputeCtpClient::connect_partitioned(
                 self.config.location.ctl_addrs.clone(),
                 version,
                 connect_timeout,
@@ -236,10 +227,7 @@ where
     /// Returns (with an `Err`) if it encounters an error condition (e.g. the replica disconnects).
     /// If no error condition is encountered, the task runs until the controller disconnects from
     /// the command channel, or the task is dropped.
-    async fn run_message_loop(mut self, mut client: Client<T>) -> Result<(), anyhow::Error>
-    where
-        T: ComputeControllerTimestamp,
-    {
+    async fn run_message_loop(mut self, mut client: Client) -> Result<(), anyhow::Error> {
         loop {
             select! {
                 // Command from controller to forward to replica.
@@ -276,7 +264,7 @@ where
     ///
     /// Most `ComputeCommand`s are independent of the target replica, but some
     /// contain replica-specific fields that must be adjusted before sending.
-    fn specialize_command(&self, command: &mut ComputeCommand<T>) {
+    fn specialize_command(&self, command: &mut ComputeCommand) {
         match command {
             ComputeCommand::Hello { nonce } => {
                 *nonce = Uuid::new_v4();
@@ -293,7 +281,7 @@ where
 
     /// Update task state according to an observed command.
     #[mz_ore::instrument(level = "debug")]
-    fn observe_command(&self, command: &ComputeCommand<T>) {
+    fn observe_command(&self, command: &ComputeCommand) {
         if let ComputeCommand::Peek(peek) = command {
             peek.otel_ctx.attach_as_parent();
         }
@@ -309,7 +297,7 @@ where
 
     /// Update task state according to an observed response.
     #[mz_ore::instrument(level = "debug")]
-    fn observe_response(&self, response: &ComputeResponse<T>) {
+    fn observe_response(&self, response: &ComputeResponse) {
         if let ComputeResponse::PeekResponse(_, _, otel_ctx) = response {
             otel_ctx.attach_as_parent();
         }

--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -48,14 +48,13 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_eq_or_log;
 use mz_ore::task::AbortOnDropHandle;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Timestamp};
 use mz_service::client::GenericClient;
 use timely::PartialOrder;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::controller::ComputeControllerTimestamp;
 use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::{ComputeResponse, FrontiersResponse};
@@ -66,11 +65,11 @@ type Token = Arc<()>;
 
 /// A client enforcing sequential dataflow hydration.
 #[derive(Debug)]
-pub(super) struct SequentialHydration<T> {
+pub(super) struct SequentialHydration {
     /// A sender for commands to the wrapped client.
-    command_tx: mpsc::UnboundedSender<ComputeCommand<T>>,
+    command_tx: mpsc::UnboundedSender<ComputeCommand>,
     /// A receiver for responses from the wrapped client.
-    response_rx: mpsc::UnboundedReceiver<Result<ComputeResponse<T>, anyhow::Error>>,
+    response_rx: mpsc::UnboundedReceiver<Result<ComputeResponse, anyhow::Error>>,
     /// Dynamic system configuration.
     dyncfg: Arc<ConfigSet>,
     /// Tracked metrics.
@@ -80,7 +79,7 @@ pub(super) struct SequentialHydration<T> {
     /// Entries are inserted in response to observed `CreateDataflow` commands.
     /// Entries are removed in response to `Frontiers` commands that report collection
     /// hydration, or in response to `AllowCompaction` commands that specify the empty frontier.
-    collections: BTreeMap<GlobalId, Collection<T>>,
+    collections: BTreeMap<GlobalId, Collection>,
     /// A queue of scheduled collections that are awaiting hydration.
     hydration_queue: VecDeque<GlobalId>,
     /// A token held by hydrating collections.
@@ -92,14 +91,11 @@ pub(super) struct SequentialHydration<T> {
     _forwarder_task: AbortOnDropHandle<()>,
 }
 
-impl<T> SequentialHydration<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl SequentialHydration {
     /// Create a new `SequentialHydration` client.
     pub fn new<C>(client: C, dyncfg: Arc<ConfigSet>, metrics: ReplicaMetrics) -> Self
     where
-        C: ComputeClient<T> + 'static,
+        C: ComputeClient + 'static,
     {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let (response_tx, response_rx) = mpsc::unbounded_channel();
@@ -126,7 +122,7 @@ where
     }
 
     /// Absorb a command and send resulting commands to the wrapped client.
-    fn absorb_command(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+    fn absorb_command(&mut self, cmd: ComputeCommand) -> Result<(), anyhow::Error> {
         // Whether to forward this command to the wrapped client.
         let mut forward = true;
 
@@ -169,7 +165,7 @@ where
     }
 
     /// Observe a response and send resulting commands to the wrapped client.
-    fn observe_response(&mut self, resp: &ComputeResponse<T>) -> Result<(), anyhow::Error> {
+    fn observe_response(&mut self, resp: &ComputeResponse) -> Result<(), anyhow::Error> {
         if let ComputeResponse::Frontiers(
             id,
             FrontiersResponse {
@@ -244,11 +240,8 @@ where
 }
 
 #[async_trait]
-impl<T> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for SequentialHydration<T>
-where
-    T: ComputeControllerTimestamp,
-{
-    async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+impl GenericClient<ComputeCommand, ComputeResponse> for SequentialHydration {
+    async fn send(&mut self, cmd: ComputeCommand) -> Result<(), anyhow::Error> {
         self.absorb_command(cmd)
     }
 
@@ -257,7 +250,7 @@ where
     /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
     /// statement and some other branch completes first, it is guaranteed that no messages were
     /// received by this client.
-    async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
+    async fn recv(&mut self) -> Result<Option<ComputeResponse>, anyhow::Error> {
         // `mpsc::UnboundedReceiver::recv` is documented as cancel safe.
         match self.response_rx.recv().await {
             Some(Ok(response)) => {
@@ -272,16 +265,16 @@ where
 
 /// Information about a tracked collection.
 #[derive(Debug)]
-struct Collection<T> {
+struct Collection {
     /// The as-of frontier at collection creation.
-    as_of: Antichain<T>,
+    as_of: Antichain<Timestamp>,
     /// The current state of the collection.
     state: State,
 }
 
-impl<T> Collection<T> {
+impl Collection {
     /// Create a new `Collection`.
-    fn new(as_of: Antichain<T>) -> Self {
+    fn new(as_of: Antichain<Timestamp>) -> Self {
         Self {
             as_of,
             state: State::Created,
@@ -317,12 +310,12 @@ enum State {
 /// This functions is run in its own task and exists to allow `SequentialHydration::recv` to be
 /// cancel safe even though it needs to send commands to the wrapped client, which isn't cancel
 /// safe.
-async fn forward_messages<C, T>(
+async fn forward_messages<C>(
     mut client: C,
-    mut rx: mpsc::UnboundedReceiver<ComputeCommand<T>>,
-    tx: mpsc::UnboundedSender<Result<ComputeResponse<T>, anyhow::Error>>,
+    mut rx: mpsc::UnboundedReceiver<ComputeCommand>,
+    tx: mpsc::UnboundedSender<Result<ComputeResponse, anyhow::Error>>,
 ) where
-    C: ComputeClient<T>,
+    C: ComputeClient,
 {
     loop {
         tokio::select! {

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -446,7 +446,7 @@ impl ReplicaMetrics {
     }
 }
 
-impl<T> transport::Metrics<ComputeCommand<T>, ComputeResponse<T>> for ReplicaMetrics {
+impl transport::Metrics<ComputeCommand, ComputeResponse> for ReplicaMetrics {
     fn bytes_sent(&mut self, len: usize) {
         self.inner
             .command_message_bytes_total
@@ -459,11 +459,11 @@ impl<T> transport::Metrics<ComputeCommand<T>, ComputeResponse<T>> for ReplicaMet
             .inc_by(u64::cast_from(len));
     }
 
-    fn message_sent(&mut self, msg: &ComputeCommand<T>) {
+    fn message_sent(&mut self, msg: &ComputeCommand) {
         self.inner.commands_total.for_command(msg).inc();
     }
 
-    fn message_received(&mut self, msg: &ComputeResponse<T>) {
+    fn message_received(&mut self, msg: &ComputeResponse) {
         self.inner.responses_total.for_response(msg).inc();
     }
 }
@@ -537,7 +537,7 @@ impl<M> CommandMetrics<M> {
     }
 
     /// TODO(database-issues#7533): Add documentation.
-    pub fn for_command<T>(&self, command: &ComputeCommand<T>) -> &M {
+    pub fn for_command(&self, command: &ComputeCommand) -> &M {
         use ComputeCommand::*;
 
         match command {
@@ -579,7 +579,7 @@ impl<M> ResponseMetrics<M> {
         }
     }
 
-    fn for_response<T>(&self, response: &ComputeResponse<T>) -> &M {
+    fn for_response(&self, response: &ComputeResponse) -> &M {
         use ComputeResponse::*;
 
         match response {

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -24,7 +24,7 @@ use crate::protocol::command::{ComputeCommand, ComputeParameters};
 
 /// TODO(database-issues#7533): Add documentation.
 #[derive(Debug)]
-pub struct ComputeCommandHistory<M, T = mz_repr::Timestamp> {
+pub struct ComputeCommandHistory<M> {
     /// The number of commands at the last time we compacted the history.
     reduced_count: usize,
     /// The sequence of commands that should be applied.
@@ -32,15 +32,14 @@ pub struct ComputeCommandHistory<M, T = mz_repr::Timestamp> {
     /// This list may not be "compact" in that there can be commands that could be optimized
     /// or removed given the context of other commands, for example compaction commands that
     /// can be unified, or dataflows that can be dropped due to allowed compaction.
-    commands: Vec<ComputeCommand<T>>,
+    commands: Vec<ComputeCommand>,
     /// Tracked metrics.
     metrics: HistoryMetrics<M>,
 }
 
-impl<M, T> ComputeCommandHistory<M, T>
+impl<M> ComputeCommandHistory<M>
 where
     M: Borrow<UIntGauge>,
-    T: timely::progress::Timestamp,
 {
     /// TODO(database-issues#7533): Add documentation.
     pub fn new(metrics: HistoryMetrics<M>) -> Self {
@@ -56,7 +55,7 @@ where
     /// Add a command to the history.
     ///
     /// This action will reduce the history every time it doubles.
-    pub fn push(&mut self, command: ComputeCommand<T>) {
+    pub fn push(&mut self, command: ComputeCommand) {
         self.commands.push(command);
 
         if self.commands.len() > 2 * self.reduced_count {
@@ -277,7 +276,7 @@ where
     /// This method should be called after compacting the history to make sure that the dataflow
     /// descriptions do not mention storage collections that don't exist anymore. Its main
     /// purpose is to advance the uppers when connecting a new replica.
-    pub fn update_source_uppers(&mut self, storage_collections: &StorageCollections<T>) {
+    pub fn update_source_uppers(&mut self, storage_collections: &StorageCollections) {
         for command in &mut self.commands {
             if let ComputeCommand::CreateDataflow(dataflow) = command {
                 for (id, import) in dataflow.source_imports.iter_mut() {
@@ -292,7 +291,7 @@ where
     }
 
     /// Iterate through the contained commands.
-    pub fn iter(&self) -> impl Iterator<Item = &ComputeCommand<T>> {
+    pub fn iter(&self) -> impl Iterator<Item = &ComputeCommand> {
         self.commands.iter()
     }
 }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -14,7 +14,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_types::ShardId;
-use mz_repr::{GlobalId, RelationDesc, UpdateCollection};
+use mz_repr::{GlobalId, RelationDesc, Timestamp, UpdateCollection};
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use uuid::Uuid;
@@ -26,7 +26,7 @@ use uuid::Uuid;
 ///
 /// [`ComputeCommand`]: super::command::ComputeCommand
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum ComputeResponse<T = mz_repr::Timestamp> {
+pub enum ComputeResponse {
     /// `Frontiers` announces the advancement of the various frontiers of the specified compute
     /// collection.
     ///
@@ -58,7 +58,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
     /// [#16271]: https://github.com/MaterializeInc/database-issues/issues/4699
     /// [#16274]: https://github.com/MaterializeInc/database-issues/issues/4701
-    Frontiers(GlobalId, FrontiersResponse<T>),
+    Frontiers(GlobalId, FrontiersResponse),
 
     /// `PeekResponse` reports the result of a previous [`Peek` command]. The peek is identified by
     /// a `Uuid` that matches the command's [`Peek::uuid`].
@@ -110,7 +110,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// [`DroppedAt`]: SubscribeResponse::DroppedAt
     /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
-    SubscribeResponse(GlobalId, SubscribeResponse<T>),
+    SubscribeResponse(GlobalId, SubscribeResponse),
 
     /// `CopyToResponse` reports the completion of an S3-oneshot sink.
     ///
@@ -143,21 +143,21 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
 /// All contained frontier fields are optional. `None` values imply that the respective frontier
 /// has not advanced and the previously reported value is still current.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct FrontiersResponse<T = mz_repr::Timestamp> {
+pub struct FrontiersResponse {
     /// The collection's new write frontier, if any.
     ///
     /// Upon receiving an updated `write_frontier`, the controller may assume that the contents of the
     /// collection are sealed for all times less than that frontier. Once it has reported the
     /// `write_frontier` as the empty frontier, the replica must no longer change the contents of the
     /// collection.
-    pub write_frontier: Option<Antichain<T>>,
+    pub write_frontier: Option<Antichain<Timestamp>>,
     /// The collection's new input frontier, if any.
     ///
     /// Upon receiving an updated `input_frontier`, the controller may assume that the replica has
     /// finished reading from the collection’s inputs up to that frontier. Once it has reported the
     /// `input_frontier` as the empty frontier, the replica must no longer read from the
     /// collection's inputs.
-    pub input_frontier: Option<Antichain<T>>,
+    pub input_frontier: Option<Antichain<Timestamp>>,
     /// The collection's new output frontier, if any.
     ///
     /// Upon receiving an updated `output_frontier`, the controller may assume that the replica
@@ -171,10 +171,10 @@ pub struct FrontiersResponse<T = mz_repr::Timestamp> {
     ///  * `REFRESH` MVs jump their write frontier ahead to the next refresh time.
     ///  * In a multi-replica cluster, slower replicas observe and report the write frontier of the
     ///    fastest replica, by witnessing advancements of the target persist shard's `upper`.
-    pub output_frontier: Option<Antichain<T>>,
+    pub output_frontier: Option<Antichain<Timestamp>>,
 }
 
-impl<T> FrontiersResponse<T> {
+impl FrontiersResponse {
     /// Returns whether there are any contained updates.
     pub fn has_updates(&self) -> bool {
         self.write_frontier.is_some()
@@ -265,14 +265,14 @@ pub enum CopyToResponse {
 
 /// Various responses that can be communicated about the progress of a SUBSCRIBE command.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum SubscribeResponse<T = mz_repr::Timestamp> {
+pub enum SubscribeResponse {
     /// A batch of updates over a non-empty interval of time.
-    Batch(SubscribeBatch<T>),
+    Batch(SubscribeBatch),
     /// The SUBSCRIBE dataflow was dropped, leaving updates from this frontier onward unspecified.
-    DroppedAt(Antichain<T>),
+    DroppedAt(Antichain<Timestamp>),
 }
 
-impl<T> SubscribeResponse<T> {
+impl SubscribeResponse {
     /// Converts `self` to an error if a maximum size is exceeded.
     pub fn to_error_if_exceeds(&mut self, max_result_size: usize) {
         if let SubscribeResponse::Batch(batch) = self {
@@ -283,11 +283,11 @@ impl<T> SubscribeResponse<T> {
 
 /// A batch of updates for the interval `[lower, upper)`.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SubscribeBatch<T = mz_repr::Timestamp> {
+pub struct SubscribeBatch {
     /// The lower frontier of the batch of updates.
-    pub lower: Antichain<T>,
+    pub lower: Antichain<Timestamp>,
     /// The upper frontier of the batch of updates.
-    pub upper: Antichain<T>,
+    pub upper: Antichain<Timestamp>,
     /// All updates greater than `lower` and not greater than `upper`.
     ///
     /// Each of the update collections is sorted first by time, and then by the ordering specified
@@ -298,10 +298,10 @@ pub struct SubscribeBatch<T = mz_repr::Timestamp> {
     /// may aggregate different batches together later as we combine results from different workers.
     ///
     /// An `Err` variant can be used to indicate e.g. that the size of the updates exceeds internal limits.
-    pub updates: Result<Vec<UpdateCollection<T>>, String>,
+    pub updates: Result<Vec<UpdateCollection>, String>,
 }
 
-impl<T> SubscribeBatch<T> {
+impl SubscribeBatch {
     /// Converts `self` to an error if a maximum size is exceeded.
     fn to_error_if_exceeds(&mut self, max_result_size: usize) {
         use bytesize::ByteSize;

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -19,13 +19,12 @@ use mz_expr::row::RowCollection;
 use mz_ore::cast::CastInto;
 use mz_ore::soft_panic_or_log;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{GlobalId, UpdateCollection};
+use mz_repr::{GlobalId, Timestamp, UpdateCollection};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use timely::PartialOrder;
 use timely::progress::frontier::{Antichain, MutableAntichain};
 use uuid::Uuid;
 
-use crate::controller::ComputeControllerTimestamp;
 use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::{
     ComputeResponse, CopyToResponse, FrontiersResponse, PeekResponse, StashedPeekResponse,
@@ -33,16 +32,13 @@ use crate::protocol::response::{
 };
 
 /// A client to a compute server.
-pub trait ComputeClient<T = mz_repr::Timestamp>:
-    GenericClient<ComputeCommand<T>, ComputeResponse<T>>
-{
-}
+pub trait ComputeClient: GenericClient<ComputeCommand, ComputeResponse> {}
 
-impl<C, T> ComputeClient<T> for C where C: GenericClient<ComputeCommand<T>, ComputeResponse<T>> {}
+impl<C> ComputeClient for C where C: GenericClient<ComputeCommand, ComputeResponse> {}
 
 #[async_trait]
-impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn ComputeClient<T>> {
-    async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+impl GenericClient<ComputeCommand, ComputeResponse> for Box<dyn ComputeClient> {
+    async fn send(&mut self, cmd: ComputeCommand) -> Result<(), anyhow::Error> {
         (**self).send(cmd).await
     }
 
@@ -51,7 +47,7 @@ impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn C
     /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
     /// statement and some other branch completes first, it is guaranteed that no messages were
     /// received by this client.
-    async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
+    async fn recv(&mut self) -> Result<Option<ComputeResponse>, anyhow::Error> {
         // `GenericClient::recv` is required to be cancel safe.
         (**self).recv().await
     }
@@ -80,7 +76,7 @@ impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn C
 /// able to cope with this limited visibility. It does so by performing most of its state management
 /// based on observed compute responses rather than commands.
 #[derive(Debug)]
-pub struct PartitionedComputeState<T> {
+pub struct PartitionedComputeState {
     /// Number of partitions the state machine represents.
     parts: usize,
     /// The maximum result size this state machine can return.
@@ -99,7 +95,7 @@ pub struct PartitionedComputeState<T> {
     /// reported. These properties ensure that a) we always cease frontier tracking for collections
     /// that have been dropped and b) frontier tracking for a collection is not re-initialized
     /// after it was ceased.
-    frontiers: BTreeMap<GlobalId, TrackedFrontiers<T>>,
+    frontiers: BTreeMap<GlobalId, TrackedFrontiers>,
     /// For each in-progress peek the response data received so far, and the set of shards that
     /// provided responses already.
     ///
@@ -145,17 +141,13 @@ pub struct PartitionedComputeState<T> {
     /// These two properties ensure that a) once a subscribe has shut down, we can eventually drop
     /// the tracking state maintained for it and b) we won't re-initialize tracking for a subscribe
     /// we have already dropped.
-    pending_subscribes: BTreeMap<GlobalId, PendingSubscribe<T>>,
+    pending_subscribes: BTreeMap<GlobalId, PendingSubscribe>,
 }
 
-impl<T> Partitionable<ComputeCommand<T>, ComputeResponse<T>>
-    for (ComputeCommand<T>, ComputeResponse<T>)
-where
-    T: ComputeControllerTimestamp,
-{
-    type PartitionedState = PartitionedComputeState<T>;
+impl Partitionable<ComputeCommand, ComputeResponse> for (ComputeCommand, ComputeResponse) {
+    type PartitionedState = PartitionedComputeState;
 
-    fn new(parts: usize) -> PartitionedComputeState<T> {
+    fn new(parts: usize) -> PartitionedComputeState {
         PartitionedComputeState {
             parts,
             max_result_size: u64::MAX,
@@ -167,12 +159,9 @@ where
     }
 }
 
-impl<T> PartitionedComputeState<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl PartitionedComputeState {
     /// Observes commands that move past.
-    pub fn observe_command(&mut self, command: &ComputeCommand<T>) {
+    pub fn observe_command(&mut self, command: &ComputeCommand) {
         match command {
             ComputeCommand::UpdateConfiguration(config) => {
                 if let Some(max_result_size) = config.max_result_size {
@@ -191,8 +180,8 @@ where
         &mut self,
         shard_id: usize,
         collection_id: GlobalId,
-        frontiers: FrontiersResponse<T>,
-    ) -> Option<ComputeResponse<T>> {
+        frontiers: FrontiersResponse,
+    ) -> Option<ComputeResponse> {
         let tracked = self
             .frontiers
             .entry(collection_id)
@@ -233,7 +222,7 @@ where
         uuid: Uuid,
         response: PeekResponse,
         otel_ctx: OpenTelemetryContext,
-    ) -> Option<ComputeResponse<T>> {
+    ) -> Option<ComputeResponse> {
         let (merged, ready_shards) = self.peek_responses.entry(uuid).or_insert((
             PeekResponse::Rows(vec![RowCollection::default()]),
             BTreeSet::new(),
@@ -259,7 +248,7 @@ where
         shard_id: usize,
         copyto_id: GlobalId,
         response: CopyToResponse,
-    ) -> Option<ComputeResponse<T>> {
+    ) -> Option<ComputeResponse> {
         use CopyToResponse::*;
 
         let (merged, ready_shards) = self
@@ -289,8 +278,8 @@ where
     fn absorb_subscribe_response(
         &mut self,
         subscribe_id: GlobalId,
-        response: SubscribeResponse<T>,
-    ) -> Option<ComputeResponse<T>> {
+        response: SubscribeResponse,
+    ) -> Option<ComputeResponse> {
         let tracked = self
             .pending_subscribes
             .entry(subscribe_id)
@@ -371,11 +360,8 @@ where
     }
 }
 
-impl<T> PartitionedState<ComputeCommand<T>, ComputeResponse<T>> for PartitionedComputeState<T>
-where
-    T: ComputeControllerTimestamp,
-{
-    fn split_command(&mut self, command: ComputeCommand<T>) -> Vec<Option<ComputeCommand<T>>> {
+impl PartitionedState<ComputeCommand, ComputeResponse> for PartitionedComputeState {
+    fn split_command(&mut self, command: ComputeCommand) -> Vec<Option<ComputeCommand>> {
         self.observe_command(&command);
 
         // As specified by the compute protocol:
@@ -397,8 +383,8 @@ where
     fn absorb_response(
         &mut self,
         shard_id: usize,
-        message: ComputeResponse<T>,
-    ) -> Option<Result<ComputeResponse<T>, anyhow::Error>> {
+        message: ComputeResponse,
+    ) -> Option<Result<ComputeResponse, anyhow::Error>> {
         let response = match message {
             ComputeResponse::Frontiers(id, frontiers) => {
                 self.absorb_frontiers(shard_id, id, frontiers)
@@ -427,19 +413,16 @@ where
 /// Each frontier is maintained both as a `MutableAntichain` across all partitions and individually
 /// for each partition.
 #[derive(Debug)]
-struct TrackedFrontiers<T> {
+struct TrackedFrontiers {
     /// The tracked write frontier.
-    write_frontier: (MutableAntichain<T>, Vec<Antichain<T>>),
+    write_frontier: (MutableAntichain<Timestamp>, Vec<Antichain<Timestamp>>),
     /// The tracked input frontier.
-    input_frontier: (MutableAntichain<T>, Vec<Antichain<T>>),
+    input_frontier: (MutableAntichain<Timestamp>, Vec<Antichain<Timestamp>>),
     /// The tracked output frontier.
-    output_frontier: (MutableAntichain<T>, Vec<Antichain<T>>),
+    output_frontier: (MutableAntichain<Timestamp>, Vec<Antichain<Timestamp>>),
 }
 
-impl<T> TrackedFrontiers<T>
-where
-    T: timely::progress::Timestamp + Lattice,
-{
+impl TrackedFrontiers {
     /// Initializes frontier tracking state for a new collection.
     fn new(parts: usize) -> Self {
         // TODO(benesch): fix this dangerous use of `as`.
@@ -447,8 +430,8 @@ where
         let parts_diff = parts as i64;
 
         let mut frontier = MutableAntichain::new();
-        frontier.update_iter([(T::minimum(), parts_diff)]);
-        let part_frontiers = vec![Antichain::from_elem(T::minimum()); parts];
+        frontier.update_iter([(Timestamp::MIN, parts_diff)]);
+        let part_frontiers = vec![Antichain::from_elem(Timestamp::MIN); parts];
         let frontier_entry = (frontier, part_frontiers);
 
         Self {
@@ -471,8 +454,8 @@ where
     fn update_write_frontier(
         &mut self,
         shard_id: usize,
-        new_shard_frontier: &Antichain<T>,
-    ) -> Option<Antichain<T>> {
+        new_shard_frontier: &Antichain<Timestamp>,
+    ) -> Option<Antichain<Timestamp>> {
         Self::update_frontier(&mut self.write_frontier, shard_id, new_shard_frontier)
     }
 
@@ -482,8 +465,8 @@ where
     fn update_input_frontier(
         &mut self,
         shard_id: usize,
-        new_shard_frontier: &Antichain<T>,
-    ) -> Option<Antichain<T>> {
+        new_shard_frontier: &Antichain<Timestamp>,
+    ) -> Option<Antichain<Timestamp>> {
         Self::update_frontier(&mut self.input_frontier, shard_id, new_shard_frontier)
     }
 
@@ -493,17 +476,17 @@ where
     fn update_output_frontier(
         &mut self,
         shard_id: usize,
-        new_shard_frontier: &Antichain<T>,
-    ) -> Option<Antichain<T>> {
+        new_shard_frontier: &Antichain<Timestamp>,
+    ) -> Option<Antichain<Timestamp>> {
         Self::update_frontier(&mut self.output_frontier, shard_id, new_shard_frontier)
     }
 
     /// Updates the provided frontier entry with a new shard frontier.
     fn update_frontier(
-        entry: &mut (MutableAntichain<T>, Vec<Antichain<T>>),
+        entry: &mut (MutableAntichain<Timestamp>, Vec<Antichain<Timestamp>>),
         shard_id: usize,
-        new_shard_frontier: &Antichain<T>,
-    ) -> Option<Antichain<T>> {
+        new_shard_frontier: &Antichain<Timestamp>,
+    ) -> Option<Antichain<Timestamp>> {
         let (frontier, shard_frontiers) = entry;
 
         let old_frontier = frontier.frontier().to_owned();
@@ -523,11 +506,11 @@ where
 }
 
 #[derive(Debug)]
-struct PendingSubscribe<T> {
+struct PendingSubscribe {
     /// The subscribe frontiers of the partitioned shards.
-    frontiers: MutableAntichain<T>,
+    frontiers: MutableAntichain<Timestamp>,
     /// The updates we are holding back until their timestamps are complete.
-    stashed_updates: Result<Vec<UpdateCollection<T>>, String>,
+    stashed_updates: Result<Vec<UpdateCollection>, String>,
     /// The row size of stashed updates, for `max_result_size` checking.
     stashed_result_size: usize,
     /// Whether we have already emitted a `DroppedAt` response for this subscribe.
@@ -536,12 +519,12 @@ struct PendingSubscribe<T> {
     dropped: bool,
 }
 
-impl<T: ComputeControllerTimestamp> PendingSubscribe<T> {
+impl PendingSubscribe {
     fn new(parts: usize) -> Self {
         let mut frontiers = MutableAntichain::new();
         // TODO(benesch): fix this dangerous use of `as`.
         #[allow(clippy::as_conversions)]
-        frontiers.update_iter([(T::minimum(), parts as i64)]);
+        frontiers.update_iter([(Timestamp::MIN, parts as i64)]);
 
         Self {
             frontiers,
@@ -555,11 +538,7 @@ impl<T: ComputeControllerTimestamp> PendingSubscribe<T> {
     ///
     /// This also implements the short-circuit behavior of error responses, and performs
     /// `max_result_size` checking.
-    fn stash(
-        &mut self,
-        new_updates: Result<Vec<UpdateCollection<T>>, String>,
-        max_result_size: u64,
-    ) {
+    fn stash(&mut self, new_updates: Result<Vec<UpdateCollection>, String>, max_result_size: u64) {
         match (&mut self.stashed_updates, new_updates) {
             (Err(_), _) => {
                 // Subscribe is borked; nothing to do.

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -22,7 +22,6 @@ use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use futures::stream::{BoxStream, StreamExt};
 use mz_cluster_client::client::{ClusterReplicaLocation, TimelyConfig};
-use mz_compute_client::controller::ComputeControllerTimestamp;
 use mz_compute_client::logging::LogVariant;
 use mz_compute_types::config::{ComputeReplicaConfig, ComputeReplicaLogging};
 use mz_controller_types::dyncfgs::{
@@ -357,10 +356,7 @@ pub struct ClusterEvent {
     pub time: DateTime<Utc>,
 }
 
-impl<T> Controller<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl Controller {
     /// Creates a cluster with the specified identifier and configuration.
     ///
     /// A cluster is a combination of a storage instance and a compute instance.

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -34,7 +34,7 @@ use mz_cluster_client::metrics::ControllerMetrics;
 use mz_cluster_client::{ReplicaId, WallclockLagFn};
 use mz_compute_client::controller::error::{CollectionLookupError, CollectionMissing};
 use mz_compute_client::controller::{
-    ComputeController, ComputeControllerResponse, ComputeControllerTimestamp, PeekNotification,
+    ComputeController, ComputeControllerResponse, PeekNotification,
 };
 use mz_compute_client::protocol::response::SubscribeBatch;
 use mz_controller_types::WatchSetId;
@@ -44,13 +44,12 @@ use mz_ore::cast::CastFrom;
 use mz_ore::id_gen::Gen;
 use mz_ore::instrument;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_client::PersistLocation;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_types::Codec64;
-use mz_repr::{Datum, GlobalId, Row, TimestampManipulation};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_service::secrets::SecretsReaderCliArgs;
 use mz_storage_client::controller::{
     IntrospectionType, StorageController, StorageMetadata, StorageTxn,
@@ -60,7 +59,7 @@ use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::StorageError;
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -111,7 +110,7 @@ pub struct ControllerConfig {
 
 /// Responses that [`Controller`] can produce.
 #[derive(Debug)]
-pub enum ControllerResponse<T = mz_repr::Timestamp> {
+pub enum ControllerResponse {
     /// Notification of a worker's response to a specified (by connection id) peek.
     ///
     /// Additionally, an `OpenTelemetryContext` to forward trace information
@@ -119,7 +118,7 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
     /// done in compute!
     PeekNotification(Uuid, PeekNotification, OpenTelemetryContext),
     /// The worker's next response to a specified subscribe.
-    SubscribeResponse(GlobalId, SubscribeBatch<T>),
+    SubscribeResponse(GlobalId, SubscribeBatch),
     /// The worker's next response to a specified copy to.
     CopyToResponse(GlobalId, Result<u64, anyhow::Error>),
     /// Notification that a watch set has finished. See
@@ -131,7 +130,7 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
 /// Whether one of the underlying controllers is ready for their `process`
 /// method to be called.
 #[derive(Debug, Default)]
-pub enum Readiness<T> {
+pub enum Readiness {
     /// No underlying controllers are ready.
     #[default]
     NotReady,
@@ -142,14 +141,14 @@ pub enum Readiness<T> {
     /// A batch of metric data is ready.
     Metrics((ReplicaId, Vec<ServiceProcessMetrics>)),
     /// An internally-generated message is ready to be returned.
-    Internal(ControllerResponse<T>),
+    Internal(ControllerResponse),
 }
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
-pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
-    pub storage: Box<dyn StorageController<Timestamp = T>>,
-    pub storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-    pub compute: ComputeController<T>,
+pub struct Controller {
+    pub storage: Box<dyn StorageController<Timestamp = Timestamp>>,
+    pub storage_collections: Arc<dyn StorageCollections<Timestamp = Timestamp> + Send + Sync>,
+    pub compute: ComputeController,
     /// The clusterd image to use when starting new cluster processes.
     clusterd_image: String,
     /// The init container image to use for clusterd.
@@ -165,7 +164,7 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
     /// The cluster orchestrator.
     orchestrator: Arc<dyn NamespacedOrchestrator>,
     /// Tracks the readiness of the underlying controllers.
-    readiness: Readiness<T>,
+    readiness: Readiness,
     /// Tasks for collecting replica metrics.
     metrics_tasks: BTreeMap<ReplicaId, AbortOnDropHandle<()>>,
     /// Sender for the channel over which replica metrics are sent.
@@ -190,7 +189,7 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
     // timestamp), the corresponding entry will be removed from the set.
     unfulfilled_watch_sets_by_object: BTreeMap<GlobalId, BTreeSet<WatchSetId>>,
     /// A map of installed watch sets indexed by id.
-    unfulfilled_watch_sets: BTreeMap<WatchSetId, (BTreeSet<GlobalId>, T)>,
+    unfulfilled_watch_sets: BTreeMap<WatchSetId, (BTreeSet<GlobalId>, Timestamp)>,
     /// A sequence of numbers used to mint unique WatchSetIds.
     watch_set_id_gen: Gen<WatchSetId>,
 
@@ -208,7 +207,7 @@ pub struct Controller<T: ComputeControllerTimestamp = mz_repr::Timestamp> {
     replica_http_locator: Arc<ReplicaHttpLocator>,
 }
 
-impl<T: ComputeControllerTimestamp> Controller<T> {
+impl Controller {
     /// Update the controller configuration.
     pub fn update_configuration(&mut self, updates: ConfigUpdates) {
         updates.apply(&self.dyncfg);
@@ -296,10 +295,7 @@ impl<T: ComputeControllerTimestamp> Controller<T> {
     }
 }
 
-impl<T> Controller<T>
-where
-    T: ComputeControllerTimestamp,
-{
+impl Controller {
     pub fn update_orchestrator_scheduling_config(
         &self,
         config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
@@ -324,7 +320,7 @@ where
     /// Returns `Some` if there is an immediately available
     /// internally-generated response that we need to return to the
     /// client (as opposed to waiting for a response from compute or storage).
-    fn take_internal_response(&mut self) -> Option<ControllerResponse<T>> {
+    fn take_internal_response(&mut self) -> Option<ControllerResponse> {
         let ws = std::mem::take(&mut self.immediate_watch_sets);
         (!ws.is_empty()).then_some(ControllerResponse::WatchSetFinished(ws))
     }
@@ -366,7 +362,7 @@ where
     }
 
     /// Returns the [Readiness] status of this controller.
-    pub fn get_readiness(&self) -> &Readiness<T> {
+    pub fn get_readiness(&self) -> &Readiness {
         &self.readiness
     }
 
@@ -381,7 +377,7 @@ where
     pub fn install_compute_watch_set(
         &mut self,
         mut objects: BTreeSet<GlobalId>,
-        t: T,
+        t: Timestamp,
     ) -> Result<WatchSetId, CollectionLookupError> {
         let ws_id = self.watch_set_id_gen.allocate_id();
 
@@ -424,7 +420,7 @@ where
     pub fn install_storage_watch_set(
         &mut self,
         mut objects: BTreeSet<GlobalId>,
-        t: T,
+        t: Timestamp,
     ) -> Result<WatchSetId, CollectionMissing> {
         let ws_id = self.watch_set_id_gen.allocate_id();
 
@@ -478,7 +474,7 @@ where
     fn process_storage_response(
         &mut self,
         storage_metadata: &StorageMetadata,
-    ) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
+    ) -> Result<Option<ControllerResponse>, anyhow::Error> {
         let maybe_response = self.storage.process(storage_metadata)?;
         Ok(maybe_response.and_then(
             |mz_storage_client::controller::Response::FrontierUpdates(r)| {
@@ -489,7 +485,7 @@ where
 
     /// Process a pending response from the compute controller. If necessary,
     /// return a higher-level response to our client.
-    fn process_compute_response(&mut self) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
+    fn process_compute_response(&mut self) -> Result<Option<ControllerResponse>, anyhow::Error> {
         let response = self.compute.process();
 
         let response = response.and_then(|r| match r {
@@ -520,7 +516,7 @@ where
     pub fn process(
         &mut self,
         storage_metadata: &StorageMetadata,
-    ) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
+    ) -> Result<Option<ControllerResponse>, anyhow::Error> {
         match mem::take(&mut self.readiness) {
             Readiness::NotReady => Ok(None),
             Readiness::Storage => self.process_storage_response(storage_metadata),
@@ -535,8 +531,8 @@ where
     /// from a frontier update is `WatchSetCompleted`.
     fn handle_frontier_updates(
         &mut self,
-        updates: &[(GlobalId, Antichain<T>)],
-    ) -> Option<ControllerResponse<T>> {
+        updates: &[(GlobalId, Antichain<Timestamp>)],
+    ) -> Option<ControllerResponse> {
         let mut finished = vec![];
         for (obj_id, antichain) in updates {
             let ws_ids = self.unfulfilled_watch_sets_by_object.entry(*obj_id);
@@ -575,7 +571,7 @@ where
         &mut self,
         id: ReplicaId,
         metrics: Vec<ServiceProcessMetrics>,
-    ) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
+    ) -> Result<Option<ControllerResponse>, anyhow::Error> {
         self.record_replica_metrics(id, &metrics);
         Ok(None)
     }
@@ -626,23 +622,15 @@ where
         &self,
         ids: BTreeSet<GlobalId>,
         timeout: Duration,
-    ) -> Result<BoxFuture<'static, Result<T, StorageError<T>>>, StorageError<T>> {
+    ) -> Result<
+        BoxFuture<'static, Result<Timestamp, StorageError<Timestamp>>>,
+        StorageError<Timestamp>,
+    > {
         self.storage.real_time_recent_timestamp(ids, timeout).await
     }
 }
 
-impl<T> Controller<T>
-where
-    // Bounds needed by `StorageController` and/or `Controller`:
-    T: Timestamp
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + std::fmt::Display
-        + Into<mz_repr::Timestamp>,
-    // Bounds needed by `ComputeController`:
-    T: ComputeControllerTimestamp,
-{
+impl Controller {
     /// Creates a new controller.
     ///
     /// For correctness, this function expects to have access to the mutations
@@ -655,7 +643,7 @@ where
         config: ControllerConfig,
         envd_epoch: NonZeroI64,
         read_only: bool,
-        storage_txn: &dyn StorageTxn<T>,
+        storage_txn: &dyn StorageTxn<Timestamp>,
     ) -> Self {
         if read_only {
             tracing::info!("starting controllers in read-only mode!");
@@ -680,7 +668,7 @@ where
         )
         .await;
 
-        let collections_ctl: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync> =
+        let collections_ctl: Arc<dyn StorageCollections<Timestamp = Timestamp> + Send + Sync> =
             Arc::new(collections_ctl);
 
         let storage_controller = mz_storage_controller::Controller::new(


### PR DESCRIPTION
The compute client code is generic over a `T: ComputeControllerTimestamp`, but that trait is so specific that only a single type fulfills it, namely `mz_repr::Timestamp`. There are no plans to support multiple timestamp types, and if we want to make changes to the timestamp type, we can always make them to `mz_repr::Timestamp`. Thus the genericity doesn't give us anything except code noise.

Change the compute client code to not be generic over the timestamp type anymore.