### PR TITLE
Tighten `Context`

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -46,8 +46,7 @@ use crate::render::errors::ErrorLogger;
 use crate::render::{LinearJoinSpec, RenderTimestamp};
 use crate::row_spine::{DatumSeq, RowRowBuilder};
 use crate::typedefs::{
-    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter,
-    RowRowSpine,
+    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter, RowRowSpine,
 };
 
 /// Dataflow-local collections and arrangements.
@@ -302,14 +301,12 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
 
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let oks =
-                    CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
+                let oks = CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let oks =
-                    CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
+                let oks = CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
@@ -342,10 +339,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
 }
 impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// Extracts the arrangement flavor from a region.
-    pub fn leave_region<'outer>(
-        &self,
-        outer: Scope<'outer, T>,
-    ) -> ArrangementFlavor<'outer, T> {
+    pub fn leave_region<'outer>(&self, outer: Scope<'outer, T>) -> ArrangementFlavor<'outer, T> {
         match self {
             ArrangementFlavor::Local(oks, errs) => ArrangementFlavor::Local(
                 oks.clone().leave_region(outer),
@@ -424,10 +418,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     }
 
     /// Brings the collection bundle into a region.
-    pub fn enter_region<'inner>(
-        &self,
-        region: Scope<'inner, T>,
-    ) -> CollectionBundle<'inner, T> {
+    pub fn enter_region<'inner>(&self, region: Scope<'inner, T>) -> CollectionBundle<'inner, T> {
         CollectionBundle {
             collection: self.collection.as_ref().map(|(oks, errs)| {
                 (
@@ -446,10 +437,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
 
 impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Extracts the collection bundle from a region.
-    pub fn leave_region<'outer>(
-        &self,
-        outer: Scope<'outer, T>,
-    ) -> CollectionBundle<'outer, T> {
+    pub fn leave_region<'outer>(&self, outer: Scope<'outer, T>) -> CollectionBundle<'outer, T> {
         CollectionBundle {
             collection: self.collection.as_ref().map(|(oks, errs)| {
                 (

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -57,15 +57,15 @@ use crate::typedefs::{
 /// These assets include dataflow-local collections and arrangements, as well as imported
 /// arrangements from outside the dataflow.
 ///
-/// Context has a timestamp type `TInner`, which is the timestamp used by the scope in question.
-pub struct Context<'scope, TInner>
+/// Context has a timestamp type `T`, which is the timestamp used by the scope in question.
+pub struct Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// The scope within which all managed collections exist.
     ///
     /// It is an error to add any collections not contained in this scope.
-    pub(crate) scope: Scope<'scope, TInner>,
+    pub(crate) scope: Scope<'scope, T>,
     /// The debug name of the dataflow associated with this context.
     pub debug_name: String,
     /// The Timely ID of the dataflow associated with this context.
@@ -81,7 +81,7 @@ where
     /// Used to limit the amount of work done when appropriate.
     pub until: Antichain<mz_repr::Timestamp>,
     /// Bindings of identifiers to collections.
-    pub bindings: BTreeMap<Id, CollectionBundle<'scope, TInner>>,
+    pub bindings: BTreeMap<Id, CollectionBundle<'scope, T>>,
     /// The logger, from Timely's logging framework, if logs are enabled.
     pub(super) compute_logger: Option<crate::logging::compute::Logger>,
     /// Specification for rendering linear joins.
@@ -93,14 +93,14 @@ where
     pub config_set: Rc<ConfigSet>,
 }
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Creates a new empty Context.
     pub fn for_dataflow_in<Plan>(
         dataflow: &DataflowDescription<Plan, CollectionMetadata>,
-        scope: Scope<'scope, TInner>,
+        scope: Scope<'scope, T>,
         compute_state: &ComputeState,
         until: Antichain<mz_repr::Timestamp>,
         dataflow_expiration: Antichain<mz_repr::Timestamp>,
@@ -139,9 +139,9 @@ where
     }
 }
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Insert a collection bundle by an identifier.
     ///
@@ -150,18 +150,18 @@ where
     pub fn insert_id(
         &mut self,
         id: Id,
-        collection: CollectionBundle<'scope, TInner>,
-    ) -> Option<CollectionBundle<'scope, TInner>> {
+        collection: CollectionBundle<'scope, T>,
+    ) -> Option<CollectionBundle<'scope, T>> {
         self.bindings.insert(id, collection)
     }
     /// Remove a collection bundle by an identifier.
     ///
     /// The primary use of this method is uninstalling `Let` bindings.
-    pub fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<'scope, TInner>> {
+    pub fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<'scope, T>> {
         self.bindings.remove(&id)
     }
     /// Melds a collection bundle to whatever exists.
-    pub fn update_id(&mut self, id: Id, collection: CollectionBundle<'scope, TInner>) {
+    pub fn update_id(&mut self, id: Id, collection: CollectionBundle<'scope, T>) {
         if !self.bindings.contains_key(&id) {
             self.bindings.insert(id, collection);
         } else {
@@ -178,7 +178,7 @@ where
         }
     }
     /// Look up a collection bundle by an identifier.
-    pub fn lookup_id(&self, id: Id) -> Option<CollectionBundle<'scope, TInner>> {
+    pub fn lookup_id(&self, id: Id) -> Option<CollectionBundle<'scope, T>> {
         self.bindings.get(&id).cloned()
     }
 
@@ -187,16 +187,16 @@ where
     }
 }
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
         &self,
-        region: Scope<'a, TInner>,
+        region: Scope<'a, T>,
         bindings: Option<&std::collections::BTreeSet<Id>>,
-    ) -> Context<'a, TInner> {
+    ) -> Context<'a, T> {
         let bindings = self
             .bindings
             .iter()
