### PR TITLE
console: reduce Sentry transaction sample rates to avoid quota exhaustion

### DIFF
--- a/console/src/sentry.ts
+++ b/console/src/sentry.ts
@@ -75,9 +75,9 @@ if (appConfig.mode === "cloud") {
     normalizeDepth: 8,
     tracesSampler: (samplingContext) => {
       if (samplingContext.attributes?.polled) {
-        return 0.01;
+        return 0.001;
       } else {
-        return 0.3;
+        return 0.05;
       }
     },
   });


### PR DESCRIPTION


Lower tracesSampler rates from 30%→5% (regular) and 1%→0.1% (polled) to reduce performance unit consumption. Console's transaction data isn't actively monitored, and we've been hitting the org-wide quota limit (~28% of transactions rate limited over the last 14 days).

Slack thread: https://materializeinc.slack.com/archives/CTESPM7FU/p1776067256626459?thread_ts=1775948251.125689&cid=CTESPM7FU

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
