### PR TITLE
console: Add dropdown for cluster list in cluster overview

### DIFF
--- a/console/src/layouts/BaseLayout.tsx
+++ b/console/src/layouts/BaseLayout.tsx
@@ -326,7 +326,9 @@ export const ContextMenu = ({ children }: { children: React.ReactNode }) => {
     <Menu>
       <ContextMenuButton />
       <Portal>
-        <MenuList>{children}</MenuList>
+        <MenuList maxHeight="60vh" overflowY="auto">
+          {children}
+        </MenuList>
       </Portal>
     </Menu>
   );


### PR DESCRIPTION

### Motivation 


The cluster dropdown on the cluster overview page spills off the page when there are many clusters. No scrollbar is present. Need to add max-height + overflow scroll to the cluster list dropdown. [Fixes CNS-47: Fix Cluster Scroll](https://linear.app/materializeinc/issue/CNS-47/fix-cluster-scroll)



## Description 
Added maxHeight="60vh" and "overflowY=auto" to cluster scroll bar


### Verification
<img width="1510" height="1342" alt="image" src="https://github.com/user-attachments/assets/c633576d-e1ef-45a7-89be-02288c997bb3" />
Verified on my staging environment