@@ -222,14 +222,14 @@ where
 
 /// Describes flavor of arrangement: local or imported trace.
 #[derive(Clone)]
-pub enum ArrangementFlavor<'scope, TInner>
+pub enum ArrangementFlavor<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// A dataflow-local arrangement.
     Local(
-        Arranged<'scope, RowRowAgent<TInner, Diff>>,
-        Arranged<'scope, ErrAgent<TInner, Diff>>,
+        Arranged<'scope, RowRowAgent<T, Diff>>,
+        Arranged<'scope, ErrAgent<T, Diff>>,
     ),
     /// An imported trace from outside the dataflow.
     ///
@@ -237,14 +237,14 @@ where
     /// can refer back to and depend on the original instance.
     Trace(
         GlobalId,
-        Arranged<'scope, RowRowEnter<mz_repr::Timestamp, Diff, TInner>>,
-        Arranged<'scope, ErrEnter<mz_repr::Timestamp, TInner>>,
+        Arranged<'scope, RowRowEnter<mz_repr::Timestamp, Diff, T>>,
+        Arranged<'scope, ErrEnter<mz_repr::Timestamp, T>>,
     ),
 }
 
-impl<'scope, TInner> ArrangementFlavor<'scope, TInner>
+impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Presents `self` as a stream of updates.
     ///
@@ -257,8 +257,8 @@ where
     pub fn as_collection(
         &self,
     ) -> (
-        VecCollection<'scope, TInner, Row, Diff>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        VecCollection<'scope, T, Row, Diff>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     ) {
         let mut datums = DatumVec::new();
         let logic = move |k: DatumSeq, v: DatumSeq| {
@@ -282,7 +282,7 @@ where
     /// Constructs and applies logic to elements of `self` and returns the results.
     ///
     /// The `logic` receives a vector of datums, a timestamp, and a diff, and produces
-    /// an iterator of `(D, TInner, Diff)` updates.
+    /// an iterator of `(D, T, Diff)` updates.
     ///
     /// If `key` is set, this is a promise that `logic` will produce no results on
     /// records for which the key does not evaluate to the value. This is used to
@@ -297,13 +297,13 @@ where
         max_demand: usize,
         mut logic: L,
     ) -> (
-        StreamVec<'scope, TInner, I::Item>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        StreamVec<'scope, T, I::Item>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     )
     where
-        I: IntoIterator<Item = (D, TInner, Diff)>,
+        I: IntoIterator<Item = (D, T, Diff)>,
         D: Data,
-        L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, TInner, Diff) -> I + 'static,
+        L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff) -> I + 'static,
     {
         // Set a number of tuples after which the operator should yield.
         // This allows us to remain responsive even when enumerating a substantial
@@ -322,25 +322,25 @@ where
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
                 let oks =
-                    CollectionBundle::<TInner>::flat_map_core(oks.clone(), key, logic, refuel);
+                    CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
                 let oks =
-                    CollectionBundle::<TInner>::flat_map_core(oks.clone(), key, logic, refuel);
+                    CollectionBundle::<T>::flat_map_core(oks.clone(), key, logic, refuel);
                 let errs = errs.clone().as_collection(|k, &()| k.clone());
                 (oks, errs)
             }
         }
     }
 }
-impl<'scope, TInner> ArrangementFlavor<'scope, TInner>
+impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// The scope containing the collection bundle.
-    pub fn scope(&self) -> Scope<'scope, TInner> {
+    pub fn scope(&self) -> Scope<'scope, T> {
         match self {
             ArrangementFlavor::Local(oks, _errs) => oks.stream.scope(),
             ArrangementFlavor::Trace(_gid, oks, _errs) => oks.stream.scope(),
@@ -348,7 +348,7 @@ where
     }
 
     /// Brings the arrangement flavor into a region.
-    pub fn enter_region<'a>(&self, region: Scope<'a, TInner>) -> ArrangementFlavor<'a, TInner> {
+    pub fn enter_region<'a>(&self, region: Scope<'a, T>) -> ArrangementFlavor<'a, T> {
         match self {
             ArrangementFlavor::Local(oks, errs) => ArrangementFlavor::Local(
                 oks.clone().enter_region(region),
@@ -362,15 +362,15 @@ where
         }
     }
 }
-impl<'scope, TInner> ArrangementFlavor<'scope, TInner>
+impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Extracts the arrangement flavor from a region.
     pub fn leave_region<'outer>(
         &self,
