### PR TITLE
De-timestamp more parts of the adapter layer

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3413,7 +3413,7 @@ mod tests {
             allow_windows: false,
         };
         let arena = RowArena::new();
-        let mut session = Session::<Timestamp>::dummy();
+        let mut session = Session::dummy();
         session
             .start_transaction(to_datetime(0), None, None)
             .expect("must succeed");

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -250,7 +250,7 @@ pub enum Command {
 
     ExecuteSlowPathPeek {
         dataflow_plan: Box<PeekDataflowPlan>,
-        determination: TimestampDetermination<mz_repr::Timestamp>,
+        determination: TimestampDetermination,
         finishing: RowSetFinishing,
         compute_instance: ComputeInstanceId,
         target_replica: Option<ReplicaId>,
@@ -342,8 +342,8 @@ pub enum Command {
         session_wall_time: DateTime<Utc>,
         cluster_id: ClusterId,
         id_bundle: CollectionIdBundle,
-        determination: TimestampDetermination<mz_repr::Timestamp>,
-        tx: oneshot::Sender<TimestampExplanation<mz_repr::Timestamp>>,
+        determination: TimestampDetermination,
+        tx: oneshot::Sender<TimestampExplanation>,
     },
 
     /// Statement logging event from frontend peek sequencing.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -645,7 +645,7 @@ pub struct PeekStageOptimize {
     source_ids: BTreeSet<GlobalId>,
     id_bundle: CollectionIdBundle,
     target_replica: Option<ReplicaId>,
-    determination: TimestampDetermination<mz_repr::Timestamp>,
+    determination: TimestampDetermination,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPLAIN for this statement.
@@ -660,7 +660,7 @@ pub struct PeekStageFinish {
     id_bundle: CollectionIdBundle,
     target_replica: Option<ReplicaId>,
     source_ids: BTreeSet<GlobalId>,
-    determination: TimestampDetermination<mz_repr::Timestamp>,
+    determination: TimestampDetermination,
     cluster_id: ComputeInstanceId,
     finishing: RowSetFinishing,
     /// When present, an optimizer trace to be used for emitting a plan insights
@@ -692,7 +692,7 @@ pub struct PeekStageExplainPlan {
 #[derive(Debug)]
 pub struct PeekStageExplainPushdown {
     validity: PlanValidity,
-    determination: TimestampDetermination<mz_repr::Timestamp>,
+    determination: TimestampDetermination,
     imports: BTreeMap<GlobalId, MapFilterProject>,
 }
 
@@ -1309,7 +1309,7 @@ pub struct PendingReadTxn {
     /// The transaction type
     txn: PendingRead,
     /// The timestamp context of the transaction.
-    timestamp_context: TimestampContext<mz_repr::Timestamp>,
+    timestamp_context: TimestampContext,
     /// When we created this pending txn, when the transaction ends. Only used for metrics.
     created: Instant,
     /// Number of times we requeued the processing of this pending read txn.
@@ -1322,7 +1322,7 @@ pub struct PendingReadTxn {
 
 impl PendingReadTxn {
     /// Return the timestamp context of the pending read transaction.
-    pub fn timestamp_context(&self) -> &TimestampContext<mz_repr::Timestamp> {
+    pub fn timestamp_context(&self) -> &TimestampContext {
         &self.timestamp_context
     }
 

--- a/src/adapter/src/coord/in_memory_oracle.rs
+++ b/src/adapter/src/coord/in_memory_oracle.rs
@@ -10,11 +10,11 @@
 //! A timestamp oracle that relies on the [`crate::catalog::Catalog`] for persistence/durability
 //! and reserves ranges of timestamps.
 
-use std::fmt::Debug;
-
 use derivative::Derivative;
-use mz_repr::TimestampManipulation;
+use mz_ore::now::NowFn;
+use mz_repr::{Timestamp, TimestampManipulation};
 use mz_timestamp_oracle::{GenericNowFn, WriteTimestamp};
+use timely::order::PartialOrder;
 
 /// A type that provides write and read timestamps, reads observe exactly their
 /// preceding writes.
@@ -29,29 +29,19 @@ use mz_timestamp_oracle::{GenericNowFn, WriteTimestamp};
 /// greater than or equal to `self.write_ts`.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct InMemoryTimestampOracle<T, N>
-where
-    T: Debug,
-    N: GenericNowFn<T>,
-{
-    read_ts: T,
-    write_ts: T,
+pub struct InMemoryTimestampOracle {
+    read_ts: Timestamp,
+    write_ts: Timestamp,
     #[derivative(Debug = "ignore")]
     #[allow(dead_code)]
-    next: N,
+    next: NowFn<Timestamp>,
 }
 
-impl<T: TimestampManipulation, N> InMemoryTimestampOracle<T, N>
-where
-    N: GenericNowFn<T>,
-{
+impl InMemoryTimestampOracle {
     /// Create a new timeline, starting at the indicated time. `next` generates
     /// new timestamps when invoked. The timestamps have no requirements, and
     /// can retreat from previous invocations.
-    pub fn new(initially: T, next: N) -> Self
-    where
-        N: GenericNowFn<T>,
-    {
+    pub fn new(initially: Timestamp, next: NowFn<Timestamp>) -> Self {
         Self {
             read_ts: initially.clone(),
             write_ts: initially,
@@ -64,7 +54,7 @@ where
     /// This timestamp will be strictly greater than all prior values of
     /// `self.read_ts()` and `self.write_ts()`.
     #[allow(dead_code)]
-    fn write_ts(&mut self) -> WriteTimestamp<T> {
+    fn write_ts(&mut self) -> WriteTimestamp<Timestamp> {
         let mut next = self.next.now();
         if next.less_equal(&self.write_ts) {
             next = TimestampManipulation::step_forward(&self.write_ts);
@@ -82,7 +72,7 @@ where
 
     /// Peek the current write timestamp.
     #[allow(dead_code)]
-    fn peek_write_ts(&self) -> T {
+    fn peek_write_ts(&self) -> Timestamp {
         self.write_ts.clone()
     }
 
@@ -91,7 +81,7 @@ where
     /// This timestamp will be greater or equal to all prior values of
     /// `self.apply_write(write_ts)`, and strictly less than all subsequent
     /// values of `self.write_ts()`.
-    pub(crate) fn read_ts(&self) -> T {
+    pub(crate) fn read_ts(&self) -> Timestamp {
         self.read_ts.clone()
     }
 
@@ -99,7 +89,7 @@ where
     ///
     /// All subsequent values of `self.read_ts()` will be greater or equal to
     /// `write_ts`.
-    pub(crate) fn apply_write(&mut self, write_ts: T) {
+    pub(crate) fn apply_write(&mut self, write_ts: Timestamp) {
         if self.read_ts.less_than(&write_ts) {
             self.read_ts = write_ts;
 

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -385,7 +385,7 @@ impl FastPathPlan {
 #[derive(Debug)]
 pub struct PlannedPeek {
     pub plan: PeekPlan,
-    pub determination: TimestampDetermination<mz_repr::Timestamp>,
+    pub determination: TimestampDetermination,
     pub conn_id: ConnectionId,
     /// The result type _after_ reading out of the "source" and applying any
     /// [MapFilterProject](mz_expr::MapFilterProject), but _before_ applying a
@@ -1233,7 +1233,7 @@ impl crate::coord::Coordinator {
     pub(crate) async fn implement_slow_path_peek(
         &mut self,
         dataflow_plan: PeekDataflowPlan,
-        determination: TimestampDetermination<mz_repr::Timestamp>,
+        determination: TimestampDetermination,
         finishing: RowSetFinishing,
         compute_instance: ComputeInstanceId,
         target_replica: Option<ReplicaId>,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -49,7 +49,7 @@ use mz_repr::{
 };
 use mz_storage_types::sources::SourceData;
 use serde::{Deserialize, Serialize};
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::sync::oneshot;
 use tracing::{Instrument, Span};
 use uuid::Uuid;
@@ -436,8 +436,8 @@ fn permute_oneshot_mfp_around_index(
 /// If the optimized plan is a `Constant` or a `Get` of a maintained arrangement,
 /// we can avoid building a dataflow (and either just return the results, or peek
 /// out of the arrangement, respectively).
-pub fn create_fast_path_plan<T: Timestamp>(
-    dataflow_plan: &mut DataflowDescription<OptimizedMirRelationExpr, (), T>,
+pub fn create_fast_path_plan(
+    dataflow_plan: &mut DataflowDescription<OptimizedMirRelationExpr>,
     view_id: GlobalId,
     finishing: Option<&RowSetFinishing>,
     persist_fast_path_limit: usize,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2135,7 +2135,7 @@ impl Coordinator {
         &mut self,
         ctx: &mut ExecuteContext,
         action: EndTransactionAction,
-    ) -> Result<(Option<TransactionOps<Timestamp>>, Option<WriteLocks>), AdapterError> {
+    ) -> Result<(Option<TransactionOps>, Option<WriteLocks>), AdapterError> {
         let txn = self.clear_transaction(ctx.session_mut()).await;
 
         if let EndTransactionAction::Commit = action {

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -220,8 +220,8 @@ impl Coordinator {
         session_wall_time: DateTime<Utc>,
         cluster_id: ClusterId,
         id_bundle: &CollectionIdBundle,
-        determination: TimestampDetermination<mz_repr::Timestamp>,
-    ) -> TimestampExplanation<mz_repr::Timestamp> {
+        determination: TimestampDetermination,
+    ) -> TimestampExplanation {
         let mut sources = Vec::new();
         {
             let storage_ids = id_bundle.storage_ids.iter().cloned().collect_vec();

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1073,7 +1073,7 @@ impl Coordinator {
         source_ids: &BTreeSet<GlobalId>,
         real_time_recency_ts: Option<Timestamp>,
         requires_linearization: RequireLinearization,
-    ) -> Result<TimestampDetermination<Timestamp>, AdapterError> {
+    ) -> Result<TimestampDetermination, AdapterError> {
         let in_immediate_multi_stmt_txn = session.transaction().in_immediate_multi_stmt_txn(when);
         let timedomain_bundle;
 

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -200,10 +200,7 @@ impl Coordinator {
 
     /// Handle removing in-progress transaction state regardless of the end action
     /// of the transaction.
-    pub(crate) async fn clear_transaction(
-        &mut self,
-        session: &mut Session,
-    ) -> TransactionStatus<mz_repr::Timestamp> {
+    pub(crate) async fn clear_transaction(&mut self, session: &mut Session) -> TransactionStatus {
         // This function is *usually* called when transactions end, but it can fail to be called in
         // some cases (for example if the session's role id was dropped, then we return early and
         // don't go through the normal sequence_end_transaction path). The `Command::Commit` handler

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -23,7 +23,7 @@ use mz_sql::plan::QueryWhen;
 use mz_sql::session::vars::IsolationLevel;
 use mz_storage_types::sources::Timeline;
 use serde::{Deserialize, Serialize};
-use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
+use timely::progress::{Antichain, Timestamp as _};
 
 use crate::AdapterError;
 use crate::catalog::CatalogState;
@@ -35,7 +35,7 @@ use crate::session::Session;
 
 /// The timeline and timestamp context of a read.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum TimestampContext<T> {
+pub enum TimestampContext {
     /// Read is executed in a specific timeline with a specific timestamp.
     TimelineTimestamp {
         timeline: Timeline,
@@ -45,24 +45,24 @@ pub enum TimestampContext<T> {
         /// is further ahead than the oracle timestamp) we have to delay
         /// returning peek results until the timestamp oracle is also
         /// sufficiently advanced.
-        chosen_ts: T,
+        chosen_ts: Timestamp,
         /// The timestamp that would have been chosen for the read by the
         /// (linearized) timestamp oracle). In most cases this will be picked as
         /// the `chosen_ts`.
-        oracle_ts: Option<T>,
+        oracle_ts: Option<Timestamp>,
     },
     /// Read is executed without a timeline or timestamp.
     NoTimestamp,
 }
 
-impl<T: TimestampManipulation> TimestampContext<T> {
+impl TimestampContext {
     /// Creates a `TimestampContext` from a timestamp and `TimelineContext`.
     pub fn from_timeline_context(
-        chosen_ts: T,
-        oracle_ts: Option<T>,
+        chosen_ts: Timestamp,
+        oracle_ts: Option<Timestamp>,
         transaction_timeline: Option<Timeline>,
         timeline_context: &TimelineContext,
-    ) -> TimestampContext<T> {
+    ) -> TimestampContext {
         match timeline_context {
             TimelineContext::TimelineDependent(timeline) => {
                 if let Some(transaction_timeline) = transaction_timeline {
@@ -92,12 +92,12 @@ impl<T: TimestampManipulation> TimestampContext<T> {
     }
 
     /// The timestamp belonging to this context, if one exists.
-    pub fn timestamp(&self) -> Option<&T> {
+    pub fn timestamp(&self) -> Option<&Timestamp> {
         self.timeline_timestamp().map(|tt| tt.1)
     }
 
     /// The timeline and timestamp belonging to this context, if one exists.
-    pub fn timeline_timestamp(&self) -> Option<(&Timeline, &T)> {
+    pub fn timeline_timestamp(&self) -> Option<(&Timeline, &Timestamp)> {
         match self {
             Self::TimelineTimestamp {
                 timeline,
@@ -109,13 +109,13 @@ impl<T: TimestampManipulation> TimestampContext<T> {
     }
 
     /// The timestamp belonging to this context, or a sensible default if one does not exists.
-    pub fn timestamp_or_default(&self) -> T {
+    pub fn timestamp_or_default(&self) -> Timestamp {
         match self {
             Self::TimelineTimestamp { chosen_ts, .. } => chosen_ts.clone(),
             // Anything without a timestamp is given the maximum possible timestamp to indicate
             // that they have been closed up until the end of time. This allows us to SUBSCRIBE to
             // static views.
-            Self::NoTimestamp => T::maximum(),
+            Self::NoTimestamp => Timestamp::maximum(),
         }
     }
 
@@ -125,7 +125,7 @@ impl<T: TimestampManipulation> TimestampContext<T> {
     }
 
     /// Converts this `TimestampContext` to an `Antichain`.
-    pub fn antichain(&self) -> Antichain<T> {
+    pub fn antichain(&self) -> Antichain<Timestamp> {
         Antichain::from_elem(self.timestamp_or_default())
     }
 }
@@ -180,10 +180,10 @@ impl TimestampProvider for Coordinator {
 /// A timestamp determination, which includes the timestamp, constraints, and session oracle read
 /// timestamp.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RawTimestampDetermination<T> {
-    pub timestamp: T,
+pub struct RawTimestampDetermination {
+    pub timestamp: Timestamp,
     pub constraints: Constraints,
-    pub session_oracle_read_ts: Option<T>,
+    pub session_oracle_read_ts: Option<Timestamp>,
 }
 
 #[async_trait(?Send)]
@@ -252,7 +252,7 @@ pub trait TimestampProvider {
         isolation_level: &IsolationLevel,
         timeline: &Option<Timeline>,
         largest_not_in_advance_of_upper: Timestamp,
-    ) -> Result<RawTimestampDetermination<Timestamp>, AdapterError> {
+    ) -> Result<RawTimestampDetermination, AdapterError> {
         use constraints::{Constraints, Preference, Reason};
 
         let mut session_oracle_read_ts = None;
@@ -443,7 +443,7 @@ pub trait TimestampProvider {
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<Timestamp>,
         isolation_level: &IsolationLevel,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
+    ) -> Result<(TimestampDetermination, ReadHolds), AdapterError> {
         // First, we acquire read holds that will ensure the queried collections
         // stay queryable at the chosen timestamp.
         let read_holds = self.acquire_read_holds(id_bundle);
@@ -474,7 +474,7 @@ pub trait TimestampProvider {
         isolation_level: &IsolationLevel,
         read_holds: ReadHolds,
         upper: Antichain<Timestamp>,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
+    ) -> Result<(TimestampDetermination, ReadHolds), AdapterError> {
         let timeline = Self::get_timeline(timeline_context);
         let largest_not_in_advance_of_upper = Coordinator::largest_not_in_advance_of_upper(&upper);
         let since = read_holds.least_valid_read();
@@ -607,7 +607,7 @@ impl Coordinator {
         timeline_context: &TimelineContext,
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<mz_repr::Timestamp>,
-    ) -> Result<(TimestampDetermination<mz_repr::Timestamp>, ReadHolds), AdapterError> {
+    ) -> Result<(TimestampDetermination, ReadHolds), AdapterError> {
         let isolation_level = session.vars().transaction_isolation();
         let (det, read_holds) = self.determine_timestamp_for(
             session,
@@ -683,27 +683,27 @@ impl Coordinator {
 
 /// Information used when determining the timestamp for a query.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TimestampDetermination<T> {
+pub struct TimestampDetermination {
     /// The chosen timestamp context from `determine_timestamp`.
-    pub timestamp_context: TimestampContext<T>,
+    pub timestamp_context: TimestampContext,
     /// The read frontier of all involved sources.
-    pub since: Antichain<T>,
+    pub since: Antichain<Timestamp>,
     /// The write frontier of all involved sources.
-    pub upper: Antichain<T>,
+    pub upper: Antichain<Timestamp>,
     /// The largest timestamp not in advance of upper.
-    pub largest_not_in_advance_of_upper: T,
+    pub largest_not_in_advance_of_upper: Timestamp,
     /// The value of the timeline's oracle timestamp, if used.
-    pub oracle_read_ts: Option<T>,
+    pub oracle_read_ts: Option<Timestamp>,
     /// The value of the session local timestamp's oracle timestamp, if used.
-    pub session_oracle_read_ts: Option<T>,
+    pub session_oracle_read_ts: Option<Timestamp>,
     /// The value of the real time recency timestamp, if used.
-    pub real_time_recency_ts: Option<T>,
+    pub real_time_recency_ts: Option<Timestamp>,
     /// The constraints used by the constraint based solver.
     /// See the [`constraints`] module for more information.
     pub constraints: Constraints,
 }
 
-impl<T: TimestampManipulation> TimestampDetermination<T> {
+impl TimestampDetermination {
     pub fn respond_immediately(&self) -> bool {
         match &self.timestamp_context {
             TimestampContext::TimelineTimestamp { chosen_ts, .. } => {
@@ -716,11 +716,11 @@ impl<T: TimestampManipulation> TimestampDetermination<T> {
 
 /// Information used when determining the timestamp for a query.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TimestampExplanation<T> {
+pub struct TimestampExplanation {
     /// The chosen timestamp from `determine_timestamp`.
-    pub determination: TimestampDetermination<T>,
+    pub determination: TimestampDetermination,
     /// Details about each source.
-    pub sources: Vec<TimestampSource<T>>,
+    pub sources: Vec<TimestampSource>,
     /// Wall time of first statement executed in this transaction
     pub session_wall_time: DateTime<Utc>,
     /// Cached value of determination.respond_immediately()
@@ -728,10 +728,10 @@ pub struct TimestampExplanation<T> {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TimestampSource<T> {
+pub struct TimestampSource {
     pub name: String,
-    pub read_frontier: Vec<T>,
-    pub write_frontier: Vec<T>,
+    pub read_frontier: Vec<Timestamp>,
+    pub write_frontier: Vec<Timestamp>,
 }
 
 pub trait DisplayableInTimeline {
@@ -777,9 +777,7 @@ where
     }
 }
 
-impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline + TimestampManipulation> fmt::Display
-    for TimestampExplanation<T>
-{
+impl fmt::Display for TimestampExplanation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let timeline = self.determination.timestamp_context.timeline();
         writeln!(

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -179,8 +179,8 @@ mod tests {
     use mz_controller_types::ClusterId;
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::{assert_contains, assert_ok};
+    use mz_repr::CatalogItemId;
     use mz_repr::role_id::RoleId;
-    use mz_repr::{CatalogItemId, Timestamp};
     use mz_sql::catalog::RoleAttributesRaw;
     use mz_sql::session::metadata::SessionMetadata;
     use uuid::Uuid;
@@ -216,7 +216,7 @@ mod tests {
                 .expect("is ok");
             let role = catalog.try_get_role_by_name(role).expect("must exist");
             // Can't use a dummy session because we need a valid role for the validity check.
-            let mut session = Session::<Timestamp>::new(
+            let mut session = Session::new(
                 &mz_build_info::DUMMY_BUILD_INFO,
                 SessionConfig {
                     conn_id,

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
 use mz_expr::{AccessStrategy, Id, MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::num::NonNeg;
+use mz_repr::GlobalId;
 use mz_repr::explain::ExprHumanizer;
-use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::Statement;
 use mz_sql::names::Aug;
 use mz_sql::optimizer_metrics::OptimizerMetrics;
@@ -49,7 +49,7 @@ pub struct PlanInsightsContext {
     pub finishing: RowSetFinishing,
     pub optimizer_config: OptimizerConfig,
     pub session: SessionMeta,
-    pub timestamp_context: TimestampContext<Timestamp>,
+    pub timestamp_context: TimestampContext,
     pub view_id: GlobalId,
     pub index_id: GlobalId,
     pub enable_re_optimize: bool,

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1502,7 +1502,7 @@ impl PeekClient {
         timeline_context: &TimelineContext,
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<Timestamp>,
-    ) -> Result<(TimestampDetermination<Timestamp>, ReadHolds), AdapterError> {
+    ) -> Result<(TimestampDetermination, ReadHolds), AdapterError> {
         // this is copy-pasted from Coordinator
 
         let isolation_level = session.vars().transaction_isolation();
@@ -1576,7 +1576,7 @@ impl PeekClient {
     fn assert_read_holds_correct(
         read_holds: &ReadHolds,
         execution: &Execution,
-        determination: &TimestampDetermination<Timestamp>,
+        determination: &TimestampDetermination,
         target_cluster_id: ClusterId,
         in_immediate_multi_stmt_txn: bool,
     ) {
@@ -1740,6 +1740,6 @@ enum Execution {
     },
     ExplainPushdown {
         imports: BTreeMap<GlobalId, mz_expr::MapFilterProject>,
-        determination: TimestampDetermination<Timestamp>,
+        determination: TimestampDetermination,
     },
 }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -79,7 +79,7 @@ pub enum AdapterNotice {
         name: String,
     },
     QueryTimestamp {
-        explanation: TimestampExplanation<mz_repr::Timestamp>,
+        explanation: TimestampExplanation,
     },
     EqualSubscribeBounds {
         bound: mz_repr::Timestamp,

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -19,8 +19,8 @@ use mz_compute_types::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, CopyToS3OneshotSinkConnection,
 };
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
+use mz_repr::GlobalId;
 use mz_repr::explain::trace_plan;
-use mz_repr::{GlobalId, Timestamp};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_sql::session::metadata::SessionMetadata;
@@ -118,7 +118,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 /// Marker type for [`LocalMirPlan`] structs representing an optimization result
 /// with attached environment context required for the next optimization stage.
 pub struct Resolved<'s> {
-    timestamp_ctx: TimestampContext<Timestamp>,
+    timestamp_ctx: TimestampContext,
     stats: Box<dyn StatisticsOracle>,
     session: &'s dyn SessionMetadata,
 }
@@ -191,7 +191,7 @@ impl LocalMirPlan<Unresolved> {
     /// required for the next stage.
     pub fn resolve(
         self,
-        timestamp_ctx: TimestampContext<Timestamp>,
+        timestamp_ctx: TimestampContext,
         session: &dyn SessionMetadata,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved<'_>> {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -145,7 +145,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 /// Marker type for [`LocalMirPlan`] structs representing an optimization result
 /// with attached environment context required for the next optimization stage.
 pub struct Resolved<'s> {
-    timestamp_ctx: TimestampContext<Timestamp>,
+    timestamp_ctx: TimestampContext,
     stats: Box<dyn StatisticsOracle>,
     session: &'s dyn SessionMetadata,
 }
@@ -206,7 +206,7 @@ impl LocalMirPlan<Unresolved> {
     /// required for the next stage.
     pub fn resolve(
         self,
-        timestamp_ctx: TimestampContext<Timestamp>,
+        timestamp_ctx: TimestampContext,
         session: &dyn SessionMetadata,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved<'_>> {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -116,7 +116,7 @@ pub struct Session {
     // on. We express this by gating access with this token.
     #[derivative(Debug = "ignore")]
     qcell_owner: QCellOwner,
-    session_oracles: BTreeMap<Timeline, InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>>>,
+    session_oracles: BTreeMap<Timeline, InMemoryTimestampOracle>,
     /// Incremented when session state that is relevant to prepared statement planning changes.
     /// Currently, only changes to `portals` are tracked. Changes to `prepared_statements` don't
     /// need to be tracked, because prepared statements can't depend on other prepared statements.
@@ -879,10 +879,7 @@ impl Session {
 
     /// Ensures that a timestamp oracle exists for `timeline` and returns a mutable reference to
     /// the timestamp oracle.
-    pub fn ensure_timestamp_oracle(
-        &mut self,
-        timeline: Timeline,
-    ) -> &mut InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>> {
+    pub fn ensure_timestamp_oracle(&mut self, timeline: Timeline) -> &mut InMemoryTimestampOracle {
         self.session_oracles.entry(timeline).or_insert_with(|| {
             InMemoryTimestampOracle::new(Timestamp::minimum(), NowFn::from(Timestamp::minimum))
         })
@@ -890,17 +887,12 @@ impl Session {
 
     /// Ensures that a timestamp oracle exists for reads and writes from/to a local input and
     /// returns a mutable reference to the timestamp oracle.
-    pub fn ensure_local_timestamp_oracle(
-        &mut self,
-    ) -> &mut InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>> {
+    pub fn ensure_local_timestamp_oracle(&mut self) -> &mut InMemoryTimestampOracle {
         self.ensure_timestamp_oracle(Timeline::EpochMilliseconds)
     }
 
     /// Returns a reference to the timestamp oracle for `timeline`.
-    pub fn get_timestamp_oracle(
-        &self,
-        timeline: &Timeline,
-    ) -> Option<&InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>>> {
+    pub fn get_timestamp_oracle(&self, timeline: &Timeline) -> Option<&InMemoryTimestampOracle> {
         self.session_oracles.get(timeline)
     }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -578,7 +578,7 @@ impl Session {
     /// ops to `None`, returning the old read timestamp context if
     /// any existed. Must only be used after verifying that no transaction
     /// anomalies will occur if cleared.
-    pub fn take_transaction_timestamp_context(&mut self) -> Option<TimestampContext<Timestamp>> {
+    pub fn take_transaction_timestamp_context(&mut self) -> Option<TimestampContext> {
         if let Some(Transaction { ops, .. }) = self.transaction.inner_mut() {
             if let TransactionOps::Peeks { .. } = ops {
                 let ops = std::mem::take(ops);
@@ -599,9 +599,7 @@ impl Session {
     ///
     /// Returns `None` if there is no active transaction, or if the active
     /// transaction is not a read transaction.
-    pub fn get_transaction_timestamp_determination(
-        &self,
-    ) -> Option<TimestampDetermination<Timestamp>> {
+    pub fn get_transaction_timestamp_determination(&self) -> Option<TimestampDetermination> {
         match self.transaction.inner() {
             Some(Transaction {
                 pcx: _,
@@ -1568,7 +1566,7 @@ pub enum TransactionOps {
     /// perform writes.
     Peeks {
         /// The timestamp and timestamp related metadata for the peek.
-        determination: TimestampDetermination<Timestamp>,
+        determination: TimestampDetermination,
         /// The cluster used to execute peeks.
         cluster_id: ClusterId,
         /// Whether this peek needs to be linearized.
@@ -1617,7 +1615,7 @@ pub enum TransactionOps {
 }
 
 impl TransactionOps {
-    fn timestamp_determination(self) -> Option<TimestampDetermination<Timestamp>> {
+    fn timestamp_determination(self) -> Option<TimestampDetermination> {
         match self {
             TransactionOps::Peeks { determination, .. } => Some(determination),
             TransactionOps::None

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -13,7 +13,6 @@
 
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Debug;
 use std::future::Future;
 use std::mem;
 use std::net::IpAddr;
@@ -32,7 +31,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_pgwire_common::Format;
 use mz_repr::role_id::RoleId;
 use mz_repr::user::{ExternalUserMetadata, InternalUserMetadata};
-use mz_repr::{CatalogItemId, Datum, Row, RowIterator, SqlScalarType, TimestampManipulation};
+use mz_repr::{CatalogItemId, Datum, Row, RowIterator, SqlScalarType, Timestamp};
 use mz_sql::ast::{AstInfo, Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, QueryWhen, StatementDesc};
 use mz_sql::session::metadata::SessionMetadata;
@@ -48,6 +47,7 @@ use mz_sql_parser::ast::TransactionIsolationLevel;
 use mz_storage_client::client::TableData;
 use mz_storage_types::sources::Timeline;
 use qcell::{QCell, QCellOwner};
+use timely::progress::Timestamp as _;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch;
 use uuid::Uuid;
@@ -70,17 +70,14 @@ const DUMMY_CONNECTION_ID: ConnectionId = ConnectionId::Static(0);
 /// A session holds per-connection state.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct Session<T = mz_repr::Timestamp>
-where
-    T: Debug + Clone + Send + Sync,
-{
+pub struct Session {
     conn_id: ConnectionId,
     /// A globally unique identifier for the session. Not to be confused
     /// with `conn_id`, which may be reused.
     uuid: Uuid,
     prepared_statements: BTreeMap<String, PreparedStatement>,
     portals: BTreeMap<String, Portal>,
-    transaction: TransactionStatus<T>,
+    transaction: TransactionStatus,
     pcx: Option<PlanContext>,
     metrics: SessionMetrics,
     #[derivative(Debug = "ignore")]
@@ -119,7 +116,7 @@ where
     // on. We express this by gating access with this token.
     #[derivative(Debug = "ignore")]
     qcell_owner: QCellOwner,
-    session_oracles: BTreeMap<Timeline, InMemoryTimestampOracle<T, NowFn<T>>>,
+    session_oracles: BTreeMap<Timeline, InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>>>,
     /// Incremented when session state that is relevant to prepared statement planning changes.
     /// Currently, only changes to `portals` are tracked. Changes to `prepared_statements` don't
     /// need to be tracked, because prepared statements can't depend on other prepared statements.
@@ -128,11 +125,7 @@ where
     state_revision: u64,
 }
 
-impl<T> SessionMetadata for Session<T>
-where
-    T: Debug + Clone + Send + Sync,
-    T: TimestampManipulation,
-{
+impl SessionMetadata for Session {
     fn conn_id(&self) -> &ConnectionId {
         &self.conn_id
     }
@@ -218,13 +211,13 @@ pub struct SessionConfig {
     pub authenticator_kind: AuthenticatorKind,
 }
 
-impl<T: TimestampManipulation> Session<T> {
+impl Session {
     /// Creates a new session for the specified connection ID.
     pub(crate) fn new(
         build_info: &'static BuildInfo,
         config: SessionConfig,
         metrics: SessionMetrics,
-    ) -> Session<T> {
+    ) -> Session {
         assert_ne!(config.conn_id, DUMMY_CONNECTION_ID);
         Self::new_internal(build_info, config, metrics)
     }
@@ -289,7 +282,7 @@ impl<T: TimestampManipulation> Session<T> {
     ///
     /// Dummy sessions are intended for use when executing queries on behalf of
     /// the system itself, rather than on behalf of a user.
-    pub fn dummy() -> Session<T> {
+    pub fn dummy() -> Session {
         let registry = MetricsRegistry::new();
         let metrics = Metrics::register_into(&registry);
         let metrics = metrics.session_metrics();
@@ -322,7 +315,7 @@ impl<T: TimestampManipulation> Session<T> {
             authenticator_kind,
         }: SessionConfig,
         metrics: SessionMetrics,
-    ) -> Session<T> {
+    ) -> Session {
         let (notices_tx, notices_rx) = mpsc::unbounded_channel();
         let default_cluster = INTERNAL_USER_NAME_TO_DEFAULT_CLUSTER.get(&user);
         let user = User {
@@ -467,7 +460,7 @@ impl<T: TimestampManipulation> Session<T> {
     /// and
     /// > An unnamed portal is destroyed at the end of the transaction
     #[must_use]
-    pub fn clear_transaction(&mut self) -> TransactionStatus<T> {
+    pub fn clear_transaction(&mut self) -> TransactionStatus {
         self.portals.clear();
         self.pcx = None;
         self.state_revision += 1;
@@ -489,12 +482,12 @@ impl<T: TimestampManipulation> Session<T> {
     }
 
     /// Returns the current transaction status.
-    pub fn transaction(&self) -> &TransactionStatus<T> {
+    pub fn transaction(&self) -> &TransactionStatus {
         &self.transaction
     }
 
     /// Returns the current transaction status.
-    pub fn transaction_mut(&mut self) -> &mut TransactionStatus<T> {
+    pub fn transaction_mut(&mut self) -> &mut TransactionStatus {
         &mut self.transaction
     }
 
@@ -506,7 +499,7 @@ impl<T: TimestampManipulation> Session<T> {
     /// Adds operations to the current transaction. An error is produced if
     /// they cannot be merged (i.e., a timestamp-dependent read cannot be
     /// merged to an insert).
-    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
+    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps) -> Result<(), AdapterError> {
         self.transaction.add_ops(add_ops)
     }
 
@@ -585,7 +578,7 @@ impl<T: TimestampManipulation> Session<T> {
     /// ops to `None`, returning the old read timestamp context if
     /// any existed. Must only be used after verifying that no transaction
     /// anomalies will occur if cleared.
-    pub fn take_transaction_timestamp_context(&mut self) -> Option<TimestampContext<T>> {
+    pub fn take_transaction_timestamp_context(&mut self) -> Option<TimestampContext<Timestamp>> {
         if let Some(Transaction { ops, .. }) = self.transaction.inner_mut() {
             if let TransactionOps::Peeks { .. } = ops {
                 let ops = std::mem::take(ops);
@@ -606,7 +599,9 @@ impl<T: TimestampManipulation> Session<T> {
     ///
     /// Returns `None` if there is no active transaction, or if the active
     /// transaction is not a read transaction.
-    pub fn get_transaction_timestamp_determination(&self) -> Option<TimestampDetermination<T>> {
+    pub fn get_transaction_timestamp_determination(
+        &self,
+    ) -> Option<TimestampDetermination<Timestamp>> {
         match self.transaction.inner() {
             Some(Transaction {
                 pcx: _,
@@ -889,15 +884,17 @@ impl<T: TimestampManipulation> Session<T> {
     pub fn ensure_timestamp_oracle(
         &mut self,
         timeline: Timeline,
-    ) -> &mut InMemoryTimestampOracle<T, NowFn<T>> {
-        self.session_oracles
-            .entry(timeline)
-            .or_insert_with(|| InMemoryTimestampOracle::new(T::minimum(), NowFn::from(T::minimum)))
+    ) -> &mut InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>> {
+        self.session_oracles.entry(timeline).or_insert_with(|| {
+            InMemoryTimestampOracle::new(Timestamp::minimum(), NowFn::from(Timestamp::minimum))
+        })
     }
 
     /// Ensures that a timestamp oracle exists for reads and writes from/to a local input and
     /// returns a mutable reference to the timestamp oracle.
-    pub fn ensure_local_timestamp_oracle(&mut self) -> &mut InMemoryTimestampOracle<T, NowFn<T>> {
+    pub fn ensure_local_timestamp_oracle(
+        &mut self,
+    ) -> &mut InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>> {
         self.ensure_timestamp_oracle(Timeline::EpochMilliseconds)
     }
 
@@ -905,13 +902,13 @@ impl<T: TimestampManipulation> Session<T> {
     pub fn get_timestamp_oracle(
         &self,
         timeline: &Timeline,
-    ) -> Option<&InMemoryTimestampOracle<T, NowFn<T>>> {
+    ) -> Option<&InMemoryTimestampOracle<Timestamp, NowFn<Timestamp>>> {
         self.session_oracles.get(timeline)
     }
 
     /// If the current session is using the Strong Session Serializable isolation level advance the
     /// session local timestamp oracle to `write_ts`.
-    pub fn apply_write(&mut self, timestamp: T) {
+    pub fn apply_write(&mut self, timestamp: Timestamp) {
         if self.vars().transaction_isolation() == &IsolationLevel::StrongSessionSerializable {
             self.ensure_local_timestamp_oracle().apply_write(timestamp);
         }
@@ -1102,7 +1099,7 @@ impl LifecycleTimestamps {
 ///
 /// PostgreSQL's transaction states are in backend/access/transam/xact.c.
 #[derive(Debug)]
-pub enum TransactionStatus<T> {
+pub enum TransactionStatus {
     /// Idle. Matches `TBLOCK_DEFAULT`.
     Default,
     /// Running a single-query transaction. Matches
@@ -1114,19 +1111,19 @@ pub enum TransactionStatus<T> {
     /// when using the extended query protocol. Therefore, we can guarantee that this state will
     /// always be a single-query transaction and never be upgraded into a multi-statement implicit
     /// query.
-    Started(Transaction<T>),
+    Started(Transaction),
     /// Currently in a transaction issued from a `BEGIN`. Matches `TBLOCK_INPROGRESS`.
-    InTransaction(Transaction<T>),
+    InTransaction(Transaction),
     /// Currently in an implicit transaction started from a multi-statement query
     /// with more than 1 statements. Matches `TBLOCK_IMPLICIT_INPROGRESS`.
-    InTransactionImplicit(Transaction<T>),
+    InTransactionImplicit(Transaction),
     /// In a failed transaction. Matches `TBLOCK_ABORT`.
-    Failed(Transaction<T>),
+    Failed(Transaction),
 }
 
-impl<T: TimestampManipulation> TransactionStatus<T> {
+impl TransactionStatus {
     /// Extracts the inner transaction ops and write lock guard if not failed.
-    pub fn into_ops_and_lock_guard(self) -> (Option<TransactionOps<T>>, Option<WriteLocks>) {
+    pub fn into_ops_and_lock_guard(self) -> (Option<TransactionOps>, Option<WriteLocks>) {
         match self {
             TransactionStatus::Default | TransactionStatus::Failed(_) => (None, None),
             TransactionStatus::Started(txn)
@@ -1138,7 +1135,7 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
     }
 
     /// Exposes the inner transaction.
-    pub fn inner(&self) -> Option<&Transaction<T>> {
+    pub fn inner(&self) -> Option<&Transaction> {
         match self {
             TransactionStatus::Default => None,
             TransactionStatus::Started(txn)
@@ -1149,7 +1146,7 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
     }
 
     /// Exposes the inner transaction.
-    pub fn inner_mut(&mut self) -> Option<&mut Transaction<T>> {
+    pub fn inner_mut(&mut self) -> Option<&mut Transaction> {
         match self {
             TransactionStatus::Default => None,
             TransactionStatus::Started(txn)
@@ -1310,7 +1307,7 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
     /// If the operations are compatible but the operation metadata doesn't match. Such as reads at
     /// different timestamps, reads on different timelines, reads on different clusters, etc. It's
     /// up to the caller to make sure these are aligned.
-    pub fn add_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
+    pub fn add_ops(&mut self, add_ops: TransactionOps) -> Result<(), AdapterError> {
         match self {
             TransactionStatus::Started(Transaction { ops, access, .. })
             | TransactionStatus::InTransaction(Transaction { ops, access, .. })
@@ -1439,7 +1436,7 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
 /// An abstraction allowing us to identify different transactions.
 pub type TransactionId = u64;
 
-impl<T> Default for TransactionStatus<T> {
+impl Default for TransactionStatus {
     fn default() -> Self {
         TransactionStatus::Default
     }
@@ -1447,11 +1444,11 @@ impl<T> Default for TransactionStatus<T> {
 
 /// State data for transactions.
 #[derive(Debug)]
-pub struct Transaction<T> {
+pub struct Transaction {
     /// Plan context.
     pub pcx: PlanContext,
     /// Transaction operations.
-    pub ops: TransactionOps<T>,
+    pub ops: TransactionOps,
     /// Uniquely identifies the transaction on a per connection basis.
     /// Two transactions started from separate connections may share the
     /// same ID.
@@ -1463,7 +1460,7 @@ pub struct Transaction<T> {
     access: Option<TransactionAccessMode>,
 }
 
-impl<T> Transaction<T> {
+impl Transaction {
     /// Tries to grant the write lock to this transaction for the remainder of its lifetime. Errors
     /// if this [`Transaction`] has already been granted write locks.
     fn try_grant_write_locks(&mut self, guards: WriteLocks) -> Result<(), &WriteLocks> {
@@ -1541,9 +1538,9 @@ impl From<TransactionCode> for String {
     }
 }
 
-impl<T> From<&TransactionStatus<T>> for TransactionCode {
+impl From<&TransactionStatus> for TransactionCode {
     /// Convert from the Session's version
-    fn from(status: &TransactionStatus<T>) -> TransactionCode {
+    fn from(status: &TransactionStatus) -> TransactionCode {
         match status {
             TransactionStatus::Default => TransactionCode::Idle,
             TransactionStatus::Started(_) => TransactionCode::InTransaction,
@@ -1561,7 +1558,7 @@ impl<T> From<&TransactionStatus<T>> for TransactionCode {
 /// happen at commit.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub enum TransactionOps<T> {
+pub enum TransactionOps {
     /// The transaction has been initiated, but no statement has yet been executed
     /// in it.
     None,
@@ -1571,7 +1568,7 @@ pub enum TransactionOps<T> {
     /// perform writes.
     Peeks {
         /// The timestamp and timestamp related metadata for the peek.
-        determination: TimestampDetermination<T>,
+        determination: TimestampDetermination<Timestamp>,
         /// The cluster used to execute peeks.
         cluster_id: ClusterId,
         /// Whether this peek needs to be linearized.
@@ -1619,8 +1616,8 @@ pub enum TransactionOps<T> {
     },
 }
 
-impl<T> TransactionOps<T> {
-    fn timestamp_determination(self) -> Option<TimestampDetermination<T>> {
+impl TransactionOps {
+    fn timestamp_determination(self) -> Option<TimestampDetermination<Timestamp>> {
         match self {
             TransactionOps::Peeks { determination, .. } => Some(determination),
             TransactionOps::None
@@ -1632,7 +1629,7 @@ impl<T> TransactionOps<T> {
     }
 }
 
-impl<T> Default for TransactionOps<T> {
+impl Default for TransactionOps {
     fn default() -> Self {
         Self::None
     }

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -1448,7 +1448,7 @@ pub async fn try_get_explain_timestamp(
 pub async fn get_explain_timestamp_determination(
     from_suffix: &str,
     client: &Client,
-) -> Result<TimestampExplanation<mz_repr::Timestamp>, anyhow::Error> {
+) -> Result<TimestampExplanation, anyhow::Error> {
     let row = client
         .query_one(
             &format!("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM {from_suffix}"),

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1290,7 +1290,7 @@ fn test_explain_timestamp_json() {
         .unwrap();
     let explain: String = row.get(0);
     // Just check that we can round-trip to the original type
-    let _explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+    let _explain: TimestampExplanation = serde_json::from_str(&explain).unwrap();
 }
 
 // Verify that `EXPLAIN TIMESTAMP ...` within acts like a peek within a transaction.
@@ -1347,7 +1347,7 @@ fn test_transactional_explain_timestamps() {
             .unwrap();
 
         let explain: String = row.get(0);
-        let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+        let explain: TimestampExplanation = serde_json::from_str(&explain).unwrap();
         let explain_timestamp = explain.determination.timestamp_context.timestamp().unwrap();
 
         if let Some(timestamp) = query_timestamp {
@@ -1411,7 +1411,7 @@ fn test_transactional_explain_timestamps() {
         .unwrap();
 
     let explain: String = row.get(0);
-    let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+    let explain: TimestampExplanation = serde_json::from_str(&explain).unwrap();
     let explain_timestamp = explain.determination.timestamp_context.timestamp().unwrap();
 
     assert_eq!(*explain_timestamp, mz_now_timestamp);
@@ -1465,7 +1465,7 @@ async fn test_utilization_hold() {
 
             let row = client.query_one(explain_q, &[]).await.unwrap();
             let explain: String = row.get(0);
-            let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
+            let explain: TimestampExplanation = serde_json::from_str(&explain).unwrap();
 
             // Assert that we actually used the indexes/tables, as required
             for s in &explain.sources {
@@ -1530,8 +1530,7 @@ async fn test_utilization_hold() {
                     .unwrap();
                 let row = client.query_one(explain_q, &[]).await.unwrap();
                 let explain: String = row.get(0);
-                let explain: TimestampExplanation<Timestamp> =
-                    serde_json::from_str(&explain).unwrap();
+                let explain: TimestampExplanation = serde_json::from_str(&explain).unwrap();
                 let since = explain
                     .determination
                     .since


### PR DESCRIPTION
This is a sequence of PRs that remove `T: Timestamp` generality from components that Claude was able to identify as not needing it. They are spelled out in the names of the commits. 