### PR TITLE
storage-{client,controller}: stop being generic over the timestamp type

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -638,9 +638,7 @@ impl Catalog {
     /// collections created between versions.
     async fn initialize_storage_state(
         &mut self,
-        storage_collections: &Arc<
-            dyn StorageCollections<Timestamp = mz_repr::Timestamp> + Send + Sync,
-        >,
+        storage_collections: &Arc<dyn StorageCollections + Send + Sync>,
     ) -> Result<(), mz_catalog::durable::CatalogError> {
         let collections = self
             .entries()

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -421,9 +421,7 @@ impl Catalog {
         &mut self,
         // n.b. this is an option to prevent us from needing to build out a
         // dummy impl of `StorageController` for tests.
-        storage_collections: Option<
-            &mut Arc<dyn StorageCollections<Timestamp = mz_repr::Timestamp> + Send + Sync>,
-        >,
+        storage_collections: Option<&mut Arc<dyn StorageCollections + Send + Sync>>,
         oracle_write_ts: mz_repr::Timestamp,
         session: Option<&ConnMeta>,
         ops: Vec<Op>,
@@ -654,9 +652,7 @@ impl Catalog {
     #[instrument(name = "catalog::transact_inner")]
     async fn transact_inner(
         mode: TransactInnerMode,
-        storage_collections: Option<
-            &mut Arc<dyn StorageCollections<Timestamp = mz_repr::Timestamp> + Send + Sync>,
-        >,
+        storage_collections: Option<&mut Arc<dyn StorageCollections + Send + Sync>>,
         oracle_write_ts: mz_repr::Timestamp,
         session: Option<&ConnMeta>,
         ops: Vec<Op>,

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -456,12 +456,8 @@ pub struct StartupResponse {
     /// Map of (name, VarInput::Flat) tuples of session default variables that should be set.
     pub session_defaults: BTreeMap<String, OwnedVarInput>,
     pub catalog: Arc<Catalog>,
-    pub storage_collections: Arc<
-        dyn mz_storage_client::storage_collections::StorageCollections<
-                Timestamp = mz_repr::Timestamp,
-            > + Send
-            + Sync,
-    >,
+    pub storage_collections:
+        Arc<dyn mz_storage_client::storage_collections::StorageCollections + Send + Sync>,
     pub transient_id_gen: Arc<TransientIdGen>,
     pub optimizer_metrics: OptimizerMetrics,
     pub persist_client: PersistClient,

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -49,7 +49,7 @@ use mz_ore::instrument;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
 use mz_ore::task;
-use mz_repr::{CatalogItemId, GlobalId, RelationVersion, RelationVersionSelector, Timestamp};
+use mz_repr::{CatalogItemId, GlobalId, RelationVersion, RelationVersionSelector};
 use mz_sql::plan::ConnectionDetails;
 use mz_storage_client::controller::{CollectionDescription, DataSource};
 use mz_storage_types::connections::PostgresConnection;
@@ -1056,7 +1056,7 @@ impl Coordinator {
     #[instrument(level = "debug")]
     async fn create_table_collections(
         &mut self,
-        table_collections_to_create: BTreeMap<GlobalId, CollectionDescription<Timestamp>>,
+        table_collections_to_create: BTreeMap<GlobalId, CollectionDescription>,
         execution_timestamps_to_set: BTreeSet<StatementLoggingId>,
     ) -> Result<(), AdapterError> {
         // If we have tables, determine the initial validity for the table.
@@ -1101,7 +1101,7 @@ impl Coordinator {
     #[instrument(level = "debug")]
     async fn create_source_collections(
         &mut self,
-        source_collections_to_create: BTreeMap<GlobalId, CollectionDescription<Timestamp>>,
+        source_collections_to_create: BTreeMap<GlobalId, CollectionDescription>,
     ) -> Result<(), AdapterError> {
         let storage_metadata = self.catalog.state().storage_metadata();
 
@@ -1141,7 +1141,7 @@ impl Coordinator {
     async fn handle_create_table(
         &self,
         ctx: &Option<&mut ExecuteContext>,
-        storage_collections_to_create: &mut BTreeMap<GlobalId, CollectionDescription<Timestamp>>,
+        storage_collections_to_create: &mut BTreeMap<GlobalId, CollectionDescription>,
         storage_policies_to_initialize: &mut BTreeMap<CompactionWindow, BTreeSet<GlobalId>>,
         execution_timestamps_to_set: &mut BTreeSet<StatementLoggingId>,
         table_id: CatalogItemId,
@@ -1192,7 +1192,7 @@ impl Coordinator {
                         let global_ingestion_id =
                             self.catalog().get_entry(ingestion_id).latest_global_id();
 
-                        let collection_desc = CollectionDescription::<Timestamp> {
+                        let collection_desc = CollectionDescription {
                             desc: table.desc.latest(),
                             data_source: DataSource::IngestionExport {
                                 ingestion_id: global_ingestion_id,
@@ -1243,7 +1243,7 @@ impl Coordinator {
                         );
                         let desc = table.desc.latest();
 
-                        let collection_desc = CollectionDescription::<Timestamp> {
+                        let collection_desc = CollectionDescription {
                             desc,
                             data_source: DataSource::Webhook,
                             since: None,
@@ -1368,7 +1368,7 @@ impl Coordinator {
     #[instrument(level = "debug")]
     async fn handle_create_source(
         &self,
-        storage_collections_to_create: &mut BTreeMap<GlobalId, CollectionDescription<Timestamp>>,
+        storage_collections_to_create: &mut BTreeMap<GlobalId, CollectionDescription>,
         storage_policies_to_initialize: &mut BTreeMap<CompactionWindow, BTreeSet<GlobalId>>,
         item_id: CatalogItemId,
         source: Source,
@@ -1447,7 +1447,7 @@ impl Coordinator {
 
         storage_collections_to_create.insert(
             source.global_id,
-            CollectionDescription::<Timestamp> {
+            CollectionDescription {
                 desc: source.desc.clone(),
                 data_source,
                 timeline: Some(source.timeline),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -52,7 +52,6 @@ use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::{OptimizerNoticeApi, OptimizerNoticeKind, RawOptimizerNotice};
 use mz_transform::{EmptyStatisticsOracle, StatisticsOracle};
 use timely::progress::Antichain;
-use timely::progress::Timestamp as TimelyTimestamp;
 use tokio::sync::oneshot;
 use tracing::{Instrument, Level, Span, event, warn};
 
@@ -1074,7 +1073,7 @@ pub(crate) async fn explain_pushdown_future_inner<
 >(
     session: &Session,
     catalog: &Catalog,
-    storage_collections: &Arc<dyn StorageCollections<Timestamp = Timestamp> + Send + Sync>,
+    storage_collections: &Arc<dyn StorageCollections + Send + Sync>,
     as_of: Antichain<Timestamp>,
     mz_now: ResultSpec<'static>,
     imports: I,
@@ -1232,10 +1231,11 @@ pub(crate) async fn statistics_oracle(
     query_as_of: &Antichain<Timestamp>,
     is_oneshot: bool,
     system_config: &vars::SystemVars,
-    storage_collections: &dyn StorageCollections<Timestamp = Timestamp>,
+    storage_collections: &dyn StorageCollections,
 ) -> Result<Box<dyn StatisticsOracle>, AdapterError> {
     if !session.vars().enable_session_cardinality_estimates() {
-        return Ok(Box::new(EmptyStatisticsOracle));
+        let stats: Box<dyn StatisticsOracle> = Box::new(EmptyStatisticsOracle);
+        return Ok(stats);
     }
 
     let timeout = if is_oneshot {
@@ -1272,11 +1272,11 @@ struct CachedStatisticsOracle {
 }
 
 impl CachedStatisticsOracle {
-    pub async fn new<T: TimelyTimestamp>(
+    pub async fn new(
         ids: &BTreeSet<GlobalId>,
-        as_of: &Antichain<T>,
-        storage_collections: &dyn StorageCollections<Timestamp = T>,
-    ) -> Result<Self, StorageError<T>> {
+        as_of: &Antichain<Timestamp>,
+        storage_collections: &dyn StorageCollections,
+    ) -> Result<Self, StorageError> {
         let mut cache = BTreeMap::new();
 
         for id in ids {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -118,7 +118,7 @@ use crate::util::{ClientTransmitter, ResultExt, viewable_variables};
 use crate::{PeekResponseUnary, ReadHolds};
 
 /// A future that resolves to a real-time recency timestamp.
-type RtrTimestampFuture = BoxFuture<'static, Result<Timestamp, StorageError<Timestamp>>>;
+type RtrTimestampFuture = BoxFuture<'static, Result<Timestamp, StorageError>>;
 
 mod cluster;
 mod copy_from;

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -218,7 +218,7 @@ pub enum AdapterError {
     /// Another session modified the Catalog while this transaction was open.
     DDLTransactionRace,
     /// An error occurred in the storage layer
-    Storage(mz_storage_types::controller::StorageError<mz_repr::Timestamp>),
+    Storage(mz_storage_types::controller::StorageError),
     /// An error occurred in the compute layer
     Compute(anyhow::Error),
     /// An error in the orchestrator layer
@@ -1227,8 +1227,8 @@ impl From<oneshot::error::RecvError> for AdapterError {
     }
 }
 
-impl From<StorageError<mz_repr::Timestamp>> for AdapterError {
-    fn from(e: StorageError<mz_repr::Timestamp>) -> Self {
+impl From<StorageError> for AdapterError {
+    fn from(e: StorageError) -> Self {
         AdapterError::Storage(e)
     }
 }

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -44,11 +44,8 @@ use crate::statement_logging::{
 use crate::{AdapterError, Client, CollectionIdBundle, ReadHolds, statement_logging};
 
 /// Storage collections trait alias we need to consult for since/frontiers.
-pub type StorageCollectionsHandle = Arc<
-    dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = Timestamp>
-        + Send
-        + Sync,
->;
+pub type StorageCollectionsHandle =
+    Arc<dyn mz_storage_client::storage_collections::StorageCollections + Send + Sync>;
 
 /// Clients needed for peek sequencing in the Adapter Frontend.
 #[derive(Debug)]

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -336,7 +336,7 @@ impl ShouldTerminateGracefully for FenceError {
     }
 }
 
-impl<T> ShouldTerminateGracefully for StorageError<T> {
+impl ShouldTerminateGracefully for StorageError {
     fn should_terminate_gracefully(&self) -> bool {
         match self {
             StorageError::ResourceExhausted(_)

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Row, RowArena, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowArena};
 use mz_secrets::SecretsReader;
 use mz_secrets::cache::CachingSecretsReader;
 use mz_sql::plan::{WebhookBodyFormat, WebhookHeaders, WebhookValidation, WebhookValidationSecret};
@@ -55,7 +55,7 @@ pub enum AppendWebhookError {
     #[error("internal error: {0:?}")]
     InternalError(#[from] anyhow::Error),
     #[error("internal storage failure! {0:?}")]
-    StorageError(#[from] StorageError<mz_repr::Timestamp>),
+    StorageError(#[from] StorageError),
 }
 
 /// Contains all of the components necessary for running webhook validation.
@@ -245,7 +245,7 @@ pub struct AppendWebhookResponse {
 /// gets modified.
 #[derive(Clone, Debug)]
 pub struct WebhookAppender {
-    tx: MonotonicAppender<Timestamp>,
+    tx: MonotonicAppender,
     guard: WebhookAppenderGuard,
     // Shared statistics related to this webhook.
     stats: Arc<WebhookStatistics>,
@@ -292,7 +292,7 @@ impl WebhookAppender {
     }
 
     pub(crate) fn new(
-        tx: MonotonicAppender<Timestamp>,
+        tx: MonotonicAppender,
         guard: WebhookAppenderGuard,
         stats: Arc<WebhookStatistics>,
     ) -> Self {

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -717,9 +717,7 @@ async fn upgrade_check(
     for (gid, item_desc) in storage_entries {
         // If a new version adds a BuiltinTable or BuiltinSource, we won't have created the shard
         // yet so there isn't anything to check.
-        let maybe_shard_id = state
-            .storage_metadata()
-            .get_collection_shard::<Timestamp>(gid);
+        let maybe_shard_id = state.storage_metadata().get_collection_shard(gid);
         let shard_id = match maybe_shard_id {
             Ok(shard_id) => shard_id,
             Err(StorageError::IdentifierMissing(_)) => {

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -79,7 +79,7 @@ pub enum DurableCatalogError {
     UniquenessViolation,
     /// A programming error occurred during a [`mz_storage_client::controller::StorageTxn`].
     #[error(transparent)]
-    Storage(StorageError<Timestamp>),
+    Storage(StorageError),
     /// An internal programming error.
     #[error("Internal catalog error: {0}")]
     Internal(String),
@@ -95,8 +95,8 @@ impl DurableCatalogError {
     }
 }
 
-impl From<StorageError<Timestamp>> for DurableCatalogError {
-    fn from(e: StorageError<Timestamp>) -> Self {
+impl From<StorageError> for DurableCatalogError {
+    fn from(e: StorageError) -> Self {
         DurableCatalogError::Storage(e)
     }
 }

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -2624,7 +2624,7 @@ use crate::durable::async_trait;
 use super::objects::{RoleAuthKey, RoleAuthValue};
 
 #[async_trait]
-impl StorageTxn<mz_repr::Timestamp> for Transaction<'_> {
+impl StorageTxn for Transaction<'_> {
     fn get_collection_metadata(&self) -> BTreeMap<GlobalId, ShardId> {
         self.storage_collection_metadata
             .items()
@@ -2641,7 +2641,7 @@ impl StorageTxn<mz_repr::Timestamp> for Transaction<'_> {
     fn insert_collection_metadata(
         &mut self,
         metadata: BTreeMap<GlobalId, ShardId>,
-    ) -> Result<(), StorageError<mz_repr::Timestamp>> {
+    ) -> Result<(), StorageError> {
         for (id, shard) in metadata {
             self.storage_collection_metadata
                 .insert(
@@ -2689,10 +2689,7 @@ impl StorageTxn<mz_repr::Timestamp> for Transaction<'_> {
             .collect()
     }
 
-    fn insert_unfinalized_shards(
-        &mut self,
-        s: BTreeSet<ShardId>,
-    ) -> Result<(), StorageError<mz_repr::Timestamp>> {
+    fn insert_unfinalized_shards(&mut self, s: BTreeSet<ShardId>) -> Result<(), StorageError> {
         for shard in s {
             match self
                 .unfinalized_shards
@@ -2722,10 +2719,7 @@ impl StorageTxn<mz_repr::Timestamp> for Transaction<'_> {
             .map(|TxnWalShardValue { shard }| *shard)
     }
 
-    fn write_txn_wal_shard(
-        &mut self,
-        shard: ShardId,
-    ) -> Result<(), StorageError<mz_repr::Timestamp>> {
+    fn write_txn_wal_shard(&mut self, shard: ShardId) -> Result<(), StorageError> {
         self.txn_wal_shard
             .insert((), TxnWalShardValue { shard }, self.op_id)
             .map_err(|err| match err {

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -101,7 +101,7 @@ use tracing::{info, warn};
 pub fn run(
     dataflows: &mut [DataflowDescription<Plan, ()>],
     read_policies: &BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
-    storage_collections: &dyn StorageCollections<Timestamp = Timestamp>,
+    storage_collections: &dyn StorageCollections,
     current_time: Timestamp,
     read_only_mode: bool,
 ) -> BTreeMap<GlobalId, ReadHold<Timestamp>> {
@@ -333,7 +333,7 @@ struct Collection<'a> {
 /// The as-of selection context.
 struct Context<'a> {
     collections: BTreeMap<GlobalId, Collection<'a>>,
-    storage_collections: &'a dyn StorageCollections<Timestamp = Timestamp>,
+    storage_collections: &'a dyn StorageCollections,
     current_time: Timestamp,
 }
 
@@ -341,7 +341,7 @@ impl<'a> Context<'a> {
     /// Initializes an as-of selection context for the given `dataflows`.
     fn new(
         dataflows: &[DataflowDescription<Plan, ()>],
-        storage_collections: &'a dyn StorageCollections<Timestamp = Timestamp>,
+        storage_collections: &'a dyn StorageCollections,
         read_policies: &'a BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
         current_time: Timestamp,
     ) -> Self {
@@ -845,7 +845,6 @@ mod tests {
     use std::collections::BTreeSet;
 
     use async_trait::async_trait;
-    use differential_dataflow::lattice::Lattice;
     use futures::future::BoxFuture;
     use futures::stream::BoxStream;
     use mz_compute_types::dataflows::{IndexDesc, IndexImport};
@@ -855,7 +854,7 @@ mod tests {
     use mz_compute_types::sources::SourceInstanceArguments;
     use mz_compute_types::sources::SourceInstanceDesc;
     use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
-    use mz_persist_types::{Codec64, ShardId};
+    use mz_persist_types::ShardId;
     use mz_repr::{RelationDesc, RelationVersion, Row, SqlRelationType};
     use mz_repr::{ReprRelationType, Timestamp};
     use mz_storage_client::client::TimestamplessUpdateBuilder;
@@ -867,7 +866,6 @@ mod tests {
     use mz_storage_types::parameters::StorageParameters;
     use mz_storage_types::sources::SourceData;
     use mz_storage_types::time_dependence::{TimeDependence, TimeDependenceError};
-    use timely::progress::Timestamp as TimelyTimestamp;
 
     use super::*;
 
@@ -886,13 +884,11 @@ mod tests {
 
     #[async_trait]
     impl StorageCollections for StorageFrontiers {
-        type Timestamp = Timestamp;
-
         async fn initialize_state(
             &self,
-            _txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
+            _txn: &mut (dyn StorageTxn + Send),
             _init_ids: BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
+        ) -> Result<(), StorageError> {
             unimplemented!()
         }
 
@@ -914,7 +910,7 @@ mod tests {
         fn collections_frontiers(
             &self,
             ids: Vec<GlobalId>,
-        ) -> Result<Vec<CollectionFrontiers<Self::Timestamp>>, CollectionMissing> {
+        ) -> Result<Vec<CollectionFrontiers>, CollectionMissing> {
             let mut frontiers = Vec::with_capacity(ids.len());
             for id in ids {
                 let (read, write) = self.0.get(&id).ok_or(CollectionMissing(id))?;
@@ -928,109 +924,88 @@ mod tests {
             Ok(frontiers)
         }
 
-        fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers<Self::Timestamp>> {
+        fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers> {
             unimplemented!()
         }
 
-        fn check_exists(&self, _id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {
+        fn check_exists(&self, _id: GlobalId) -> Result<(), StorageError> {
             unimplemented!()
         }
 
         async fn snapshot_stats(
             &self,
             _id: GlobalId,
-            _as_of: Antichain<Self::Timestamp>,
-        ) -> Result<SnapshotStats, StorageError<Self::Timestamp>> {
+            _as_of: Antichain<Timestamp>,
+        ) -> Result<SnapshotStats, StorageError> {
             unimplemented!()
         }
 
         async fn snapshot_parts_stats(
             &self,
             _id: GlobalId,
-            _as_of: Antichain<Self::Timestamp>,
-        ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
+            _as_of: Antichain<Timestamp>,
+        ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError>> {
             unimplemented!()
         }
 
         fn snapshot(
             &self,
             _id: GlobalId,
-            _as_of: Self::Timestamp,
-        ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError<Self::Timestamp>>>
-        {
+            _as_of: Timestamp,
+        ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError>> {
             unimplemented!()
         }
 
-        async fn snapshot_latest(
-            &self,
-            _id: GlobalId,
-        ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
+        async fn snapshot_latest(&self, _id: GlobalId) -> Result<Vec<Row>, StorageError> {
             unimplemented!()
         }
 
         fn snapshot_cursor(
             &self,
             _id: GlobalId,
-            _as_of: Self::Timestamp,
-        ) -> BoxFuture<
-            'static,
-            Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>,
-        >
-        where
-            Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
-        {
+            _as_of: Timestamp,
+        ) -> BoxFuture<'static, Result<SnapshotCursor, StorageError>> {
             unimplemented!()
         }
 
         fn snapshot_and_stream(
             &self,
             _id: GlobalId,
-            _as_of: Self::Timestamp,
+            _as_of: Timestamp,
         ) -> BoxFuture<
             'static,
-            Result<
-                BoxStream<'static, (SourceData, Self::Timestamp, StorageDiff)>,
-                StorageError<Self::Timestamp>,
-            >,
+            Result<BoxStream<'static, (SourceData, Timestamp, StorageDiff)>, StorageError>,
         > {
             unimplemented!()
         }
 
-        /// Create a [`TimestamplessUpdateBuilder`] that can be used to stage
-        /// updates for the provided [`GlobalId`].
         fn create_update_builder(
             &self,
             _id: GlobalId,
         ) -> BoxFuture<
             'static,
-            Result<
-                TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, StorageDiff>,
-                StorageError<Self::Timestamp>,
-            >,
-        >
-        where
-            Self::Timestamp: Lattice + Codec64,
-        {
+            Result<TimestamplessUpdateBuilder<SourceData, (), StorageDiff>, StorageError>,
+        > {
             unimplemented!()
         }
 
         async fn prepare_state(
             &self,
-            _txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
+            _txn: &mut (dyn StorageTxn + Send),
             _ids_to_add: BTreeSet<GlobalId>,
             _ids_to_drop: BTreeSet<GlobalId>,
             _ids_to_register: BTreeMap<GlobalId, ShardId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
+        ) -> Result<(), StorageError> {
             unimplemented!()
         }
 
         async fn create_collections_for_bootstrap(
             &self,
             _storage_metadata: &StorageMetadata,
-            _register_ts: Option<Self::Timestamp>,
-            _collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+            _register_ts: Option<Timestamp>,
+            _collections: Vec<(GlobalId, CollectionDescription)>,
             _migrated_storage_collections: &BTreeSet<GlobalId>,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
+        ) -> Result<(), StorageError> {
             unimplemented!()
         }
 
@@ -1040,7 +1015,7 @@ mod tests {
             _new_collection: GlobalId,
             _new_desc: RelationDesc,
             _expected_version: RelationVersion,
-        ) -> Result<(), StorageError<Self::Timestamp>> {
+        ) -> Result<(), StorageError> {
             unimplemented!()
         }
 
@@ -1052,14 +1027,14 @@ mod tests {
             unimplemented!()
         }
 
-        fn set_read_policies(&self, _policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
+        fn set_read_policies(&self, _policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
             unimplemented!()
         }
 
         fn acquire_read_holds(
             &self,
             desired_holds: Vec<GlobalId>,
-        ) -> Result<Vec<ReadHold<Self::Timestamp>>, CollectionMissing> {
+        ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing> {
             let mut holds = Vec::with_capacity(desired_holds.len());
             for id in desired_holds {
                 let (read, _write) = self.0.get(&id).ok_or(CollectionMissing(id))?;

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -89,11 +89,8 @@ pub mod error;
 pub mod instance_client;
 pub use instance_client::InstanceClient;
 
-pub(crate) type StorageCollections = Arc<
-    dyn mz_storage_client::storage_collections::StorageCollections<Timestamp = Timestamp>
-        + Send
-        + Sync,
->;
+pub(crate) type StorageCollections =
+    Arc<dyn mz_storage_client::storage_collections::StorageCollections + Send + Sync>;
 
 /// Responses from the compute controller.
 #[derive(Debug)]
@@ -321,10 +318,7 @@ impl ComputeController {
     ///
     /// This method should be called once the introspection collections have been registered with
     /// the storage controller. It will panic if invoked earlier than that.
-    pub fn start_introspection_sink(
-        &mut self,
-        storage_controller: &dyn StorageController<Timestamp = Timestamp>,
-    ) {
+    pub fn start_introspection_sink(&mut self, storage_controller: &dyn StorageController) {
         if let Some(rx) = self.introspection_rx.take() {
             spawn_introspection_sink(rx, storage_controller);
         }

--- a/src/compute-client/src/controller/introspection.rs
+++ b/src/compute-client/src/controller/introspection.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_repr::{Diff, Row, Timestamp};
+use mz_repr::{Diff, Row};
 use mz_storage_client::client::AppendOnlyUpdate;
 use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
 use mz_storage_types::controller::StorageError;
@@ -19,7 +19,7 @@ pub type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
 /// Spawn a task sinking introspection updates produced by the compute controller to storage.
 pub fn spawn_introspection_sink(
     mut rx: mpsc::UnboundedReceiver<IntrospectionUpdates>,
-    storage_controller: &dyn StorageController<Timestamp = Timestamp>,
+    storage_controller: &dyn StorageController,
 ) {
     let sink = IntrospectionSink::new(storage_controller);
 
@@ -34,7 +34,7 @@ pub fn spawn_introspection_sink(
     });
 }
 
-type Notifier = oneshot::Sender<Result<(), StorageError<Timestamp>>>;
+type Notifier = oneshot::Sender<Result<(), StorageError>>;
 type AppendOnlySender = mpsc::UnboundedSender<(Vec<AppendOnlyUpdate>, Notifier)>;
 type DifferentialSender = mpsc::UnboundedSender<(StorageWriteOp, Notifier)>;
 
@@ -60,7 +60,7 @@ struct IntrospectionSink {
 
 impl IntrospectionSink {
     /// Create a new `IntrospectionSink`.
-    pub fn new(storage_controller: &dyn StorageController<Timestamp = Timestamp>) -> Self {
+    pub fn new(storage_controller: &dyn StorageController) -> Self {
         use IntrospectionType::*;
         Self {
             frontiers_tx: storage_controller.differential_introspection_tx(Frontiers),

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -146,8 +146,8 @@ pub enum Readiness {
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
 pub struct Controller {
-    pub storage: Box<dyn StorageController<Timestamp = Timestamp>>,
-    pub storage_collections: Arc<dyn StorageCollections<Timestamp = Timestamp> + Send + Sync>,
+    pub storage: Box<dyn StorageController>,
+    pub storage_collections: Arc<dyn StorageCollections + Send + Sync>,
     pub compute: ComputeController,
     /// The clusterd image to use when starting new cluster processes.
     clusterd_image: String,
@@ -622,10 +622,7 @@ impl Controller {
         &self,
         ids: BTreeSet<GlobalId>,
         timeout: Duration,
-    ) -> Result<
-        BoxFuture<'static, Result<Timestamp, StorageError<Timestamp>>>,
-        StorageError<Timestamp>,
-    > {
+    ) -> Result<BoxFuture<'static, Result<Timestamp, StorageError>>, StorageError> {
         self.storage.real_time_recent_timestamp(ids, timeout).await
     }
 }
@@ -643,7 +640,7 @@ impl Controller {
         config: ControllerConfig,
         envd_epoch: NonZeroI64,
         read_only: bool,
-        storage_txn: &dyn StorageTxn<Timestamp>,
+        storage_txn: &dyn StorageTxn,
     ) -> Self {
         if read_only {
             tracing::info!("starting controllers in read-only mode!");
@@ -668,8 +665,7 @@ impl Controller {
         )
         .await;
 
-        let collections_ctl: Arc<dyn StorageCollections<Timestamp = Timestamp> + Send + Sync> =
-            Arc::new(collections_ctl);
+        let collections_ctl: Arc<dyn StorageCollections + Send + Sync> = Arc::new(collections_ctl);
 
         let storage_controller = mz_storage_controller::Controller::new(
             config.build_info,

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -17,7 +17,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::str::StrExt;
 use mz_repr::adt::jsonb::Jsonb;
-use mz_repr::{Datum, Diff, Row, RowPacker, SqlScalarType, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowPacker, SqlScalarType};
 use mz_sql::plan::{WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders};
 use mz_storage_types::controller::StorageError;
 
@@ -328,7 +328,7 @@ pub enum WebhookError {
     #[error("service unavailable")]
     Unavailable,
     #[error("internal storage failure! {0:?}")]
-    InternalStorageError(StorageError<Timestamp>),
+    InternalStorageError(StorageError),
     #[error("internal failure! {0:?}")]
     Internal(#[from] anyhow::Error),
 }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -24,7 +24,7 @@ use mz_ore::assert_none;
 use mz_persist_client::batch::{BatchBuilder, ProtoBatch};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_types::{Codec, Codec64, StepForward};
-use mz_repr::{Diff, GlobalId, Row, TimestampManipulation};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::oneshot_sources::OneshotIngestionRequest;
@@ -34,23 +34,19 @@ use mz_storage_types::sources::IngestionDescription;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use timely::PartialOrder;
-use timely::progress::Timestamp;
 use timely::progress::frontier::{Antichain, MutableAntichain};
 use uuid::Uuid;
 
 use crate::statistics::{SinkStatisticsUpdate, SourceStatisticsUpdate};
 
 /// A client to a storage server.
-pub trait StorageClient<T = mz_repr::Timestamp>:
-    GenericClient<StorageCommand<T>, StorageResponse<T>>
-{
-}
+pub trait StorageClient: GenericClient<StorageCommand, StorageResponse> {}
 
-impl<C, T> StorageClient<T> for C where C: GenericClient<StorageCommand<T>, StorageResponse<T>> {}
+impl<C> StorageClient for C where C: GenericClient<StorageCommand, StorageResponse> {}
 
 #[async_trait]
-impl<T: Send> GenericClient<StorageCommand<T>, StorageResponse<T>> for Box<dyn StorageClient<T>> {
-    async fn send(&mut self, cmd: StorageCommand<T>) -> Result<(), anyhow::Error> {
+impl GenericClient<StorageCommand, StorageResponse> for Box<dyn StorageClient> {
+    async fn send(&mut self, cmd: StorageCommand) -> Result<(), anyhow::Error> {
         (**self).send(cmd).await
     }
 
@@ -59,7 +55,7 @@ impl<T: Send> GenericClient<StorageCommand<T>, StorageResponse<T>> for Box<dyn S
     /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
     /// statement and some other branch completes first, it is guaranteed that no messages were
     /// received by this client.
-    async fn recv(&mut self) -> Result<Option<StorageResponse<T>>, anyhow::Error> {
+    async fn recv(&mut self) -> Result<Option<StorageResponse>, anyhow::Error> {
         // `GenericClient::recv` is required to be cancel safe.
         (**self).recv().await
     }
@@ -67,7 +63,7 @@ impl<T: Send> GenericClient<StorageCommand<T>, StorageResponse<T>> for Box<dyn S
 
 /// Commands related to the ingress and egress of collections.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum StorageCommand<T = mz_repr::Timestamp> {
+pub enum StorageCommand {
     /// Transmits connection meta information, before other commands are sent.
     Hello {
         nonce: Uuid,
@@ -89,8 +85,8 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// Enable compaction in storage-managed collections.
     ///
     /// A collection id and a frontier after which accumulations must be correct.
-    AllowCompaction(GlobalId, Antichain<T>),
-    RunSink(Box<RunSinkCommand<T>>),
+    AllowCompaction(GlobalId, Antichain<Timestamp>),
+    RunSink(Box<RunSinkCommand>),
     /// Run a dataflow which will ingest data from an external source and only __stage__ it in
     /// Persist.
     ///
@@ -108,7 +104,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     CancelOneshotIngestion(Uuid),
 }
 
-impl<T> StorageCommand<T> {
+impl StorageCommand {
     /// Returns whether this command instructs the installation of storage objects.
     pub fn installs_objects(&self) -> bool {
         use StorageCommand::*;
@@ -152,9 +148,9 @@ pub struct RunOneshotIngestion {
 
 /// A command that starts exporting the given sink description
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct RunSinkCommand<T> {
+pub struct RunSinkCommand {
     pub id: GlobalId,
-    pub description: StorageSinkDesc<CollectionMetadata, T>,
+    pub description: StorageSinkDesc<CollectionMetadata>,
 }
 
 /// A "kind" enum for statuses tracked by the health operator
@@ -332,9 +328,9 @@ impl From<StatusUpdate> for AppendOnlyUpdate {
 
 /// Responses that the storage nature of a worker/dataflow can provide back to the coordinator.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum StorageResponse<T = mz_repr::Timestamp> {
+pub enum StorageResponse {
     /// A new upper frontier for the specified identifier.
-    FrontierUpper(GlobalId, Antichain<T>),
+    FrontierUpper(GlobalId, Antichain<Timestamp>),
     /// Punctuation indicates that no more responses will be transmitted for the specified id
     DroppedId(GlobalId),
     /// Batches that have been staged in Persist and maybe will be linked into a shard.
@@ -351,25 +347,27 @@ pub enum StorageResponse<T = mz_repr::Timestamp> {
 /// This helper type unifies the responses of multiple partitioned
 /// workers in order to present as a single worker.
 #[derive(Debug)]
-pub struct PartitionedStorageState<T> {
+pub struct PartitionedStorageState {
     /// Number of partitions the state machine represents.
     parts: usize,
     /// Upper frontiers for sources and sinks, both unioned across all partitions and from each
     /// individual partition.
-    uppers: BTreeMap<GlobalId, (MutableAntichain<T>, Vec<Option<Antichain<T>>>)>,
+    uppers: BTreeMap<
+        GlobalId,
+        (
+            MutableAntichain<Timestamp>,
+            Vec<Option<Antichain<Timestamp>>>,
+        ),
+    >,
     /// Staged batches from oneshot sources that will get appended by `environmentd`.
     oneshot_source_responses:
         BTreeMap<uuid::Uuid, BTreeMap<usize, Vec<Result<ProtoBatch, String>>>>,
 }
 
-impl<T> Partitionable<StorageCommand<T>, StorageResponse<T>>
-    for (StorageCommand<T>, StorageResponse<T>)
-where
-    T: timely::progress::Timestamp + Lattice,
-{
-    type PartitionedState = PartitionedStorageState<T>;
+impl Partitionable<StorageCommand, StorageResponse> for (StorageCommand, StorageResponse) {
+    type PartitionedState = PartitionedStorageState;
 
-    fn new(parts: usize) -> PartitionedStorageState<T> {
+    fn new(parts: usize) -> PartitionedStorageState {
         PartitionedStorageState {
             parts,
             uppers: BTreeMap::new(),
@@ -378,11 +376,8 @@ where
     }
 }
 
-impl<T> PartitionedStorageState<T>
-where
-    T: timely::progress::Timestamp,
-{
-    fn observe_command(&mut self, command: &StorageCommand<T>) {
+impl PartitionedStorageState {
+    fn observe_command(&mut self, command: &StorageCommand) {
         // Note that `observe_command` is quite different in `mz_compute_client`.
         // Compute (currently) only sends the command to 1 process,
         // but storage fans out to all workers, allowing the storage processes
@@ -418,8 +413,8 @@ where
                 // TODO(guswynn): cluster-unification: fix this dangerous use of `as`, by
                 // merging the types that compute and storage use.
                 #[allow(clippy::as_conversions)]
-                frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                let part_frontiers = vec![Some(Antichain::from_elem(T::minimum())); self.parts];
+                frontier.update_iter(iter::once((Timestamp::MIN, self.parts as i64)));
+                let part_frontiers = vec![Some(Antichain::from_elem(Timestamp::MIN)); self.parts];
 
                 (frontier, part_frontiers)
             });
@@ -427,11 +422,8 @@ where
     }
 }
 
-impl<T> PartitionedState<StorageCommand<T>, StorageResponse<T>> for PartitionedStorageState<T>
-where
-    T: timely::progress::Timestamp + Lattice,
-{
-    fn split_command(&mut self, command: StorageCommand<T>) -> Vec<Option<StorageCommand<T>>> {
+impl PartitionedState<StorageCommand, StorageResponse> for PartitionedStorageState {
+    fn split_command(&mut self, command: StorageCommand) -> Vec<Option<StorageCommand>> {
         self.observe_command(&command);
 
         // Fan out to all processes (which will fan out to all workers).
@@ -442,8 +434,8 @@ where
     fn absorb_response(
         &mut self,
         shard_id: usize,
-        response: StorageResponse<T>,
-    ) -> Option<Result<StorageResponse<T>, anyhow::Error>> {
+        response: StorageResponse,
+    ) -> Option<Result<StorageResponse, anyhow::Error>> {
         match response {
             // Avoid multiple retractions of minimum time, to present as updates from one worker.
             StorageResponse::FrontierUpper(id, new_shard_upper) => {
@@ -456,8 +448,8 @@ where
                     Some(shard_upper) => shard_upper,
                     None => panic!("Reference to absent shard {shard_id} for collection {id}"),
                 };
-                frontier.update_iter(shard_upper.iter().map(|t| (t.clone(), -1)));
-                frontier.update_iter(new_shard_upper.iter().map(|t| (t.clone(), 1)));
+                frontier.update_iter(shard_upper.iter().map(|t| (*t, -1)));
+                frontier.update_iter(new_shard_upper.iter().map(|t| (*t, 1)));
                 shard_upper.join_assign(&new_shard_upper);
 
                 let new_upper = frontier.frontier();
@@ -534,9 +526,9 @@ where
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// A batch of updates to be fed to a local input
-pub struct Update<T = mz_repr::Timestamp> {
+pub struct Update {
     pub row: Row,
-    pub timestamp: T,
+    pub timestamp: Timestamp,
     pub diff: Diff,
 }
 
@@ -571,29 +563,27 @@ impl TableData {
 
 /// A collection of timestamp-less updates. As updates are added to the builder
 /// they are automatically spilled to blob storage.
-pub struct TimestamplessUpdateBuilder<K, V, T, D>
+pub struct TimestamplessUpdateBuilder<K, V, D>
 where
     K: Codec,
     V: Codec,
-    T: Timestamp + Lattice + Codec64,
     D: Codec64,
 {
-    builder: BatchBuilder<K, V, T, D>,
-    initial_ts: T,
+    builder: BatchBuilder<K, V, Timestamp, D>,
+    initial_ts: Timestamp,
 }
 
-impl<K, V, T, D> TimestamplessUpdateBuilder<K, V, T, D>
+impl<K, V, D> TimestamplessUpdateBuilder<K, V, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: TimestampManipulation + Lattice + Codec64 + Sync,
     D: Monoid + Ord + Codec64 + Send + Sync,
 {
     /// Create a new [`TimestamplessUpdateBuilder`] for the shard associated
     /// with the provided [`WriteHandle`].
-    pub fn new(handle: &WriteHandle<K, V, T, D>) -> Self {
-        let initial_ts = T::minimum();
-        let builder = handle.builder(Antichain::from_elem(initial_ts.clone()));
+    pub fn new(handle: &WriteHandle<K, V, Timestamp, D>) -> Self {
+        let initial_ts = Timestamp::MIN;
+        let builder = handle.builder(Antichain::from_elem(initial_ts));
         TimestamplessUpdateBuilder {
             builder,
             initial_ts,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -38,7 +38,7 @@ use mz_persist_client::batch::ProtoBatch;
 use mz_persist_types::{Codec64, ShardId};
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row};
+use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row, Timestamp};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::InlinedConnection;
 use mz_storage_types::controller::{CollectionMetadata, StorageError};
@@ -54,9 +54,8 @@ use mz_storage_types::sources::{
     SourceExportDetails, Timeline,
 };
 use serde::{Deserialize, Serialize};
-use timely::progress::Timestamp as TimelyTimestamp;
+use timely::progress::Antichain;
 use timely::progress::frontier::MutableAntichain;
-use timely::progress::{Antichain, Timestamp};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::client::{AppendOnlyUpdate, StatusUpdate, TableData};
@@ -116,7 +115,7 @@ pub enum IntrospectionType {
 
 /// Describes how data is written to the collection.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum DataSource<T> {
+pub enum DataSource {
     /// Ingest data from some external source.
     Ingestion(IngestionDescription),
     /// This source receives its data from the identified ingestion,
@@ -141,18 +140,18 @@ pub enum DataSource<T> {
     /// controller, e.g. it's a materialized view or the catalog collection.
     Other,
     /// This collection is the output collection of a sink.
-    Sink { desc: ExportDescription<T> },
+    Sink { desc: ExportDescription },
 }
 
 /// Describes a request to create a source.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CollectionDescription<T> {
+pub struct CollectionDescription {
     /// The schema of this collection
     pub desc: RelationDesc,
     /// The source of this collection's data.
-    pub data_source: DataSource<T>,
+    pub data_source: DataSource,
     /// An optional frontier to which the collection's `since` should be advanced.
-    pub since: Option<Antichain<T>>,
+    pub since: Option<Antichain<Timestamp>>,
     /// The timeline of the source. Absent for materialized views, continual tasks, etc.
     pub timeline: Option<Timeline>,
     /// The primary of this collections.
@@ -164,9 +163,9 @@ pub struct CollectionDescription<T> {
     pub primary: Option<GlobalId>,
 }
 
-impl<T> CollectionDescription<T> {
+impl CollectionDescription {
     /// Create a CollectionDescription for [`DataSource::Other`].
-    pub fn for_other(desc: RelationDesc, since: Option<Antichain<T>>) -> Self {
+    pub fn for_other(desc: RelationDesc, since: Option<Antichain<Timestamp>>) -> Self {
         Self {
             desc,
             data_source: DataSource::Other,
@@ -196,8 +195,8 @@ pub struct ExportDescription<T = mz_repr::Timestamp> {
 }
 
 #[derive(Debug)]
-pub enum Response<T> {
-    FrontierUpdates(Vec<(GlobalId, Antichain<T>)>),
+pub enum Response {
+    FrontierUpdates(Vec<(GlobalId, Antichain<Timestamp>)>),
 }
 
 /// Metadata that the storage controller must know to properly handle the life
@@ -216,7 +215,7 @@ pub struct StorageMetadata {
 }
 
 impl StorageMetadata {
-    pub fn get_collection_shard<T>(&self, id: GlobalId) -> Result<ShardId, StorageError<T>> {
+    pub fn get_collection_shard(&self, id: GlobalId) -> Result<ShardId, StorageError> {
         let shard_id = self
             .collection_metadata
             .get(&id)
@@ -232,7 +231,7 @@ impl StorageMetadata {
 /// Data written to the implementor of this trait should make a consistent view
 /// of the data available through [`StorageMetadata`].
 #[async_trait]
-pub trait StorageTxn<T> {
+pub trait StorageTxn {
     /// Retrieve all of the visible storage metadata.
     ///
     /// The value of this map should be treated as opaque.
@@ -245,7 +244,7 @@ pub trait StorageTxn<T> {
     fn insert_collection_metadata(
         &mut self,
         s: BTreeMap<GlobalId, ShardId>,
-    ) -> Result<(), StorageError<T>>;
+    ) -> Result<(), StorageError>;
 
     /// Remove the metadata associated with the identified collections.
     ///
@@ -258,7 +257,7 @@ pub trait StorageTxn<T> {
     fn get_unfinalized_shards(&self) -> BTreeSet<ShardId>;
 
     /// Insert the specified values as unfinalized shards.
-    fn insert_unfinalized_shards(&mut self, s: BTreeSet<ShardId>) -> Result<(), StorageError<T>>;
+    fn insert_unfinalized_shards(&mut self, s: BTreeSet<ShardId>) -> Result<(), StorageError>;
 
     /// Mark the specified shards as finalized, deleting them from the
     /// unfinalized shard collection.
@@ -270,7 +269,7 @@ pub trait StorageTxn<T> {
     /// Store the specified shard as the environment's txn WAL shard.
     ///
     /// The implementor should error if the shard is already specified.
-    fn write_txn_wal_shard(&mut self, shard: ShardId) -> Result<(), StorageError<T>>;
+    fn write_txn_wal_shard(&mut self, shard: ShardId) -> Result<(), StorageError>;
 }
 
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
@@ -301,8 +300,6 @@ impl StorageWriteOp {
 
 #[async_trait(?Send)]
 pub trait StorageController: Debug {
-    type Timestamp: TimelyTimestamp;
-
     /// Marks the end of any initialization commands.
     ///
     /// The implementor may wait for this method to be called before implementing prior commands,
@@ -324,10 +321,7 @@ pub trait StorageController: Debug {
     /// For this check, zero-replica clusters are always considered hydrated.
     /// Their collections would never normally be considered hydrated but it's
     /// clearly intentional that they have no replicas.
-    fn collection_hydrated(
-        &self,
-        collection_id: GlobalId,
-    ) -> Result<bool, StorageError<Self::Timestamp>>;
+    fn collection_hydrated(&self, collection_id: GlobalId) -> Result<bool, StorageError>;
 
     /// Returns `true` if each non-transient, non-excluded collection is
     /// hydrated on at least one of the provided replicas.
@@ -341,13 +335,13 @@ pub trait StorageController: Debug {
         target_replica_ids: Option<Vec<ReplicaId>>,
         target_cluster_ids: &StorageInstanceId,
         exclude_collections: &BTreeSet<GlobalId>,
-    ) -> Result<bool, StorageError<Self::Timestamp>>;
+    ) -> Result<bool, StorageError>;
 
     /// Returns the since/upper frontiers of the identified collection.
     fn collection_frontiers(
         &self,
         id: GlobalId,
-    ) -> Result<(Antichain<Self::Timestamp>, Antichain<Self::Timestamp>), CollectionMissing>;
+    ) -> Result<(Antichain<Timestamp>, Antichain<Timestamp>), CollectionMissing>;
 
     /// Returns the since/upper frontiers of the identified collections.
     ///
@@ -360,14 +354,7 @@ pub trait StorageController: Debug {
     fn collections_frontiers(
         &self,
         id: Vec<GlobalId>,
-    ) -> Result<
-        Vec<(
-            GlobalId,
-            Antichain<Self::Timestamp>,
-            Antichain<Self::Timestamp>,
-        )>,
-        CollectionMissing,
-    >;
+    ) -> Result<Vec<(GlobalId, Antichain<Timestamp>, Antichain<Timestamp>)>, CollectionMissing>;
 
     /// Acquire an iterator over [CollectionMetadata] for all active
     /// collections.
@@ -386,7 +373,7 @@ pub trait StorageController: Debug {
 
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.
-    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>>;
+    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError>;
 
     /// Creates a storage instance with the specified ID.
     ///
@@ -439,7 +426,7 @@ pub trait StorageController: Debug {
         &mut self,
         storage_metadata: &StorageMetadata,
         collections: Vec<(GlobalId, RelationDesc)>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Create the sources described in the individual RunIngestionCommand commands.
     ///
@@ -462,9 +449,9 @@ pub trait StorageController: Debug {
     async fn create_collections(
         &mut self,
         storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+        register_ts: Option<Timestamp>,
+        collections: Vec<(GlobalId, CollectionDescription)>,
+    ) -> Result<(), StorageError> {
         self.create_collections_for_bootstrap(
             storage_metadata,
             register_ts,
@@ -481,10 +468,10 @@ pub trait StorageController: Debug {
     async fn create_collections_for_bootstrap(
         &mut self,
         storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+        register_ts: Option<Timestamp>,
+        collections: Vec<(GlobalId, CollectionDescription)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Check that the ingestion associated with `id` can use the provided
     /// [`SourceDesc`].
@@ -496,25 +483,25 @@ pub trait StorageController: Debug {
         &mut self,
         ingestion_id: GlobalId,
         source_desc: &SourceDesc,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Alters each identified ingestion to use the correlated [`SourceDesc`].
     async fn alter_ingestion_source_desc(
         &mut self,
         ingestion_ids: BTreeMap<GlobalId, SourceDesc>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Alters each identified collection to use the correlated [`GenericSourceConnection`].
     async fn alter_ingestion_connections(
         &mut self,
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Alters the data config for the specified source exports of the specified ingestions.
     async fn alter_ingestion_export_data_configs(
         &mut self,
         source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     async fn alter_table_desc(
         &mut self,
@@ -522,20 +509,14 @@ pub trait StorageController: Debug {
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-        register_ts: Self::Timestamp,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+        register_ts: Timestamp,
+    ) -> Result<(), StorageError>;
 
     /// Acquire an immutable reference to the export state, should it exist.
-    fn export(
-        &self,
-        id: GlobalId,
-    ) -> Result<&ExportState<Self::Timestamp>, StorageError<Self::Timestamp>>;
+    fn export(&self, id: GlobalId) -> Result<&ExportState, StorageError>;
 
     /// Acquire a mutable reference to the export state, should it exist.
-    fn export_mut(
-        &mut self,
-        id: GlobalId,
-    ) -> Result<&mut ExportState<Self::Timestamp>, StorageError<Self::Timestamp>>;
+    fn export_mut(&mut self, id: GlobalId) -> Result<&mut ExportState, StorageError>;
 
     /// Create a oneshot ingestion.
     async fn create_oneshot_ingestion(
@@ -545,48 +526,45 @@ pub trait StorageController: Debug {
         instance_id: StorageInstanceId,
         request: OneshotIngestionRequest,
         result_tx: OneshotResultCallback<ProtoBatch>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Cancel a oneshot ingestion.
-    fn cancel_oneshot_ingestion(
-        &mut self,
-        ingestion_id: uuid::Uuid,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    fn cancel_oneshot_ingestion(&mut self, ingestion_id: uuid::Uuid) -> Result<(), StorageError>;
 
     /// Alter the sink identified by the given id to match the provided `ExportDescription`.
     async fn alter_export(
         &mut self,
         id: GlobalId,
-        export: ExportDescription<Self::Timestamp>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+        export: ExportDescription,
+    ) -> Result<(), StorageError>;
 
     /// For each identified export, alter its [`StorageSinkConnection`].
     async fn alter_export_connections(
         &mut self,
         exports: BTreeMap<GlobalId, StorageSinkConnection>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the tables and allows their resources to be reclaimed.
     fn drop_tables(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-        ts: Self::Timestamp,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+        ts: Timestamp,
+    ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
     fn drop_sources(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.
     fn drop_sinks(
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.
     ///
@@ -618,7 +596,7 @@ pub trait StorageController: Debug {
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Append `updates` into the local input named `id` and advance its upper to `upper`.
     ///
@@ -630,20 +608,14 @@ pub trait StorageController: Debug {
     // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
     fn append_table(
         &mut self,
-        write_ts: Self::Timestamp,
-        advance_to: Self::Timestamp,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
-    ) -> Result<
-        tokio::sync::oneshot::Receiver<Result<(), StorageError<Self::Timestamp>>>,
-        StorageError<Self::Timestamp>,
-    >;
+    ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
 
     /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically
     /// append to the specified [`GlobalId`].
-    fn monotonic_appender(
-        &self,
-        id: GlobalId,
-    ) -> Result<MonotonicAppender<Self::Timestamp>, StorageError<Self::Timestamp>>;
+    fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError>;
 
     /// Returns a shared [`WebhookStatistics`] which can be used to report user-facing
     /// statistics for this given webhhook, specified by the [`GlobalId`].
@@ -652,10 +624,7 @@ pub trait StorageController: Debug {
     // from outside the ordinary controller-clusterd path. Its possible to merge this with
     // `monotonic_appender`, whose only current user is webhooks, but given that they will
     // likely be moved to clusterd, we just leave this a special case.
-    fn webhook_statistics(
-        &self,
-        id: GlobalId,
-    ) -> Result<Arc<WebhookStatistics>, StorageError<Self::Timestamp>>;
+    fn webhook_statistics(&self, id: GlobalId) -> Result<Arc<WebhookStatistics>, StorageError>;
 
     /// Waits until the controller is ready to process a response.
     ///
@@ -671,7 +640,7 @@ pub trait StorageController: Debug {
     fn process(
         &mut self,
         storage_metadata: &StorageMetadata,
-    ) -> Result<Option<Response<Self::Timestamp>>, anyhow::Error>;
+    ) -> Result<Option<Response>, anyhow::Error>;
 
     /// Exposes the internal state of the data shard for debugging and QA.
     ///
@@ -716,7 +685,7 @@ pub trait StorageController: Debug {
         type_: IntrospectionType,
     ) -> mpsc::UnboundedSender<(
         Vec<AppendOnlyUpdate>,
-        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
+        oneshot::Sender<Result<(), StorageError>>,
     )>;
 
     /// Returns a sender for updates to the specified differential introspection collection.
@@ -727,25 +696,19 @@ pub trait StorageController: Debug {
     fn differential_introspection_tx(
         &self,
         type_: IntrospectionType,
-    ) -> mpsc::UnboundedSender<(
-        StorageWriteOp,
-        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
-    )>;
+    ) -> mpsc::UnboundedSender<(StorageWriteOp, oneshot::Sender<Result<(), StorageError>>)>;
 
     async fn real_time_recent_timestamp(
         &self,
         source_ids: BTreeSet<GlobalId>,
         timeout: Duration,
-    ) -> Result<
-        BoxFuture<Result<Self::Timestamp, StorageError<Self::Timestamp>>>,
-        StorageError<Self::Timestamp>,
-    >;
+    ) -> Result<BoxFuture<Result<Timestamp, StorageError>>, StorageError>;
 
     /// Returns the state of the [`StorageController`] formatted as JSON.
     fn dump(&self) -> Result<serde_json::Value, anyhow::Error>;
 }
 
-impl<T> DataSource<T> {
+impl DataSource {
     /// Returns true if the storage controller manages the data shard for this
     /// source using txn-wal.
     pub fn in_txns(&self) -> bool {
@@ -790,41 +753,38 @@ impl From<NonZeroI64> for PersistEpoch {
 
 /// State maintained about individual exports.
 #[derive(Debug)]
-pub struct ExportState<T: TimelyTimestamp> {
+pub struct ExportState {
     /// Really only for keeping track of changes to the `derived_since`.
-    pub read_capabilities: MutableAntichain<T>,
+    pub read_capabilities: MutableAntichain<Timestamp>,
 
     /// The cluster this export is associated with.
     pub cluster_id: StorageInstanceId,
 
     /// The current since frontier, derived from `write_frontier` using
     /// `hold_policy`.
-    pub derived_since: Antichain<T>,
+    pub derived_since: Antichain<Timestamp>,
 
     /// The read holds that this export has on its dependencies (its input and itself). When
     /// the upper of the export changes, we downgrade this, which in turn
     /// downgrades holds we have on our dependencies' sinces.
-    pub read_holds: [ReadHold<T>; 2],
+    pub read_holds: [ReadHold<Timestamp>; 2],
 
     /// The policy to use to downgrade `self.read_capability`.
-    pub read_policy: ReadPolicy<T>,
+    pub read_policy: ReadPolicy<Timestamp>,
 
     /// Reported write frontier.
-    pub write_frontier: Antichain<T>,
+    pub write_frontier: Antichain<Timestamp>,
 }
 
-impl<T: Timestamp> ExportState<T> {
+impl ExportState {
     pub fn new(
         cluster_id: StorageInstanceId,
-        read_hold: ReadHold<T>,
-        self_hold: ReadHold<T>,
-        write_frontier: Antichain<T>,
-        read_policy: ReadPolicy<T>,
-    ) -> Self
-    where
-        T: Lattice,
-    {
-        let mut dependency_since = Antichain::from_elem(T::minimum());
+        read_hold: ReadHold<Timestamp>,
+        self_hold: ReadHold<Timestamp>,
+        write_frontier: Antichain<Timestamp>,
+        read_policy: ReadPolicy<Timestamp>,
+    ) -> Self {
+        let mut dependency_since = Antichain::from_elem(Timestamp::MIN);
         for read_hold in [&read_hold, &self_hold] {
             dependency_since.join_assign(read_hold.since());
         }
@@ -844,7 +804,7 @@ impl<T: Timestamp> ExportState<T> {
     }
 
     /// Returns the cluster to which the export is bound.
-    pub fn input_hold(&self) -> &ReadHold<T> {
+    pub fn input_hold(&self) -> &ReadHold<Timestamp> {
         &self.read_holds[0]
     }
 
@@ -857,25 +817,25 @@ impl<T: Timestamp> ExportState<T> {
 ///
 /// See `CollectionManager::monotonic_appender` to acquire a [`MonotonicAppender`].
 #[derive(Clone, Debug)]
-pub struct MonotonicAppender<T> {
+pub struct MonotonicAppender {
     /// Channel that sends to a [`tokio::task`] which pushes updates to Persist.
     tx: mpsc::UnboundedSender<(
         Vec<AppendOnlyUpdate>,
-        oneshot::Sender<Result<(), StorageError<T>>>,
+        oneshot::Sender<Result<(), StorageError>>,
     )>,
 }
 
-impl<T> MonotonicAppender<T> {
+impl MonotonicAppender {
     pub fn new(
         tx: mpsc::UnboundedSender<(
             Vec<AppendOnlyUpdate>,
-            oneshot::Sender<Result<(), StorageError<T>>>,
+            oneshot::Sender<Result<(), StorageError>>,
         )>,
     ) -> Self {
         MonotonicAppender { tx }
     }
 
-    pub async fn append(&self, updates: Vec<AppendOnlyUpdate>) -> Result<(), StorageError<T>> {
+    pub async fn append(&self, updates: Vec<AppendOnlyUpdate>) -> Result<(), StorageError> {
         let (tx, rx) = oneshot::channel();
 
         // Send our update to the CollectionManager.

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -231,7 +231,7 @@ impl ReplicaMetrics {
     }
 }
 
-impl<T> transport::Metrics<StorageCommand<T>, StorageResponse<T>> for ReplicaMetrics {
+impl transport::Metrics<StorageCommand, StorageResponse> for ReplicaMetrics {
     fn bytes_sent(&mut self, len: usize) {
         self.inner
             .command_message_bytes_total
@@ -244,11 +244,11 @@ impl<T> transport::Metrics<StorageCommand<T>, StorageResponse<T>> for ReplicaMet
             .inc_by(u64::cast_from(len));
     }
 
-    fn message_sent(&mut self, msg: &StorageCommand<T>) {
+    fn message_sent(&mut self, msg: &StorageCommand) {
         self.inner.commands_total.for_command(msg).inc();
     }
 
-    fn message_received(&mut self, msg: &StorageResponse<T>) {
+    fn message_received(&mut self, msg: &StorageResponse) {
         self.inner.responses_total.for_response(msg).inc();
     }
 }
@@ -309,7 +309,7 @@ impl<M> CommandMetrics<M> {
         f(&self.cancel_oneshot_ingestion);
     }
 
-    pub fn for_command<T>(&self, command: &StorageCommand<T>) -> &M {
+    pub fn for_command(&self, command: &StorageCommand) -> &M {
         use StorageCommand::*;
 
         match command {
@@ -350,7 +350,7 @@ impl<M> ResponseMetrics<M> {
         }
     }
 
-    fn for_response<T>(&self, response: &StorageResponse<T>) -> &M {
+    fn for_response(&self, response: &StorageResponse) -> &M {
         use StorageResponse::*;
 
         match response {

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -25,7 +25,7 @@ use futures::{Future, FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::{assert_none, instrument, soft_assert_or_log};
 use mz_persist_client::cache::PersistClientCache;
@@ -36,10 +36,9 @@ use mz_persist_client::schema::CaESchema;
 use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
-use mz_persist_types::Codec64;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::txn::TxnsCodec;
-use mz_repr::{GlobalId, RelationDesc, RelationVersion, Row, TimestampManipulation};
+use mz_repr::{GlobalId, RelationDesc, RelationVersion, Row, Timestamp};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::ConnectionContext;
@@ -55,9 +54,8 @@ use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::{DataSnapshot, TxnsRead};
 use mz_txn_wal::txns::TxnsHandle;
 use timely::PartialOrder;
-use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
-use timely::progress::{Antichain, ChangeBatch, Timestamp as TimelyTimestamp};
+use timely::progress::{Antichain, ChangeBatch};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, trace, warn};
@@ -85,8 +83,6 @@ mod metrics;
 /// advancing while it needs to be read at a specific time.
 #[async_trait]
 pub trait StorageCollections: Debug + Sync {
-    type Timestamp: TimelyTimestamp;
-
     /// On boot, reconcile this [StorageCollections] with outside state. We get
     /// a [StorageTxn] where we can record any durable state that we need.
     ///
@@ -95,9 +91,9 @@ pub trait StorageCollections: Debug + Sync {
     /// know yet about.
     async fn initialize_state(
         &self,
-        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
+        txn: &mut (dyn StorageTxn + Send),
         init_ids: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Update storage configuration with new parameters.
     fn update_parameters(&self, config_params: StorageParameters);
@@ -113,10 +109,7 @@ pub trait StorageCollections: Debug + Sync {
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)>;
 
     /// Returns the frontiers of the identified collection.
-    fn collection_frontiers(
-        &self,
-        id: GlobalId,
-    ) -> Result<CollectionFrontiers<Self::Timestamp>, CollectionMissing> {
+    fn collection_frontiers(&self, id: GlobalId) -> Result<CollectionFrontiers, CollectionMissing> {
         let frontiers = self
             .collections_frontiers(vec![id])?
             .expect_element(|| "known to exist");
@@ -129,25 +122,25 @@ pub trait StorageCollections: Debug + Sync {
     fn collections_frontiers(
         &self,
         id: Vec<GlobalId>,
-    ) -> Result<Vec<CollectionFrontiers<Self::Timestamp>>, CollectionMissing>;
+    ) -> Result<Vec<CollectionFrontiers>, CollectionMissing>;
 
     /// Atomically gets and returns the frontiers of all active collections.
     ///
     /// A collection is "active" when it has a non-empty frontier of read
     /// capabilities.
-    fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers<Self::Timestamp>>;
+    fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers>;
 
     /// Checks whether a collection exists under the given `GlobalId`. Returns
     /// an error if the collection does not exist.
-    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>>;
+    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError>;
 
     /// Returns aggregate statistics about the contents of the local input named
     /// `id` at `as_of`.
     async fn snapshot_stats(
         &self,
         id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotStats, StorageError<Self::Timestamp>>;
+        as_of: Antichain<Timestamp>,
+    ) -> Result<SnapshotStats, StorageError>;
 
     /// Returns aggregate statistics about the contents of the local input named
     /// `id` at `as_of`.
@@ -160,31 +153,26 @@ pub trait StorageCollections: Debug + Sync {
     async fn snapshot_parts_stats(
         &self,
         id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>>;
+        as_of: Antichain<Timestamp>,
+    ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError>>;
 
     /// Returns a snapshot of the contents of collection `id` at `as_of`.
     fn snapshot(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError<Self::Timestamp>>>;
+        as_of: Timestamp,
+    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError>>;
 
     /// Returns a snapshot of the contents of collection `id` at the largest
     /// readable `as_of`.
-    async fn snapshot_latest(
-        &self,
-        id: GlobalId,
-    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>>;
+    async fn snapshot_latest(&self, id: GlobalId) -> Result<Vec<Row>, StorageError>;
 
     /// Returns a snapshot of the contents of collection `id` at `as_of`.
     fn snapshot_cursor(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> BoxFuture<'static, Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>>
-    where
-        Self::Timestamp: Codec64 + TimelyTimestamp + Lattice;
+        as_of: Timestamp,
+    ) -> BoxFuture<'static, Result<SnapshotCursor, StorageError>>;
 
     /// Generates a snapshot of the contents of collection `id` at `as_of` and
     /// streams out all of the updates in bounded memory.
@@ -193,13 +181,10 @@ pub trait StorageCollections: Debug + Sync {
     fn snapshot_and_stream(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
+        as_of: Timestamp,
     ) -> BoxFuture<
         'static,
-        Result<
-            BoxStream<'static, (SourceData, Self::Timestamp, StorageDiff)>,
-            StorageError<Self::Timestamp>,
-        >,
+        Result<BoxStream<'static, (SourceData, Timestamp, StorageDiff)>, StorageError>,
     >;
 
     /// Create a [`TimestamplessUpdateBuilder`] that can be used to stage
@@ -209,13 +194,8 @@ pub trait StorageCollections: Debug + Sync {
         id: GlobalId,
     ) -> BoxFuture<
         'static,
-        Result<
-            TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, StorageDiff>,
-            StorageError<Self::Timestamp>,
-        >,
-    >
-    where
-        Self::Timestamp: Lattice + Codec64;
+        Result<TimestamplessUpdateBuilder<SourceData, (), StorageDiff>, StorageError>,
+    >;
 
     /// Update the given [`StorageTxn`] with the appropriate metadata given the
     /// IDs to add and drop.
@@ -224,11 +204,11 @@ pub trait StorageCollections: Debug + Sync {
     /// subsequent calls that require [`StorageMetadata`] as a parameter.
     async fn prepare_state(
         &self,
-        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
+        txn: &mut (dyn StorageTxn + Send),
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
         ids_to_register: BTreeMap<GlobalId, ShardId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Create the collections described by the individual
     /// [CollectionDescriptions](CollectionDescription).
@@ -258,10 +238,10 @@ pub trait StorageCollections: Debug + Sync {
     async fn create_collections_for_bootstrap(
         &self,
         storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+        register_ts: Option<Timestamp>,
+        collections: Vec<(GlobalId, CollectionDescription)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Updates the [`RelationDesc`] for the specified table.
     async fn alter_table_desc(
@@ -270,7 +250,7 @@ pub trait StorageCollections: Debug + Sync {
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-    ) -> Result<(), StorageError<Self::Timestamp>>;
+    ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sources and allows their resources to
     /// be reclaimed.
@@ -302,14 +282,14 @@ pub trait StorageCollections: Debug + Sync {
     ///
     /// Identifiers not present in `policies` retain their existing read
     /// policies.
-    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>);
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>);
 
     /// Acquires and returns the earliest possible read holds for the specified
     /// collections.
     fn acquire_read_holds(
         &self,
         desired_holds: Vec<GlobalId>,
-    ) -> Result<Vec<ReadHold<Self::Timestamp>>, CollectionMissing>;
+    ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing>;
 
     /// Get the time dependence for a storage collection. Returns no value if unknown or if
     /// the object isn't managed by storage.
@@ -324,17 +304,17 @@ pub trait StorageCollections: Debug + Sync {
 
 /// A cursor over a snapshot, allowing us to read just part of a snapshot in its
 /// consolidated form.
-pub struct SnapshotCursor<T: Codec64 + TimelyTimestamp + Lattice> {
+pub struct SnapshotCursor {
     // We allocate a temporary read handle for each snapshot, and that handle needs to live at
     // least as long as the cursor itself, which holds part leases. Bundling them together!
-    pub _read_handle: ReadHandle<SourceData, (), T, StorageDiff>,
-    pub cursor: Cursor<SourceData, (), T, StorageDiff>,
+    pub _read_handle: ReadHandle<SourceData, (), Timestamp, StorageDiff>,
+    pub cursor: Cursor<SourceData, (), Timestamp, StorageDiff>,
 }
 
-impl<T: Codec64 + TimelyTimestamp + Lattice + Sync> SnapshotCursor<T> {
+impl SnapshotCursor {
     pub async fn next(
         &mut self,
-    ) -> Option<impl Iterator<Item = (SourceData, T, StorageDiff)> + Sized + '_> {
+    ) -> Option<impl Iterator<Item = (SourceData, Timestamp, StorageDiff)> + Sized + '_> {
         let iter = self.cursor.next().await?;
         Some(iter.map(|((k, ()), t, d)| (k, t, d)))
     }
@@ -342,12 +322,12 @@ impl<T: Codec64 + TimelyTimestamp + Lattice + Sync> SnapshotCursor<T> {
 
 /// Frontiers of the collection identified by `id`.
 #[derive(Debug)]
-pub struct CollectionFrontiers<T> {
+pub struct CollectionFrontiers {
     /// The [GlobalId] of the collection that these frontiers belong to.
     pub id: GlobalId,
 
     /// The upper/write frontier of the collection.
-    pub write_frontier: Antichain<T>,
+    pub write_frontier: Antichain<Timestamp>,
 
     /// The since frontier that is implied by the collection's existence,
     /// disregarding any read holds.
@@ -355,19 +335,17 @@ pub struct CollectionFrontiers<T> {
     /// Concretely, it is the since frontier that is implied by the combination
     /// of the `write_frontier` and a [ReadPolicy]. The implied capability is
     /// derived from the write frontier using the [ReadPolicy].
-    pub implied_capability: Antichain<T>,
+    pub implied_capability: Antichain<Timestamp>,
 
     /// The frontier of all oustanding [ReadHolds](ReadHold). This includes the
     /// implied capability.
-    pub read_capabilities: Antichain<T>,
+    pub read_capabilities: Antichain<Timestamp>,
 }
 
 /// Implementation of [StorageCollections] that is shallow-cloneable and uses a
 /// background task for doing work concurrently, in the background.
 #[derive(Debug, Clone)]
-pub struct StorageCollectionsImpl<
-    T: TimelyTimestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-> {
+pub struct StorageCollectionsImpl {
     /// The fencing token for this instance of [StorageCollections], and really
     /// all of the controllers and Coordinator.
     envd_epoch: NonZeroI64,
@@ -390,10 +368,10 @@ pub struct StorageCollectionsImpl<
     finalized_shards: Arc<ShardIdSet>,
 
     /// Collections maintained by this [StorageCollections].
-    collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState<T>>>>,
+    collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState>>>,
 
     /// A shared TxnsCache running in a task and communicated with over a channel.
-    txns_read: TxnsRead<T>,
+    txns_read: TxnsRead<Timestamp>,
 
     /// Storage configuration parameters.
     config: Arc<Mutex<StorageConfiguration>>,
@@ -406,7 +384,7 @@ pub struct StorageCollectionsImpl<
     /// existing indexes when bootstrapping, where tables that have an upper
     /// that is less than the initially known txn upper can lead to indexes that
     /// cannot hydrate in read-only mode.
-    initial_txn_upper: Antichain<T>,
+    initial_txn_upper: Antichain<Timestamp>,
 
     /// The persist location where all storage collections are being written to
     persist_location: PersistLocation,
@@ -415,10 +393,10 @@ pub struct StorageCollectionsImpl<
     persist: Arc<PersistClientCache>,
 
     /// For sending commands to our internal task.
-    cmd_tx: mpsc::UnboundedSender<BackgroundCmd<T>>,
+    cmd_tx: mpsc::UnboundedSender<BackgroundCmd>,
 
     /// For sending updates about read holds to our internal task.
-    holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+    holds_tx: mpsc::UnboundedSender<(GlobalId, ChangeBatch<Timestamp>)>,
 
     /// Handles to tasks we own, making sure they're dropped when we are.
     _background_task: Arc<AbortOnDropHandle<()>>,
@@ -433,20 +411,11 @@ pub struct StorageCollectionsImpl<
 // We follow a pattern where `_inner` methods get a mutable reference to the
 // shared collections state, and it's the public-facing method that locks the
 /// A boxed stream of source data with timestamps and diffs.
-type SourceDataStream<T> = BoxStream<'static, (SourceData, T, StorageDiff)>;
+type SourceDataStream = BoxStream<'static, (SourceData, Timestamp, StorageDiff)>;
 
 // state for the duration of its invocation. This allows calling other `_inner`
 // methods from within `_inner` methods.
-impl<T> StorageCollectionsImpl<T>
-where
-    T: TimelyTimestamp
-        + Lattice
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + Into<mz_repr::Timestamp>
-        + Sync,
-{
+impl StorageCollectionsImpl {
     /// Creates and returns a new [StorageCollections].
     ///
     /// Note that when creating a new [StorageCollections], you must also
@@ -463,7 +432,7 @@ where
         envd_epoch: NonZeroI64,
         read_only: bool,
         connection_context: ConnectionContext,
-        txn: &dyn StorageTxn<T>,
+        txn: &dyn StorageTxn,
     ) -> Self {
         let metrics = StorageCollectionsMetrics::register_into(metrics_registry);
 
@@ -481,9 +450,9 @@ where
 
         // We have to initialize, so that TxnsRead::start() below does not
         // block.
-        let _txns_handle: TxnsHandle<SourceData, (), T, StorageDiff, TxnsCodecRow> =
+        let _txns_handle: TxnsHandle<SourceData, (), Timestamp, StorageDiff, TxnsCodecRow> =
             TxnsHandle::open(
-                T::minimum(),
+                Timestamp::MIN,
                 txns_client.clone(),
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
@@ -543,7 +512,7 @@ where
 
         let finalize_shards_task = mz_ore::task::spawn(
             || "storage_collections::finalize_shards_task",
-            finalize_shards_task::<T>(FinalizeShardsTaskConfig {
+            finalize_shards_task(FinalizeShardsTaskConfig {
                 envd_epoch: envd_epoch.clone(),
                 config: Arc::clone(&config),
                 metrics,
@@ -584,12 +553,12 @@ where
         &self,
         id: &GlobalId,
         shard: ShardId,
-        since: Option<&Antichain<T>>,
+        since: Option<&Antichain<Timestamp>>,
         relation_desc: RelationDesc,
         persist_client: &PersistClient,
     ) -> (
-        WriteHandle<SourceData, (), T, StorageDiff>,
-        SinceHandleWrapper<T>,
+        WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        SinceHandleWrapper,
     ) {
         let since_handle = if self.read_only {
             let read_handle = self
@@ -600,7 +569,7 @@ where
             // We're managing the data for this shard in read-write mode, which would fence out other
             // processes in read-only mode; it's safe to upgrade the metadata version.
             persist_client
-                .upgrade_version::<SourceData, (), T, StorageDiff>(
+                .upgrade_version::<SourceData, (), Timestamp, StorageDiff>(
                     shard,
                     Diagnostics {
                         shard_name: id.to_string(),
@@ -643,7 +612,7 @@ where
         shard: ShardId,
         relation_desc: RelationDesc,
         persist_client: &PersistClient,
-    ) -> WriteHandle<SourceData, (), T, StorageDiff> {
+    ) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
         let diagnostics = Diagnostics {
             shard_name: id.to_string(),
             handle_purpose: format!("controller data for {}", id),
@@ -673,9 +642,9 @@ where
         &self,
         id: &GlobalId,
         shard: ShardId,
-        since: Option<&Antichain<T>>,
+        since: Option<&Antichain<Timestamp>>,
         persist_client: &PersistClient,
-    ) -> SinceHandle<SourceData, (), T, StorageDiff> {
+    ) -> SinceHandle<SourceData, (), Timestamp, StorageDiff> {
         tracing::debug!(%id, ?since, "opening critical handle");
 
         assert!(
@@ -708,7 +677,7 @@ where
             // read handles "start."
             let provided_since = match since {
                 Some(since) => since,
-                None => &Antichain::from_elem(T::minimum()),
+                None => &Antichain::from_elem(Timestamp::MIN),
             };
             let since = handle.since().join(provided_since);
 
@@ -752,9 +721,9 @@ where
         id: &GlobalId,
         shard: ShardId,
         relation_desc: RelationDesc,
-        since: Option<&Antichain<T>>,
+        since: Option<&Antichain<Timestamp>>,
         persist_client: &PersistClient,
-    ) -> ReadHandle<SourceData, (), T, StorageDiff> {
+    ) -> ReadHandle<SourceData, (), Timestamp, StorageDiff> {
         tracing::debug!(%id, ?since, "opening leased handle");
 
         let diagnostics = Diagnostics {
@@ -779,7 +748,7 @@ where
         // read handles "start."
         let provided_since = match since {
             Some(since) => since,
-            None => &Antichain::from_elem(T::minimum()),
+            None => &Antichain::from_elem(Timestamp::MIN),
         };
         let since = handle.since().join(provided_since);
 
@@ -792,8 +761,8 @@ where
         &self,
         id: GlobalId,
         is_in_txns: bool,
-        since_handle: SinceHandleWrapper<T>,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        since_handle: SinceHandleWrapper,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     ) {
         self.send(BackgroundCmd::Register {
             id,
@@ -803,15 +772,15 @@ where
         });
     }
 
-    fn send(&self, cmd: BackgroundCmd<T>) {
+    fn send(&self, cmd: BackgroundCmd) {
         let _ = self.cmd_tx.send(cmd);
     }
 
     async fn snapshot_stats_inner(
         &self,
         id: GlobalId,
-        as_of: SnapshotStatsAsOf<T>,
-    ) -> Result<SnapshotStats, StorageError<T>> {
+        as_of: SnapshotStatsAsOf,
+    ) -> Result<SnapshotStats, StorageError> {
         // TODO: Pull this out of BackgroundTask. Unlike the other methods, the
         // caller of this one drives it to completion.
         //
@@ -830,9 +799,9 @@ where
     /// beyond its dependents'.
     fn install_collection_dependency_read_holds_inner(
         &self,
-        self_collections: &mut BTreeMap<GlobalId, CollectionState<T>>,
+        self_collections: &mut BTreeMap<GlobalId, CollectionState>,
         id: GlobalId,
-    ) -> Result<(), StorageError<T>> {
+    ) -> Result<(), StorageError> {
         let (deps, collection_implied_capability) = match self_collections.get(&id) {
             Some(CollectionState {
                 storage_dependencies: deps,
@@ -870,10 +839,10 @@ where
 
     /// Returns the given collection's dependencies.
     fn determine_collection_dependencies(
-        self_collections: &BTreeMap<GlobalId, CollectionState<T>>,
+        self_collections: &BTreeMap<GlobalId, CollectionState>,
         source_id: GlobalId,
-        collection_desc: &CollectionDescription<T>,
-    ) -> Result<Vec<GlobalId>, StorageError<T>> {
+        collection_desc: &CollectionDescription,
+    ) -> Result<Vec<GlobalId>, StorageError> {
         let mut dependencies = Vec::new();
 
         if let Some(id) = collection_desc.primary {
@@ -921,14 +890,14 @@ where
     #[instrument(level = "debug")]
     fn install_read_capabilities_inner(
         &self,
-        self_collections: &mut BTreeMap<GlobalId, CollectionState<T>>,
+        self_collections: &mut BTreeMap<GlobalId, CollectionState>,
         from_id: GlobalId,
         storage_dependencies: &[GlobalId],
-        read_capability: Antichain<T>,
-    ) -> Result<(), StorageError<T>> {
+        read_capability: Antichain<Timestamp>,
+    ) -> Result<(), StorageError> {
         let mut changes = ChangeBatch::new();
         for time in read_capability.iter() {
-            changes.update(time.clone(), 1);
+            changes.update(*time, 1);
         }
 
         if tracing::span_enabled!(tracing::Level::TRACE) {
@@ -983,7 +952,7 @@ where
         Ok(())
     }
 
-    async fn recent_upper(&self, id: GlobalId) -> Result<Antichain<T>, StorageError<T>> {
+    async fn recent_upper(&self, id: GlobalId) -> Result<Antichain<Timestamp>, StorageError> {
         let metadata = &self.collection_metadata(id)?;
         let persist_client = self
             .persist
@@ -999,7 +968,7 @@ where
         // NB: Opening a WriteHandle is cheap if it's never used in a
         // compare_and_append operation.
         let write = persist_client
-            .open_writer::<SourceData, (), T, StorageDiff>(
+            .open_writer::<SourceData, (), Timestamp, StorageDiff>(
                 metadata.data_shard,
                 Arc::new(metadata.relation_desc.clone()),
                 Arc::new(UnitSchema),
@@ -1014,7 +983,7 @@ where
         persist: Arc<PersistClientCache>,
         metadata: &CollectionMetadata,
         id: GlobalId,
-    ) -> Result<ReadHandle<SourceData, (), T, StorageDiff>, StorageError<T>> {
+    ) -> Result<ReadHandle<SourceData, (), Timestamp, StorageDiff>, StorageError> {
         let persist_client = persist
             .open(metadata.persist_location.clone())
             .await
@@ -1041,20 +1010,12 @@ where
         Ok(read_handle)
     }
 
-    // TODO(petrosagg): This signature is not very useful in the context of partially ordered times
-    // where the as_of frontier might have multiple elements. In the current form the mutually
-    // incomparable updates will be accumulated together to a state of the collection that never
-    // actually existed. We should include the original time in the updates advanced by the as_of
-    // frontier in the result and let the caller decide what to do with the information.
     fn snapshot(
         &self,
         id: GlobalId,
-        as_of: T,
-        txns_read: &TxnsRead<T>,
-    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError<T>>>
-    where
-        T: Codec64 + From<EpochMillis> + TimestampManipulation,
-    {
+        as_of: Timestamp,
+        txns_read: &TxnsRead<Timestamp>,
+    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError>> {
         let metadata = match self.collection_metadata(id) {
             Ok(metadata) => metadata.clone(),
             Err(e) => return async { Err(e.into()) }.boxed(),
@@ -1087,10 +1048,8 @@ where
                     // - This branch allows it to handle that advancing the physical upper of Table A to
                     //   10 (NB but only once we see it get past the write at 5!)
                     // - Then we can read it normally.
-                    txns_read.update_gt(as_of.clone()).await;
-                    let data_snapshot = txns_read
-                        .data_snapshot(metadata.data_shard, as_of.clone())
-                        .await;
+                    txns_read.update_gt(as_of).await;
+                    let data_snapshot = txns_read.data_snapshot(metadata.data_shard, as_of).await;
                     data_snapshot.snapshot_and_fetch(&mut read_handle).await
                 }
             };
@@ -1114,9 +1073,9 @@ where
     fn snapshot_and_stream(
         &self,
         id: GlobalId,
-        as_of: T,
-        txns_read: &TxnsRead<T>,
-    ) -> BoxFuture<'static, Result<SourceDataStream<T>, StorageError<T>>> {
+        as_of: Timestamp,
+        txns_read: &TxnsRead<Timestamp>,
+    ) -> BoxFuture<'static, Result<SourceDataStream, StorageError>> {
         use futures::stream::StreamExt;
 
         let metadata = match self.collection_metadata(id) {
@@ -1141,10 +1100,8 @@ where
                         .boxed()
                 }
                 Some(txns_read) => {
-                    txns_read.update_gt(as_of.clone()).await;
-                    let data_snapshot = txns_read
-                        .data_snapshot(metadata.data_shard, as_of.clone())
-                        .await;
+                    txns_read.update_gt(as_of).await;
+                    let data_snapshot = txns_read.data_snapshot(metadata.data_shard, as_of).await;
                     data_snapshot
                         .snapshot_and_stream(&mut read_handle)
                         .await
@@ -1162,8 +1119,8 @@ where
 
     fn set_read_policies_inner(
         &self,
-        collections: &mut BTreeMap<GlobalId, CollectionState<T>>,
-        policies: Vec<(GlobalId, ReadPolicy<T>)>,
+        collections: &mut BTreeMap<GlobalId, CollectionState>,
+        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
     ) {
         trace!("set_read_policies: {:?}", policies);
 
@@ -1181,9 +1138,9 @@ where
 
             if PartialOrder::less_equal(&collection.implied_capability, &new_read_capability) {
                 let mut update = ChangeBatch::new();
-                update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
+                update.extend(new_read_capability.iter().map(|time| (*time, 1)));
                 std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
-                update.extend(new_read_capability.iter().map(|time| (time.clone(), -1)));
+                update.extend(new_read_capability.iter().map(|time| (*time, -1)));
                 if !update.is_empty() {
                     read_capability_changes.insert(id, update);
                 }
@@ -1211,9 +1168,9 @@ where
     // that updates the persist handles and also has a reference to the shared
     // collections state.
     fn update_read_capabilities_inner(
-        cmd_tx: &mpsc::UnboundedSender<BackgroundCmd<T>>,
-        collections: &mut BTreeMap<GlobalId, CollectionState<T>>,
-        updates: &mut BTreeMap<GlobalId, ChangeBatch<T>>,
+        cmd_tx: &mpsc::UnboundedSender<BackgroundCmd>,
+        collections: &mut BTreeMap<GlobalId, CollectionState>,
+        updates: &mut BTreeMap<GlobalId, ChangeBatch<Timestamp>>,
     ) {
         // Location to record consequences that we need to act on.
         let mut collections_net = BTreeMap::new();
@@ -1330,23 +1287,12 @@ where
 
 // See comments on the above impl for StorageCollectionsImpl.
 #[async_trait]
-impl<T> StorageCollections for StorageCollectionsImpl<T>
-where
-    T: TimelyTimestamp
-        + Lattice
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + Into<mz_repr::Timestamp>
-        + Sync,
-{
-    type Timestamp = T;
-
+impl StorageCollections for StorageCollectionsImpl {
     async fn initialize_state(
         &self,
-        txn: &mut (dyn StorageTxn<T> + Send),
+        txn: &mut (dyn StorageTxn + Send),
         init_ids: BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<T>> {
+    ) -> Result<(), StorageError> {
         let metadata = txn.get_collection_metadata();
         let existing_metadata: BTreeSet<_> = metadata.into_iter().map(|(id, _)| id).collect();
 
@@ -1411,7 +1357,7 @@ where
     fn collections_frontiers(
         &self,
         ids: Vec<GlobalId>,
-    ) -> Result<Vec<CollectionFrontiers<Self::Timestamp>>, CollectionMissing> {
+    ) -> Result<Vec<CollectionFrontiers>, CollectionMissing> {
         if ids.is_empty() {
             return Ok(vec![]);
         }
@@ -1436,7 +1382,7 @@ where
         Ok(res)
     }
 
-    fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers<Self::Timestamp>> {
+    fn active_collection_frontiers(&self) -> Vec<CollectionFrontiers> {
         let collections = self.collections.lock().expect("lock poisoned");
 
         let res = collections
@@ -1456,8 +1402,8 @@ where
     async fn snapshot_stats(
         &self,
         id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotStats, StorageError<Self::Timestamp>> {
+        as_of: Antichain<Timestamp>,
+    ) -> Result<SnapshotStats, StorageError> {
         let metadata = self.collection_metadata(id)?;
 
         // See the comments in StorageController::snapshot for what's going on
@@ -1469,10 +1415,10 @@ where
                 let as_of = as_of
                     .into_option()
                     .expect("cannot read as_of the empty antichain");
-                self.txns_read.update_gt(as_of.clone()).await;
+                self.txns_read.update_gt(as_of).await;
                 let data_snapshot = self
                     .txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
+                    .data_snapshot(metadata.data_shard, as_of)
                     .await;
                 SnapshotStatsAsOf::Txns(data_snapshot)
             }
@@ -1483,8 +1429,8 @@ where
     async fn snapshot_parts_stats(
         &self,
         id: GlobalId,
-        as_of: Antichain<Self::Timestamp>,
-    ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
+        as_of: Antichain<Timestamp>,
+    ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError>> {
         let metadata = {
             let self_collections = self.collections.lock().expect("lock poisoned");
 
@@ -1514,11 +1460,8 @@ where
                 Some(as_of),
             ) => {
                 assert_eq!(txns_id, *self.txns_read.txns_id());
-                self.txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = self
-                    .txns_read
-                    .data_snapshot(data_shard, as_of.clone())
-                    .await;
+                self.txns_read.update_gt(*as_of).await;
+                let data_snapshot = self.txns_read.data_snapshot(data_shard, *as_of).await;
                 Some(data_snapshot)
             }
             _ => None,
@@ -1535,26 +1478,18 @@ where
         })
     }
 
-    // TODO(petrosagg): This signature is not very useful in the context of partially ordered times
-    // where the as_of frontier might have multiple elements. In the current form the mutually
-    // incomparable updates will be accumulated together to a state of the collection that never
-    // actually existed. We should include the original time in the updates advanced by the as_of
-    // frontier in the result and let the caller decide what to do with the information.
     fn snapshot(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError<Self::Timestamp>>> {
+        as_of: Timestamp,
+    ) -> BoxFuture<'static, Result<Vec<(Row, StorageDiff)>, StorageError>> {
         self.snapshot(id, as_of, &self.txns_read)
     }
 
-    async fn snapshot_latest(
-        &self,
-        id: GlobalId,
-    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>> {
+    async fn snapshot_latest(&self, id: GlobalId) -> Result<Vec<Row>, StorageError> {
         let upper = self.recent_upper(id).await?;
         let res = match upper.as_option() {
-            Some(f) if f > &T::minimum() => {
+            Some(f) if f > &Timestamp::MIN => {
                 let as_of = f.step_back().unwrap();
 
                 let snapshot = self.snapshot(id, as_of, &self.txns_read).await.unwrap();
@@ -1586,11 +1521,8 @@ where
     fn snapshot_cursor(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
-    ) -> BoxFuture<'static, Result<SnapshotCursor<Self::Timestamp>, StorageError<Self::Timestamp>>>
-    where
-        Self::Timestamp: TimelyTimestamp + Lattice + Codec64,
-    {
+        as_of: Timestamp,
+    ) -> BoxFuture<'static, Result<SnapshotCursor, StorageError>> {
         let metadata = match self.collection_metadata(id) {
             Ok(metadata) => metadata.clone(),
             Err(e) => return async { Err(e.into()) }.boxed(),
@@ -1618,10 +1550,8 @@ where
                     }
                 }
                 Some(txns_read) => {
-                    txns_read.update_gt(as_of.clone()).await;
-                    let data_snapshot = txns_read
-                        .data_snapshot(metadata.data_shard, as_of.clone())
-                        .await;
+                    txns_read.update_gt(as_of).await;
+                    let data_snapshot = txns_read.data_snapshot(metadata.data_shard, as_of).await;
                     let cursor = data_snapshot
                         .snapshot_cursor(&mut handle, |_| true)
                         .await
@@ -1641,17 +1571,11 @@ where
     fn snapshot_and_stream(
         &self,
         id: GlobalId,
-        as_of: Self::Timestamp,
+        as_of: Timestamp,
     ) -> BoxFuture<
         'static,
-        Result<
-            BoxStream<'static, (SourceData, Self::Timestamp, StorageDiff)>,
-            StorageError<Self::Timestamp>,
-        >,
-    >
-    where
-        Self::Timestamp: TimelyTimestamp + Lattice + Codec64 + 'static,
-    {
+        Result<BoxStream<'static, (SourceData, Timestamp, StorageDiff)>, StorageError>,
+    > {
         self.snapshot_and_stream(id, as_of, &self.txns_read)
     }
 
@@ -1660,10 +1584,7 @@ where
         id: GlobalId,
     ) -> BoxFuture<
         'static,
-        Result<
-            TimestamplessUpdateBuilder<SourceData, (), Self::Timestamp, StorageDiff>,
-            StorageError<Self::Timestamp>,
-        >,
+        Result<TimestamplessUpdateBuilder<SourceData, (), StorageDiff>, StorageError>,
     > {
         let metadata = match self.collection_metadata(id) {
             Ok(m) => m,
@@ -1677,7 +1598,7 @@ where
                 .await
                 .expect("invalid persist usage");
             let write_handle = persist_client
-                .open_writer::<SourceData, (), Self::Timestamp, StorageDiff>(
+                .open_writer::<SourceData, (), Timestamp, StorageDiff>(
                     metadata.data_shard,
                     Arc::new(metadata.relation_desc.clone()),
                     Arc::new(UnitSchema),
@@ -1695,7 +1616,7 @@ where
         .boxed()
     }
 
-    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {
+    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError> {
         let collections = self.collections.lock().expect("lock poisoned");
 
         if collections.contains_key(&id) {
@@ -1707,11 +1628,11 @@ where
 
     async fn prepare_state(
         &self,
-        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
+        txn: &mut (dyn StorageTxn + Send),
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
         ids_to_register: BTreeMap<GlobalId, ShardId>,
-    ) -> Result<(), StorageError<T>> {
+    ) -> Result<(), StorageError> {
         txn.insert_collection_metadata(
             ids_to_add
                 .into_iter()
@@ -1744,10 +1665,10 @@ where
     async fn create_collections_for_bootstrap(
         &self,
         storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        mut collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+        register_ts: Option<Timestamp>,
+        mut collections: Vec<(GlobalId, CollectionDescription)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let is_in_txns = |id, metadata: &CollectionMetadata| {
             metadata.txns_shard.is_some()
                 && !(self.read_only && migrated_storage_collections.contains(&id))
@@ -1770,7 +1691,7 @@ where
         let enriched_with_metadata = collections
             .into_iter()
             .map(|(id, description)| {
-                let data_shard = storage_metadata.get_collection_shard::<T>(id)?;
+                let data_shard = storage_metadata.get_collection_shard(id)?;
 
                 // If the shard is being managed by txn-wal (initially,
                 // tables), then we need to pass along the shard id for the txns
@@ -1803,8 +1724,7 @@ where
         use futures::stream::{StreamExt, TryStreamExt};
         let this = &*self;
         let mut to_register: Vec<_> = futures::stream::iter(enriched_with_metadata)
-            .map(|data: Result<_, StorageError<Self::Timestamp>>| {
-                let register_ts = register_ts.clone();
+            .map(|data: Result<_, StorageError>| {
                 async move {
                     let (id, description, metadata) = data?;
 
@@ -1853,7 +1773,7 @@ where
                             let register_ts = register_ts.expect(
                                 "caller should have provided a register_ts when creating a table",
                             );
-                            if since_handle.since().elements() == &[T::minimum()]
+                            if since_handle.since().elements() == &[Timestamp::MIN]
                                 && !migrated_storage_collections.contains(&id)
                             {
                                 debug!("advancing {} to initial since of {:?}", id, register_ts);
@@ -1861,20 +1781,14 @@ where
                                 let _ = since_handle
                                     .compare_and_downgrade_since(
                                         &token,
-                                        (&token, &Antichain::from_elem(register_ts.clone())),
+                                        (&token, &Antichain::from_elem(register_ts)),
                                     )
                                     .await;
                             }
                         }
                     }
 
-                    Ok::<_, StorageError<Self::Timestamp>>((
-                        id,
-                        description,
-                        write,
-                        since_handle,
-                        metadata,
-                    ))
+                    Ok::<_, StorageError>((id, description, write, since_handle, metadata))
                 }
             })
             // Poll each future for each collection concurrently, maximum of 50 at a time.
@@ -1965,7 +1879,7 @@ where
                         // write frontier is empty. In that case, no-one can
                         // write down any more updates.
                         mz_ore::soft_assert_or_log!(
-                            write_frontier.elements() == &[T::minimum()]
+                            write_frontier.elements() == &[Timestamp::MIN]
                                 || write_frontier.is_empty()
                                 || PartialOrder::less_than(&dependency_since, write_frontier),
                             "dependency ({dep}) since has advanced past dependent ({id}) upper \n
@@ -2097,7 +2011,7 @@ where
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let data_shard = {
             let self_collections = self.collections.lock().expect("lock poisoned");
             let existing = self_collections
@@ -2121,7 +2035,7 @@ where
         // We map the Adapter's RelationVersion 1:1 with SchemaId.
         let expected_schema = expected_version.into();
         let schema_result = persist_client
-            .compare_and_evolve_schema::<SourceData, (), T, StorageDiff>(
+            .compare_and_evolve_schema::<SourceData, (), Timestamp, StorageDiff>(
                 data_shard,
                 expected_schema,
                 &new_desc,
@@ -2206,7 +2120,7 @@ where
             // capability of the existing collection. This would cause runtime panics because it
             // would eventually result in negative read capabilities.
             let mut changes = ChangeBatch::new();
-            changes.extend(implied_capability.iter().map(|t| (t.clone(), 1)));
+            changes.extend(implied_capability.iter().map(|t| (*t, 1)));
 
             // Note: The new collection is now the "primary collection".
             let collection_meta = CollectionMetadata {
@@ -2271,7 +2185,7 @@ where
             // Unless the collection has a primary, its shard must have been previously removed
             // by `StorageCollections::prepare_state`.
             if collection.primary.is_none() {
-                let metadata = storage_metadata.get_collection_shard::<T>(id);
+                let metadata = storage_metadata.get_collection_shard(id);
                 mz_ore::soft_assert_or_log!(
                     matches!(metadata, Err(StorageError::IdentifierMissing(_))),
                     "dropping {id}, but drop was not synchronized with storage \
@@ -2289,7 +2203,7 @@ where
         self.synchronize_finalized_shards(storage_metadata);
     }
 
-    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
         let mut collections = self.collections.lock().expect("lock poisoned");
 
         if tracing::enabled!(tracing::Level::TRACE) {
@@ -2324,7 +2238,7 @@ where
     fn acquire_read_holds(
         &self,
         desired_holds: Vec<GlobalId>,
-    ) -> Result<Vec<ReadHold<Self::Timestamp>>, CollectionMissing> {
+    ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing> {
         if desired_holds.is_empty() {
             return Ok(vec![]);
         }
@@ -2352,7 +2266,7 @@ where
             .iter()
             .map(|(id, hold)| {
                 let mut changes = ChangeBatch::new();
-                changes.extend(hold.iter().map(|time| (time.clone(), 1)));
+                changes.extend(hold.iter().map(|time| (*time, 1)));
                 (*id, changes)
             })
             .collect::<BTreeMap<_, _>>();
@@ -2441,19 +2355,13 @@ where
 /// since is considered a write. Conversely, when in read-write mode, we acquire
 /// [SinceHandle].
 #[derive(Debug)]
-enum SinceHandleWrapper<T>
-where
-    T: TimelyTimestamp + Lattice + Codec64,
-{
-    Critical(SinceHandle<SourceData, (), T, StorageDiff>),
-    Leased(ReadHandle<SourceData, (), T, StorageDiff>),
+enum SinceHandleWrapper {
+    Critical(SinceHandle<SourceData, (), Timestamp, StorageDiff>),
+    Leased(ReadHandle<SourceData, (), Timestamp, StorageDiff>),
 }
 
-impl<T> SinceHandleWrapper<T>
-where
-    T: TimelyTimestamp + Lattice + Codec64 + TotalOrder + Sync,
-{
-    pub fn since(&self) -> &Antichain<T> {
+impl SinceHandleWrapper {
+    pub fn since(&self) -> &Antichain<Timestamp> {
         match self {
             Self::Critical(handle) => handle.since(),
             Self::Leased(handle) => handle.since(),
@@ -2476,8 +2384,8 @@ where
     pub async fn compare_and_downgrade_since(
         &mut self,
         expected: &PersistEpoch,
-        (opaque, since): (&PersistEpoch, &Antichain<T>),
-    ) -> Result<Antichain<T>, PersistEpoch> {
+        (opaque, since): (&PersistEpoch, &Antichain<Timestamp>),
+    ) -> Result<Antichain<Timestamp>, PersistEpoch> {
         match self {
             Self::Critical(handle) => handle
                 .compare_and_downgrade_since(
@@ -2499,8 +2407,8 @@ where
     pub async fn maybe_compare_and_downgrade_since(
         &mut self,
         expected: &PersistEpoch,
-        (opaque, since): (&PersistEpoch, &Antichain<T>),
-    ) -> Option<Result<Antichain<T>, PersistEpoch>> {
+        (opaque, since): (&PersistEpoch, &Antichain<Timestamp>),
+    ) -> Option<Result<Antichain<Timestamp>, PersistEpoch>> {
         match self {
             Self::Critical(handle) => handle
                 .maybe_compare_and_downgrade_since(
@@ -2522,8 +2430,8 @@ where
     pub fn snapshot_stats(
         &self,
         id: GlobalId,
-        as_of: Option<Antichain<T>>,
-    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError<T>>> {
+        as_of: Option<Antichain<Timestamp>>,
+    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError>> {
         match self {
             Self::Critical(handle) => {
                 let res = handle
@@ -2543,8 +2451,8 @@ where
     pub fn snapshot_stats_from_txn(
         &self,
         id: GlobalId,
-        data_snapshot: DataSnapshot<T>,
-    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError<T>>> {
+        data_snapshot: DataSnapshot<Timestamp>,
+    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError>> {
         match self {
             Self::Critical(handle) => Box::pin(
                 data_snapshot
@@ -2562,7 +2470,7 @@ where
 
 /// State maintained about individual collections.
 #[derive(Debug, Clone)]
-struct CollectionState<T> {
+struct CollectionState {
     /// The primary of this collections.
     ///
     /// Multiple storage collections can point to the same persist shard,
@@ -2581,39 +2489,39 @@ struct CollectionState<T> {
     /// This accumulation will always contain `self.implied_capability`, but may
     /// also contain capabilities held by others who have read dependencies on
     /// this collection.
-    pub read_capabilities: MutableAntichain<T>,
+    pub read_capabilities: MutableAntichain<Timestamp>,
 
     /// The implicit capability associated with collection creation.  This
     /// should never be less than the since of the associated persist
     /// collection.
-    pub implied_capability: Antichain<T>,
+    pub implied_capability: Antichain<Timestamp>,
 
     /// The policy to use to downgrade `self.implied_capability`.
-    pub read_policy: ReadPolicy<T>,
+    pub read_policy: ReadPolicy<Timestamp>,
 
     /// Storage identifiers on which this collection depends.
     pub storage_dependencies: Vec<GlobalId>,
 
     /// Reported write frontier.
-    pub write_frontier: Antichain<T>,
+    pub write_frontier: Antichain<Timestamp>,
 
     pub collection_metadata: CollectionMetadata,
 }
 
-impl<T: TimelyTimestamp> CollectionState<T> {
+impl CollectionState {
     /// Creates a new collection state, with an initial read policy valid from
     /// `since`.
     pub fn new(
         primary: Option<GlobalId>,
         time_dependence: Option<TimeDependence>,
         ingestion_remap_collection_id: Option<GlobalId>,
-        since: Antichain<T>,
-        write_frontier: Antichain<T>,
+        since: Antichain<Timestamp>,
+        write_frontier: Antichain<Timestamp>,
         storage_dependencies: Vec<GlobalId>,
         metadata: CollectionMetadata,
     ) -> Self {
         let mut read_capabilities = MutableAntichain::new();
-        read_capabilities.update_iter(since.iter().map(|time| (time.clone(), 1)));
+        read_capabilities.update_iter(since.iter().map(|time| (*time, 1)));
         Self {
             primary,
             time_dependence,
@@ -2641,56 +2549,47 @@ impl<T: TimelyTimestamp> CollectionState<T> {
 ///
 /// This shares state with [StorageCollectionsImpl] via `Arcs` and channels.
 #[derive(Debug)]
-struct BackgroundTask<T: TimelyTimestamp + Lattice + Codec64> {
+struct BackgroundTask {
     config: Arc<Mutex<StorageConfiguration>>,
-    cmds_tx: mpsc::UnboundedSender<BackgroundCmd<T>>,
-    cmds_rx: mpsc::UnboundedReceiver<BackgroundCmd<T>>,
-    holds_rx: mpsc::UnboundedReceiver<(GlobalId, ChangeBatch<T>)>,
+    cmds_tx: mpsc::UnboundedSender<BackgroundCmd>,
+    cmds_rx: mpsc::UnboundedReceiver<BackgroundCmd>,
+    holds_rx: mpsc::UnboundedReceiver<(GlobalId, ChangeBatch<Timestamp>)>,
     finalizable_shards: Arc<ShardIdSet>,
-    collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState<T>>>>,
+    collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState>>>,
     // So we know what shard ID corresponds to what global ID, which we need
     // when re-enqueing futures for determining the next upper update.
     shard_by_id: BTreeMap<GlobalId, ShardId>,
-    since_handles: BTreeMap<GlobalId, SinceHandleWrapper<T>>,
-    txns_handle: Option<WriteHandle<SourceData, (), T, StorageDiff>>,
+    since_handles: BTreeMap<GlobalId, SinceHandleWrapper>,
+    txns_handle: Option<WriteHandle<SourceData, (), Timestamp, StorageDiff>>,
     txns_shards: BTreeSet<GlobalId>,
 }
 
 #[derive(Debug)]
-enum BackgroundCmd<T: TimelyTimestamp + Lattice + Codec64> {
+enum BackgroundCmd {
     Register {
         id: GlobalId,
         is_in_txns: bool,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
-        since_handle: SinceHandleWrapper<T>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        since_handle: SinceHandleWrapper,
     },
-    DowngradeSince(Vec<(GlobalId, Antichain<T>)>),
+    DowngradeSince(Vec<(GlobalId, Antichain<Timestamp>)>),
     SnapshotStats(
         GlobalId,
-        SnapshotStatsAsOf<T>,
-        oneshot::Sender<SnapshotStatsRes<T>>,
+        SnapshotStatsAsOf,
+        oneshot::Sender<SnapshotStatsRes>,
     ),
 }
 
 /// A newtype wrapper to hang a Debug impl off of.
-pub(crate) struct SnapshotStatsRes<T>(BoxFuture<'static, Result<SnapshotStats, StorageError<T>>>);
+pub(crate) struct SnapshotStatsRes(BoxFuture<'static, Result<SnapshotStats, StorageError>>);
 
-impl<T> Debug for SnapshotStatsRes<T> {
+impl Debug for SnapshotStatsRes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SnapshotStatsRes").finish_non_exhaustive()
     }
 }
 
-impl<T> BackgroundTask<T>
-where
-    T: TimelyTimestamp
-        + Lattice
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + Into<mz_repr::Timestamp>
-        + Sync,
-{
+impl BackgroundTask {
     async fn run(&mut self) {
         // Futures that fetch the recent upper from all other shards.
         let mut upper_futures: FuturesUnordered<
@@ -2699,8 +2598,8 @@ where
                     dyn Future<
                             Output = (
                                 GlobalId,
-                                WriteHandle<SourceData, (), T, StorageDiff>,
-                                Antichain<T>,
+                                WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+                                Antichain<Timestamp>,
                             ),
                         > + Send,
                 >,
@@ -2708,7 +2607,7 @@ where
         > = FuturesUnordered::new();
 
         let gen_upper_future =
-            |id, mut handle: WriteHandle<_, _, _, _>, prev_upper: Antichain<T>| {
+            |id, mut handle: WriteHandle<_, _, _, _>, prev_upper: Antichain<Timestamp>| {
                 let fut = async move {
                     soft_assert_or_log!(
                         !prev_upper.is_empty(),
@@ -2827,7 +2726,7 @@ where
                                     Some(x) => {
                                         let fut: BoxFuture<
                                             'static,
-                                            Result<SnapshotStats, StorageError<T>>,
+                                            Result<SnapshotStats, StorageError>,
                                         > = match as_of {
                                             SnapshotStatsAsOf::Direct(as_of) => {
                                                 x.snapshot_stats(id, Some(as_of))
@@ -2890,7 +2789,7 @@ where
     }
 
     #[instrument(level = "debug")]
-    async fn update_write_frontiers(&self, updates: &[(GlobalId, &Antichain<T>)]) {
+    async fn update_write_frontiers(&self, updates: &[(GlobalId, &Antichain<Timestamp>)]) {
         let mut read_capability_changes = BTreeMap::default();
 
         let mut self_collections = self.collections.lock().expect("lock poisoned");
@@ -2925,9 +2824,9 @@ where
 
             if PartialOrder::less_equal(&collection.implied_capability, &new_read_capability) {
                 let mut update = ChangeBatch::new();
-                update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
+                update.extend(new_read_capability.iter().map(|time| (*time, 1)));
                 std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
-                update.extend(new_read_capability.iter().map(|time| (time.clone(), -1)));
+                update.extend(new_read_capability.iter().map(|time| (*time, -1)));
 
                 if !update.is_empty() {
                     read_capability_changes.insert(*id, update);
@@ -2944,7 +2843,7 @@ where
         }
     }
 
-    async fn downgrade_sinces(&mut self, cmds: BTreeMap<GlobalId, Antichain<T>>) {
+    async fn downgrade_sinces(&mut self, cmds: BTreeMap<GlobalId, Antichain<Timestamp>>) {
         // Process all persist calls concurrently.
         let mut futures = Vec::with_capacity(cmds.len());
         for (id, new_since) in cmds {
@@ -3042,7 +2941,7 @@ struct FinalizeShardsTaskConfig {
     read_only: bool,
 }
 
-async fn finalize_shards_task<T>(
+async fn finalize_shards_task(
     FinalizeShardsTaskConfig {
         envd_epoch,
         config,
@@ -3053,9 +2952,7 @@ async fn finalize_shards_task<T>(
         persist,
         read_only,
     }: FinalizeShardsTaskConfig,
-) where
-    T: TimelyTimestamp + TotalOrder + Lattice + Codec64 + Sync,
-{
+) {
     if read_only {
         info!("disabling shard finalization in read only mode");
         return;
@@ -3114,7 +3011,7 @@ async fn finalize_shards_task<T>(
                 metrics.finalization_started.inc();
 
                 let is_finalized = persist_client
-                    .is_finalized::<SourceData, (), T, StorageDiff>(shard_id, diagnostics)
+                    .is_finalized::<SourceData, (), Timestamp, StorageDiff>(shard_id, diagnostics)
                     .await
                     .expect("invalid persist usage");
 
@@ -3129,7 +3026,7 @@ async fn finalize_shards_task<T>(
 
                         // We only use the writer to advance the upper, so using a dummy schema is
                         // fine.
-                        let mut write_handle: WriteHandle<SourceData, (), T, StorageDiff> =
+                        let mut write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff> =
                             persist_client
                                 .open_writer(
                                     shard_id,
@@ -3144,16 +3041,20 @@ async fn finalize_shards_task<T>(
 
                         if force_downgrade_since {
                             let our_opaque = Opaque::encode(&epoch);
-                            let mut since_handle: SinceHandle<SourceData, (), T, StorageDiff> =
-                                persist_client
-                                    .open_critical_since(
-                                        shard_id,
-                                        PersistClient::CONTROLLER_CRITICAL_SINCE,
-                                        our_opaque.clone(),
-                                        Diagnostics::from_purpose("finalizing shards"),
-                                    )
-                                    .await
-                                    .expect("invalid persist usage");
+                            let mut since_handle: SinceHandle<
+                                SourceData,
+                                (),
+                                Timestamp,
+                                StorageDiff,
+                            > = persist_client
+                                .open_critical_since(
+                                    shard_id,
+                                    PersistClient::CONTROLLER_CRITICAL_SINCE,
+                                    our_opaque.clone(),
+                                    Diagnostics::from_purpose("finalizing shards"),
+                                )
+                                .await
+                                .expect("invalid persist usage");
                             let handle_opaque = since_handle.opaque().clone();
                             let opaque = if our_opaque.codec_name() == handle_opaque.codec_name()
                                 && epoch.0 > handle_opaque.decode::<PersistEpoch>().0
@@ -3182,7 +3083,7 @@ async fn finalize_shards_task<T>(
                         }
 
                         persist_client
-                            .finalize_shard::<SourceData, (), T, StorageDiff>(
+                            .finalize_shard::<SourceData, (), Timestamp, StorageDiff>(
                                 shard_id,
                                 Diagnostics::from_purpose("finalizing shards"),
                             )
@@ -3239,13 +3140,13 @@ async fn finalize_shards_task<T>(
 }
 
 #[derive(Debug)]
-pub(crate) enum SnapshotStatsAsOf<T: TimelyTimestamp + Lattice + Codec64> {
+pub(crate) enum SnapshotStatsAsOf {
     /// Stats for a shard with an "eager" upper (one that continually advances
     /// as time passes, even if no writes are coming in).
-    Direct(Antichain<T>),
+    Direct(Antichain<Timestamp>),
     /// Stats for a shard with a "lazy" upper (one that only physically advances
     /// in response to writes).
-    Txns(DataSnapshot<T>),
+    Txns(DataSnapshot<Timestamp>),
 }
 
 #[cfg(test)]
@@ -3389,11 +3290,11 @@ mod tests {
         drop(background_task);
     }
 
-    async fn snapshot_stats<T: TimelyTimestamp + Lattice + Codec64>(
-        cmds_tx: &mpsc::UnboundedSender<BackgroundCmd<T>>,
+    async fn snapshot_stats(
+        cmds_tx: &mpsc::UnboundedSender<BackgroundCmd>,
         id: GlobalId,
-        as_of: Antichain<T>,
-    ) -> Result<SnapshotStats, StorageError<T>> {
+        as_of: Antichain<Timestamp>,
+    ) -> Result<SnapshotStats, StorageError> {
         let (tx, rx) = oneshot::channel();
         cmds_tx
             .send(BackgroundCmd::SnapshotStats(
@@ -3407,11 +3308,11 @@ mod tests {
         res.await
     }
 
-    impl<T: TimelyTimestamp + Lattice + Codec64> BackgroundTask<T> {
+    impl BackgroundTask {
         fn new_for_test(
             _persist_location: PersistLocation,
             _persist_client: Arc<PersistClientCache>,
-        ) -> (mpsc::UnboundedSender<BackgroundCmd<T>>, Self) {
+        ) -> (mpsc::UnboundedSender<BackgroundCmd>, Self) {
             let (cmds_tx, cmds_rx) = mpsc::unbounded_channel();
             let (_holds_tx, holds_rx) = mpsc::unbounded_channel();
             let connection_context =

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -70,22 +70,20 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, bail};
 use chrono::{DateTime, Utc};
 use differential_dataflow::consolidation;
-use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
 use futures::stream::StreamExt;
 use futures::{Future, FutureExt};
 use mz_cluster_client::ReplicaId;
 use mz_dyncfg::ConfigSet;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::soft_panic_or_log;
 use mz_ore::task::AbortOnDropHandle;
 use mz_persist_client::batch::Added;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_types::Codec64;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::{ColumnName, Diff, GlobalId, Row, TimestampManipulation};
+use mz_repr::{ColumnName, Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::client::{AppendOnlyUpdate, Status, TimestamplessUpdate};
 use mz_storage_client::controller::{IntrospectionType, MonotonicAppender, StorageWriteOp};
 use mz_storage_client::healthcheck::{
@@ -105,7 +103,7 @@ use mz_storage_types::parameters::{
     STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT, StorageParameters,
 };
 use mz_storage_types::sources::SourceData;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info};
@@ -120,13 +118,13 @@ use crate::{
 const DEFAULT_TICK_MS: u64 = 1_000;
 
 /// A channel for sending writes to a differential collection.
-type DifferentialWriteChannel<T> =
-    mpsc::UnboundedSender<(StorageWriteOp, oneshot::Sender<Result<(), StorageError<T>>>)>;
+type DifferentialWriteChannel =
+    mpsc::UnboundedSender<(StorageWriteOp, oneshot::Sender<Result<(), StorageError>>)>;
 
 /// A channel for sending writes to an append-only collection.
-type AppendOnlyWriteChannel<T> = mpsc::UnboundedSender<(
+type AppendOnlyWriteChannel = mpsc::UnboundedSender<(
     Vec<AppendOnlyUpdate>,
-    oneshot::Sender<Result<(), StorageError<T>>>,
+    oneshot::Sender<Result<(), StorageError>>,
 )>;
 
 type WriteTask = AbortOnDropHandle<()>;
@@ -150,10 +148,7 @@ pub enum CollectionManagerKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct CollectionManager<T>
-where
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
-{
+pub struct CollectionManager {
     /// When a [`CollectionManager`] is in read-only mode it must not affect any
     /// changes to external state.
     read_only: bool,
@@ -164,14 +159,14 @@ where
     /// internal _desired_ collection. The `CollectionManager` continually makes
     /// sure that collection contents (in persist) match the desired state.
     differential_collections:
-        Arc<Mutex<BTreeMap<GlobalId, (DifferentialWriteChannel<T>, WriteTask, ShutdownSender)>>>,
+        Arc<Mutex<BTreeMap<GlobalId, (DifferentialWriteChannel, WriteTask, ShutdownSender)>>>,
 
     /// Collections that we only append to using blind-writes.
     ///
     /// Every write succeeds at _some_ timestamp, and we never check what the
     /// actual contents of the collection (in persist) are.
     append_only_collections:
-        Arc<Mutex<BTreeMap<GlobalId, (AppendOnlyWriteChannel<T>, WriteTask, ShutdownSender)>>>,
+        Arc<Mutex<BTreeMap<GlobalId, (AppendOnlyWriteChannel, WriteTask, ShutdownSender)>>>,
 
     /// Amount of time we'll wait before sending a batch of inserts to Persist, for user
     /// collections.
@@ -188,11 +183,8 @@ where
 ///   second. For this usecase:
 ///     - The `CollectionManager` handles contention by permitting and ignoring errors.
 ///     - Closed collections will not panic if they continue receiving these requests.
-impl<T> CollectionManager<T>
-where
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
-    pub(super) fn new(read_only: bool, now: NowFn) -> CollectionManager<T> {
+impl CollectionManager {
+    pub(super) fn new(read_only: bool, now: NowFn) -> CollectionManager {
         let batch_duration_ms: u64 = STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT
             .as_millis()
             .try_into()
@@ -224,13 +216,13 @@ where
     pub(super) fn register_differential_collection<R>(
         &self,
         id: GlobalId,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         read_handle_fn: R,
         force_writable: bool,
-        introspection_config: DifferentialIntrospectionConfig<T>,
+        introspection_config: DifferentialIntrospectionConfig,
     ) where
         R: FnMut() -> Pin<
-                Box<dyn Future<Output = ReadHandle<SourceData, (), T, StorageDiff>> + Send>,
+                Box<dyn Future<Output = ReadHandle<SourceData, (), Timestamp, StorageDiff>> + Send>,
             > + Send
             + Sync
             + 'static,
@@ -279,9 +271,9 @@ where
     pub(super) fn register_append_only_collection(
         &self,
         id: GlobalId,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         force_writable: bool,
-        introspection_config: Option<AppendOnlyIntrospectionConfig<T>>,
+        introspection_config: Option<AppendOnlyIntrospectionConfig>,
     ) {
         let mut guard = self
             .append_only_collections
@@ -363,7 +355,7 @@ where
     ///
     /// # Panics
     /// - If `id` does not belong to an append-only collections.
-    pub(super) fn append_only_write_sender(&self, id: GlobalId) -> AppendOnlyWriteChannel<T> {
+    pub(super) fn append_only_write_sender(&self, id: GlobalId) -> AppendOnlyWriteChannel {
         let collections = self.append_only_collections.lock().expect("poisoned");
         match collections.get(&id) {
             Some((tx, _, _)) => tx.clone(),
@@ -375,7 +367,7 @@ where
     ///
     /// # Panics
     /// - If `id` does not belong to a differential collections.
-    pub(super) fn differential_write_sender(&self, id: GlobalId) -> DifferentialWriteChannel<T> {
+    pub(super) fn differential_write_sender(&self, id: GlobalId) -> DifferentialWriteChannel {
         let collections = self.differential_collections.lock().expect("poisoned");
         match collections.get(&id) {
             Some((tx, _, _)) => tx.clone(),
@@ -445,7 +437,7 @@ where
     pub(super) fn monotonic_appender(
         &self,
         id: GlobalId,
-    ) -> Result<MonotonicAppender<T>, StorageError<T>> {
+    ) -> Result<MonotonicAppender, StorageError> {
         let guard = self
             .append_only_collections
             .lock()
@@ -468,14 +460,11 @@ where
     }
 }
 
-pub(crate) struct DifferentialIntrospectionConfig<T>
-where
-    T: Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
-    pub(crate) recent_upper: Antichain<T>,
+pub(crate) struct DifferentialIntrospectionConfig {
+    pub(crate) recent_upper: Antichain<Timestamp>,
     pub(crate) introspection_type: IntrospectionType,
-    pub(crate) storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-    pub(crate) collection_manager: collection_mgmt::CollectionManager<T>,
+    pub(crate) storage_collections: Arc<dyn StorageCollections + Send + Sync>,
+    pub(crate) collection_manager: collection_mgmt::CollectionManager,
     pub(crate) source_statistics: Arc<Mutex<statistics::SourceStatistics>>,
     pub(crate) sink_statistics:
         Arc<Mutex<BTreeMap<(GlobalId, Option<ReplicaId>), ControllerSinkStatistics>>>,
@@ -492,17 +481,17 @@ where
 /// NOTE: This implementation is a bit clunky, and could be optimized by not keeping
 /// all of desired in memory (see commend below). It is meant to showcase the
 /// general approach.
-struct DifferentialWriteTask<T, R>
+struct DifferentialWriteTask<R>
 where
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-    R: FnMut() -> Pin<Box<dyn Future<Output = ReadHandle<SourceData, (), T, StorageDiff>> + Send>>
-        + Send
+    R: FnMut() -> Pin<
+            Box<dyn Future<Output = ReadHandle<SourceData, (), Timestamp, StorageDiff>> + Send>,
+        > + Send
         + 'static,
 {
     /// The collection that we are writing to.
     id: GlobalId,
 
-    write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+    write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
 
     /// For getting a [`ReadHandle`] to sync our state to persist contents.
     read_handle_fn: R,
@@ -517,7 +506,7 @@ where
     upper_tick_interval: tokio::time::Interval,
 
     /// Receiver for write commands. These change our desired state.
-    cmd_rx: mpsc::UnboundedReceiver<(StorageWriteOp, oneshot::Sender<Result<(), StorageError<T>>>)>,
+    cmd_rx: mpsc::UnboundedReceiver<(StorageWriteOp, oneshot::Sender<Result<(), StorageError>>)>,
 
     /// We have to shut down when receiving from this.
     shutdown_rx: oneshot::Receiver<()>,
@@ -543,14 +532,14 @@ where
     /// realize when someone else writes to the shard, in which case we have to
     /// update our state of the world, that is update our `to_write` based on
     /// `desired` and the contents of the persist shard.
-    current_upper: T,
+    current_upper: Timestamp,
 }
 
-impl<T, R> DifferentialWriteTask<T, R>
+impl<R> DifferentialWriteTask<R>
 where
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-    R: FnMut() -> Pin<Box<dyn Future<Output = ReadHandle<SourceData, (), T, StorageDiff>> + Send>>
-        + Send
+    R: FnMut() -> Pin<
+            Box<dyn Future<Output = ReadHandle<SourceData, (), Timestamp, StorageDiff>> + Send>,
+        > + Send
         + Sync
         + 'static,
 {
@@ -558,18 +547,16 @@ where
     /// handles for interacting with it.
     fn spawn(
         id: GlobalId,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         read_handle_fn: R,
         read_only: bool,
         now: NowFn,
-        introspection_config: DifferentialIntrospectionConfig<T>,
-    ) -> (DifferentialWriteChannel<T>, WriteTask, ShutdownSender) {
+        introspection_config: DifferentialIntrospectionConfig,
+    ) -> (DifferentialWriteChannel, WriteTask, ShutdownSender) {
         let (tx, rx) = mpsc::unbounded_channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         let upper_tick_interval = tokio::time::interval(Duration::from_millis(DEFAULT_TICK_MS));
-
-        let current_upper = T::minimum();
 
         let task = Self {
             id,
@@ -582,7 +569,7 @@ where
             shutdown_rx,
             desired: Vec::new(),
             to_write: Vec::new(),
-            current_upper,
+            current_upper: Timestamp::MIN,
         };
 
         let handle = mz_ore::task::spawn(
@@ -615,7 +602,7 @@ where
     ///
     /// This might include consolidation, deleting older entries or seeding
     /// in-memory state of, say, scrapers, with current collection contents.
-    async fn prepare(&self, introspection_config: DifferentialIntrospectionConfig<T>) {
+    async fn prepare(&self, introspection_config: DifferentialIntrospectionConfig) {
         tracing::info!(%self.id, ?introspection_config.introspection_type, "preparing differential introspection collection for writes");
 
         match introspection_config.introspection_type {
@@ -752,7 +739,7 @@ where
     }
 
     async fn tick_upper(&mut self) -> ControlFlow<String> {
-        let now = T::from((self.now)());
+        let now = Timestamp::from((self.now)());
 
         if now <= self.current_upper {
             // Upper is already further along than current wall-clock time, no
@@ -765,8 +752,8 @@ where
             .write_handle
             .compare_and_append_batch(
                 &mut [],
-                Antichain::from_elem(self.current_upper.clone()),
-                Antichain::from_elem(now.clone()),
+                Antichain::from_elem(self.current_upper),
+                Antichain::from_elem(now),
                 true,
             )
             .await
@@ -783,7 +770,7 @@ where
                 // our `to_write`, based on what we learn and `desired`.
 
                 let actual_upper = if let Some(ts) = err.current.as_option() {
-                    ts.clone()
+                    *ts
                 } else {
                     return ControlFlow::Break("upper is the empty antichain".to_string());
                 };
@@ -820,7 +807,7 @@ where
 
     async fn handle_updates(
         &mut self,
-        batch: &mut Vec<(StorageWriteOp, oneshot::Sender<Result<(), StorageError<T>>>)>,
+        batch: &mut Vec<(StorageWriteOp, oneshot::Sender<Result<(), StorageError>>)>,
     ) -> ControlFlow<String> {
         // Put in place _some_ rate limiting.
         let batch_duration_ms = STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT;
@@ -888,7 +875,7 @@ where
     /// upper was not what we expected.
     async fn write_to_persist(
         &mut self,
-        responders: Vec<oneshot::Sender<Result<(), StorageError<T>>>>,
+        responders: Vec<oneshot::Sender<Result<(), StorageError>>>,
     ) -> ControlFlow<String> {
         if self.read_only {
             tracing::debug!(%self.id, "not writing to differential collection: read-only");
@@ -912,11 +899,8 @@ where
 
         loop {
             // Append updates to persist!
-            let now = T::from((self.now)());
-            let new_upper = std::cmp::max(
-                now,
-                TimestampManipulation::step_forward(&self.current_upper),
-            );
+            let now = Timestamp::from((self.now)());
+            let new_upper = std::cmp::max(now, self.current_upper.step_forward());
 
             let updates_to_write = self
                 .to_write
@@ -924,7 +908,7 @@ where
                 .map(|(row, diff)| {
                     (
                         (SourceData(Ok(row.clone())), ()),
-                        self.current_upper.clone(),
+                        self.current_upper,
                         diff.into_inner(),
                     )
                 })
@@ -935,8 +919,8 @@ where
                 .write_handle
                 .compare_and_append(
                     updates_to_write,
-                    Antichain::from_elem(self.current_upper.clone()),
-                    Antichain::from_elem(new_upper.clone()),
+                    Antichain::from_elem(self.current_upper),
+                    Antichain::from_elem(new_upper),
                 )
                 .await
                 .expect("valid usage");
@@ -963,7 +947,7 @@ where
                     // from persist and update to_write based on that and the
                     // desired state.
                     let actual_upper = if let Some(ts) = err.current.as_option() {
-                        ts.clone()
+                        *ts
                     } else {
                         return ControlFlow::Break("upper is the empty antichain".to_string());
                     };
@@ -1011,10 +995,7 @@ where
     /// match what we expected.
     async fn sync_to_persist(&mut self) {
         let mut read_handle = (self.read_handle_fn)().await;
-        let as_of = self
-            .current_upper
-            .step_back()
-            .unwrap_or_else(|| T::minimum());
+        let as_of = self.current_upper.step_back().unwrap_or(Timestamp::MIN);
         let as_of = Antichain::from_elem(as_of);
         let snapshot = read_handle.snapshot_and_fetch(as_of).await;
 
@@ -1037,34 +1018,28 @@ where
     }
 }
 
-pub(crate) struct AppendOnlyIntrospectionConfig<T>
-where
-    T: Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+pub(crate) struct AppendOnlyIntrospectionConfig {
     pub(crate) introspection_type: IntrospectionType,
     pub(crate) config_set: Arc<ConfigSet>,
     pub(crate) parameters: StorageParameters,
-    pub(crate) storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
+    pub(crate) storage_collections: Arc<dyn StorageCollections + Send + Sync>,
 }
 
 /// A task that writes to an append only collection and continuously bumps the upper for the specified
 /// collection.
 ///
 /// For status history collections, this task can deduplicate redundant [`Statuses`](Status).
-struct AppendOnlyWriteTask<T>
-where
-    T: Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+struct AppendOnlyWriteTask {
     /// The collection that we are writing to.
     id: GlobalId,
-    write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+    write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     read_only: bool,
     now: NowFn,
     user_batch_duration_ms: Arc<AtomicU64>,
     /// Receiver for write commands.
     rx: mpsc::UnboundedReceiver<(
         Vec<AppendOnlyUpdate>,
-        oneshot::Sender<Result<(), StorageError<T>>>,
+        oneshot::Sender<Result<(), StorageError>>,
     )>,
 
     /// We have to shut down when receiving from this.
@@ -1073,10 +1048,7 @@ where
     previous_statuses: Option<BTreeMap<(GlobalId, Option<ReplicaId>), Status>>,
 }
 
-impl<T> AppendOnlyWriteTask<T>
-where
-    T: Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+impl AppendOnlyWriteTask {
     /// Spawns an [`AppendOnlyWriteTask`] in an [`mz_ore::task`] that will continuously bump the
     /// upper for the specified collection,
     /// and append data that is sent via the provided [`mpsc::UnboundedSender`].
@@ -1086,12 +1058,12 @@ where
     /// TODO(parkmycar): Maybe add prometheus metrics for each collection?
     fn spawn(
         id: GlobalId,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         read_only: bool,
         now: NowFn,
         user_batch_duration_ms: Arc<AtomicU64>,
-        introspection_config: Option<AppendOnlyIntrospectionConfig<T>>,
-    ) -> (AppendOnlyWriteChannel<T>, WriteTask, ShutdownSender) {
+        introspection_config: Option<AppendOnlyIntrospectionConfig>,
+    ) -> (AppendOnlyWriteChannel, WriteTask, ShutdownSender) {
         let (tx, rx) = mpsc::unbounded_channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1157,7 +1129,7 @@ where
     /// writing to the given append only introspection collection.
     ///
     /// This might include consolidation or deleting older entries.
-    async fn prepare(&mut self, introspection_config: Option<AppendOnlyIntrospectionConfig<T>>) {
+    async fn prepare(&mut self, introspection_config: Option<AppendOnlyIntrospectionConfig>) {
         let Some(AppendOnlyIntrospectionConfig {
             introspection_type,
             config_set,
@@ -1404,7 +1376,7 @@ where
                     }
 
                     // Append updates to persist!
-                    let at_least = T::from((self.now)());
+                    let at_least = Timestamp::from((self.now)());
 
                     if !all_rows.is_empty() {
                         monotonic_append(&mut self.write_handle, all_rows, at_least).await;
@@ -1427,9 +1399,9 @@ where
                     }
 
                     // Update our collection.
-                    let now = T::from((self.now)());
+                    let now = Timestamp::from((self.now)());
                     let updates = vec![];
-                    let at_least = now.clone();
+                    let at_least = now;
 
                     // Failures don't matter when advancing collections' uppers. This might
                     // fail when a clusterd happens to be writing to this concurrently.
@@ -1488,17 +1460,14 @@ where
 /// # Panics
 ///
 /// Panics if `collection` is not a metrics history.
-async fn partially_truncate_metrics_history<T>(
+async fn partially_truncate_metrics_history(
     id: GlobalId,
     introspection_type: IntrospectionType,
-    write_handle: &mut WriteHandle<SourceData, (), T, StorageDiff>,
+    write_handle: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     config_set: Arc<ConfigSet>,
     now: NowFn,
-    storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-) -> Result<(), anyhow::Error>
-where
-    T: Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+    storage_collections: Arc<dyn StorageCollections + Send + Sync>,
+) -> Result<(), anyhow::Error> {
     let (keep_duration, occurred_at_col) = match introspection_type {
         IntrospectionType::ReplicaMetricsHistory => (
             REPLICA_METRICS_HISTORY_RETENTION_INTERVAL.get(&config_set),
@@ -1544,11 +1513,11 @@ where
     // right after the timestamp at which we got our snapshot. Otherwise,
     // it's possible for someone else to sneak in retractions or other
     // unexpected changes.
-    let old_upper_ts = upper_ts.clone();
-    let new_upper_ts = TimestampManipulation::step_forward(&old_upper_ts);
+    let old_upper_ts = *upper_ts;
+    let new_upper_ts = old_upper_ts.step_forward();
 
     // Produce retractions by inverting diffs of rows we want to delete.
-    let mut builder = write_handle.builder(Antichain::from_elem(old_upper_ts.clone()));
+    let mut builder = write_handle.builder(Antichain::from_elem(old_upper_ts));
     while let Some(chunk) = rows.next().await {
         for (data, _t, diff) in chunk {
             let Ok(row) = &data.0 else { continue };
@@ -1567,9 +1536,7 @@ where
         }
     }
 
-    let mut updates = builder
-        .finish(Antichain::from_elem(new_upper_ts.clone()))
-        .await?;
+    let mut updates = builder.finish(Antichain::from_elem(new_upper_ts)).await?;
     let mut batches = vec![&mut updates];
 
     write_handle
@@ -1593,22 +1560,21 @@ where
 /// cannot maintain a desired state for them.
 ///
 /// Returns a map with latest unpacked row per key.
-pub(crate) async fn partially_truncate_status_history<T, K>(
+pub(crate) async fn partially_truncate_status_history<K>(
     id: GlobalId,
     introspection_type: IntrospectionType,
-    write_handle: &mut WriteHandle<SourceData, (), T, StorageDiff>,
+    write_handle: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     status_history_desc: StatusHistoryDesc<K>,
     now: NowFn,
-    storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
+    storage_collections: &Arc<dyn StorageCollections + Send + Sync>,
 ) -> BTreeMap<K, Row>
 where
-    T: Codec64 + From<EpochMillis> + TimestampManipulation,
     K: Clone + Debug + Ord + Send + Sync,
 {
     let upper = write_handle.fetch_recent_upper().await.clone();
 
     let mut rows = match upper.as_option() {
-        Some(f) if f > &T::minimum() => {
+        Some(f) if f > &Timestamp::MIN => {
             let as_of = f.step_back().unwrap();
 
             storage_collections
@@ -1630,9 +1596,9 @@ where
     // it's possible for someone else to sneak in retractions or other
     // unexpected changes.
     let expected_upper = upper.into_option().expect("checked above");
-    let new_upper = TimestampManipulation::step_forward(&expected_upper);
+    let new_upper = expected_upper.step_forward();
 
-    let mut deletions = write_handle.builder(Antichain::from_elem(expected_upper.clone()));
+    let mut deletions = write_handle.builder(Antichain::from_elem(expected_upper));
 
     let mut handle_row = {
         let latest_row_per_key = &mut latest_row_per_key;
@@ -1723,7 +1689,7 @@ where
     }
 
     let mut updates = deletions
-        .finish(Antichain::from_elem(new_upper.clone()))
+        .finish(Antichain::from_elem(new_upper))
         .await
         .expect("expected valid usage");
     let mut batches = vec![&mut updates];
@@ -1732,7 +1698,7 @@ where
     let res = write_handle
         .compare_and_append_batch(
             batches.as_mut_slice(),
-            Antichain::from_elem(expected_upper.clone()),
+            Antichain::from_elem(expected_upper),
             Antichain::from_elem(new_upper),
             true,
         )
@@ -1764,10 +1730,10 @@ where
         .collect()
 }
 
-async fn monotonic_append<T: Timestamp + Lattice + Codec64 + TimestampManipulation>(
-    write_handle: &mut WriteHandle<SourceData, (), T, StorageDiff>,
+async fn monotonic_append(
+    write_handle: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     updates: Vec<TimestamplessUpdate>,
-    at_least: T,
+    at_least: Timestamp,
 ) {
     let mut expected_upper = write_handle.shared_upper();
     loop {
@@ -1782,21 +1748,12 @@ async fn monotonic_append<T: Timestamp + Lattice + Codec64 + TimestampManipulati
             .into_option()
             .expect("cannot append data to closed collection");
 
-        let lower = if upper.less_than(&at_least) {
-            at_least.clone()
-        } else {
-            upper.clone()
-        };
-
-        let new_upper = TimestampManipulation::step_forward(&lower);
+        let lower = std::cmp::max(upper, at_least);
+        let new_upper = lower.step_forward();
         let updates = updates
             .iter()
             .map(|TimestamplessUpdate { row, diff }| {
-                (
-                    (SourceData(Ok(row.clone())), ()),
-                    lower.clone(),
-                    diff.into_inner(),
-                )
+                ((SourceData(Ok(row.clone())), ()), lower, diff.into_inner())
             })
             .collect::<Vec<_>>();
         let res = write_handle

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -15,11 +15,10 @@ use mz_ore::cast::CastFrom;
 use mz_storage_client::client::StorageCommand;
 use mz_storage_client::metrics::HistoryMetrics;
 use mz_storage_types::parameters::StorageParameters;
-use timely::order::TotalOrder;
 
 /// A history of storage commands.
 #[derive(Debug)]
-pub(crate) struct CommandHistory<T> {
+pub(crate) struct CommandHistory {
     /// The number of commands at the last time we compacted the history.
     reduced_count: usize,
     /// The sequence of commands that should be applied.
@@ -27,12 +26,12 @@ pub(crate) struct CommandHistory<T> {
     /// This list may not be "compact" in that there can be commands that could be optimized or
     /// removed given the context of other commands, for example compaction commands that can be
     /// unified, or run commands that can be dropped due to allowed compaction.
-    commands: Vec<StorageCommand<T>>,
+    commands: Vec<StorageCommand>,
     /// Tracked metrics.
     metrics: HistoryMetrics,
 }
 
-impl<T: timely::progress::Timestamp + TotalOrder> CommandHistory<T> {
+impl CommandHistory {
     /// Constructs a new command history.
     pub fn new(metrics: HistoryMetrics) -> Self {
         metrics.reset();
@@ -45,14 +44,14 @@ impl<T: timely::progress::Timestamp + TotalOrder> CommandHistory<T> {
     }
 
     /// Returns an iterator over the contained storage commands.
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &StorageCommand<T>> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &StorageCommand> {
         self.commands.iter()
     }
 
     /// Adds a command to the history.
     ///
     /// This action will reduce the history every time it doubles.
-    pub fn push(&mut self, command: StorageCommand<T>) {
+    pub fn push(&mut self, command: StorageCommand) {
         self.commands.push(command);
 
         if self.commands.len() > 2 * self.reduced_count {
@@ -243,7 +242,7 @@ mod tests {
 
     use super::*;
 
-    fn history() -> CommandHistory<u64> {
+    fn history() -> CommandHistory {
         let registry = MetricsRegistry::new();
         let controller_metrics = ControllerMetrics::new(&registry);
         let metrics = StorageControllerMetrics::new(&registry, controller_metrics)
@@ -324,7 +323,7 @@ mod tests {
         }
     }
 
-    fn sink_description() -> StorageSinkDesc<CollectionMetadata, u64> {
+    fn sink_description() -> StorageSinkDesc<CollectionMetadata> {
         StorageSinkDesc {
             from: GlobalId::System(1),
             from_desc: RelationDesc::new(
@@ -370,7 +369,7 @@ mod tests {
             with_snapshot: Default::default(),
             version: Default::default(),
             envelope: SinkEnvelope::Upsert,
-            as_of: Antichain::from_elem(0),
+            as_of: Antichain::from_elem(0.into()),
             from_storage_metadata: CollectionMetadata {
                 persist_location: PersistLocation {
                     blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
@@ -438,9 +437,9 @@ mod tests {
                 id: GlobalId::User(1),
                 description: ingestion_description(1, [2], 3),
             })),
-            StorageCommand::AllowCompaction(GlobalId::User(1), Antichain::from_elem(1)),
-            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(2)),
-            StorageCommand::AllowCompaction(GlobalId::User(3), Antichain::from_elem(3)),
+            StorageCommand::AllowCompaction(GlobalId::User(1), Antichain::from_elem(1.into())),
+            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(2.into())),
+            StorageCommand::AllowCompaction(GlobalId::User(3), Antichain::from_elem(3.into())),
         ];
 
         for cmd in commands.clone() {
@@ -507,7 +506,7 @@ mod tests {
                 id: GlobalId::User(1),
                 description: sink_desc.clone(),
             })),
-            StorageCommand::AllowCompaction(GlobalId::User(1), Antichain::from_elem(42)),
+            StorageCommand::AllowCompaction(GlobalId::User(1), Antichain::from_elem(42.into())),
         ];
 
         for cmd in commands {
@@ -532,8 +531,8 @@ mod tests {
 
         let commands = [
             StorageCommand::AllowCompaction(GlobalId::User(1), Antichain::new()),
-            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(1)),
-            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(2)),
+            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(1.into())),
+            StorageCommand::AllowCompaction(GlobalId::User(2), Antichain::from_elem(2.into())),
         ];
 
         for cmd in commands {

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, atomic};
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
-use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::ReplicaId;
@@ -25,7 +24,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_ore::retry::{Retry, RetryState};
 use mz_ore::task::AbortOnDropHandle;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Timestamp};
 use mz_service::client::{GenericClient, Partitioned};
 use mz_service::params::GrpcClientParameters;
 use mz_service::transport;
@@ -35,8 +34,7 @@ use mz_storage_client::client::{
 use mz_storage_client::metrics::{InstanceMetrics, ReplicaMetrics};
 use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::{IngestionDescription, SourceConnection};
-use timely::order::TotalOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::select;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -54,13 +52,13 @@ use crate::history::CommandHistory;
 /// add more than one replica to instances that have storage objects installed, is illegal and will
 /// lead to panics.
 #[derive(Debug)]
-pub(crate) struct Instance<T> {
+pub(crate) struct Instance {
     /// The workload class of this instance.
     ///
     /// This is currently only used to annotate metrics.
     pub workload_class: Option<String>,
     /// The replicas connected to this storage instance.
-    replicas: BTreeMap<ReplicaId, Replica<T>>,
+    replicas: BTreeMap<ReplicaId, Replica>,
     /// The ingestions currently running on this instance.
     ///
     /// While this is derivable from `history` on demand, keeping a denormalized
@@ -77,7 +75,7 @@ pub(crate) struct Instance<T> {
     active_exports: BTreeMap<GlobalId, ActiveExport>,
     /// The command history, used to replay past commands when introducing new replicas or
     /// reconnecting to existing replicas.
-    history: CommandHistory<T>,
+    history: CommandHistory,
     /// Metrics tracked for this storage instance.
     metrics: InstanceMetrics,
     /// A function that returns the current time.
@@ -87,7 +85,7 @@ pub(crate) struct Instance<T> {
     /// Responses are tagged with the [`ReplicaId`] of the replica that sent the
     /// response. Responses that don't originate from a replica (e.g. a "paused"
     /// status update, when no replicas are connected) are tagged with `None`.
-    response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse<T>)>,
+    response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse)>,
 }
 
 #[derive(Debug)]
@@ -102,16 +100,13 @@ struct ActiveExport {
     active_replicas: BTreeSet<ReplicaId>,
 }
 
-impl<T> Instance<T>
-where
-    T: Timestamp + Lattice + TotalOrder + Sync,
-{
+impl Instance {
     /// Creates a new [`Instance`].
     pub fn new(
         workload_class: Option<String>,
         metrics: InstanceMetrics,
         now: NowFn,
-        instance_response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse<T>)>,
+        instance_response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse)>,
     ) -> Self {
         let history = CommandHistory::new(metrics.for_history());
 
@@ -328,7 +323,7 @@ where
     }
 
     /// Sends a command to this storage instance.
-    pub fn send(&mut self, command: StorageCommand<T>) {
+    pub fn send(&mut self, command: StorageCommand) {
         // Record the command so that new replicas can be brought up to speed.
         self.history.push(command.clone());
 
@@ -415,7 +410,7 @@ where
     ///
     /// This does _not_ send commands to replicas, we only record the export
     /// in state and potentially update scheduling decisions.
-    fn absorb_export(&mut self, export: RunSinkCommand<T>) {
+    fn absorb_export(&mut self, export: RunSinkCommand) {
         let existing_export_state = self.active_exports.get_mut(&export.id);
 
         if let Some(export_state) = existing_export_state {
@@ -628,7 +623,7 @@ where
     pub fn get_export_description(
         &self,
         id: &GlobalId,
-    ) -> Option<StorageSinkDesc<CollectionMetadata, T>> {
+    ) -> Option<StorageSinkDesc<CollectionMetadata>> {
         if !self.active_exports.contains_key(id) {
             return None;
         }
@@ -647,7 +642,7 @@ where
     }
 
     /// Updates internal state based on incoming compaction commands.
-    fn absorb_compaction(&mut self, id: GlobalId, frontier: Antichain<T>) {
+    fn absorb_compaction(&mut self, id: GlobalId, frontier: Antichain<Timestamp>) {
         tracing::debug!(?self.active_ingestions, ?id, ?frontier, "allow_compaction");
 
         if frontier.is_empty() {
@@ -658,7 +653,7 @@ where
     }
 
     /// Returns the replicas that are actively running the given object (ingestion or export).
-    fn active_replicas(&mut self, id: &GlobalId) -> Box<dyn Iterator<Item = &mut Replica<T>> + '_> {
+    fn active_replicas(&mut self, id: &GlobalId) -> Box<dyn Iterator<Item = &mut Replica> + '_> {
         if let Some(ingestion_id) = self.ingestion_exports.get(id) {
             match self.active_ingestions.get(ingestion_id) {
                 Some(ingestion) => Box::new(self.replicas.iter_mut().filter_map(
@@ -769,30 +764,27 @@ pub(super) struct ReplicaConfig {
 
 /// State maintained about individual replicas.
 #[derive(Debug)]
-pub struct Replica<T> {
+pub struct Replica {
     /// Replica configuration.
     config: ReplicaConfig,
     /// A sender for commands for the replica.
     ///
     /// If sending to this channel fails, the replica has failed and requires
     /// rehydration.
-    command_tx: mpsc::UnboundedSender<StorageCommand<T>>,
+    command_tx: mpsc::UnboundedSender<StorageCommand>,
     /// A handle to the task that aborts it when the replica is dropped.
     task: AbortOnDropHandle<()>,
     /// Flag reporting whether the replica connection has been established.
     connected: Arc<AtomicBool>,
 }
 
-impl<T> Replica<T>
-where
-    T: Timestamp + Lattice + Sync,
-{
+impl Replica {
     /// Creates a new [`Replica`].
     fn new(
         id: ReplicaId,
         config: ReplicaConfig,
         metrics: ReplicaMetrics,
-        response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse<T>)>,
+        response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse)>,
     ) -> Self {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let connected = Arc::new(AtomicBool::new(false));
@@ -819,7 +811,7 @@ where
     }
 
     /// Sends a command to the replica.
-    fn send(&self, command: StorageCommand<T>) {
+    fn send(&self, command: StorageCommand) {
         // Send failures ignored, we'll check for failed replicas separately.
         let _ = self.command_tx.send(command);
     }
@@ -836,11 +828,11 @@ where
     }
 }
 
-type StorageCtpClient<T> = transport::Client<StorageCommand<T>, StorageResponse<T>>;
-type ReplicaClient<T> = Partitioned<StorageCtpClient<T>, StorageCommand<T>, StorageResponse<T>>;
+type StorageCtpClient = transport::Client<StorageCommand, StorageResponse>;
+type ReplicaClient = Partitioned<StorageCtpClient, StorageCommand, StorageResponse>;
 
 /// A task handling communication with a replica.
-struct ReplicaTask<T> {
+struct ReplicaTask {
     /// The ID of the replica.
     replica_id: ReplicaId,
     /// Replica configuration.
@@ -850,15 +842,12 @@ struct ReplicaTask<T> {
     /// Flag to report successful replica connection.
     connected: Arc<AtomicBool>,
     /// A channel upon which commands intended for the replica are delivered.
-    command_rx: mpsc::UnboundedReceiver<StorageCommand<T>>,
+    command_rx: mpsc::UnboundedReceiver<StorageCommand>,
     /// A channel upon which responses from the replica are delivered.
-    response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse<T>)>,
+    response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse)>,
 }
 
-impl<T> ReplicaTask<T>
-where
-    T: Timestamp + Lattice + Sync,
-{
+impl ReplicaTask {
     /// Runs the replica task.
     async fn run(self) {
         let replica_id = self.replica_id;
@@ -875,7 +864,7 @@ where
     ///
     /// The connection is retried forever (with backoff) and this method returns only after
     /// a connection was successfully established.
-    async fn connect(&self) -> ReplicaClient<T> {
+    async fn connect(&self) -> ReplicaClient {
         let try_connect = async move |retry: RetryState| {
             let version = self.config.build_info.semver_version();
             let client_params = &self.config.grpc_client;
@@ -886,7 +875,7 @@ where
                 .http2_keep_alive_timeout
                 .unwrap_or(Duration::MAX);
 
-            let connect_result = StorageCtpClient::<T>::connect_partitioned(
+            let connect_result = StorageCtpClient::connect_partitioned(
                 self.config.location.ctl_addrs.clone(),
                 version,
                 connect_timeout,
@@ -930,7 +919,7 @@ where
     /// Returns (with an `Err`) if it encounters an error condition (e.g. the replica disconnects).
     /// If no error condition is encountered, the task runs until the controller disconnects from
     /// the command channel, or the task is dropped.
-    async fn run_message_loop(mut self, mut client: ReplicaClient<T>) -> Result<(), anyhow::Error> {
+    async fn run_message_loop(mut self, mut client: ReplicaClient) -> Result<(), anyhow::Error> {
         loop {
             select! {
                 // Command from controller to forward to replica.
@@ -966,7 +955,7 @@ where
     ///
     /// Most [`StorageCommand`]s are independent of the target replica, but some contain
     /// replica-specific fields that must be adjusted before sending.
-    fn specialize_command(&self, command: &mut StorageCommand<T>) {
+    fn specialize_command(&self, command: &mut StorageCommand) {
         if let StorageCommand::Hello { nonce } = command {
             *nonce = Uuid::new_v4();
         }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -12,7 +12,7 @@
 use std::any::Any;
 use std::collections::btree_map;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -37,7 +37,7 @@ use mz_controller_types::dyncfgs::{
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::{assert_none, halt, instrument, soft_panic_or_log};
 use mz_persist_client::batch::ProtoBatch;
@@ -48,10 +48,9 @@ use mz_persist_client::read::ReadHandle;
 use mz_persist_client::schema::CaESchema;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
-use mz_persist_types::Codec64;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row, TimestampManipulation};
+use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row, Timestamp};
 use mz_storage_client::client::{
     AppendOnlyUpdate, RunIngestionCommand, RunOneshotIngestion, RunSinkCommand, Status,
     StatusUpdate, StorageCommand, StorageResponse, TableData,
@@ -89,10 +88,9 @@ use mz_storage_types::{AlterCompatible, StorageDiff, dyncfgs};
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::TxnsRead;
 use mz_txn_wal::txns::TxnsHandle;
-use timely::order::{PartialOrder, TotalOrder};
-use timely::progress::Timestamp as TimelyTimestamp;
+use timely::order::PartialOrder;
 use timely::progress::frontier::MutableAntichain;
-use timely::progress::{Antichain, ChangeBatch, Timestamp};
+use timely::progress::{Antichain, ChangeBatch};
 use tokio::sync::watch::{Sender, channel};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::MissedTickBehavior;
@@ -128,8 +126,7 @@ impl PendingOneshotIngestion {
 /// A storage controller for a storage instance.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation>
-{
+pub struct Controller {
     /// The build information for this process.
     build_info: &'static BuildInfo,
     /// A function that returns the current time.
@@ -146,7 +143,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     ///
     /// This collection only grows, although individual collections may be rendered unusable.
     /// This is to prevent the re-binding of identifiers to other descriptions.
-    pub(crate) collections: BTreeMap<GlobalId, CollectionState<T>>,
+    pub(crate) collections: BTreeMap<GlobalId, CollectionState>,
 
     /// Map from IDs of objects that have been dropped to replicas we are still
     /// expecting DroppedId messages from. This is cleared out once all replicas
@@ -159,11 +156,11 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     dropped_objects: BTreeMap<GlobalId, BTreeSet<ReplicaId>>,
 
     /// Write handle for table shards.
-    pub(crate) persist_table_worker: persist_handles::PersistTableWriteWorker<T>,
+    pub(crate) persist_table_worker: persist_handles::PersistTableWriteWorker,
     /// A shared TxnsCache running in a task and communicated with over a channel.
-    txns_read: TxnsRead<T>,
+    txns_read: TxnsRead<Timestamp>,
     txns_metrics: Arc<TxnMetrics>,
-    stashed_responses: Vec<(Option<ReplicaId>, StorageResponse<T>)>,
+    stashed_responses: Vec<(Option<ReplicaId>, StorageResponse)>,
     /// Channel for sending table handle drops.
     #[derivative(Debug = "ignore")]
     pending_table_handle_drops_tx: mpsc::UnboundedSender<GlobalId>,
@@ -175,7 +172,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     pending_oneshot_ingestions: BTreeMap<uuid::Uuid, PendingOneshotIngestion>,
 
     /// Interface for managed collections
-    pub(crate) collection_manager: collection_mgmt::CollectionManager<T>,
+    pub(crate) collection_manager: collection_mgmt::CollectionManager,
 
     /// Tracks which collection is responsible for which [`IntrospectionType`].
     pub(crate) introspection_ids: BTreeMap<IntrospectionType, GlobalId>,
@@ -197,7 +194,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     statistics_interval_sender: Sender<Duration>,
 
     /// Clients for all known storage instances.
-    instances: BTreeMap<StorageInstanceId, Instance<T>>,
+    instances: BTreeMap<StorageInstanceId, Instance>,
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
     /// Storage configuration to apply to newly provisioned instances, and use during purification.
@@ -210,19 +207,19 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     metrics: StorageControllerMetrics,
     /// `(read, write)` frontiers that have been recorded in the `Frontiers` collection, kept to be
     /// able to retract old rows.
-    recorded_frontiers: BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)>,
+    recorded_frontiers: BTreeMap<GlobalId, (Antichain<Timestamp>, Antichain<Timestamp>)>,
     /// Write frontiers that have been recorded in the `ReplicaFrontiers` collection, kept to be
     /// able to retract old rows.
-    recorded_replica_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<T>>,
+    recorded_replica_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<Timestamp>>,
 
     /// A function that computes the lag between the given time and wallclock time.
     #[derivative(Debug = "ignore")]
-    wallclock_lag: WallclockLagFn<T>,
+    wallclock_lag: WallclockLagFn<Timestamp>,
     /// The last time wallclock lag introspection was recorded.
     wallclock_lag_last_recorded: DateTime<Utc>,
 
     /// Handle to a [StorageCollections].
-    storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
+    storage_collections: Arc<dyn StorageCollections + Send + Sync>,
     /// Migrated storage collections that can be written even in read only mode.
     migrated_storage_collections: BTreeSet<GlobalId>,
 
@@ -232,9 +229,9 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     maintenance_scheduled: bool,
 
     /// Shared transmit channel for replicas to send responses.
-    instance_response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse<T>)>,
+    instance_response_tx: mpsc::UnboundedSender<(Option<ReplicaId>, StorageResponse)>,
     /// Receive end for replica responses.
-    instance_response_rx: mpsc::UnboundedReceiver<(Option<ReplicaId>, StorageResponse<T>)>,
+    instance_response_rx: mpsc::UnboundedReceiver<(Option<ReplicaId>, StorageResponse)>,
 
     /// Background task run at startup to warm persist state.
     persist_warm_task: Option<AbortOnDropHandle<Box<dyn Debug + Send>>>,
@@ -276,19 +273,7 @@ fn warm_persist_state_in_background(
 }
 
 #[async_trait(?Send)]
-impl<T> StorageController for Controller<T>
-where
-    T: Timestamp
-        + Lattice
-        + TotalOrder
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + Into<Datum<'static>>
-        + Display,
-{
-    type Timestamp = T;
-
+impl StorageController for Controller {
     fn initialization_complete(&mut self) {
         self.reconcile_dangling_statistics();
         self.initialized = true;
@@ -329,10 +314,7 @@ where
         self.storage_collections.collection_metadata(id)
     }
 
-    fn collection_hydrated(
-        &self,
-        collection_id: GlobalId,
-    ) -> Result<bool, StorageError<Self::Timestamp>> {
+    fn collection_hydrated(&self, collection_id: GlobalId) -> Result<bool, StorageError> {
         let collection = self.collection(collection_id)?;
 
         let instance_id = match &collection.data_source {
@@ -390,7 +372,7 @@ where
         target_replica_ids: Option<Vec<ReplicaId>>,
         target_cluster_id: &StorageInstanceId,
         exclude_collections: &BTreeSet<GlobalId>,
-    ) -> Result<bool, StorageError<Self::Timestamp>> {
+    ) -> Result<bool, StorageError> {
         // If an empty set of replicas is provided there can be
         // no collections on them, we'll count this as hydrated.
         if target_replica_ids.as_ref().is_some_and(|v| v.is_empty()) {
@@ -448,7 +430,7 @@ where
     fn collection_frontiers(
         &self,
         id: GlobalId,
-    ) -> Result<(Antichain<Self::Timestamp>, Antichain<Self::Timestamp>), CollectionMissing> {
+    ) -> Result<(Antichain<Timestamp>, Antichain<Timestamp>), CollectionMissing> {
         let frontiers = self.storage_collections.collection_frontiers(id)?;
         Ok((frontiers.implied_capability, frontiers.write_frontier))
     }
@@ -456,7 +438,8 @@ where
     fn collections_frontiers(
         &self,
         mut ids: Vec<GlobalId>,
-    ) -> Result<Vec<(GlobalId, Antichain<T>, Antichain<T>)>, CollectionMissing> {
+    ) -> Result<Vec<(GlobalId, Antichain<Timestamp>, Antichain<Timestamp>)>, CollectionMissing>
+    {
         let mut result = vec![];
         // In theory, we could pull all our frontiers from storage collections...
         // but in practice those frontiers may not be identical. For historical reasons, we use the
@@ -520,7 +503,7 @@ where
         Box::new(active_exports)
     }
 
-    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError<Self::Timestamp>> {
+    fn check_exists(&self, id: GlobalId) -> Result<(), StorageError> {
         self.storage_collections.check_exists(id)
     }
 
@@ -674,7 +657,7 @@ where
         &mut self,
         storage_metadata: &StorageMetadata,
         collections: Vec<(GlobalId, RelationDesc)>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let persist_client = self
             .persist
             .open(self.persist_location.clone())
@@ -688,7 +671,7 @@ where
                 handle_purpose: "evolve nullability for bootstrap".to_string(),
             };
             let latest_schema = persist_client
-                .latest_schema::<SourceData, (), T, StorageDiff>(shard_id, diagnostics)
+                .latest_schema::<SourceData, (), Timestamp, StorageDiff>(shard_id, diagnostics)
                 .await
                 .expect("invalid persist usage");
             let Some((schema_id, current_schema, _)) = latest_schema else {
@@ -702,7 +685,7 @@ where
                 handle_purpose: "evolve nullability for bootstrap".to_string(),
             };
             let evolve_result = persist_client
-                .compare_and_evolve_schema::<SourceData, (), T, StorageDiff>(
+                .compare_and_evolve_schema::<SourceData, (), Timestamp, StorageDiff>(
                     shard_id,
                     schema_id,
                     &relation_desc,
@@ -759,17 +742,17 @@ where
     async fn create_collections_for_bootstrap(
         &mut self,
         storage_metadata: &StorageMetadata,
-        register_ts: Option<Self::Timestamp>,
-        mut collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+        register_ts: Option<Timestamp>,
+        mut collections: Vec<(GlobalId, CollectionDescription)>,
         migrated_storage_collections: &BTreeSet<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         self.migrated_storage_collections
             .extend(migrated_storage_collections.iter().cloned());
 
         self.storage_collections
             .create_collections_for_bootstrap(
                 storage_metadata,
-                register_ts.clone(),
+                register_ts,
                 collections.clone(),
                 migrated_storage_collections,
             )
@@ -795,7 +778,7 @@ where
         let enriched_with_metadata = collections
             .into_iter()
             .map(|(id, description)| {
-                let data_shard = storage_metadata.get_collection_shard::<T>(id)?;
+                let data_shard = storage_metadata.get_collection_shard(id)?;
 
                 // If the shard is being managed by txn-wal (initially, tables), then we need to
                 // pass along the shard id for the txns shard to dataflow rendering.
@@ -828,7 +811,7 @@ where
         use futures::stream::{StreamExt, TryStreamExt};
         let this = &*self;
         let mut to_register: Vec<_> = futures::stream::iter(enriched_with_metadata)
-            .map(|data: Result<_, StorageError<Self::Timestamp>>| {
+            .map(|data: Result<_, StorageError>| {
                 async move {
                     let (id, description, metadata) = data?;
 
@@ -845,7 +828,7 @@ where
                         )
                         .await;
 
-                    Ok::<_, StorageError<T>>((id, description, write, metadata))
+                    Ok::<_, StorageError>((id, description, write, metadata))
                 }
             })
             // Poll each future for each collection concurrently, maximum of 50 at a time.
@@ -915,7 +898,7 @@ where
                 .acquire_read_holds(storage_dependencies)
                 .expect("can acquire read holds");
 
-            let mut dependency_since = Antichain::from_elem(T::minimum());
+            let mut dependency_since = Antichain::from_elem(Timestamp::MIN);
             for read_hold in dependency_read_holds.iter() {
                 dependency_since.join_assign(read_hold.since());
             }
@@ -968,7 +951,7 @@ where
                 // more updates.
                 if description.primary.is_none() {
                     mz_ore::soft_assert_or_log!(
-                        write_frontier.elements() == &[T::minimum()]
+                        write_frontier.elements() == &[Timestamp::MIN]
                             || write_frontier.is_empty()
                             || PartialOrder::less_than(&dependency_since, write_frontier),
                         "dependency since has advanced past dependent ({id}) upper \n
@@ -1064,7 +1047,7 @@ where
                         read_capabilities: MutableAntichain::from(dependency_since.clone()),
                         dependency_read_holds,
                         derived_since: dependency_since,
-                        write_frontier: Antichain::from_elem(Self::Timestamp::minimum()),
+                        write_frontier: Antichain::from_elem(Timestamp::MIN),
                         hold_policy: ReadPolicy::step_back(),
                         instance_id,
                         hydrated_on: BTreeSet::new(),
@@ -1092,7 +1075,7 @@ where
                         "not registering {id} with a controller persist worker",
                     );
 
-                    let mut dependency_since = Antichain::from_elem(T::minimum());
+                    let mut dependency_since = Antichain::from_elem(Timestamp::MIN);
                     for read_hold in dependency_read_holds.iter() {
                         dependency_since.join_assign(read_hold.since());
                     }
@@ -1101,7 +1084,7 @@ where
                         read_capabilities: MutableAntichain::from(dependency_since.clone()),
                         dependency_read_holds,
                         derived_since: dependency_since,
-                        write_frontier: Antichain::from_elem(Self::Timestamp::minimum()),
+                        write_frontier: Antichain::from_elem(Timestamp::MIN),
                         hold_policy: ReadPolicy::step_back(),
                         instance_id: ingestion_desc.instance_id,
                         hydrated_on: BTreeSet::new(),
@@ -1111,7 +1094,7 @@ where
                     maybe_instance_id = Some(ingestion_desc.instance_id);
                 }
                 DataSource::Sink { desc } => {
-                    let mut dependency_since = Antichain::from_elem(T::minimum());
+                    let mut dependency_since = Antichain::from_elem(Timestamp::MIN);
                     for read_hold in dependency_read_holds.iter() {
                         dependency_since.join_assign(read_hold.since());
                     }
@@ -1218,7 +1201,7 @@ where
         &mut self,
         ingestion_id: GlobalId,
         source_desc: &SourceDesc,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let source_collection = self.collection(ingestion_id)?;
         let data_source = &source_collection.data_source;
         match &data_source {
@@ -1242,7 +1225,7 @@ where
     async fn alter_ingestion_source_desc(
         &mut self,
         ingestion_ids: BTreeMap<GlobalId, SourceDesc>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let mut ingestions_to_run = BTreeSet::new();
 
         for (id, new_desc) in ingestion_ids {
@@ -1279,7 +1262,7 @@ where
     async fn alter_ingestion_connections(
         &mut self,
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let mut ingestions_to_run = BTreeSet::new();
 
         for (id, conn) in source_connections {
@@ -1319,7 +1302,7 @@ where
     async fn alter_ingestion_export_data_configs(
         &mut self,
         source_exports: BTreeMap<GlobalId, SourceExportDataConfig>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let mut ingestions_to_run = BTreeSet::new();
 
         for (source_export_id, new_data_config) in source_exports {
@@ -1391,8 +1374,8 @@ where
         new_collection: GlobalId,
         new_desc: RelationDesc,
         expected_version: RelationVersion,
-        register_ts: Self::Timestamp,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+        register_ts: Timestamp,
+    ) -> Result<(), StorageError> {
         let data_shard = {
             let Controller {
                 collections,
@@ -1464,10 +1447,7 @@ where
         Ok(())
     }
 
-    fn export(
-        &self,
-        id: GlobalId,
-    ) -> Result<&ExportState<Self::Timestamp>, StorageError<Self::Timestamp>> {
+    fn export(&self, id: GlobalId) -> Result<&ExportState, StorageError> {
         self.collections
             .get(&id)
             .and_then(|c| match &c.extra_state {
@@ -1477,10 +1457,7 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
-    fn export_mut(
-        &mut self,
-        id: GlobalId,
-    ) -> Result<&mut ExportState<Self::Timestamp>, StorageError<Self::Timestamp>> {
+    fn export_mut(&mut self, id: GlobalId) -> Result<&mut ExportState, StorageError> {
         self.collections
             .get_mut(&id)
             .and_then(|c| match &mut c.extra_state {
@@ -1498,7 +1475,7 @@ where
         instance_id: StorageInstanceId,
         request: OneshotIngestionRequest,
         result_tx: OneshotResultCallback<ProtoBatch>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let collection_meta = self
             .collections
             .get(&collection_id)
@@ -1532,10 +1509,7 @@ where
         }
     }
 
-    fn cancel_oneshot_ingestion(
-        &mut self,
-        ingestion_id: uuid::Uuid,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    fn cancel_oneshot_ingestion(&mut self, ingestion_id: uuid::Uuid) -> Result<(), StorageError> {
         if self.read_only {
             return Err(StorageError::ReadOnly);
         }
@@ -1569,8 +1543,8 @@ where
     async fn alter_export(
         &mut self,
         id: GlobalId,
-        new_description: ExportDescription<Self::Timestamp>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+        new_description: ExportDescription,
+    ) -> Result<(), StorageError> {
         let from_id = new_description.sink.from;
 
         // Acquire read holds at StorageCollections to ensure that the
@@ -1647,9 +1621,9 @@ where
     async fn alter_export_connections(
         &mut self,
         exports: BTreeMap<GlobalId, StorageSinkConnection>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         let mut updates_by_instance =
-            BTreeMap::<StorageInstanceId, Vec<(RunSinkCommand<T>, ExportDescription<T>)>>::new();
+            BTreeMap::<StorageInstanceId, Vec<(RunSinkCommand, ExportDescription)>>::new();
 
         for (id, connection) in exports {
             // We stage changes in new_export_description and then apply all
@@ -1659,7 +1633,7 @@ where
             // update that because `ExportState` is not clone, because it holds
             // a `ReadHandle` and cloning that would cause additional work for
             // whoever guarantees those read holds.
-            let (mut new_export_description, as_of): (ExportDescription<Self::Timestamp>, _) = {
+            let (mut new_export_description, as_of): (ExportDescription, _) = {
                 let export = &self.collections[&id];
                 let DataSource::Sink { desc } = &export.data_source else {
                     panic!("export exists")
@@ -1773,8 +1747,8 @@ where
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-        ts: Self::Timestamp,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+        ts: Timestamp,
+    ) -> Result<(), StorageError> {
         // Collect tables by their data_source
         let (table_write_ids, data_source_ids): (Vec<_>, Vec<_>) = identifiers
             .into_iter()
@@ -1811,7 +1785,7 @@ where
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         self.validate_collection_ids(identifiers.iter().cloned())?;
         self.drop_sources_unvalidated(storage_metadata, identifiers)
     }
@@ -1820,7 +1794,7 @@ where
         &mut self,
         storage_metadata: &StorageMetadata,
         ids: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         // Keep track of which ingestions we have to execute still, and which we
         // have to change because of dropped subsources.
         let mut ingestions_to_execute = BTreeSet::new();
@@ -2017,7 +1991,7 @@ where
         &mut self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError<Self::Timestamp>> {
+    ) -> Result<(), StorageError> {
         self.validate_export_ids(identifiers.iter().cloned())?;
         self.drop_sinks_unvalidated(storage_metadata, identifiers);
         Ok(())
@@ -2107,13 +2081,10 @@ where
     #[instrument(level = "debug")]
     fn append_table(
         &mut self,
-        write_ts: Self::Timestamp,
-        advance_to: Self::Timestamp,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
-    ) -> Result<
-        tokio::sync::oneshot::Receiver<Result<(), StorageError<Self::Timestamp>>>,
-        StorageError<Self::Timestamp>,
-    > {
+    ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError> {
         if self.read_only {
             // While in read only mode, ONLY collections that have been migrated
             // and need to be re-hydrated in read only mode can be written to.
@@ -2139,17 +2110,11 @@ where
             .append(write_ts, advance_to, commands))
     }
 
-    fn monotonic_appender(
-        &self,
-        id: GlobalId,
-    ) -> Result<MonotonicAppender<Self::Timestamp>, StorageError<Self::Timestamp>> {
+    fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError> {
         self.collection_manager.monotonic_appender(id)
     }
 
-    fn webhook_statistics(
-        &self,
-        id: GlobalId,
-    ) -> Result<Arc<WebhookStatistics>, StorageError<Self::Timestamp>> {
+    fn webhook_statistics(&self, id: GlobalId) -> Result<Arc<WebhookStatistics>, StorageError> {
         // Call to this method are usually cached so the lock is not in the critical path.
         let source_statistics = self.source_statistics.lock().expect("poisoned");
         source_statistics
@@ -2185,7 +2150,7 @@ where
     fn process(
         &mut self,
         storage_metadata: &StorageMetadata,
-    ) -> Result<Option<Response<T>>, anyhow::Error> {
+    ) -> Result<Option<Response>, anyhow::Error> {
         // Perform periodic maintenance work.
         if self.maintenance_scheduled {
             self.maintain();
@@ -2452,7 +2417,7 @@ where
             .open(collection.persist_location.clone())
             .await?;
         let shard_state = client
-            .inspect_shard::<Self::Timestamp>(&collection.data_shard)
+            .inspect_shard::<Timestamp>(&collection.data_shard)
             .await?;
         let json_state = serde_json::to_value(shard_state)?;
         Ok(json_state)
@@ -2490,7 +2455,7 @@ where
         type_: IntrospectionType,
     ) -> mpsc::UnboundedSender<(
         Vec<AppendOnlyUpdate>,
-        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
+        oneshot::Sender<Result<(), StorageError>>,
     )> {
         let id = self.introspection_ids[&type_];
         self.collection_manager.append_only_write_sender(id)
@@ -2499,10 +2464,7 @@ where
     fn differential_introspection_tx(
         &self,
         type_: IntrospectionType,
-    ) -> mpsc::UnboundedSender<(
-        StorageWriteOp,
-        oneshot::Sender<Result<(), StorageError<Self::Timestamp>>>,
-    )> {
+    ) -> mpsc::UnboundedSender<(StorageWriteOp, oneshot::Sender<Result<(), StorageError>>)> {
         let id = self.introspection_ids[&type_];
         self.collection_manager.differential_write_sender(id)
     }
@@ -2511,10 +2473,7 @@ where
         &self,
         timestamp_objects: BTreeSet<GlobalId>,
         timeout: Duration,
-    ) -> Result<
-        BoxFuture<Result<Self::Timestamp, StorageError<Self::Timestamp>>>,
-        StorageError<Self::Timestamp>,
-    > {
+    ) -> Result<BoxFuture<Result<Timestamp, StorageError>>, StorageError> {
         use mz_storage_types::sources::GenericSourceConnection;
 
         let mut rtr_futures = BTreeMap::new();
@@ -2618,10 +2577,10 @@ where
             let (ids, futs): (Vec<_>, Vec<_>) = rtr_futures.into_iter().unzip();
             ids.into_iter()
                 .zip_eq(futures::future::join_all(futs).await)
-                .try_fold(T::minimum(), |curr, (id, per_source_res)| {
+                .try_fold(Timestamp::MIN, |curr, (id, per_source_res)| {
                     let new =
                         per_source_res.map_err(|_e: Elapsed| StorageError::RtrTimeout(id))??;
-                    Ok::<_, StorageError<Self::Timestamp>>(std::cmp::max(curr, new))
+                    Ok::<_, StorageError>(std::cmp::max(curr, new))
                 })
         }))
     }
@@ -2727,7 +2686,7 @@ where
 /// This cannot be a member of [`StorageController`] because it cannot take a
 /// `self` parameter.
 ///
-pub fn prepare_initialization<T>(txn: &mut dyn StorageTxn<T>) -> Result<(), StorageError<T>> {
+pub fn prepare_initialization(txn: &mut dyn StorageTxn) -> Result<(), StorageError> {
     if txn.get_txn_wal_shard().is_none() {
         let txns_id = ShardId::new();
         txn.write_txn_wal_shard(txns_id)?;
@@ -2736,16 +2695,9 @@ pub fn prepare_initialization<T>(txn: &mut dyn StorageTxn<T>) -> Result<(), Stor
     Ok(())
 }
 
-impl<T> Controller<T>
+impl Controller
 where
-    T: Timestamp
-        + Lattice
-        + TotalOrder
-        + Codec64
-        + From<EpochMillis>
-        + TimestampManipulation
-        + Into<Datum<'static>>,
-    Self: StorageController<Timestamp = T>,
+    Self: StorageController,
 {
     /// Create a new storage controller from a client it should wrap.
     ///
@@ -2759,14 +2711,14 @@ where
         persist_location: PersistLocation,
         persist_clients: Arc<PersistClientCache>,
         now: NowFn,
-        wallclock_lag: WallclockLagFn<T>,
+        wallclock_lag: WallclockLagFn<Timestamp>,
         txns_metrics: Arc<TxnMetrics>,
         read_only: bool,
         metrics_registry: &MetricsRegistry,
         controller_metrics: ControllerMetrics,
         connection_context: ConnectionContext,
-        txn: &dyn StorageTxn<T>,
-        storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
+        txn: &dyn StorageTxn,
+        storage_collections: Arc<dyn StorageCollections + Send + Sync>,
     ) -> Self {
         let txns_client = persist_clients
             .open(persist_location.clone())
@@ -2802,7 +2754,7 @@ where
             persist_handles::PersistTableWriteWorker::new_read_only_mode(txns_write)
         } else {
             let mut txns = TxnsHandle::open(
-                T::minimum(),
+                Timestamp::MIN,
                 txns_client.clone(),
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
@@ -2885,7 +2837,7 @@ where
     // This is really only used when dropping things, where we set the
     // ReadPolicy to the empty Antichain.
     #[instrument(level = "debug")]
-    fn set_hold_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy<T>)>) {
+    fn set_hold_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
         let mut read_capability_changes = BTreeMap::default();
 
         for (id, policy) in policies.into_iter() {
@@ -2923,7 +2875,7 @@ where
     }
 
     #[instrument(level = "debug", fields(updates))]
-    fn update_write_frontier(&mut self, id: GlobalId, new_upper: &Antichain<T>) {
+    fn update_write_frontier(&mut self, id: GlobalId, new_upper: &Antichain<Timestamp>) {
         let mut read_capability_changes = BTreeMap::default();
 
         if let Some(collection) = self.collections.get_mut(&id) {
@@ -2977,7 +2929,10 @@ where
     // This method is for maintaining the read holds that the controller has at
     // the StorageCollections, for storage dependencies.
     #[instrument(level = "debug", fields(updates))]
-    fn update_hold_capabilities(&mut self, updates: &mut BTreeMap<GlobalId, ChangeBatch<T>>) {
+    fn update_hold_capabilities(
+        &mut self,
+        updates: &mut BTreeMap<GlobalId, ChangeBatch<Timestamp>>,
+    ) {
         // Location to record consequences that we need to act on.
         let mut collections_net = BTreeMap::new();
 
@@ -3086,7 +3041,7 @@ where
     fn validate_collection_ids(
         &self,
         ids: impl Iterator<Item = GlobalId>,
-    ) -> Result<(), StorageError<T>> {
+    ) -> Result<(), StorageError> {
         for id in ids {
             self.storage_collections.check_exists(id)?;
         }
@@ -3094,10 +3049,7 @@ where
     }
 
     /// Validate that a collection exists for all identifiers, and error if any do not.
-    fn validate_export_ids(
-        &self,
-        ids: impl Iterator<Item = GlobalId>,
-    ) -> Result<(), StorageError<T>> {
+    fn validate_export_ids(&self, ids: impl Iterator<Item = GlobalId>) -> Result<(), StorageError> {
         for id in ids {
             self.export(id)?;
         }
@@ -3117,7 +3069,7 @@ where
         shard: ShardId,
         relation_desc: RelationDesc,
         persist_client: &PersistClient,
-    ) -> WriteHandle<SourceData, (), T, StorageDiff> {
+    ) -> WriteHandle<SourceData, (), Timestamp, StorageDiff> {
         let diagnostics = Diagnostics {
             shard_name: id.to_string(),
             handle_purpose: format!("controller data for {}", id),
@@ -3154,9 +3106,9 @@ where
         &mut self,
         id: GlobalId,
         introspection_type: IntrospectionType,
-        write_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        write_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         persist_client: PersistClient,
-    ) -> Result<(), StorageError<T>> {
+    ) -> Result<(), StorageError> {
         tracing::info!(%id, ?introspection_type, "registering introspection collection");
 
         // In read-only mode we create a new shard for all migrated storage collections. So we
@@ -3182,7 +3134,7 @@ where
 
             let fut = async move {
                 let read_handle = persist_client
-                    .open_leased_reader::<SourceData, (), T, StorageDiff>(
+                    .open_leased_reader::<SourceData, (), Timestamp, StorageDiff>(
                         metadata.data_shard,
                         Arc::new(metadata.relation_desc.clone()),
                         Arc::new(UnitSchema),
@@ -3322,8 +3274,8 @@ where
     fn determine_collection_dependencies(
         &self,
         self_id: GlobalId,
-        collection_desc: &CollectionDescription<T>,
-    ) -> Result<Vec<GlobalId>, StorageError<T>> {
+        collection_desc: &CollectionDescription,
+    ) -> Result<Vec<GlobalId>, StorageError> {
         let mut dependencies = Vec::new();
 
         if let Some(id) = collection_desc.primary {
@@ -3377,7 +3329,7 @@ where
     async fn read_handle_for_snapshot(
         &self,
         id: GlobalId,
-    ) -> Result<ReadHandle<SourceData, (), T, StorageDiff>, StorageError<T>> {
+    ) -> Result<ReadHandle<SourceData, (), Timestamp, StorageDiff>, StorageError> {
         let metadata = self.storage_collections.collection_metadata(id)?;
         read_handle_for_snapshot(&self.persist, id, &metadata).await
     }
@@ -3411,7 +3363,7 @@ where
         );
     }
 
-    fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, StorageError<T>> {
+    fn collection(&self, id: GlobalId) -> Result<&CollectionState, StorageError> {
         self.collections
             .get(&id)
             .ok_or(StorageError::IdentifierMissing(id))
@@ -3419,7 +3371,7 @@ where
 
     /// Runs the identified ingestion using the current definition of the
     /// ingestion in-memory.
-    fn run_ingestion(&mut self, id: GlobalId) -> Result<(), StorageError<T>> {
+    fn run_ingestion(&mut self, id: GlobalId) -> Result<(), StorageError> {
         tracing::info!(%id, "starting ingestion");
 
         let collection = self.collection(id)?;
@@ -3474,7 +3426,7 @@ where
 
     /// Runs the identified export using the current definition of the export
     /// that we have in memory.
-    fn run_export(&mut self, id: GlobalId) -> Result<(), StorageError<T>> {
+    fn run_export(&mut self, id: GlobalId) -> Result<(), StorageError> {
         let DataSource::Sink { desc: description } = &self.collections[&id].data_source else {
             return Err(StorageError::IdentifierMissing(id));
         };
@@ -3569,7 +3521,9 @@ where
         let mut replica_updates = Vec::new();
 
         let mut push_global_update =
-            |id: GlobalId, (since, upper): (Antichain<T>, Antichain<T>), diff: Diff| {
+            |id: GlobalId,
+             (since, upper): (Antichain<Timestamp>, Antichain<Timestamp>),
+             diff: Diff| {
                 let read_frontier = since.into_option().map_or(Datum::Null, |t| t.into());
                 let write_frontier = upper.into_option().map_or(Datum::Null, |t| t.into());
                 let row = Row::pack_slice(&[
@@ -3581,7 +3535,7 @@ where
             };
 
         let mut push_replica_update =
-            |(id, replica_id): (GlobalId, ReplicaId), upper: Antichain<T>, diff: Diff| {
+            |(id, replica_id): (GlobalId, ReplicaId), upper: Antichain<Timestamp>, diff: Diff| {
                 let write_frontier = upper.into_option().map_or(Datum::Null, |t| t.into());
                 let row = Row::pack_slice(&[
                     Datum::String(&id.to_string()),
@@ -3655,8 +3609,8 @@ where
         let histogram_period =
             WallclockLagHistogramPeriod::from_epoch_millis(now_ms, self.config.config_set());
 
-        let frontier_lag = |frontier: &Antichain<T>| match frontier.as_option() {
-            Some(ts) => (self.wallclock_lag)(ts.clone()),
+        let frontier_lag = |frontier: &Antichain<Timestamp>| match frontier.as_option() {
+            Some(ts) => (self.wallclock_lag)(*ts),
             None => Duration::ZERO,
         };
 
@@ -3840,16 +3794,13 @@ impl From<&IntrospectionType> for CollectionManagerKind {
 ///
 // TODO(guswynn): we need to be more careful about the update time we get here:
 // <https://github.com/MaterializeInc/database-issues/issues/7564>
-async fn snapshot_statistics<T>(
+async fn snapshot_statistics(
     id: GlobalId,
-    upper: Antichain<T>,
-    storage_collections: &Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
-) -> Vec<Row>
-where
-    T: Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+    upper: Antichain<Timestamp>,
+    storage_collections: &Arc<dyn StorageCollections + Send + Sync>,
+) -> Vec<Row> {
     match upper.as_option() {
-        Some(f) if f > &T::minimum() => {
+        Some(f) if f > &Timestamp::MIN => {
             let as_of = f.step_back().unwrap();
 
             let snapshot = storage_collections.snapshot(id, as_of).await.unwrap();
@@ -3867,14 +3818,11 @@ where
     }
 }
 
-async fn read_handle_for_snapshot<T>(
+async fn read_handle_for_snapshot(
     persist: &PersistClientCache,
     id: GlobalId,
     metadata: &CollectionMetadata,
-) -> Result<ReadHandle<SourceData, (), T, StorageDiff>, StorageError<T>>
-where
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
-{
+) -> Result<ReadHandle<SourceData, (), Timestamp, StorageDiff>, StorageError> {
     let persist_client = persist
         .open(metadata.persist_location.clone())
         .await
@@ -3902,13 +3850,13 @@ where
 
 /// State maintained about individual collections.
 #[derive(Debug)]
-struct CollectionState<T: TimelyTimestamp> {
+struct CollectionState {
     /// The source of this collection's data.
-    pub data_source: DataSource<T>,
+    pub data_source: DataSource,
 
     pub collection_metadata: CollectionMetadata,
 
-    pub extra_state: CollectionStateExtra<T>,
+    pub extra_state: CollectionStateExtra,
 
     /// Maximum frontier wallclock lag since the last `WallclockLagHistory` introspection update.
     wallclock_lag_max: WallclockLag,
@@ -3932,11 +3880,11 @@ struct CollectionState<T: TimelyTimestamp> {
     wallclock_lag_metrics: WallclockLagMetrics,
 }
 
-impl<T: TimelyTimestamp> CollectionState<T> {
+impl CollectionState {
     fn new(
-        data_source: DataSource<T>,
+        data_source: DataSource,
         collection_metadata: CollectionMetadata,
-        extra_state: CollectionStateExtra<T>,
+        extra_state: CollectionStateExtra,
         wallclock_lag_metrics: WallclockLagMetrics,
     ) -> Self {
         // Only collect wallclock lag histogram data for collections written by storage, to avoid
@@ -3960,27 +3908,27 @@ impl<T: TimelyTimestamp> CollectionState<T> {
 
 /// Additional state that the controller maintains for select collection types.
 #[derive(Debug)]
-enum CollectionStateExtra<T: TimelyTimestamp> {
-    Ingestion(IngestionState<T>),
-    Export(ExportState<T>),
+enum CollectionStateExtra {
+    Ingestion(IngestionState),
+    Export(ExportState),
     None,
 }
 
 /// State maintained about ingestions and ingestion exports
 #[derive(Debug)]
-struct IngestionState<T: TimelyTimestamp> {
+struct IngestionState {
     /// Really only for keeping track of changes to the `derived_since`.
-    pub read_capabilities: MutableAntichain<T>,
+    pub read_capabilities: MutableAntichain<Timestamp>,
 
     /// The current since frontier, derived from `write_frontier` using
     /// `hold_policy`.
-    pub derived_since: Antichain<T>,
+    pub derived_since: Antichain<Timestamp>,
 
     /// Holds that this ingestion (or ingestion export) has on its dependencies.
-    pub dependency_read_holds: Vec<ReadHold<T>>,
+    pub dependency_read_holds: Vec<ReadHold<Timestamp>>,
 
     /// Reported write frontier.
-    pub write_frontier: Antichain<T>,
+    pub write_frontier: Antichain<Timestamp>,
 
     /// The policy that drives how we downgrade our read hold. That is how we
     /// derive our since from our upper.
@@ -3988,7 +3936,7 @@ struct IngestionState<T: TimelyTimestamp> {
     /// This is a _storage-controller-internal_ policy used to derive its
     /// personal read hold on the collection. It should not be confused with any
     /// read policies that the adapter might install at [StorageCollections].
-    pub hold_policy: ReadPolicy<T>,
+    pub hold_policy: ReadPolicy<Timestamp>,
 
     /// The ID of the instance in which the ingestion is running.
     pub instance_id: StorageInstanceId,
@@ -4108,15 +4056,15 @@ fn replica_status_history_desc(params: &StorageParameters) -> StatusHistoryDesc<
 }
 
 /// Replace one antichain with another, tracking the overall changes in the returned `ChangeBatch`.
-fn swap_updates<T: Timestamp>(
-    from: &mut Antichain<T>,
-    mut replace_with: Antichain<T>,
-) -> ChangeBatch<T> {
+fn swap_updates(
+    from: &mut Antichain<Timestamp>,
+    mut replace_with: Antichain<Timestamp>,
+) -> ChangeBatch<Timestamp> {
     let mut update = ChangeBatch::new();
     if PartialOrder::less_equal(from, &replace_with) {
-        update.extend(replace_with.iter().map(|time| (time.clone(), 1)));
+        update.extend(replace_with.iter().map(|time| (*time, 1)));
         std::mem::swap(from, &mut replace_with);
-        update.extend(replace_with.iter().map(|time| (time.clone(), -1)));
+        update.extend(replace_with.iter().map(|time| (*time, -1)));
     }
     update
 }

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -15,7 +15,6 @@ use std::fmt::Debug;
 use std::fmt::Write;
 use std::sync::Arc;
 
-use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
@@ -23,15 +22,13 @@ use itertools::Itertools;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_client::ShardId;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_types::Codec64;
-use mz_repr::{GlobalId, TimestampManipulation};
+use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::client::{TableData, Update};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::{InvalidUpper, TxnsCodecRow};
 use mz_storage_types::sources::SourceData;
 use mz_txn_wal::txns::{Tidy, TxnsHandle};
-use timely::order::TotalOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tracing::{Instrument, Span, debug, info_span};
@@ -41,16 +38,19 @@ use crate::StorageError;
 mod read_only_table_worker;
 
 #[derive(Debug, Clone)]
-pub struct PersistTableWriteWorker<T: Timestamp + Lattice + Codec64 + TimestampManipulation> {
-    inner: Arc<PersistTableWriteWorkerInner<T>>,
+pub struct PersistTableWriteWorker {
+    inner: Arc<PersistTableWriteWorkerInner>,
 }
 
 /// Commands for [PersistTableWriteWorker].
 #[derive(Debug)]
-enum PersistTableWriteCmd<T: Timestamp + Lattice + Codec64> {
+enum PersistTableWriteCmd {
     Register(
-        T,
-        Vec<(GlobalId, WriteHandle<SourceData, (), T, StorageDiff>)>,
+        Timestamp,
+        Vec<(
+            GlobalId,
+            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        )>,
         tokio::sync::oneshot::Sender<()>,
     ),
     Update {
@@ -59,31 +59,31 @@ enum PersistTableWriteCmd<T: Timestamp + Lattice + Codec64> {
         /// New collection we'll emit writes to.
         new_collection: GlobalId,
         /// Timestamp to forget the original handle at.
-        forget_ts: T,
+        forget_ts: Timestamp,
         /// Timestamp to register the new handle at.
-        register_ts: T,
+        register_ts: Timestamp,
         /// New write handle to register.
-        handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         /// Notifies us when the handle has been updated.
         tx: oneshot::Sender<()>,
     },
     DropHandles {
-        forget_ts: T,
+        forget_ts: Timestamp,
         /// Tables that we want to drop our handle for.
         ids: Vec<GlobalId>,
         /// Notifies us when all resources have been cleaned up.
         tx: oneshot::Sender<()>,
     },
     Append {
-        write_ts: T,
-        advance_to: T,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
-        tx: tokio::sync::oneshot::Sender<Result<(), StorageError<T>>>,
+        tx: tokio::sync::oneshot::Sender<Result<(), StorageError>>,
     },
     Shutdown,
 }
 
-impl<T: Timestamp + Lattice + Codec64> PersistTableWriteCmd<T> {
+impl PersistTableWriteCmd {
     fn name(&self) -> &'static str {
         match self {
             PersistTableWriteCmd::Register(_, _, _) => "PersistTableWriteCmd::Register",
@@ -95,13 +95,18 @@ impl<T: Timestamp + Lattice + Codec64> PersistTableWriteCmd<T> {
     }
 }
 
-async fn append_work<T2: Timestamp + TotalOrder + Lattice + Codec64 + Sync>(
-    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), T2, StorageDiff>>,
+async fn append_work(
+    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>,
     mut commands: BTreeMap<
         GlobalId,
-        (tracing::Span, Vec<Update<T2>>, Antichain<T2>, Antichain<T2>),
+        (
+            tracing::Span,
+            Vec<Update>,
+            Antichain<Timestamp>,
+            Antichain<Timestamp>,
+        ),
     >,
-) -> Result<(), Vec<(GlobalId, Antichain<T2>)>> {
+) -> Result<(), Vec<(GlobalId, Antichain<Timestamp>)>> {
     let futs = FuturesUnordered::new();
 
     // We cannot iterate through the updates and then set off a persist call
@@ -129,7 +134,7 @@ async fn append_work<T2: Timestamp + TotalOrder + Lattice + Codec64 + Sync>(
                     .expect("cannot append updates")
                     .or_else(|upper_mismatch| Err((*id, upper_mismatch.current)))?;
 
-                Ok::<_, (GlobalId, Antichain<T2>)>((*id, new_upper))
+                Ok::<_, (GlobalId, Antichain<Timestamp>)>((*id, new_upper))
             })
         }
     }
@@ -148,7 +153,7 @@ async fn append_work<T2: Timestamp + TotalOrder + Lattice + Codec64 + Sync>(
     }
 }
 
-impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWriteWorker<T> {
+impl PersistTableWriteWorker {
     /// Create a new read-only table worker that continually bumps the upper of
     /// it's tables. It is expected that we only register migrated builtin
     /// tables, that cannot yet be registered in the txns system in read-only
@@ -158,10 +163,10 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
     /// upper and continually bump the upper of registered tables to follow the
     /// upper of the txns shard.
     pub(crate) fn new_read_only_mode(
-        txns_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        txns_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     ) -> Self {
         let (tx, rx) =
-            tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd<T>)>();
+            tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd)>();
         mz_ore::task::spawn(
             || "PersistTableWriteWorker",
             read_only_table_worker::read_only_mode_table_worker(rx, txns_handle),
@@ -171,9 +176,11 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
         }
     }
 
-    pub(crate) fn new_txns(txns: TxnsHandle<SourceData, (), T, StorageDiff, TxnsCodecRow>) -> Self {
+    pub(crate) fn new_txns(
+        txns: TxnsHandle<SourceData, (), Timestamp, StorageDiff, TxnsCodecRow>,
+    ) -> Self {
         let (tx, rx) =
-            tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd<T>)>();
+            tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd)>();
         mz_ore::task::spawn(|| "PersistTableWriteWorker", async move {
             let mut worker = TxnsTableWorker {
                 txns,
@@ -189,8 +196,11 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
 
     pub(crate) fn register(
         &self,
-        register_ts: T,
-        ids_handles: Vec<(GlobalId, WriteHandle<SourceData, (), T, StorageDiff>)>,
+        register_ts: Timestamp,
+        ids_handles: Vec<(
+            GlobalId,
+            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        )>,
     ) -> tokio::sync::oneshot::Receiver<()> {
         // We expect this to be awaited, so keep the span connected.
         let span = info_span!("PersistTableWriteCmd::Register");
@@ -212,9 +222,9 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
         &self,
         existing_collection: GlobalId,
         new_collection: GlobalId,
-        forget_ts: T,
-        register_ts: T,
-        handle: WriteHandle<SourceData, (), T, StorageDiff>,
+        forget_ts: Timestamp,
+        register_ts: Timestamp,
+        handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     ) -> oneshot::Receiver<()> {
         let (tx, rx) = oneshot::channel();
         self.send(PersistTableWriteCmd::Update {
@@ -230,10 +240,10 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
 
     pub(crate) fn append(
         &self,
-        write_ts: T,
-        advance_to: T,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
-    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError<T>>> {
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         if updates.is_empty() {
             tx.send(Ok(()))
@@ -254,27 +264,31 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWrite
     ///
     /// Note that this does not perform any other cleanup, such as finalizing
     /// the handle's shard.
-    pub(crate) fn drop_handles(&self, ids: Vec<GlobalId>, forget_ts: T) -> BoxFuture<'static, ()> {
+    pub(crate) fn drop_handles(
+        &self,
+        ids: Vec<GlobalId>,
+        forget_ts: Timestamp,
+    ) -> BoxFuture<'static, ()> {
         let (tx, rx) = oneshot::channel();
         self.send(PersistTableWriteCmd::DropHandles { forget_ts, ids, tx });
         Box::pin(rx.map(|_| ()))
     }
 
-    fn send(&self, cmd: PersistTableWriteCmd<T>) {
+    fn send(&self, cmd: PersistTableWriteCmd) {
         self.inner.send(cmd);
     }
 }
 
-struct TxnsTableWorker<T: Timestamp + Lattice + TotalOrder + Codec64> {
-    txns: TxnsHandle<SourceData, (), T, StorageDiff, TxnsCodecRow>,
+struct TxnsTableWorker {
+    txns: TxnsHandle<SourceData, (), Timestamp, StorageDiff, TxnsCodecRow>,
     write_handles: BTreeMap<GlobalId, ShardId>,
     tidy: Tidy,
 }
 
-impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T> {
+impl TxnsTableWorker {
     async fn run(
         &mut self,
-        mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd<T>)>,
+        mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd)>,
     ) {
         while let Some((span, command)) = rx.recv().await {
             match command {
@@ -331,8 +345,11 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
 
     async fn register(
         &mut self,
-        register_ts: T,
-        mut ids_handles: Vec<(GlobalId, WriteHandle<SourceData, (), T, StorageDiff>)>,
+        register_ts: Timestamp,
+        mut ids_handles: Vec<(
+            GlobalId,
+            WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        )>,
     ) {
         // As tables evolve (e.g. columns are added) we treat the older versions as
         // "views" on the later versions. While it's not required, it's easier to reason
@@ -354,7 +371,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
         // Registering also advances the logical upper of all shards in the txns set.
         let new_ids = ids_handles.iter().map(|(id, _)| *id).collect_vec();
         let handles = ids_handles.into_iter().map(|(_, handle)| handle);
-        let res = self.txns.register(register_ts.clone(), handles).await;
+        let res = self.txns.register(register_ts, handles).await;
         match res {
             Ok(tidy) => {
                 self.tidy.merge(tidy);
@@ -368,7 +385,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
         }
     }
 
-    async fn drop_handles(&mut self, ids: Vec<GlobalId>, forget_ts: T) {
+    async fn drop_handles(&mut self, ids: Vec<GlobalId>, forget_ts: Timestamp) {
         tracing::info!(?ids, "drop tables");
         let data_ids = ids
             .iter()
@@ -379,7 +396,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
             .filter_map(|id| self.write_handles.remove(id))
             .collect::<BTreeSet<_>>();
         if !data_ids.is_empty() {
-            match self.txns.forget(forget_ts.clone(), data_ids.clone()).await {
+            match self.txns.forget(forget_ts, data_ids.clone()).await {
                 Ok(tidy) => {
                     self.tidy.merge(tidy);
                 }
@@ -395,10 +412,10 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
 
     async fn append(
         &mut self,
-        write_ts: T,
-        advance_to: T,
+        write_ts: Timestamp,
+        advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
-        tx: tokio::sync::oneshot::Sender<Result<(), StorageError<T>>>,
+        tx: tokio::sync::oneshot::Sender<Result<(), StorageError>>,
     ) {
         debug!(
             "tables append timestamp={:?} advance_to={:?} len={} ids={:?}{}",
@@ -460,7 +477,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
         }
         // Sneak in any txns shard tidying from previous commits.
         txn.tidy(std::mem::take(&mut self.tidy));
-        let txn_res = txn.commit_at(&mut self.txns, write_ts.clone()).await;
+        let txn_res = txn.commit_at(&mut self.txns, write_ts).await;
         let response = match txn_res {
             Ok(apply) => {
                 // TODO: Do the applying in a background task. This will be a
@@ -488,7 +505,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
                         .copied()
                         .map(|id| InvalidUpper {
                             id,
-                            current_upper: Antichain::from_elem(current.clone()),
+                            current_upper: Antichain::from_elem(current),
                         })
                         .collect(),
                 ))
@@ -508,37 +525,31 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
 /// #[derive(Clone)] <-- do not do this.
 ///
 #[derive(Debug)]
-struct PersistTableWriteWorkerInner<T: Timestamp + Lattice + Codec64 + TimestampManipulation> {
+struct PersistTableWriteWorkerInner {
     /// Sending side of a channel that we can use to send commands.
-    tx: UnboundedSender<(tracing::Span, PersistTableWriteCmd<T>)>,
+    tx: UnboundedSender<(tracing::Span, PersistTableWriteCmd)>,
 }
 
-impl<T> Drop for PersistTableWriteWorkerInner<T>
-where
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
-{
+impl Drop for PersistTableWriteWorkerInner {
     fn drop(&mut self) {
         self.send(PersistTableWriteCmd::Shutdown);
         // TODO: Can't easily block on shutdown occurring.
     }
 }
 
-impl<T> PersistTableWriteWorkerInner<T>
-where
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
-{
-    fn new(tx: UnboundedSender<(tracing::Span, PersistTableWriteCmd<T>)>) -> Self {
+impl PersistTableWriteWorkerInner {
+    fn new(tx: UnboundedSender<(tracing::Span, PersistTableWriteCmd)>) -> Self {
         PersistTableWriteWorkerInner { tx }
     }
 
-    fn send(&self, cmd: PersistTableWriteCmd<T>) {
+    fn send(&self, cmd: PersistTableWriteCmd) {
         let span =
             info_span!(parent: None, "PersistTableWriteWorkerInner::send", otel.name = cmd.name());
         OpenTelemetryContext::obtain().attach_as_parent_to(&span);
         self.send_with_span(span, cmd)
     }
 
-    fn send_with_span(&self, span: Span, cmd: PersistTableWriteCmd<T>) {
+    fn send_with_span(&self, span: Span, cmd: PersistTableWriteCmd) {
         match self.tx.send((span, cmd)) {
             Ok(()) => (), // All good!
             Err(e) => {

--- a/src/storage-controller/src/persist_handles/read_only_table_worker.rs
+++ b/src/storage-controller/src/persist_handles/read_only_table_worker.rs
@@ -16,14 +16,13 @@ use std::ops::ControlFlow;
 use differential_dataflow::lattice::Lattice;
 use futures::FutureExt;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_types::Codec64;
-use mz_repr::{GlobalId, TimestampManipulation};
+use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::client::{TableData, Update};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::InvalidUpper;
 use mz_storage_types::sources::SourceData;
 use timely::PartialOrder;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tracing::Span;
 
 use crate::StorageError;
@@ -47,16 +46,14 @@ use crate::persist_handles::{PersistTableWriteCmd, append_work};
 /// writing to tables before the txn-wal system. This code can (again) be
 /// deleted when we switch to using native persist schema migrations to perform
 /// mgirations of built-in tables.
-pub(crate) async fn read_only_mode_table_worker<
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
->(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd<T>)>,
-    txns_handle: WriteHandle<SourceData, (), T, StorageDiff>,
+pub(crate) async fn read_only_mode_table_worker(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd)>,
+    txns_handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
 ) {
     let mut write_handles =
-        BTreeMap::<GlobalId, WriteHandle<SourceData, (), T, StorageDiff>>::new();
+        BTreeMap::<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>::new();
 
-    let gen_upper_future = |mut handle: WriteHandle<SourceData, (), T, StorageDiff>| {
+    let gen_upper_future = |mut handle: WriteHandle<SourceData, (), Timestamp, StorageDiff>| {
         let fut = async move {
             let current_upper = handle.shared_upper();
             handle.wait_for_upper_past(&current_upper).await;
@@ -115,13 +112,10 @@ pub(crate) async fn read_only_mode_table_worker<
 }
 
 /// Handles the given commands.
-async fn handle_commands<T>(
-    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), T, StorageDiff>>,
-    mut commands: VecDeque<(Span, PersistTableWriteCmd<T>)>,
-) -> ControlFlow<String>
-where
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
-{
+async fn handle_commands(
+    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>,
+    mut commands: VecDeque<(Span, PersistTableWriteCmd)>,
+) -> ControlFlow<String> {
     let mut shutdown = false;
 
     // Accumulated updates and upper frontier.
@@ -189,8 +183,8 @@ where
                             (
                                 span.clone(),
                                 Vec::default(),
-                                Antichain::from_elem(write_ts.clone()),
-                                Antichain::from_elem(T::minimum()),
+                                Antichain::from_elem(write_ts),
+                                Antichain::from_elem(Timestamp::MIN),
                             )
                         });
 
@@ -206,7 +200,7 @@ where
                         TableData::Rows(rows) => {
                             let iter = rows.into_iter().map(|(row, diff)| Update {
                                 row,
-                                timestamp: write_ts.clone(),
+                                timestamp: write_ts,
                                 diff,
                             });
                             itertools::Either::Left(iter)
@@ -220,7 +214,7 @@ where
                         }
                     });
                     updates.extend(updates_with_ts);
-                    old_new_upper.join_assign(&Antichain::from_elem(advance_to.clone()));
+                    old_new_upper.join_assign(&Antichain::from_elem(advance_to));
                 }
                 all_responses.push((ids, tx));
             }
@@ -260,12 +254,10 @@ where
 
 /// Advances the upper of all registered tables (which are only the migrated
 /// builtin tables) to the given `upper`.
-async fn advance_uppers<T>(
-    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), T, StorageDiff>>,
-    upper: Antichain<T>,
-) where
-    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
-{
+async fn advance_uppers(
+    write_handles: &mut BTreeMap<GlobalId, WriteHandle<SourceData, (), Timestamp, StorageDiff>>,
+    upper: Antichain<Timestamp>,
+) {
     let mut all_updates = BTreeMap::default();
 
     for (id, write_handle) in write_handles.iter_mut() {
@@ -279,7 +271,7 @@ async fn advance_uppers<T>(
         let expected_upper = write_handle.fetch_recent_upper().await.to_owned();
 
         // Avoid advancing the upper until the coordinator has a chance to back-fill the shard.
-        if expected_upper.elements() == &[T::minimum()] {
+        if expected_upper.elements() == &[Timestamp::MIN] {
             continue;
         }
 

--- a/src/storage-controller/src/rtr.rs
+++ b/src/storage-controller/src/rtr.rs
@@ -14,9 +14,7 @@ use std::collections::BinaryHeap;
 use std::collections::binary_heap::PeekMut;
 
 use differential_dataflow::lattice::Lattice;
-use mz_ore::now::EpochMillis;
 use mz_persist_client::read::{ListenEvent, Subscribe};
-use mz_persist_types::Codec64;
 use mz_repr::{GlobalId, Row};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::configuration::StorageConfiguration;
@@ -25,7 +23,6 @@ use mz_storage_types::sources::{
 };
 use mz_timely_util::antichain::AntichainExt;
 use timely::PartialOrder;
-use timely::order::TotalOrder;
 use timely::progress::Antichain;
 use timely::progress::frontier::MutableAntichain;
 
@@ -44,15 +41,13 @@ use crate::Timestamp;
 ///   generator sources do not yet (or might never) support real-time
 ///   recency. You can avoid this panic by choosing to not call this
 ///   function on load generator sources.
-pub(super) async fn real_time_recency_ts<
-    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + Sync,
->(
+pub(super) async fn real_time_recency_ts(
     connection: GenericSourceConnection,
     id: GlobalId,
     config: StorageConfiguration,
-    as_of: Antichain<T>,
-    remap_subscribe: Subscribe<SourceData, (), T, StorageDiff>,
-) -> Result<T, StorageError<T>> {
+    as_of: Antichain<Timestamp>,
+    remap_subscribe: Subscribe<SourceData, (), Timestamp, StorageDiff>,
+) -> Result<Timestamp, StorageError> {
     match connection {
         GenericSourceConnection::Kafka(kafka) => {
             let external_frontier = kafka
@@ -119,15 +114,12 @@ pub(super) async fn real_time_recency_ts<
     }
 }
 
-async fn decode_remap_data_until_geq_external_frontier<
-    FromTime: SourceTimestamp,
-    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + Sync,
->(
+async fn decode_remap_data_until_geq_external_frontier<FromTime: SourceTimestamp>(
     id: GlobalId,
     external_frontier: timely::progress::Antichain<FromTime>,
-    as_of: Antichain<T>,
-    mut remap_subscribe: Subscribe<SourceData, (), T, StorageDiff>,
-) -> Result<T, StorageError<T>> {
+    as_of: Antichain<Timestamp>,
+    mut remap_subscribe: Subscribe<SourceData, (), Timestamp, StorageDiff>,
+) -> Result<Timestamp, StorageError> {
     tracing::debug!(
         ?id,
         "fetched real time recency frontier: {}",
@@ -137,10 +129,10 @@ async fn decode_remap_data_until_geq_external_frontier<
     let external_frontier = external_frontier.borrow();
     let mut native_upper = MutableAntichain::new();
 
-    let mut remap_frontier = Antichain::from_elem(T::minimum());
+    let mut remap_frontier = Antichain::from_elem(Timestamp::MIN);
     let mut pending_remap = BinaryHeap::new();
 
-    let mut min_ts = T::minimum();
+    let mut min_ts = Timestamp::MIN;
     min_ts.advance_by(as_of.borrow());
     let mut min_ts = Some(min_ts);
 
@@ -176,7 +168,7 @@ async fn decode_remap_data_until_geq_external_frontier<
                             break;
                         };
                         if !remap_frontier.less_equal(into_ts) {
-                            into_ts.clone()
+                            *into_ts
                         } else {
                             break;
                         }

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -16,19 +16,15 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use differential_dataflow::consolidation;
-use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
 use mz_cluster_client::ReplicaId;
-use mz_ore::now::EpochMillis;
-use mz_persist_types::Codec64;
-use mz_repr::{Diff, TimestampManipulation};
+use mz_repr::Diff;
 use mz_repr::{GlobalId, Row};
 use mz_storage_client::statistics::{
     ControllerSourceStatistics, ExpirableStats, ZeroInitializedStats,
 };
 use mz_storage_client::statistics::{PackableStats, WebhookStatistics};
 use timely::progress::ChangeBatch;
-use timely::progress::Timestamp;
 use tokio::sync::oneshot;
 use tokio::sync::watch::Receiver;
 
@@ -52,9 +48,9 @@ impl<Stats> AsStats<Stats> for BTreeMap<(GlobalId, Option<ReplicaId>), Stats> {
 
 /// Spawns a task that continually (at an interval) writes statistics from storaged's
 /// that are consolidated in shared memory in the controller.
-pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats, T>(
+pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats>(
     statistics_collection_id: GlobalId,
-    collection_mgmt: CollectionManager<T>,
+    collection_mgmt: CollectionManager,
     shared_stats: Arc<Mutex<StatsWrapper>>,
     previous_values: Vec<Row>,
     initial_interval: Duration,
@@ -65,7 +61,6 @@ pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats, T>(
 where
     StatsWrapper: AsStats<Stats> + Debug + Send + 'static,
     Stats: PackableStats + ExpirableStats + ZeroInitializedStats + Clone + Debug + Send + 'static,
-    T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
 {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::error::Error;
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 
 use itertools::Itertools;
 use mz_ore::assert_none;
@@ -17,7 +17,7 @@ use mz_persist_types::schema::SchemaId;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::txn::{TxnsCodec, TxnsEntry};
 use mz_persist_types::{PersistLocation, ShardId};
-use mz_repr::{Datum, GlobalId, RelationDesc, Row, SqlScalarType};
+use mz_repr::{Datum, GlobalId, RelationDesc, Row, SqlScalarType, Timestamp};
 use mz_sql_parser::ast::UnresolvedItemName;
 use mz_timely_util::antichain::AntichainExt;
 use serde::{Deserialize, Serialize};
@@ -87,7 +87,7 @@ pub struct DurableCollectionMetadata {
 }
 
 #[derive(Debug)]
-pub enum StorageError<T> {
+pub enum StorageError {
     /// The source identifier was re-created after having been dropped,
     /// or installed with a different description.
     CollectionIdReused(GlobalId),
@@ -103,7 +103,7 @@ pub enum StorageError<T> {
     /// The read was at a timestamp before the collection's since
     ReadBeforeSince(GlobalId),
     /// The expected upper of one or more appends was different from the actual upper of the collection
-    InvalidUppers(Vec<InvalidUpper<T>>),
+    InvalidUppers(Vec<InvalidUpper>),
     /// The (client for) the requested cluster instance is missing.
     IngestionInstanceMissing {
         storage_instance_id: StorageInstanceId,
@@ -161,7 +161,7 @@ pub enum StorageError<T> {
     ReadOnly,
 }
 
-impl<T: Debug + Display + 'static> Error for StorageError<T> {
+impl Error for StorageError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::CollectionIdReused(_) => None,
@@ -192,7 +192,7 @@ impl<T: Debug + Display + 'static> Error for StorageError<T> {
     }
 }
 
-impl<T: fmt::Display + 'static> fmt::Display for StorageError<T> {
+impl fmt::Display for StorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("storage error: ")?;
         match self {
@@ -302,9 +302,9 @@ impl<T: fmt::Display + 'static> fmt::Display for StorageError<T> {
 }
 
 #[derive(Debug, Clone)]
-pub struct InvalidUpper<T> {
+pub struct InvalidUpper {
     pub id: GlobalId,
-    pub current_upper: Antichain<T>,
+    pub current_upper: Antichain<Timestamp>,
 }
 
 #[derive(Debug)]
@@ -320,19 +320,19 @@ impl fmt::Display for AlterError {
     }
 }
 
-impl<T> From<AlterError> for StorageError<T> {
+impl From<AlterError> for StorageError {
     fn from(error: AlterError) -> Self {
         Self::InvalidAlter(error)
     }
 }
 
-impl<T> From<DataflowError> for StorageError<T> {
+impl From<DataflowError> for StorageError {
     fn from(error: DataflowError) -> Self {
         Self::DataflowError(error)
     }
 }
 
-impl<T> From<CollectionMissing> for StorageError<T> {
+impl From<CollectionMissing> for StorageError {
     fn from(err: CollectionMissing) -> Self {
         Self::IdentifierMissing(err.0)
     }


### PR DESCRIPTION
The storage client code is generic over a `T: Timestamp`, though it's only ever used with `mz_repr::Timestamp`. There are no plans to support multiple timestamp types, and if we want to make changes to the timestamp type, we can always make them to `mz_repr::Timestamp`. Thus the genericity doesn't give us anything except code noise.

Change the storage client and storage controller code to not be generic over the timestamp type anymore.

### Motivation

Part of a push to remove abstraction we don't need, see Slack threads [1](https://materializeinc.slack.com/archives/C08ACQNGSQK/p1775911944776659) and [2](https://materializeinc.slack.com/archives/C08A62E0751/p1775926643153079).

An equivalent change for the compute client landed in https://github.com/MaterializeInc/materialize/pull/36042.