-        outer: Scope<'outer, TInner>,
-    ) -> ArrangementFlavor<'outer, TInner> {
+        outer: Scope<'outer, T>,
+    ) -> ArrangementFlavor<'outer, T> {
         match self {
             ArrangementFlavor::Local(oks, errs) => ArrangementFlavor::Local(
                 oks.clone().leave_region(outer),
@@ -390,25 +390,25 @@ where
 /// This type maintains the invariant that it does contain at least one valid
 /// source of data, either a collection or at least one arrangement.
 #[derive(Clone)]
-pub struct CollectionBundle<'scope, TInner>
+pub struct CollectionBundle<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     pub collection: Option<(
-        VecCollection<'scope, TInner, Row, Diff>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        VecCollection<'scope, T, Row, Diff>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     )>,
-    pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<'scope, TInner>>,
+    pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<'scope, T>>,
 }
 
-impl<'scope, TInner> CollectionBundle<'scope, TInner>
+impl<'scope, T> CollectionBundle<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
-        oks: VecCollection<'scope, TInner, Row, Diff>,
-        errs: VecCollection<'scope, TInner, DataflowError, Diff>,
+        oks: VecCollection<'scope, T, Row, Diff>,
+        errs: VecCollection<'scope, T, DataflowError, Diff>,
     ) -> Self {
         Self {
             collection: Some((oks, errs)),
@@ -419,7 +419,7 @@ where
     /// Inserts arrangements by the expressions on which they are keyed.
     pub fn from_expressions(
         exprs: Vec<MirScalarExpr>,
-        arrangements: ArrangementFlavor<'scope, TInner>,
+        arrangements: ArrangementFlavor<'scope, T>,
     ) -> Self {
         let mut arranged = BTreeMap::new();
         arranged.insert(exprs, arrangements);
@@ -432,7 +432,7 @@ where
     /// Inserts arrangements by the columns on which they are keyed.
     pub fn from_columns<I: IntoIterator<Item = usize>>(
         columns: I,
-        arrangements: ArrangementFlavor<'scope, TInner>,
+        arrangements: ArrangementFlavor<'scope, T>,
     ) -> Self {
         let mut keys = Vec::new();
         for column in columns {
@@ -442,7 +442,7 @@ where
     }
 
     /// The scope containing the collection bundle.
-    pub fn scope(&self) -> Scope<'scope, TInner> {
+    pub fn scope(&self) -> Scope<'scope, T> {
         if let Some((oks, _errs)) = &self.collection {
             oks.inner.scope()
         } else {
@@ -457,8 +457,8 @@ where
     /// Brings the collection bundle into a region.
     pub fn enter_region<'inner>(
         &self,
-        region: Scope<'inner, TInner>,
-    ) -> CollectionBundle<'inner, TInner> {
+        region: Scope<'inner, T>,
+    ) -> CollectionBundle<'inner, T> {
         CollectionBundle {
             collection: self.collection.as_ref().map(|(oks, errs)| {
                 (
@@ -475,15 +475,15 @@ where
     }
 }
 
-impl<'scope, TInner> CollectionBundle<'scope, TInner>
+impl<'scope, T> CollectionBundle<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Extracts the collection bundle from a region.
     pub fn leave_region<'outer>(
         &self,
-        outer: Scope<'outer, TInner>,
-    ) -> CollectionBundle<'outer, TInner> {
+        outer: Scope<'outer, T>,
+    ) -> CollectionBundle<'outer, T> {
         CollectionBundle {
             collection: self.collection.as_ref().map(|(oks, errs)| {
                 (
@@ -500,9 +500,9 @@ where
     }
 }
 
-impl<'scope, TInner> CollectionBundle<'scope, TInner>
+impl<'scope, T> CollectionBundle<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,
@@ -521,8 +521,8 @@ where
         key: Option<&[MirScalarExpr]>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, TInner, Row, Diff>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        VecCollection<'scope, T, Row, Diff>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     ) {
         // Any operator that uses this method was told to use a particular
         // collection during LIR planning, where we should have made
@@ -573,13 +573,13 @@ where
         max_demand: usize,
         mut logic: L,
     ) -> (
-        StreamVec<'scope, TInner, I::Item>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        StreamVec<'scope, T, I::Item>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     )
     where
-        I: IntoIterator<Item = (D, TInner, Diff)>,
+        I: IntoIterator<Item = (D, T, Diff)>,
         D: Data,
-        L: for<'a> FnMut(&'a mut DatumVecBorrow<'_>, TInner, Diff) -> I + 'static,
+        L: for<'a> FnMut(&'a mut DatumVecBorrow<'_>, T, Diff) -> I + 'static,
     {
         // If `key_val` is set, we should have to use the corresponding arrangement.
         // If there isn't one, that implies an error in the contract between
@@ -614,19 +614,19 @@ where
         key: Option<&<Tr::KeyContainer as BatchContainer>::Owned>,
         mut logic: L,
         refuel: usize,
-    ) -> StreamVec<'scope, TInner, I::Item>
+    ) -> StreamVec<'scope, T, I::Item>
     where
         Tr: for<'a> TraceReader<
                 Key<'a>: ToDatumIter,
                 Val<'a>: ToDatumIter,
-                Time = TInner,
+                Time = T,
                 Diff = mz_repr::Diff,
             > + Clone
             + 'static,
         <Tr::KeyContainer as BatchContainer>::Owned: PartialEq,
         I: IntoIterator<Item = (D, Tr::Time, Tr::Diff)>,
         D: Data,
-        L: FnMut(Tr::Key<'_>, Tr::Val<'_>, TInner, mz_repr::Diff) -> I + 'static,
+        L: FnMut(Tr::Key<'_>, Tr::Val<'_>, T, mz_repr::Diff) -> I + 'static,
     {
         use differential_dataflow::consolidation::ConsolidatingContainerBuilder as CB;
         let scope = trace.stream.scope();
@@ -685,14 +685,14 @@ where
     ///
     /// The result may be `None` if no such arrangement exists, or it may be one of many
     /// "arrangement flavors" that represent the types of arranged data we might have.
-    pub fn arrangement(&self, key: &[MirScalarExpr]) -> Option<ArrangementFlavor<'scope, TInner>> {
+    pub fn arrangement(&self, key: &[MirScalarExpr]) -> Option<ArrangementFlavor<'scope, T>> {
         self.arranged.get(key).map(|x| x.clone())
     }
 }
 
-impl<'scope, TInner> CollectionBundle<'scope, TInner>
+impl<'scope, T> CollectionBundle<'scope, T>
 where
-    TInner: RenderTimestamp,
+    T: RenderTimestamp,
 {
     /// Presents `self` as a stream of updates, having been subjected to `mfp`.
     ///
@@ -709,8 +709,8 @@ where
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, TInner, mz_repr::Row, Diff>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
+        VecCollection<'scope, T, mz_repr::Row, Diff>,
+        VecCollection<'scope, T, DataflowError, Diff>,
     ) {
         mfp.optimize();
         let mfp_plan = mfp.clone().into_plan().unwrap();
@@ -761,13 +761,13 @@ where
                 .map(move |x| match x {
                     Ok((row, event_time, diff)) => {
                         // Copy the whole time, and re-populate event time.
-                        let mut time: TInner = time.clone();
+                        let mut time: T = time.clone();
                         *time.event_time_mut() = event_time;
                         (Ok(row), time, diff)
                     }
                     Err((e, event_time, diff)) => {
                         // Copy the whole time, and re-populate event time.
-                        let mut time: TInner = time.clone();
+                        let mut time: T = time.clone();
                         *time.event_time_mut() = event_time;
                         (Err(e), time, diff)
                     }
@@ -860,13 +860,13 @@ where
     /// teeing the stream.
     fn arrange_collection(
         name: &String,
-        oks: VecCollection<'scope, TInner, Row, Diff>,
+        oks: VecCollection<'scope, T, Row, Diff>,
         key: Vec<MirScalarExpr>,
         thinning: Vec<usize>,
     ) -> (
-        Arranged<'scope, RowRowAgent<TInner, Diff>>,
-        VecCollection<'scope, TInner, DataflowError, Diff>,
-        VecCollection<'scope, TInner, Row, Diff>,
+        Arranged<'scope, RowRowAgent<T, Diff>>,
+        VecCollection<'scope, T, DataflowError, Diff>,
+        VecCollection<'scope, T, Row, Diff>,
     ) {
         // This operator implements a `map_fallible`, but produces columnar updates for the ok
         // stream. The `map_fallible` cannot be used here because the closure cannot return
@@ -875,7 +875,7 @@ where
         let mut builder = OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
         let (ok_output, ok_stream) = builder.new_output();
         let mut ok_output =
-            OutputBuilder::<_, ColumnBuilder<((Row, Row), TInner, Diff)>>::from(ok_output);
+            OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
         let (err_output, err_stream) = builder.new_output();
         let mut err_output = OutputBuilder::from(err_output);
         let (passthrough_output, passthrough_stream) = builder.new_output();
@@ -922,7 +922,7 @@ where
                 RowRowSpine<_, _>,
             >(
                 ExchangeCore::<ColumnBuilder<_>, _>::new_core(
-                    columnar_exchange::<Row, Row, TInner, Diff>,
+                    columnar_exchange::<Row, Row, T, Diff>,
                 ),
                 name
             );

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -38,7 +38,6 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OutputBuilder, OutputBuilderSession};
 use timely::dataflow::{Scope, StreamVec};
 use timely::progress::operate::FrontierInterest;
-use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
@@ -47,7 +46,7 @@ use crate::render::errors::ErrorLogger;
 use crate::render::{LinearJoinSpec, RenderTimestamp};
 use crate::row_spine::{DatumSeq, RowRowBuilder};
 use crate::typedefs::{
-    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, MzTimestamp, RowRowAgent, RowRowEnter,
+    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter,
     RowRowSpine,
 };
 
@@ -60,7 +59,7 @@ use crate::typedefs::{
 /// Context has a timestamp type `T`, which is the timestamp used by the scope in question.
 pub struct Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// The scope within which all managed collections exist.
     ///
@@ -95,7 +94,7 @@ where
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Creates a new empty Context.
     pub fn for_dataflow_in<Plan>(
@@ -141,7 +140,7 @@ where
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Insert a collection bundle by an identifier.
     ///
@@ -189,7 +188,7 @@ where
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
@@ -224,7 +223,7 @@ where
 #[derive(Clone)]
 pub enum ArrangementFlavor<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// A dataflow-local arrangement.
     Local(
@@ -244,7 +243,7 @@ where
 
 impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Presents `self` as a stream of updates.
     ///
@@ -337,7 +336,7 @@ where
 }
 impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> Scope<'scope, T> {
@@ -364,7 +363,7 @@ where
 }
 impl<'scope, T> ArrangementFlavor<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Extracts the arrangement flavor from a region.
     pub fn leave_region<'outer>(
@@ -392,7 +391,7 @@ where
 #[derive(Clone)]
 pub struct CollectionBundle<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     pub collection: Option<(
         VecCollection<'scope, T, Row, Diff>,
@@ -403,7 +402,7 @@ where
 
 impl<'scope, T> CollectionBundle<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
@@ -477,7 +476,7 @@ where
 
 impl<'scope, T> CollectionBundle<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Extracts the collection bundle from a region.
     pub fn leave_region<'outer>(
@@ -502,7 +501,7 @@ where
 
 impl<'scope, T> CollectionBundle<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -57,10 +57,7 @@ use crate::typedefs::{
 /// arrangements from outside the dataflow.
 ///
 /// Context has a timestamp type `T`, which is the timestamp used by the scope in question.
-pub struct Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+pub struct Context<'scope, T: RenderTimestamp> {
     /// The scope within which all managed collections exist.
     ///
     /// It is an error to add any collections not contained in this scope.
@@ -92,10 +89,7 @@ where
     pub config_set: Rc<ConfigSet>,
 }
 
-impl<'scope, T> Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     /// Creates a new empty Context.
     pub fn for_dataflow_in<Plan>(
         dataflow: &DataflowDescription<Plan, CollectionMetadata>,
@@ -138,10 +132,7 @@ where
     }
 }
 
-impl<'scope, T> Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     /// Insert a collection bundle by an identifier.
     ///
     /// This is expected to be used to install external collections (sources, indexes, other views),
@@ -186,10 +177,7 @@ where
     }
 }
 
-impl<'scope, T> Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     /// Brings the underlying arrangements and collections into a region.
     pub fn enter_region<'a>(
         &self,
@@ -221,10 +209,7 @@ where
 
 /// Describes flavor of arrangement: local or imported trace.
 #[derive(Clone)]
-pub enum ArrangementFlavor<'scope, T>
-where
-    T: RenderTimestamp,
-{
+pub enum ArrangementFlavor<'scope, T: RenderTimestamp> {
     /// A dataflow-local arrangement.
     Local(
         Arranged<'scope, RowRowAgent<T, Diff>>,
@@ -241,10 +226,7 @@ where
     ),
 }
 
-impl<'scope, T> ArrangementFlavor<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// Presents `self` as a stream of updates.
     ///
     /// Deprecated: This function is not fueled and hence risks flattening the whole arrangement.
@@ -334,10 +316,7 @@ where
         }
     }
 }
