### PR TITLE
lint: Minor fixes with Python 3.10 and on macOS

### DIFF
--- a/bin/gen-completion
+++ b/bin/gen-completion
@@ -32,12 +32,25 @@ python_autocompletions=(scratch mzcompose)
 
 . misc/shlib/shlib.bash
 
+# GNU sed is required for the multi-line sed expressions used below.
+# On macOS, the default sed is BSD sed, which has incompatible syntax.
+if command_exists gsed; then
+    SED="gsed"
+elif sed --version 2>/dev/null | grep -q "GNU sed"; then
+    SED="sed"
+else
+    echo -e "lint: $(red fatal:) GNU sed is required but not found" >&2
+    echo -e "hint: on macOS, install it with: brew install gnu-sed" >&2
+    exit 1
+fi
+
 case "$cmd" in
     generate)
         for name in "${python_autocompletions[@]}"; do
           for shell in "${supported_shells[@]}"; do
             mkdir -p "$directory"/../misc/completions/"$shell"
-            "$directory"/pyactivate -m materialize.cli."$name" completion "$shell" | sed -e 's/[[:space:]]*$//' -e :a -e '/^\n*$/{$d;N;ba}' > "$directory"/../misc/completions/"$shell"/_"$name"
+            # shellcheck disable=SC2016
+            "$directory"/pyactivate -m materialize.cli."$name" completion "$shell" | "$SED" -e 's/[[:space:]]*$//' -e :a -e '/^\n*$/{$d;N;ba}' > "$directory"/../misc/completions/"$shell"/_"$name"
           done
         done
         ;;
@@ -54,7 +67,8 @@ case "$cmd" in
               exit 1
             fi
 
-            latest=$("$directory"/pyactivate -m materialize.cli."$name" completion "$shell" | sed -e 's/[[:space:]]*$//' -e :a -e '/^\n*$/{$d;N;ba}' | "$shasum")
+            # shellcheck disable=SC2016
+            latest=$("$directory"/pyactivate -m materialize.cli."$name" completion "$shell" | "$SED" -e 's/[[:space:]]*$//' -e :a -e '/^\n*$/{$d;N;ba}' | "$shasum")
             existing=$("$shasum" < "$directory"/../misc/completions/"$shell"/_"$name")
 
             if [[ "$latest" != "$existing" ]]; then

--- a/ci/cleanup/aws.py
+++ b/ci/cleanup/aws.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import PurePosixPath
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -29,7 +29,7 @@ def clean_up_kinesis() -> None:
             continue
         desc = client.describe_stream(StreamName=stream)
         created_at = desc["StreamDescription"]["StreamCreationTimestamp"]
-        age = datetime.now(UTC) - created_at
+        age = datetime.now(timezone.utc) - created_at
         if age <= MAX_AGE:
             print(f"Skipping stream {stream} whose age is beneath threshold")
             continue
@@ -45,7 +45,7 @@ def clean_up_s3() -> None:
         if not desc["Name"].startswith("testdrive"):
             print("Skipping non-testdrive bucket {}".format(desc["Name"]))
             continue
-        age = datetime.now(UTC) - desc["CreationDate"]
+        age = datetime.now(timezone.utc) - desc["CreationDate"]
         if age <= MAX_AGE:
             print(
                 "Skipping bucket {} whose age is beneath threshold".format(desc["Name"])
@@ -76,7 +76,9 @@ def clean_up_sqs() -> None:
                 QueueUrl=queue, AttributeNames=["All"]
             )
             created_at = int(attributes["Attributes"]["CreatedTimestamp"])
-            age = datetime.now(UTC) - datetime.fromtimestamp(created_at, UTC)
+            age = datetime.now(timezone.utc) - datetime.fromtimestamp(
+                created_at, timezone.utc
+            )
             if age <= MAX_AGE:
                 print(f"Skipping queue {name} whose age is beneath threshold")
                 continue

--- a/ci/deploy/pypi.py
+++ b/ci/deploy/pypi.py
@@ -52,7 +52,11 @@ def main() -> None:
 
 def get_metadata_from_setup_py(path: Path) -> tuple[str, str]:
     distribution = distutils.core.run_setup(str(path / "setup.py"))
-    return distribution.metadata.name, distribution.metadata.version
+    name = distribution.metadata.name
+    version = distribution.metadata.version
+    assert name is not None, f"missing name in {path}/setup.py"
+    assert version is not None, f"missing version in {path}/setup.py"
+    return name, version
 
 
 def get_metadata_from_pyproject(path: Path) -> tuple[str, str]:

