### PR TITLE
papercut(CNS-47): console fix

### DIFF
--- a/console/src/layouts/BaseLayout.tsx
+++ b/console/src/layouts/BaseLayout.tsx
@@ -326,7 +326,9 @@ export const ContextMenu = ({ children }: { children: React.ReactNode }) => {
     <Menu>
       <ContextMenuButton />
       <Portal>
-        <MenuList>{children}</MenuList>
+        <MenuList maxHeight="60vh" overflowY="auto">
+          {children}
+        </MenuList>
       </Portal>
     </Menu>
   );


### PR DESCRIPTION
## Papercut Fix: CNS-47

Generated by [Papercut Factory](https://github.com/MaterializeInc/console-papercut-factory/actions/runs/24424551453)

### What was changed

# Agent Thinking — CNS-47: Fix Cluster scroll

## Understanding the issue
The screenshot shows a cluster dropdown menu that lists many clusters (cold_fy2022, cold_fy2023, dev_akshata, dev_frank, etc.) and it spills off the bottom of the page with no scroll. Users can't reach clusters at the bottom of the list.

## What I found
- `ClusterDetail.tsx` (line 56-76): Renders `MenuItem`s for each cluster, passed as `contextMenuChildren` to `PageBreadcrumbs`.
- `PageBreadcrumbs` (line 260-318 in `BaseLayout.tsx`): Renders `contextMenuChildren` inside a `ContextMenu` component.
- `ContextMenu` (line 324-333 in `BaseLayout.tsx`): Wraps children in a `Menu` > `Portal` > `MenuList` — but the `MenuList` has NO height constraint or overflow handling.

This is the root cause: the `MenuList` grows unbounded with the number of clusters.

## The fix
- File: `console/src/layouts/BaseLayout.tsx`
- Line: 329 (`<MenuList>{children}</MenuList>`)
- Change: Add `maxHeight="60vh"` and `overflowY="auto"` to the `MenuList`
- Why: This constrains the dropdown to 60% of viewport height and makes it scrollable when content exceeds that height. 60vh is a reasonable value that leaves room for the header and some page content while showing many items.
- Why `ContextMenu` and not `ClusterDetail`: The fix belongs in the generic `ContextMenu` component since any breadcrumb context menu could have this problem. It's the right level of abstraction.

## After editing
Changed `<MenuList>{children}</MenuList>` to `<MenuList maxHeight="60vh" overflowY="auto">{children}</MenuList>` in the `ContextMenu` component. This makes the cluster dropdown scrollable when there are many clusters, fixing the issue where the menu spills off the page.


### Verification

# Verification Report: CNS-47

## Issue Summary
The cluster dropdown in the breadcrumb context menu spills off the page when there are many clusters, with no way to scroll.

## What Was Fixed
- **File**: `console/src/layouts/BaseLayout.tsx`, line 329
- **Change**: Added `maxHeight="60vh"` and `overflowY="auto"` to the `<MenuList>` component inside the generic `ContextMenu` component.
- **Why**: The `MenuList` had no height constraint or overflow handling, so it grew unbounded with the number of clusters. The fix constrains the dropdown to 60% of viewport height and makes it scrollable when content exceeds that height. The fix was applied to the generic `ContextMenu` component (not cluster-specific code) since any breadcrumb context menu could have this problem.

## Steps Taken
1. Navigated to `http://localhost:3000` and authenticated with the provided credentials.
2. Navigated to the Clusters page (`/regions/aws-us-east-1/clusters`).
3. Dismissed the welcome dialog.
4. Clicked on the "quickstart" cluster to navigate to the cluster detail page.
5. Clicked the "Navigation actions" breadcrumb context menu button to open the cluster dropdown.
6. Verified the dropdown opens correctly and is contained within the page.
7. Used JavaScript evaluation to inspect the computed CSS styles of the cluster context menu `MenuList` element.

## Result
**PASS**

## Evidence
- The cluster context menu (`MenuList` with class `css-1l1njeh`) has the correct computed styles applied:
  - `maxHeight: "295.8px"` (which equals 60vh of the 493px viewport height)
  - `overflowY: "auto"`
- The source code at `BaseLayout.tsx:329` confirms the fix: `<MenuList maxHeight="60vh" overflowY="auto">`
- With only 1 cluster ("quickstart") in this test environment, the menu is 46px tall, well within the max height constraint. The dropdown displays correctly and does not spill off the page.
- With many clusters (as shown in the original bug screenshot with 20+ items), the menu would be capped at ~296px (60vh) and become scrollable, preventing the off-page overflow described in the bug.
- The fix is applied at the generic `ContextMenu` component level, so it protects all breadcrumb context menus, not just the cluster dropdown.

## Screenshots
- `/tmp/artifacts/auth-success.png` - Successful authentication, app loaded
- `/tmp/artifacts/clusters-page.png` - Clusters list page showing quickstart cluster
- `/tmp/artifacts/cluster-dropdown-open.png` - Cluster breadcrumb context menu open with fix applied
- `/tmp/artifacts/fix-verified.png` - Final state showing dropdown correctly constrained
- `/tmp/artifacts/issue-screenshot-0.png` - Original bug screenshot (for comparison)


### Code Review

APPROVED: Adds scrollability to the ContextMenu's MenuList when content exceeds 60% of viewport height — minimal, focused fix with no hardcoded colors, no drive-by changes, and no files touched outside console/.

---
_Generated by Papercut Factory | [View full artifacts](https://github.com/MaterializeInc/console-papercut-factory/actions/runs/24424551453)_