-impl<'scope, T> ArrangementFlavor<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// The scope containing the collection bundle.
     pub fn scope(&self) -> Scope<'scope, T> {
         match self {
@@ -361,10 +340,7 @@ where
         }
     }
 }
-impl<'scope, T> ArrangementFlavor<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// Extracts the arrangement flavor from a region.
     pub fn leave_region<'outer>(
         &self,
@@ -389,10 +365,7 @@ where
 /// This type maintains the invariant that it does contain at least one valid
 /// source of data, either a collection or at least one arrangement.
 #[derive(Clone)]
-pub struct CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+pub struct CollectionBundle<'scope, T: RenderTimestamp> {
     pub collection: Option<(
         VecCollection<'scope, T, Row, Diff>,
         VecCollection<'scope, T, DataflowError, Diff>,
@@ -400,10 +373,7 @@ where
     pub arranged: BTreeMap<Vec<MirScalarExpr>, ArrangementFlavor<'scope, T>>,
 }
 
-impl<'scope, T> CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Construct a new collection bundle from update streams.
     pub fn from_collections(
         oks: VecCollection<'scope, T, Row, Diff>,
@@ -474,10 +444,7 @@ where
     }
 }
 
-impl<'scope, T> CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Extracts the collection bundle from a region.
     pub fn leave_region<'outer>(
         &self,