--- a/ci/load/periodic.py
+++ b/ci/load/periodic.py
@@ -31,7 +31,7 @@ def main() -> None:
     now = datetime.datetime.utcnow()
     scratch.launch_cluster(
         [desc],
-        nonce=now.replace(tzinfo=datetime.UTC).isoformat(),
+        nonce=now.replace(tzinfo=datetime.timezone.utc).isoformat(),
         # Keep alive for at least a day.
         delete_after=datetime.datetime.utcnow() + datetime.timedelta(days=1),
     )

--- a/ci/test/lint-main/before/can-lint.sh
+++ b/ci/test/lint-main/before/can-lint.sh
@@ -32,3 +32,20 @@ if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
         exit 1
     fi
 fi
+
+# Check that GNU sed is available (required by gen-completion).
+if ! command_exists gsed && ! (sed --version 2>/dev/null | grep -q "GNU sed"); then
+    echo -e "lint: $(red fatal:) GNU sed is required but not found" >&2
+    echo -e "hint: on macOS, install it with: brew install gnu-sed" >&2
+    exit 1
+fi
+
+# Check that Python dependencies are importable. A broken httpx (transitive
+# dependency of confluent-kafka) is a common symptom of a stale virtualenv.
+if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
+    if ! bin/pyactivate -c "import httpx" 2>/dev/null; then
+        echo -e "lint: $(red fatal:) Python virtualenv has broken dependencies (cannot import \`httpx\`)" >&2
+        echo -e "hint: rebuild the virtualenv: rm -rf misc/python/venv" >&2
+        exit 1
+    fi
+fi

--- a/ci/test/lint-main/checks/check-python-version.sh
+++ b/ci/test/lint-main/checks/check-python-version.sh
@@ -24,10 +24,13 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
         exit 1
     fi
 
-    try uv venv --python 3.10
+    py310_venv="$(mktemp -d)/venv-py310"
+    trap 'rm -rf "$py310_venv"' EXIT
+
+    try uv venv --python 3.10 "$py310_venv"
     try uv pip compile --python-version 3.10 ci/builder/requirements.txt
-    try uv pip install --python 3.10 --requirement ci/builder/requirements.txt
-    try git_files '*.py' | xargs uv run --no-project --python 3.10 -- python -m compileall -q
+    try uv pip install --python "$py310_venv/bin/python" --requirement ci/builder/requirements.txt
+    try git_files '*.py' | xargs "$py310_venv/bin/python" -m compileall -q
 fi
 
 try_status_report

--- a/misc/python/materialize/cli/mz_workload_capture.py
+++ b/misc/python/materialize/cli/mz_workload_capture.py
@@ -13,11 +13,12 @@ import threading
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, LiteralString
+from typing import Any
 
 import psycopg
 import yaml
 from psycopg.sql import SQL, Composable, Composed, Identifier, Literal
+from typing_extensions import LiteralString
 
 
 @contextmanager

--- a/misc/python/materialize/mzexplore/common.py
+++ b/misc/python/materialize/mzexplore/common.py
@@ -411,7 +411,7 @@ class ArrangementSizesFile:
 def resource_path(name: str) -> Path:
     # NOTE: we have to do this cast because pyright is not comfortable with the
     # Traversable protocol.
-    return cast(Path, resources.files(__package__)) / name
+    return cast(Path, resources.files(__name__)) / name
 
 
 def info(msg: str, fg: str = "green") -> None:

--- a/misc/python/materialize/optbench/__init__.py
+++ b/misc/python/materialize/optbench/__init__.py
@@ -15,7 +15,7 @@ from typing import cast
 def resource_path(name: str) -> Path:
     # NOTE: we have to do this cast because pyright is not comfortable with the
     # Traversable protocol.
-    return cast(Path, resources.files(__package__)) / name
+    return cast(Path, resources.files(__name__)) / name
 
 
 def scenarios() -> list[str]:

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -23,9 +23,6 @@ from materialize.mzcompose.composition import Composition
 from materialize.util import PgConnInfo
 
 DB_FILE = "parallel-benchmark.db"
-assert (
-    sqlite3.threadsafety == 3
-), f"Thread safety level 3 (serialized) required, but is: {sqlite3.threadsafety}"
 
 
 class Measurement:


### PR DESCRIPTION
I had a weird setup defaulting to Python 3.10 on macOS, which we claim to support. So fixed it up before upgrading to Python 3.14.