### PR TITLE
mcp: enable agent and developer endpoints by default

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -163,7 +163,7 @@ pub const ENABLE_S3_TABLES_REGION_CHECK: Config<bool> = Config::new(
 /// Whether the MCP agent endpoint is enabled.
 pub const ENABLE_MCP_AGENT: Config<bool> = Config::new(
     "enable_mcp_agent",
-    false,
+    true,
     "Whether the MCP agent HTTP endpoint is enabled. When false, requests to /api/mcp/agent return 503 Service Unavailable.",
 );
 
@@ -179,7 +179,7 @@ pub const ENABLE_MCP_AGENT_QUERY_TOOL: Config<bool> = Config::new(
 /// Whether the MCP developer endpoint is enabled.
 pub const ENABLE_MCP_DEVELOPER: Config<bool> = Config::new(
     "enable_mcp_developer",
-    false,
+    true,
     "Whether the MCP developer HTTP endpoint is enabled. When false, requests to /api/mcp/developer return 503 Service Unavailable.",
 );
 

--- a/test/mcp/mzcompose.py
+++ b/test/mcp/mzcompose.py
@@ -47,19 +47,7 @@ def post_mcp(c: Composition, endpoint: str, body: dict) -> requests.Response:
 def workflow_default(c: Composition) -> None:
     c.up("materialized")
 
-    # MCP feature flags default to false; enable them for testing.
-    c.sql(
-        "ALTER SYSTEM SET enable_mcp_agent = true",
-        user="mz_system",
-        port=6877,
-        print_statement=False,
-    )
-    c.sql(
-        "ALTER SYSTEM SET enable_mcp_developer = true",
-        user="mz_system",
-        port=6877,
-        print_statement=False,
-    )
+    # MCP feature flags default to true; no explicit enable needed.
 
     with c.test_case("agent_initialize"):
         r = post_mcp(

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -444,31 +444,11 @@ def workflow_mcp_feature_flags(c: Composition) -> None:
         agent_url = f"http://localhost:{http_port}/api/mcp/agent"
         developer_url = f"http://localhost:{http_port}/api/mcp/developer"
 
-        # Both endpoints should be disabled by default (feature flags default to false).
-        assert requests.post(agent_url, json=mcp_request).status_code == 503
-        assert requests.post(developer_url, json=mcp_request).status_code == 503
-
-        # Enable the agent endpoint individually.
-        c.sql(
-            "ALTER SYSTEM SET enable_mcp_agent = true",
-            port=6877,
-            user="mz_system",
-        )
-
+        # Both endpoints should be enabled by default.
         assert requests.post(agent_url, json=mcp_request).status_code == 200
-        # Developer should still be disabled.
-        assert requests.post(developer_url, json=mcp_request).status_code == 503
-
-        # Enable developer too.
-        c.sql(
-            "ALTER SYSTEM SET enable_mcp_developer = true",
-            port=6877,
-            user="mz_system",
-        )
-
         assert requests.post(developer_url, json=mcp_request).status_code == 200
 
-        # Disable agent again — developer should remain enabled.
+        # Disable the agent endpoint individually.
         c.sql(
             "ALTER SYSTEM SET enable_mcp_agent = false",
             port=6877,
@@ -476,11 +456,31 @@ def workflow_mcp_feature_flags(c: Composition) -> None:
         )
 
         assert requests.post(agent_url, json=mcp_request).status_code == 503
+        # Developer should still be enabled.
         assert requests.post(developer_url, json=mcp_request).status_code == 200
 
-        # Re-enable agent.
+        # Disable developer too.
+        c.sql(
+            "ALTER SYSTEM SET enable_mcp_developer = false",
+            port=6877,
+            user="mz_system",
+        )
+
+        assert requests.post(developer_url, json=mcp_request).status_code == 503
+
+        # Re-enable agent — developer should remain disabled.
         c.sql(
             "ALTER SYSTEM SET enable_mcp_agent = true",
+            port=6877,
+            user="mz_system",
+        )
+
+        assert requests.post(agent_url, json=mcp_request).status_code == 200
+        assert requests.post(developer_url, json=mcp_request).status_code == 503
+
+        # Re-enable developer.
+        c.sql(
+            "ALTER SYSTEM SET enable_mcp_developer = true",
             port=6877,
             user="mz_system",
         )


### PR DESCRIPTION
As discussed here: https://github.com/MaterializeInc/materialize/pull/35604#issuecomment-4237944667