### PR TITLE
console: fix cursor not showing up in shell 

### DIFF
--- a/console/src/components/CommandBlock/index.tsx
+++ b/console/src/components/CommandBlock/index.tsx
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { history } from "@codemirror/commands";
+import { drawSelection } from "@codemirror/view";
 import {
   extensionManager,
   updateListener,
@@ -26,6 +27,7 @@ export const CodeMirrorProvider = ({ children }: PropsWithChildren) => {
         extensions: [
           updateListener(),
           history(),
+          drawSelection(),
           languageExt,
           extensionManager(),
         ],

--- a/console/src/components/CommandBlock/theme.ts
+++ b/console/src/components/CommandBlock/theme.ts
@@ -52,6 +52,9 @@ export const createCmTheme = (theme: MaterializeTheme) =>
         padding: "2px 0",
         caretColor: baseThemeSettings[theme.colorMode].caretColor,
       },
+      ".cm-cursor": {
+        borderLeftColor: baseThemeSettings[theme.colorMode].caretColor,
+      },
       ".cm-scroller": {
         lineHeight,
       },


### PR DESCRIPTION
### Motivation
Fixes cursor not showing up in shell possibly due to a dependency update. Fixes[ CNS-49](https://linear.app/materializeinc/issue/CNS-49/cursor-not-appearing-in-sql-editing-box-for-general-mills),[ CNS-55
](https://linear.app/materializeinc/issue/CNS-55/sql-input-in-console-lacks-initial-cursor-visibility)

### Verification
<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/bb166f3c-a96f-4f77-be11-0077dd9cea53" />