@@ -499,10 +466,7 @@ where
     }
 }
 
-impl<'scope, T> CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Asserts that the arrangement for a specific key
     /// (or the raw collection for no key) exists,
     /// and returns the corresponding collection.
@@ -689,10 +653,7 @@ where
     }
 }
 
-impl<'scope, T> CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Presents `self` as a stream of updates, having been subjected to `mfp`.
     ///
     /// This operator is able to apply the logic of `mfp` early, which can substantially

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -31,14 +31,12 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::OkErr;
-use timely::progress::timestamp::Refines;
-
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::row_spine::{RowRowBuilder, RowRowSpine};
-use crate::typedefs::{MzTimestamp, RowRowAgent, RowRowEnter};
+use crate::typedefs::{RowRowAgent, RowRowEnter};
 
 /// Available linear join implementations.
 ///
@@ -184,7 +182,7 @@ impl YieldSpec {
 /// Different forms the streamed data might take.
 enum JoinedFlavor<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Streamed data as a collection.
     Collection(VecCollection<'scope, T, Row, Diff>),

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -180,10 +180,7 @@ impl YieldSpec {
 }
 
 /// Different forms the streamed data might take.
-enum JoinedFlavor<'scope, T>
-where
-    T: RenderTimestamp,
-{
+enum JoinedFlavor<'scope, T: RenderTimestamp> {
     /// Streamed data as a collection.
     Collection(VecCollection<'scope, T, Row, Diff>),
     /// A dataflow-local arrangement.

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -31,6 +31,7 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::OkErr;
+
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
@@ -467,9 +468,7 @@ where
     )
     where
         Tr1: TraceReader<Time = T, Diff = Diff> + Clone + 'static,
-        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = T, Diff = Diff>
-            + Clone
-            + 'static,
+        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = T, Diff = Diff> + Clone + 'static,
         for<'a> Tr1::Key<'a>: ToDatumIter,
         for<'a> Tr1::Val<'a>: ToDatumIter,
         for<'a> Tr2::Val<'a>: ToDatumIter,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -182,27 +182,27 @@ impl YieldSpec {
 }
 
 /// Different forms the streamed data might take.
-enum JoinedFlavor<'scope, TInner>
+enum JoinedFlavor<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Streamed data as a collection.
-    Collection(VecCollection<'scope, TInner, Row, Diff>),
+    Collection(VecCollection<'scope, T, Row, Diff>),
     /// A dataflow-local arrangement.
-    Local(Arranged<'scope, RowRowAgent<TInner, Diff>>),
+    Local(Arranged<'scope, RowRowAgent<T, Diff>>),
     /// An imported arrangement.
-    Trace(Arranged<'scope, RowRowEnter<mz_repr::Timestamp, Diff, TInner>>),
+    Trace(Arranged<'scope, RowRowEnter<mz_repr::Timestamp, Diff, T>>),
 }
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: Lattice + RenderTimestamp,
+    T: Lattice + RenderTimestamp,
 {
     pub(crate) fn render_join(
         &self,
-        inputs: Vec<CollectionBundle<'scope, TInner>>,
+        inputs: Vec<CollectionBundle<'scope, T>>,
         linear_plan: LinearJoinPlan,
-    ) -> CollectionBundle<'scope, TInner> {
+    ) -> CollectionBundle<'scope, T> {
         self.scope.clone().region_named("Join(Linear)", |inner| {
             self.render_join_inner(inputs, linear_plan, inner)
         })
@@ -210,10 +210,10 @@ where
 
     fn render_join_inner(
         &self,
-        inputs: Vec<CollectionBundle<'scope, TInner>>,
+        inputs: Vec<CollectionBundle<'scope, T>>,
         linear_plan: LinearJoinPlan,
-        inner: Scope<'_, TInner>,
-    ) -> CollectionBundle<'scope, TInner> {
+        inner: Scope<'_, T>,
+    ) -> CollectionBundle<'scope, T> {
         // Collect all error streams, and concatenate them at the end.
         let mut errors = Vec::new();
 
@@ -330,8 +330,8 @@ where
     /// version of the join of previous inputs.
     fn differential_join<'s>(
         &self,
-        mut joined: JoinedFlavor<'s, TInner>,
-        lookup_relation: CollectionBundle<'s, TInner>,
+        mut joined: JoinedFlavor<'s, T>,
+        lookup_relation: CollectionBundle<'s, T>,
         LinearStagePlan {
             stream_key,
             stream_thinning,
@@ -339,14 +339,14 @@ where
             closure,
             lookup_relation: _,
         }: LinearStagePlan,
-        errors: &mut Vec<VecCollection<'s, TInner, DataflowError, Diff>>,
-    ) -> VecCollection<'s, TInner, Row, Diff> {
+        errors: &mut Vec<VecCollection<'s, T, DataflowError, Diff>>,
+    ) -> VecCollection<'s, T, Row, Diff> {
         // If we have only a streamed collection, we must first form an arrangement.
         if let JoinedFlavor::Collection(stream) = joined {
             let name = "LinearJoinKeyPreparation";
             let (keyed, errs) = stream
                 .inner
-                .unary_fallible::<ColumnBuilder<((Row, Row), TInner, Diff)>, _, _, _>(
+                .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
                     Pipeline,
                     name,
                     |_, _| {
@@ -392,7 +392,7 @@ where
                     RowRowSpine<_, _>,
                 >(
                     ExchangeCore::<ColumnBuilder<_>, _>::new_core(
-                        columnar_exchange::<Row, Row, TInner, Diff>,
+                        columnar_exchange::<Row, Row, T, Diff>,
                     ),
                     "JoinStage"
                 );
@@ -467,12 +467,12 @@ where
         next_input: Arranged<'s, Tr2>,
         closure: JoinClosure,
     ) -> (
-        VecCollection<'s, TInner, Row, Diff>,
-        Option<VecCollection<'s, TInner, DataflowError, Diff>>,
+        VecCollection<'s, T, Row, Diff>,
+        Option<VecCollection<'s, T, DataflowError, Diff>>,
     )
     where
-        Tr1: TraceReader<Time = TInner, Diff = Diff> + Clone + 'static,
-        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = TInner, Diff = Diff>
+        Tr1: TraceReader<Time = T, Diff = Diff> + Clone + 'static,
+        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = T, Diff = Diff>
             + Clone
             + 'static,
         for<'a> Tr1::Key<'a>: ToDatumIter,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -42,7 +42,6 @@ use mz_timely_util::operator::CollectionExt;
 use serde::{Deserialize, Serialize};
 use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
-use timely::progress::timestamp::Refines;
 use tracing::warn;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
@@ -50,18 +49,18 @@ use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{ReductionMonoid, get_monoid};
-use crate::render::{ArrangementFlavor, Pairer};
+use crate::render::{ArrangementFlavor, Pairer, RenderTimestamp};
 use crate::row_spine::{
     DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBatcher, RowValBuilder,
 };
 use crate::typedefs::{
-    ErrBatcher, ErrBuilder, KeyBatcher, MzTimestamp, RowErrBuilder, RowErrSpine, RowRowAgent,
+    ErrBatcher, ErrBuilder, KeyBatcher, RowErrBuilder, RowErrSpine, RowRowAgent,
     RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
 };
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -58,10 +58,7 @@ use crate::typedefs::{
     RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
 };
 
-impl<'scope, T> Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.
     pub fn render_reduce(

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -54,8 +54,8 @@ use crate::row_spine::{
     DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBatcher, RowValBuilder,
 };
 use crate::typedefs::{
-    ErrBatcher, ErrBuilder, KeyBatcher, RowErrBuilder, RowErrSpine, RowRowAgent,
-    RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
+    ErrBatcher, ErrBuilder, KeyBatcher, RowErrBuilder, RowErrSpine, RowRowAgent, RowRowArrangement,
+    RowRowSpine, RowSpine, RowValSpine,
 };
 
 impl<'scope, T: RenderTimestamp> Context<'scope, T> {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -59,20 +59,20 @@ use crate::typedefs::{
     RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
 };
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.
     pub fn render_reduce(
         &self,
         input_key: Option<Vec<MirScalarExpr>>,
-        input: CollectionBundle<'scope, TInner>,
+        input: CollectionBundle<'scope, T>,
         key_val_plan: KeyValPlan,
         reduce_plan: ReducePlan,
         mfp_after: Option<MapFilterProject>,
-    ) -> CollectionBundle<'scope, TInner> {
+    ) -> CollectionBundle<'scope, T> {
         // Convert `mfp_after` to an actionable plan.
         let mfp_after = mfp_after.map(|m| {
             m.into_plan()
@@ -171,11 +171,11 @@ where
     fn render_reduce_plan<'s>(
         &self,
         plan: ReducePlan,
-        collection: VecCollection<'s, TInner, (Row, Row), Diff>,
-        err_input: VecCollection<'s, TInner, DataflowError, Diff>,
+        collection: VecCollection<'s, T, (Row, Row), Diff>,
+        err_input: VecCollection<'s, T, DataflowError, Diff>,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
-    ) -> CollectionBundle<'s, TInner> {
+    ) -> CollectionBundle<'s, T> {
         let mut errors = Default::default();
         let arrangement =
             self.render_reduce_plan_inner(plan, collection, &mut errors, key_arity, mfp_after);
@@ -192,11 +192,11 @@ where
     fn render_reduce_plan_inner<'s>(
         &self,
         plan: ReducePlan,
-        collection: VecCollection<'s, TInner, (Row, Row), Diff>,
-        errors: &mut Vec<VecCollection<'s, TInner, DataflowError, Diff>>,
+        collection: VecCollection<'s, T, (Row, Row), Diff>,
+        errors: &mut Vec<VecCollection<'s, T, DataflowError, Diff>>,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
-    ) -> Arranged<'s, RowRowAgent<TInner, Diff>> {
+    ) -> Arranged<'s, RowRowAgent<T, Diff>> {
         // TODO(vmarcos): Arrangement specialization here could eventually be extended to keys,
         // not only values (database-issues#6658).
         let arrangement = match plan {
@@ -258,11 +258,11 @@ where
     /// Build the dataflow to compute the set of distinct keys.
     fn build_distinct<'s>(
         &self,
-        collection: VecCollection<'s, TInner, (Row, Row), Diff>,
+        collection: VecCollection<'s, T, (Row, Row), Diff>,
         mfp_after: Option<SafeMfpPlan>,
     ) -> (
-        Arranged<'s, TraceAgent<RowRowSpine<TInner, Diff>>>,
-        VecCollection<'s, TInner, DataflowError, Diff>,
+        Arranged<'s, TraceAgent<RowRowSpine<T, Diff>>>,
+        VecCollection<'s, T, DataflowError, Diff>,
     ) {
         let error_logger = self.error_logger();
 
@@ -337,13 +337,13 @@ where
     /// in the order specified by `aggrs`.
     fn build_basic_aggregates<'s>(
         &self,
-        input: VecCollection<'s, TInner, (Row, Row), Diff>,
+        input: VecCollection<'s, T, (Row, Row), Diff>,
         aggrs: Vec<AggregateExpr>,
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
     ) -> (
-        RowRowArrangement<'s, TInner>,
-        VecCollection<'s, TInner, DataflowError, Diff>,
+        RowRowArrangement<'s, T>,
+        VecCollection<'s, T, DataflowError, Diff>,
     ) {
         // We are only using this function to render multiple basic aggregates and
         // stitch them together. If that's not true we should complain.
@@ -442,7 +442,7 @@ where
     /// This method also applies distinctness if required.
     fn build_basic_aggregate<'s>(
         &self,
-        input: VecCollection<'s, TInner, (Row, Row), Diff>,
+        input: VecCollection<'s, T, (Row, Row), Diff>,
         index: usize,
         aggr: &AggregateExpr,
         validating: bool,
@@ -450,8 +450,8 @@ where
         mfp_after: Option<SafeMfpPlan>,
         fused_unnest_list: bool,
     ) -> (
-        RowRowArrangement<'s, TInner>,
-        Option<VecCollection<'s, TInner, DataflowError, Diff>>,
+        RowRowArrangement<'s, T>,
+        Option<VecCollection<'s, T, DataflowError, Diff>>,
     ) {
         let AggregateExpr {
             func,
@@ -721,19 +721,19 @@ where
 
     fn build_reduce_inaccumulable_distinct<'s, Bu, Tr>(
         &self,
-        input: VecCollection<'s, TInner, Row, Diff>,
+        input: VecCollection<'s, T, Row, Diff>,
         name_tag: Option<&str>,
     ) -> Arranged<'s, TraceAgent<Tr>>
     where
         Tr: for<'a> Trace<
                 Key<'a> = DatumSeq<'a>,
                 KeyContainer: BatchContainer<Owned = Row>,
-                Time = TInner,
+                Time = T,
                 Diff = Diff,
                 ValOwn: Data + MaybeValidatingRow<(), String>,
             > + 'static,
         Bu: Builder<
-                Time = TInner,
+                Time = T,
                 Input: Container
                            + InternalMerge
                            + ClearContainer
@@ -790,7 +790,7 @@ where
     /// stage.
     fn build_bucketed<'s>(
         &self,
-        input: VecCollection<'s, TInner, (Row, Row), Diff>,
+        input: VecCollection<'s, T, (Row, Row), Diff>,
         BucketedPlan {
             aggr_funcs,
             buckets,
@@ -798,10 +798,10 @@ where
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
     ) -> (
-        RowRowArrangement<'s, TInner>,
-        VecCollection<'s, TInner, DataflowError, Diff>,
+        RowRowArrangement<'s, T>,
+        VecCollection<'s, T, DataflowError, Diff>,
     ) {
-        let mut err_output: Option<VecCollection<'s, TInner, _, _>> = None;
+        let mut err_output: Option<VecCollection<'s, T, _, _>> = None;
         let outer_scope = input.scope();
         let arranged_output = outer_scope
             .clone()
@@ -988,11 +988,11 @@ where
     fn build_bucketed_stage<'s>(
         &self,
         aggr_funcs: &Vec<AggregateFunc>,
-        input: VecCollection<'s, TInner, (Row, Row), Diff>,
+        input: VecCollection<'s, T, (Row, Row), Diff>,
         validating: bool,
     ) -> (
-        VecCollection<'s, TInner, (Row, Row), Diff>,
-        Option<VecCollection<'s, TInner, DataflowError, Diff>>,
+        VecCollection<'s, T, (Row, Row), Diff>,
+        Option<VecCollection<'s, T, DataflowError, Diff>>,
     ) {
         let (input, negated_output, errs) = if validating {
             let (input, reduced) = self
@@ -1044,10 +1044,10 @@ where
     /// with all diffs in the reduction's output negated.
     fn build_bucketed_negated_output<'s, Bu, Tr>(
         &self,
-        input: VecCollection<'s, TInner, (Row, Row), Diff>,
+        input: VecCollection<'s, T, (Row, Row), Diff>,
         aggrs: Vec<AggregateFunc>,
     ) -> (
-        Arranged<'s, TraceAgent<RowRowSpine<TInner, Diff>>>,
+        Arranged<'s, TraceAgent<RowRowSpine<T, Diff>>>,
         Arranged<'s, TraceAgent<Tr>>,
     )
     where
@@ -1055,11 +1055,11 @@ where
                 Key<'a> = DatumSeq<'a>,
                 KeyContainer: BatchContainer<Owned = Row>,
                 ValOwn: Data + MaybeValidatingRow<Row, Row>,
-                Time = TInner,
+                Time = T,
                 Diff = Diff,
             > + 'static,
         Bu: Builder<
-                Time = TInner,
+                Time = T,
                 Input: Container
                            + InternalMerge
                            + ClearContainer
@@ -1132,15 +1132,15 @@ where
     /// on monotonic inputs.
     fn build_monotonic<'s>(
         &self,
-        collection: VecCollection<'s, TInner, (Row, Row), Diff>,
+        collection: VecCollection<'s, T, (Row, Row), Diff>,
         MonotonicPlan {
             aggr_funcs,
             must_consolidate,
         }: MonotonicPlan,
         mfp_after: Option<SafeMfpPlan>,
     ) -> (
-        RowRowArrangement<'s, TInner>,
-        VecCollection<'s, TInner, DataflowError, Diff>,
+        RowRowArrangement<'s, T>,
+        VecCollection<'s, T, DataflowError, Diff>,
     ) {
         let aggregations = aggr_funcs.len();
         // Gather the relevant values into a vec of rows ordered by aggregation_index
@@ -1255,7 +1255,7 @@ where
     /// yield the final aggregate.
     fn build_accumulable<'s>(
         &self,
-        collection: VecCollection<'s, TInner, (Row, Row), Diff>,
+        collection: VecCollection<'s, T, (Row, Row), Diff>,
         AccumulablePlan {
             full_aggrs,
             simple_aggrs,
@@ -1264,8 +1264,8 @@ where
         key_arity: usize,
         mfp_after: Option<SafeMfpPlan>,
     ) -> (
-        RowRowArrangement<'s, TInner>,
-        VecCollection<'s, TInner, DataflowError, Diff>,
+        RowRowArrangement<'s, T>,
+        VecCollection<'s, T, DataflowError, Diff>,
     ) {
         let collection_scope = collection.scope();
 

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -33,10 +33,7 @@ use crate::logging::compute::LogDataflowErrors;
 use crate::render::context::Context;
 use crate::render::{RenderTimestamp, StartSignal};
 
-impl<'g, T> Context<'g, T>
-where
-    T: RenderTimestamp,
-{
+impl<'g, T: RenderTimestamp> Context<'g, T> {
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(
         &self,

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -80,12 +80,12 @@ where
 ///
 /// This implementation maintains rows in the output, i.e. all rows that have a count greater than
 /// zero. It returns a [CollectionBundle] populated from a local arrangement.
-pub fn build_threshold_basic<'scope, TInner>(
-    input: CollectionBundle<'scope, TInner>,
+pub fn build_threshold_basic<'scope, T>(
+    input: CollectionBundle<'scope, T>,
     key: Vec<MirScalarExpr>,
-) -> CollectionBundle<'scope, TInner>
+) -> CollectionBundle<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     let arrangement = input
         .arrangement(&key)
@@ -113,15 +113,15 @@ where
     }
 }
 
-impl<'scope, TInner> Context<'scope, TInner>
+impl<'scope, T> Context<'scope, T>
 where
-    TInner: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: MzTimestamp + Refines<mz_repr::Timestamp>,
 {
     pub(crate) fn render_threshold(
         &self,
-        input: CollectionBundle<'scope, TInner>,
+        input: CollectionBundle<'scope, T>,
         threshold_plan: ThresholdPlan,
-    ) -> CollectionBundle<'scope, TInner> {
+    ) -> CollectionBundle<'scope, T> {
         match threshold_plan {
             ThresholdPlan::Basic(BasicThresholdPlan {
                 ensure_arrangement: (key, _, _),

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -21,10 +21,9 @@ use mz_expr::MirScalarExpr;
 use mz_repr::Diff;
 use timely::Container;
 use timely::container::PushInto;
-use timely::progress::timestamp::Refines;
-
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
+use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::row_spine::RowRowBuilder;
 use crate::typedefs::{ErrBatcher, ErrBuilder, MzData, MzTimestamp};
@@ -85,7 +84,7 @@ pub fn build_threshold_basic<'scope, T>(
     key: Vec<MirScalarExpr>,
 ) -> CollectionBundle<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     let arrangement = input
         .arrangement(&key)
@@ -115,7 +114,7 @@ where
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: MzTimestamp + Refines<mz_repr::Timestamp>,
+    T: RenderTimestamp,
 {
     pub(crate) fn render_threshold(
         &self,

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -21,6 +21,7 @@ use mz_expr::MirScalarExpr;
 use mz_repr::Diff;
 use timely::Container;
 use timely::container::PushInto;
+
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::RenderTimestamp;

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -79,13 +79,10 @@ where
 ///
 /// This implementation maintains rows in the output, i.e. all rows that have a count greater than
 /// zero. It returns a [CollectionBundle] populated from a local arrangement.
-pub fn build_threshold_basic<'scope, T>(
+pub fn build_threshold_basic<'scope, T: RenderTimestamp>(
     input: CollectionBundle<'scope, T>,
     key: Vec<MirScalarExpr>,
-) -> CollectionBundle<'scope, T>
-where
-    T: RenderTimestamp,
-{
+) -> CollectionBundle<'scope, T> {
     let arrangement = input
         .arrangement(&key)
         .expect("Arrangement ensured to exist");
@@ -112,10 +109,7 @@ where
     }
 }
 
-impl<'scope, T> Context<'scope, T>
-where
-    T: RenderTimestamp,
-{
+impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     pub(crate) fn render_threshold(
         &self,
         input: CollectionBundle<'scope, T>,


### PR DESCRIPTION
This is a mostly cosmetic PR that tightens up text around `Context`, removing a bunch of blank space. It also pushes `RenderTimestamp` down into bounds, but it is required by `render_plan` so it's not actually optional.