### PR TITLE
crypto: add rustls TLS foundation alongside openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7135,6 +7135,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",
+ "tokio-rustls",
  "tokio-test",
  "tonic",
  "tracing",
@@ -7421,8 +7422,8 @@ dependencies = [
  "mz-ore",
  "mz-server-core",
  "tokio",
- "tokio-openssl",
  "tokio-postgres",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -8432,12 +8433,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "mz-ore",
- "openssl",
- "openssl-sys",
- "postgres-openssl",
+ "rustls",
+ "rustls-pki-types",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,8 +1265,7 @@ dependencies = [
 [[package]]
 name = "azure_core"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b552ad43a45a746461ec3d3a51dfb6466b4759209414b439c165eb6a6b7729e"
+source = "git+https://github.com/MaterializeInc/azure-sdk-for-rust.git?branch=mz%2Fenable-reqwest-rustls-no-provider#cb4696ed0bbc195ec6e635fc8902a7a4bd0704c3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1295,8 +1294,7 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ddd80344317c40c04b603807b63a5cefa532f1b43522e72f480a988141f744"
+source = "git+https://github.com/MaterializeInc/azure-sdk-for-rust.git?branch=mz%2Fenable-reqwest-rustls-no-provider#cb4696ed0bbc195ec6e635fc8902a7a4bd0704c3"
 dependencies = [
  "async-lock",
  "async-process",
@@ -1316,8 +1314,7 @@ dependencies = [
 [[package]]
 name = "azure_storage"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f838159f4d29cb400a14d9d757578ba495ae64feb07a7516bf9e4415127126"
+source = "git+https://github.com/MaterializeInc/azure-sdk-for-rust.git?branch=mz%2Fenable-reqwest-rustls-no-provider#cb4696ed0bbc195ec6e635fc8902a7a4bd0704c3"
 dependencies = [
  "RustyXML",
  "async-lock",
@@ -1335,8 +1332,7 @@ dependencies = [
 [[package]]
 name = "azure_storage_blobs"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e83c3636ae86d9a6a7962b2112e3b19eb3903915c50ce06ff54ff0a2e6a7e4"
+source = "git+https://github.com/MaterializeInc/azure-sdk-for-rust.git?branch=mz%2Fenable-reqwest-rustls-no-provider#cb4696ed0bbc195ec6e635fc8902a7a4bd0704c3"
 dependencies = [
  "RustyXML",
  "azure_core",
@@ -1356,8 +1352,7 @@ dependencies = [
 [[package]]
 name = "azure_svc_blobstorage"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c6f20c5611b885ba94c7bae5e02849a267381aecb8aee577e8c35ff4064c6"
+source = "git+https://github.com/MaterializeInc/azure-sdk-for-rust.git?branch=mz%2Fenable-reqwest-rustls-no-provider#cb4696ed0bbc195ec6e635fc8902a7a4bd0704c3"
 dependencies = [
  "azure_core",
  "bytes",
@@ -7089,6 +7084,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-lc-rs",
  "bytemuck",
  "bytes",
  "chrono",
@@ -7126,6 +7122,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.9.3",
+ "rustls",
  "scopeguard",
  "sentry",
  "sentry-panic",
@@ -10788,6 +10785,7 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -10810,6 +10808,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,8 +2894,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3054,7 +3067,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3653,6 +3666,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -4578,7 +4597,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4797,7 +4816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -4891,7 +4910,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4978,7 +4997,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -9003,12 +9022,15 @@ dependencies = [
  "openssl-sys",
  "postgres-openssl",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "tokio-rustls",
  "tracing",
+ "x509-cert",
 ]
 
 [[package]]
@@ -10515,7 +10537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -10536,7 +10558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11488,7 +11510,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12610,7 +12632,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12629,7 +12651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12887,6 +12909,27 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -14345,6 +14388,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9025,6 +9025,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7621,6 +7621,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.9.4",
+ "rustls",
  "scopeguard",
  "sentry",
  "sentry-panic",
@@ -7634,6 +7635,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",
+ "tokio-rustls",
  "tokio-test",
  "tonic",
  "tracing",
@@ -7922,9 +7924,11 @@ dependencies = [
  "derivative",
  "mz-ore",
  "mz-server-core",
+ "openssl",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -8998,9 +9002,12 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "postgres-openssl",
+ "rustls",
+ "rustls-pki-types",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -11491,7 +11498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"
 rpassword = "7.4.0"
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
 rustls-pemfile = "2"
 rustls-pki-types = { version = "1", features = ["std"] }
 ryu = "1.0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,6 +361,7 @@ httparse = "1.8.0"
 humantime = "2.3.0"
 hyper = { version = "1.9.0", features = ["http1", "server"] }
 hyper-openssl = "0.10.2"
+hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "http2", "native-tokio", "tls12"] }
 hyper-util = "0.1.20"
 iceberg = "0.7.0"
 iceberg-catalog-rest = "0.7.0"
@@ -438,6 +439,7 @@ quote = "1.0.45"
 rand = "0.9.2"
 rand-8 = { package = "rand", version = "0.8.5", features = ["small_rng"] }
 rand_chacha = "0.9.0"
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
 rdkafka = { version = "0.29.0", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = "1.12.3"
@@ -449,6 +451,9 @@ rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"
 rpassword = "7.4.0"
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
+rustls-pemfile = "2"
+rustls-pki-types = { version = "1", features = ["std"] }
 ryu = "1.0.23"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 scopeguard = "1.2.0"
@@ -496,6 +501,7 @@ tokio = { version = "1.49.0", features = ["full", "test-util"] }
 tokio-metrics = "0.4.9"
 tokio-native-tls = "0.3.1"
 tokio-openssl = "0.6.5"
+tokio-rustls = { version = "0.26", default-features = false }
 tokio-postgres = "0.7.15"
 tokio-stream = "0.1.18"
 tokio-test = "0.4.5"
@@ -599,6 +605,15 @@ serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 
 # Waiting for resolution of https://github.com/launchdarkly/rust-server-sdk/issues/116
 launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", rev = "3e0a0b98b09a2970f292577a07e1c9382b65b5da" }
+
+# Add enable_reqwest_rustls_no_provider feature to avoid pulling in ring,
+# which conflicts with aws-lc-fips-sys in FIPS builds.
+# See https://github.com/Azure/azure-sdk-for-rust/issues/1680
+azure_core = { git = "https://github.com/MaterializeInc/azure-sdk-for-rust.git", branch = "mz/enable-reqwest-rustls-no-provider" }
+azure_identity = { git = "https://github.com/MaterializeInc/azure-sdk-for-rust.git", branch = "mz/enable-reqwest-rustls-no-provider" }
+azure_storage = { git = "https://github.com/MaterializeInc/azure-sdk-for-rust.git", branch = "mz/enable-reqwest-rustls-no-provider" }
+azure_storage_blobs = { git = "https://github.com/MaterializeInc/azure-sdk-for-rust.git", branch = "mz/enable-reqwest-rustls-no-provider" }
+azure_svc_blobstorage = { git = "https://github.com/MaterializeInc/azure-sdk-for-rust.git", branch = "mz/enable-reqwest-rustls-no-provider" }
 
 # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,6 +487,7 @@ rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"
 rustls = { version = "0.23.38", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
+rustls-native-certs = "0.8.3"
 rustls-pki-types = { version = "1", features = ["std"] }
 rpassword = "7.5.1"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
@@ -571,6 +572,7 @@ uuid = "1.19.0"
 version-compare = "0.2.1"
 walkdir = "2.5.0"
 which = "8"
+x509-cert = "0.2.5"
 yansi = "1.0.1"
 zeroize = { version = "1.8.2", features = ["derive", "serde"] }
 zip = { version = "6.0.0", default-features = false, features = ["deflate-flate2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,7 +486,8 @@ reqwest-retry = "0.8.0"
 rlimit = "0.11.0"
 rocksdb = { version = "0.24.0", default-features = false, features = ["lz4", "snappy", "zstd"] }
 ropey = "1.6.1"
-rustls = "0.23.38"
+rustls = { version = "0.23.38", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
 rpassword = "7.5.1"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 ryu = "1.0.23"
@@ -538,6 +539,7 @@ tokio = { version = "1.52.3", features = ["full", "test-util"] }
 tokio-metrics = "0.5.0"
 tokio-native-tls = "0.3.1"
 tokio-openssl = "0.6.5"
+tokio-rustls = { version = "0.26", default-features = false }
 tokio-postgres = "0.7.15"
 tokio-stream = "0.1.18"
 tokio-test = "0.4.5"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -172,6 +172,23 @@ steps:
       queue: hetzner-aarch64-16cpu-32gb
     sanitizer: skip
 
+  - id: cargo-test-tls-external
+    label: ":rust: TLS validation against public CAs"
+    depends_on: []
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        # Tolerate transient network failures reaching the external endpoint.
+        - exit_status: 1
+          limit: 1
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: cargo-test
+          args: [--tls-external]
+    agents:
+      queue: hetzner-aarch64-4cpu-8gb
+    sanitizer: skip
+
   - group: Benchmarks
     key: benchmark
     steps:

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -105,6 +105,7 @@ def pull_image(image: str) -> None:
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--miri-full", action="store_true")
     parser.add_argument("--miri-fast", action="store_true")
+    parser.add_argument("--tls-external", action="store_true")
     parser.add_argument("args", nargs="*")
     args = parser.parse_args()
 
@@ -118,6 +119,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     if os.path.exists(junit_path):
         os.remove(junit_path)
+
+    # Needs no services, only external network access.
+    if args.tls_external:
+        run_tls_external()
+        return
 
     c.up(
         "kafka",
@@ -177,6 +183,25 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         run_sanitizer(args, env, metadata, sanitizer)
     else:
         run_cargo_nextest(c, args, env, metadata)
+
+
+def run_tls_external() -> None:
+    """Validate the TLS connectors against an endpoint whose certificate
+    chains to a public CA. Requires external network access, so this runs in
+    Nightly rather than the PR pipeline."""
+    spawn.runv(
+        [
+            "cargo",
+            "nextest",
+            "run",
+            "--profile=ci",
+            "--package=mz-tls-util",
+            "-E",
+            "test(external_public_ca_endpoint)",
+        ],
+        env=dict(os.environ, MZ_TLS_UTIL_TEST_EXTERNAL_CAS="1"),
+        cwd=MZ_ROOT,
+    )
 
 
 def run_coverage_test(args: Namespace, env: dict[str, str]):

--- a/deny.toml
+++ b/deny.toml
@@ -128,6 +128,18 @@ skip = [
     { name = "fallible-iterator", version = "0.3.0" },
     # arrow
     { name = "hashbrown", version = "0.16.1" },
+    # aws-lc-rs
+    { name = "untrusted", version = "0.7.1" },
+    # Pulled in by rustls ecosystem
+    { name = "base64", version = "0.21.7" },
+    { name = "core-foundation", version = "0.9.3" },
+    { name = "getrandom", version = "0.3.4" },
+    { name = "openssl-probe", version = "0.1.6" },
+    { name = "security-framework", version = "2.10.0" },
+    { name = "toml_datetime", version = "0.6.11" },
+    { name = "toml_edit", version = "0.22.27" },
+    { name = "webpki-roots", version = "0.26.11" },
+    { name = "winnow", version = "0.7.15" },
 ]
 
 [[bans.deny]]
@@ -176,6 +188,7 @@ wrappers = [
     "eventsource-client",
     "fail",
     "globset",
+    "hyper-rustls",
     "launchdarkly-server-sdk",
     "launchdarkly-server-sdk-evaluation",
     "native-tls",
@@ -188,6 +201,7 @@ wrappers = [
     "rdkafka",
     "reqsign",
     "reqwest",
+    "rustls",
     "tokio-postgres",
     "tokio-tungstenite",
     "tracing-log",
@@ -197,10 +211,8 @@ wrappers = [
     "zopfli",
 ]
 
-# We prefer the system's native TLS or OpenSSL to Rustls, since they are more
-# mature and more widely used.
-[[bans.deny]]
-name = "rustls"
+# FIPS 140-3 compliance: migrating to rustls + aws-lc-rs as the single crypto
+# backend. The rustls ban has been removed; see doc/developer/openssl-to-rustls-migration.md.
 
 # once_cell is going to be added to std, and doesn't use macros
 # Unfortunately, its heavily used, so we have lots of exceptions.

--- a/deny.toml
+++ b/deny.toml
@@ -159,6 +159,10 @@ skip = [
     { name = "rand_core", version = "0.10.1" },
     { name = "getrandom", version = "0.4.2" },
     { name = "cpufeatures", version = "0.3.0" },
+    # Pulled in by rustls ecosystem
+    { name = "core-foundation", version = "0.9.3" },
+    { name = "openssl-probe", version = "0.1.6" },
+    { name = "security-framework", version = "2.10.0" },
 ]
 
 [[bans.deny]]

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -52,7 +52,8 @@ use mz_ore::tracing::TracingHandle;
 use mz_ore::{metric, netio};
 use mz_pgwire_common::{
     ACCEPT_SSL_ENCRYPTION, CONN_UUID_KEY, Conn, ErrorResponse, FrontendMessage,
-    FrontendStartupMessage, MZ_FORWARDED_FOR_KEY, REJECT_ENCRYPTION, VERSION_3, decode_startup,
+    FrontendStartupMessage, MZ_FORWARDED_FOR_KEY, REJECT_ENCRYPTION, TlsStream, VERSION_3,
+    decode_startup,
 };
 use mz_server_core::{
     Connection, ConnectionStream, ListenerHandle, ReloadTrigger, ReloadingSslContext,
@@ -734,7 +735,7 @@ impl PgwireBalancer {
                     .configure()?
                     .into_ssl(&envd_addr.to_string())?;
                 ssl.set_connect_state();
-                Conn::Ssl(SslStream::new(ssl, mz_stream)?)
+                Conn::Ssl(TlsStream::Openssl(SslStream::new(ssl, mz_stream)?))
             } else {
                 Conn::Unencrypted(mz_stream)
             }
@@ -914,7 +915,7 @@ impl mz_server_core::Server for PgwireBalancer {
                                     let _ = ssl_stream.get_mut().shutdown().await;
                                     return Err(e.into());
                                 }
-                                Conn::Ssl(ssl_stream)
+                                Conn::Ssl(TlsStream::Openssl(ssl_stream))
                             }
                             (mut conn, _) => {
                                 conn.write_all(&[REJECT_ENCRYPTION]).await?;
@@ -1288,7 +1289,7 @@ impl mz_server_core::Server for HttpsBalancer {
                         .configure()?
                         .into_ssl(&resolved.addr.to_string())?;
                     ssl.set_connect_state();
-                    Conn::Ssl(SslStream::new(ssl, mz_stream)?)
+                    Conn::Ssl(TlsStream::Openssl(SslStream::new(ssl, mz_stream)?))
                 } else {
                     Conn::Unencrypted(mz_stream)
                 };
@@ -1357,11 +1358,9 @@ impl Resolver {
             ) => {
                 let servername = match conn.inner() {
                     Conn::Ssl(ssl_stream) => {
-                        ssl_stream.ssl().servername(NameType::HOST_NAME).map(|sn| {
-                            match sn.split_once('.') {
-                                Some((left, _right)) => left,
-                                None => sn,
-                            }
+                        ssl_stream.server_name().map(|sn| match sn.split_once('.') {
+                            Some((left, _right)) => left,
+                            None => sn,
                         })
                     }
                     Conn::Unencrypted(_) => None,

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -19,7 +19,12 @@ anyhow = { workspace = true, optional = true }
 # Exceptions: `either` (zero deps, quasi-stdlib) and `zeroize` (zero runtime
 # deps, security-critical — must be available unconditionally so that
 # `ore::secure` types are always accessible without feature-flag opt-in).
+# aws-lc-rs is the crypto backend. default-features=false avoids pulling in
+# aws-lc-sys unconditionally; the `crypto` or `fips` features select which
+# C library to link (aws-lc-sys vs aws-lc-fips-sys).
+aws-lc-rs = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
+rustls = { workspace = true, features = ["aws_lc_rs"], optional = true, default-features = false }
 bytemuck = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
@@ -144,6 +149,13 @@ assert-no-tracing = []
 assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
+# `crypto` enables the aws-lc-rs crypto backend in standard (non-FIPS) mode.
+# `fips` is a marker feature for FIPS 140-3 builds. It does NOT activate
+# aws-lc-rs/fips at the Cargo level to avoid duplicate symbol conflicts with
+# `crypto` under --all-features. Actual FIPS builds must pass
+# --cfg=aws_lc_fips or use the dedicated FIPS build profile (SEC-260).
+crypto = ["aws-lc-rs", "rustls", "ctor"]
+fips = ["crypto"]
 
 [[test]]
 name = "future"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -60,6 +60,7 @@ sentry-panic = { workspace = true, optional = true }
 serde.workspace = true
 tokio = { workspace = true, optional = true }
 tokio-openssl = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true, default-features = false }
 thiserror.workspace = true
 tracing-capture = { workspace = true, optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
@@ -110,6 +111,7 @@ async = [
     "openssl",
     "tokio/tracing",
     "tokio-openssl",
+    "tokio-rustls",
     "tokio",
     "dep:tracing",
 ]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true, optional = true }
 # deps, security-critical — must be available unconditionally so that
 # `ore::secure` types are always accessible without feature-flag opt-in).
 async-trait = { workspace = true, optional = true }
+rustls = { workspace = true, features = ["aws_lc_rs"], optional = true, default-features = false }
 bytemuck = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
@@ -56,6 +57,7 @@ sentry-panic = { workspace = true, optional = true }
 serde.workspace = true
 tokio = { workspace = true, optional = true }
 tokio-openssl = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true, default-features = false }
 thiserror.workspace = true
 tracing-capture = { workspace = true, optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
@@ -107,6 +109,7 @@ async = [
     "openssl",
     "tokio/tracing",
     "tokio-openssl",
+    "tokio-rustls",
     "tokio",
     "dep:tracing",
 ]
@@ -147,6 +150,10 @@ assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
 pager = ["dep:bytemuck", "libc", "rand", "dep:tracing"]
+# Installs the aws-lc-rs rustls crypto provider process-wide at startup, so
+# every binary that links a `crypto`-enabled mz-ore can build rustls
+# configurations without selecting a provider explicitly.
+crypto = ["rustls", "ctor"]
 
 [[test]]
 name = "future"

--- a/src/ore/src/crypto.rs
+++ b/src/ore/src/crypto.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! FIPS-aware cryptographic provider helpers.
+//!
+//! This module provides a [`fips_crypto_provider`] function that returns the
+//! correct [`rustls::crypto::CryptoProvider`] for the build configuration:
+//!
+//! - When the `fips` feature is enabled, the provider is backed by
+//!   `aws_lc_rs` compiled against the FIPS-validated module.
+//! - Otherwise, the default `aws_lc_rs` provider is used.
+
+use std::sync::Arc;
+
+/// Auto-install the crypto provider when any binary links mz-ore with the
+/// `crypto` feature. This ensures reqwest (with `rustls-tls-*-no-provider`)
+/// can build TLS clients in any context — main binaries, test binaries, and
+/// build scripts — without requiring explicit `fips_crypto_provider()` calls.
+///
+/// In FIPS mode, uses the FIPS-validated aws-lc module. Otherwise, uses the
+/// standard aws-lc-rs provider. The two paths link different C libraries
+/// (aws-lc-fips-sys vs aws-lc-sys) and must not both be active.
+#[ctor::ctor]
+fn auto_install_crypto_provider() {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = provider.install_default();
+}
+
+/// Returns the [`rustls::crypto::CryptoProvider`] appropriate for the current
+/// build.
+///
+/// - With the `fips` feature: uses the FIPS 140-3 validated aws-lc module.
+/// - Without `fips`: uses the standard aws-lc-rs provider.
+///
+/// On the first call, this also installs the provider as the process-wide
+/// default so that any rustls usage (including transitive dependencies like
+/// `hyper-rustls` or `tokio-postgres-rustls`) picks it up automatically.
+///
+/// The returned provider is cached in an `Arc` so cloning is cheap.
+pub fn fips_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    // Both paths use aws_lc_rs::default_provider(), but with the `fips`
+    // feature enabled, aws-lc-rs links against aws-lc-fips-sys instead of
+    // aws-lc-sys, providing the FIPS-validated cryptographic module.
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = provider.clone().install_default();
+    Arc::new(provider)
+}

--- a/src/ore/src/crypto.rs
+++ b/src/ore/src/crypto.rs
@@ -1,0 +1,39 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Rustls crypto provider selection.
+//!
+//! Materialize standardizes on the aws-lc-rs crypto provider for all rustls
+//! usage. This module installs it as the process-wide default so that rustls
+//! configurations built anywhere in the process, including in transitive
+//! dependencies, pick it up without selecting a provider explicitly.
+
+use std::sync::Arc;
+
+// Install the provider at startup of any binary that links mz-ore with the
+// `crypto` feature. This covers main binaries, test binaries, and build
+// scripts, which are separate processes and do not inherit each other's
+// provider.
+#[ctor::ctor]
+fn auto_install_crypto_provider() {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = provider.install_default();
+}
+
+/// Returns the aws-lc-rs [`rustls::crypto::CryptoProvider`], for rustls
+/// configurations that select a provider explicitly.
+pub fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -37,6 +37,9 @@ pub mod channel;
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod collections;
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "crypto")))]
+#[cfg(feature = "crypto")]
+pub mod crypto;
 pub mod env;
 pub mod error;
 pub mod fmt;

--- a/src/ore/src/netio/async_ready.rs
+++ b/src/ore/src/netio/async_ready.rs
@@ -16,7 +16,6 @@
 use async_trait::async_trait;
 use tokio::io::{self, Interest, Ready};
 use tokio::net::TcpStream;
-use tokio_openssl::SslStream;
 
 /// Asynchronous IO readiness.
 ///
@@ -38,11 +37,21 @@ impl AsyncReady for TcpStream {
 }
 
 #[async_trait]
-impl<S> AsyncReady for SslStream<S>
+impl<S> AsyncReady for tokio_rustls::server::TlsStream<S>
 where
-    S: AsyncReady + Sync,
+    S: AsyncReady + Sync + Send,
 {
     async fn ready(&self, interest: Interest) -> io::Result<Ready> {
-        self.get_ref().ready(interest).await
+        self.get_ref().0.ready(interest).await
+    }
+}
+
+#[async_trait]
+impl<S> AsyncReady for tokio_rustls::client::TlsStream<S>
+where
+    S: AsyncReady + Sync + Send,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.get_ref().0.ready(interest).await
     }
 }

--- a/src/ore/src/netio/async_ready.rs
+++ b/src/ore/src/netio/async_ready.rs
@@ -46,3 +46,23 @@ where
         self.get_ref().ready(interest).await
     }
 }
+
+#[async_trait]
+impl<S> AsyncReady for tokio_rustls::server::TlsStream<S>
+where
+    S: AsyncReady + Sync + Send,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.get_ref().0.ready(interest).await
+    }
+}
+
+#[async_trait]
+impl<S> AsyncReady for tokio_rustls::client::TlsStream<S>
+where
+    S: AsyncReady + Sync + Send,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.get_ref().0.ready(interest).await
+    }
+}

--- a/src/pgwire-common/Cargo.toml
+++ b/src/pgwire-common/Cargo.toml
@@ -18,7 +18,7 @@ derivative.workspace = true
 mz-ore = { path = "../ore", features = ["network"], default-features = false }
 mz-server-core = { path = "../server-core", default-features = false }
 tokio.workspace = true
-tokio-openssl.workspace = true
+tokio-rustls = { workspace = true, default-features = false }
 tokio-postgres.workspace = true
 tracing.workspace = true
 

--- a/src/pgwire-common/Cargo.toml
+++ b/src/pgwire-common/Cargo.toml
@@ -17,8 +17,10 @@ bytesize.workspace = true
 derivative.workspace = true
 mz-ore = { path = "../ore", features = ["network"], default-features = false }
 mz-server-core = { path = "../server-core", default-features = false }
+openssl.workspace = true
 tokio.workspace = true
 tokio-openssl.workspace = true
+tokio-rustls = { workspace = true, default-features = false }
 tokio-postgres.workspace = true
 tracing.workspace = true
 

--- a/src/pgwire-common/src/conn.rs
+++ b/src/pgwire-common/src/conn.rs
@@ -16,7 +16,6 @@ use derivative::Derivative;
 use mz_ore::netio::AsyncReady;
 use mz_server_core::TlsMode;
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
-use tokio_openssl::SslStream;
 use tokio_postgres::error::SqlState;
 
 use crate::ErrorResponse;
@@ -24,10 +23,98 @@ use crate::ErrorResponse;
 pub const CONN_UUID_KEY: &str = "mz_connection_uuid";
 pub const MZ_FORWARDED_FOR_KEY: &str = "mz_forwarded_for";
 
+/// A TLS stream that can be either server-side or client-side.
+#[derive(Debug)]
+pub enum TlsStream<A> {
+    /// Server-side TLS (e.g., pgwire accept, HTTP accept).
+    Server(tokio_rustls::server::TlsStream<A>),
+    /// Client-side TLS (e.g., balancerd connecting to upstream environmentd).
+    Client(tokio_rustls::client::TlsStream<A>),
+}
+
+impl<A> TlsStream<A> {
+    /// Returns a mutable reference to the underlying IO stream.
+    pub fn get_mut(&mut self) -> &mut A {
+        match self {
+            TlsStream::Server(s) => s.get_mut().0,
+            TlsStream::Client(s) => s.get_mut().0,
+        }
+    }
+
+    /// Returns a reference to the underlying IO stream.
+    pub fn get_ref(&self) -> &A {
+        match self {
+            TlsStream::Server(s) => s.get_ref().0,
+            TlsStream::Client(s) => s.get_ref().0,
+        }
+    }
+
+    /// Returns the SNI server name from the TLS session, if available.
+    ///
+    /// For server-side streams, this is the server name the client requested
+    /// via Server Name Indication (SNI). For client-side streams, this returns
+    /// `None`.
+    pub fn server_name(&self) -> Option<&str> {
+        match self {
+            TlsStream::Server(s) => s.get_ref().1.server_name(),
+            TlsStream::Client(_) => None,
+        }
+    }
+}
+
+impl<A: AsyncRead + AsyncWrite + Unpin> AsyncRead for TlsStream<A> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_read(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl<A: AsyncRead + AsyncWrite + Unpin> AsyncWrite for TlsStream<A> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_write(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_flush(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_shutdown(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+#[async_trait]
+impl<A> AsyncReady for TlsStream<A>
+where
+    A: AsyncRead + AsyncWrite + AsyncReady + Sync + Send + Unpin,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        match self {
+            TlsStream::Server(s) => s.get_ref().0.ready(interest).await,
+            TlsStream::Client(s) => s.get_ref().0.ready(interest).await,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Conn<A> {
     Unencrypted(A),
-    Ssl(SslStream<A>),
+    Ssl(TlsStream<A>),
 }
 
 impl<A> Conn<A> {
@@ -110,7 +197,7 @@ where
 #[async_trait]
 impl<A> AsyncReady for Conn<A>
 where
-    A: AsyncRead + AsyncWrite + AsyncReady + Sync + Unpin,
+    A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
 {
     async fn ready(&self, interest: Interest) -> io::Result<Ready> {
         match self {

--- a/src/pgwire-common/src/conn.rs
+++ b/src/pgwire-common/src/conn.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use derivative::Derivative;
 use mz_ore::netio::AsyncReady;
 use mz_server_core::TlsMode;
+use openssl::ssl::NameType;
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use tokio_openssl::SslStream;
 use tokio_postgres::error::SqlState;
@@ -24,10 +25,112 @@ use crate::ErrorResponse;
 pub const CONN_UUID_KEY: &str = "mz_connection_uuid";
 pub const MZ_FORWARDED_FOR_KEY: &str = "mz_forwarded_for";
 
+/// A TLS stream over either the openssl or the rustls backend.
+///
+/// The `Openssl` variant exists while consumers migrate to rustls one at a
+/// time. It is removed once no consumer constructs it anymore.
+#[derive(Debug)]
+pub enum TlsStream<A> {
+    /// Server- or client-side TLS on the openssl backend.
+    Openssl(SslStream<A>),
+    /// Server-side rustls TLS (e.g., pgwire accept, HTTP accept).
+    Server(tokio_rustls::server::TlsStream<A>),
+    /// Client-side rustls TLS (e.g., balancerd connecting to upstream
+    /// environmentd).
+    Client(tokio_rustls::client::TlsStream<A>),
+}
+
+impl<A> TlsStream<A> {
+    /// Returns a mutable reference to the underlying IO stream.
+    pub fn get_mut(&mut self) -> &mut A {
+        match self {
+            TlsStream::Openssl(s) => s.get_mut(),
+            TlsStream::Server(s) => s.get_mut().0,
+            TlsStream::Client(s) => s.get_mut().0,
+        }
+    }
+
+    /// Returns a reference to the underlying IO stream.
+    pub fn get_ref(&self) -> &A {
+        match self {
+            TlsStream::Openssl(s) => s.get_ref(),
+            TlsStream::Server(s) => s.get_ref().0,
+            TlsStream::Client(s) => s.get_ref().0,
+        }
+    }
+
+    /// Returns the SNI server name from the TLS session, if available.
+    ///
+    /// For server-side streams, this is the server name the client requested
+    /// via Server Name Indication (SNI). For rustls client-side streams, this
+    /// returns `None`.
+    pub fn server_name(&self) -> Option<&str> {
+        match self {
+            TlsStream::Openssl(s) => s.ssl().servername(NameType::HOST_NAME),
+            TlsStream::Server(s) => s.get_ref().1.server_name(),
+            TlsStream::Client(_) => None,
+        }
+    }
+}
+
+impl<A: AsyncRead + AsyncWrite + Unpin> AsyncRead for TlsStream<A> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Openssl(s) => Pin::new(s).poll_read(cx, buf),
+            TlsStream::Server(s) => Pin::new(s).poll_read(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl<A: AsyncRead + AsyncWrite + Unpin> AsyncWrite for TlsStream<A> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Openssl(s) => Pin::new(s).poll_write(cx, buf),
+            TlsStream::Server(s) => Pin::new(s).poll_write(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Openssl(s) => Pin::new(s).poll_flush(cx),
+            TlsStream::Server(s) => Pin::new(s).poll_flush(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Openssl(s) => Pin::new(s).poll_shutdown(cx),
+            TlsStream::Server(s) => Pin::new(s).poll_shutdown(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+#[async_trait]
+impl<A> AsyncReady for TlsStream<A>
+where
+    A: AsyncRead + AsyncWrite + AsyncReady + Sync + Send + Unpin,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        match self {
+            TlsStream::Openssl(s) => s.get_ref().ready(interest).await,
+            TlsStream::Server(s) => s.get_ref().0.ready(interest).await,
+            TlsStream::Client(s) => s.get_ref().0.ready(interest).await,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Conn<A> {
     Unencrypted(A),
-    Ssl(SslStream<A>),
+    Ssl(TlsStream<A>),
 }
 
 impl<A> Conn<A> {
@@ -110,7 +213,7 @@ where
 #[async_trait]
 impl<A> AsyncReady for Conn<A>
 where
-    A: AsyncRead + AsyncWrite + AsyncReady + Sync + Unpin,
+    A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin,
 {
     async fn ready(&self, interest: Interest) -> io::Result<Ready> {
         match self {

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -24,7 +24,7 @@ pub use codec::{
 };
 pub use conn::{
     CONN_UUID_KEY, Conn, ConnectionCounter, ConnectionError, ConnectionHandle,
-    MZ_FORWARDED_FOR_KEY, UserMetadata,
+    MZ_FORWARDED_FOR_KEY, TlsStream, UserMetadata,
 };
 pub use format::Format;
 pub use message::{

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -19,7 +19,7 @@ use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 use mz_ore::now::{SYSTEM_TIME, epoch_to_uuid_v7};
 use mz_pgwire_common::{
     ACCEPT_SSL_ENCRYPTION, CONN_UUID_KEY, Conn, ConnectionCounter, FrontendStartupMessage,
-    MZ_FORWARDED_FOR_KEY, REJECT_ENCRYPTION, decode_startup,
+    MZ_FORWARDED_FOR_KEY, REJECT_ENCRYPTION, TlsStream, decode_startup,
 };
 use mz_server_core::listeners::{AllowedRoles, AuthenticatorKind};
 use mz_server_core::{Connection, ConnectionHandler, ReloadingTlsConfig};
@@ -245,7 +245,7 @@ impl Server {
                                         let _ = ssl_stream.get_mut().shutdown().await;
                                         return Err(e.into());
                                     }
-                                    Conn::Ssl(ssl_stream)
+                                    Conn::Ssl(TlsStream::Openssl(ssl_stream))
                                 }
                                 (mut conn, _) => {
                                     trace!("cid={} send=RejectSsl", conn_id);

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -11,13 +11,13 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-mz-ore = { path = "../ore", default-features = false }
-openssl.workspace = true
-openssl-sys.workspace = true
-postgres-openssl.workspace = true
+mz-ore = { path = "../ore" }
+rustls = { workspace = true, features = ["aws_lc_rs", "std"], default-features = false }
+rustls-pki-types = { workspace = true, features = ["std"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres.workspace = true
+tokio-rustls.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -11,13 +11,16 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-mz-ore = { path = "../ore", default-features = false }
+mz-ore = { path = "../ore", features = ["crypto"], default-features = false }
 openssl.workspace = true
 openssl-sys.workspace = true
 postgres-openssl.workspace = true
+rustls = { workspace = true, features = ["aws_lc_rs", "std"], default-features = false }
+rustls-pki-types = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
+tokio-rustls.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -27,7 +27,8 @@ tracing.workspace = true
 x509-cert.workspace = true
 
 [dev-dependencies]
-mz-ore = { path = "../ore", features = ["test"] }
+mz-ore = { path = "../ore", features = ["async", "test"] }
+tempfile.workspace = true
 
 [features]
 default = []

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -16,12 +16,15 @@ openssl.workspace = true
 openssl-sys.workspace = true
 postgres-openssl.workspace = true
 rustls = { workspace = true, features = ["aws_lc_rs", "std"], default-features = false }
+rustls-native-certs.workspace = true
 rustls-pki-types = { workspace = true, features = ["std"] }
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-rustls.workspace = true
 tracing.workspace = true
+x509-cert.workspace = true
 
 [dev-dependencies]
 mz-ore = { path = "../ore", features = ["test"] }

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -9,14 +9,17 @@
 
 //! A tiny utility library for making TLS connectors.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use mz_ore::secure::{Zeroize, Zeroizing};
-use openssl::pkcs12::Pkcs12;
-use openssl::pkey::PKey;
-use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use openssl::stack::Stack;
-use openssl::x509::X509;
-use postgres_openssl::MakeTlsConnector;
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_postgres::config::SslMode;
+use tokio_postgres::tls::{ChannelBinding, TlsStream};
+use tokio_rustls::TlsConnector;
 
 macro_rules! bail_generic {
     ($err:expr $(,)?) => {
@@ -30,43 +33,163 @@ pub enum TlsError {
     /// Any other error we bail on.
     #[error(transparent)]
     Generic(#[from] anyhow::Error),
-    /// Error setting up postgres ssl.
-    #[error(transparent)]
-    OpenSsl(#[from] openssl::error::ErrorStack),
+    /// Error setting up TLS.
+    #[error("TLS configuration error: {0}")]
+    Rustls(#[from] rustls::Error),
+}
+
+/// Wrapper around `tokio_rustls::client::TlsStream` that implements
+/// `tokio_postgres::tls::TlsStream`.
+pub struct RustlsTlsStream<S>(tokio_rustls::client::TlsStream<S>);
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for RustlsTlsStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for RustlsTlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> TlsStream for RustlsTlsStream<S> {
+    fn channel_binding(&self) -> ChannelBinding {
+        ChannelBinding::none()
+    }
+}
+
+/// A `MakeTlsConnect` implementation backed by rustls.
+#[derive(Clone)]
+pub struct MakeRustlsConnect {
+    config: Arc<rustls::ClientConfig>,
+}
+
+impl MakeRustlsConnect {
+    pub fn new(config: rustls::ClientConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+impl<S> tokio_postgres::tls::MakeTlsConnect<S> for MakeRustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsTlsStream<S>;
+    type TlsConnect = RustlsConnect;
+    type Error = rustls_pki_types::InvalidDnsNameError;
+
+    fn make_tls_connect(&mut self, domain: &str) -> Result<Self::TlsConnect, Self::Error> {
+        // For Unix socket connections, tokio-postgres passes an empty string as
+        // the domain. Socket paths starting with "/" are also not valid DNS names.
+        // TLS is never negotiated over Unix sockets, so use a placeholder.
+        let server_name = if domain.is_empty() || domain.starts_with('/') {
+            ServerName::try_from("localhost").unwrap()
+        } else {
+            ServerName::try_from(domain.to_owned())?
+        };
+        Ok(RustlsConnect {
+            connector: TlsConnector::from(Arc::clone(&self.config)),
+            server_name,
+        })
+    }
+}
+
+pub struct RustlsConnect {
+    connector: TlsConnector,
+    server_name: ServerName<'static>,
+}
+
+impl<S> tokio_postgres::tls::TlsConnect<S> for RustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsTlsStream<S>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
+
+    fn connect(self, stream: S) -> Self::Future {
+        Box::pin(async move {
+            let tls_stream = self.connector.connect(self.server_name, stream).await?;
+            Ok(RustlsTlsStream(tls_stream))
+        })
+    }
 }
 
 /// Creates a TLS connector for the given [`Config`](tokio_postgres::Config).
-pub fn make_tls(config: &tokio_postgres::Config) -> Result<MakeTlsConnector, TlsError> {
-    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+pub fn make_tls(config: &tokio_postgres::Config) -> Result<MakeRustlsConnect, TlsError> {
+    let mut root_store = rustls::RootCertStore::empty();
+
     // The mode dictates whether we verify peer certs and hostnames. By default, Postgres is
     // pretty relaxed and recommends SslMode::VerifyCa or SslMode::VerifyFull for security.
     //
     // For more details, check out Table 33.1. SSL Mode Descriptions in
     // https://postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION.
-    let (verify_mode, verify_hostname) = match config.get_ssl_mode() {
-        SslMode::Disable | SslMode::Prefer => (SslVerifyMode::NONE, false),
-        SslMode::Require => match config.get_ssl_root_cert() {
-            // If a root CA file exists, the behavior of sslmode=require will be the same as
-            // that of verify-ca, meaning the server certificate is validated against the CA.
-            //
-            // For more details, check out the note about backwards compatibility in
-            // https://postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES.
-            Some(_) => (SslVerifyMode::PEER, false),
-            None => (SslVerifyMode::NONE, false),
-        },
-        SslMode::VerifyCa => (SslVerifyMode::PEER, false),
-        SslMode::VerifyFull => (SslVerifyMode::PEER, true),
+    let verify_mode = match config.get_ssl_mode() {
+        SslMode::Disable | SslMode::Prefer => false,
+        SslMode::Require => config.get_ssl_root_cert().is_some(),
+        SslMode::VerifyCa | SslMode::VerifyFull => true,
         _ => panic!("unexpected sslmode {:?}", config.get_ssl_mode()),
     };
 
-    // Configure peer verification
-    builder.set_verify(verify_mode);
+    // Load root certificates if verification is needed.
+    if let Some(ssl_root_cert) = config.get_ssl_root_cert() {
+        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(ssl_root_cert)
+            .collect::<Result<_, _>>()
+            .map_err(|e| TlsError::Generic(anyhow::anyhow!("failed to parse root certs: {e}")))?;
+        for cert in certs {
+            root_store
+                .add(cert)
+                .map_err(|e| TlsError::Generic(anyhow::anyhow!("invalid root cert: {e}")))?;
+        }
+    }
 
-    // Configure certificates
-    match (config.get_ssl_cert(), config.get_ssl_key()) {
+    let builder = if verify_mode {
+        rustls::ClientConfig::builder().with_root_certificates(root_store)
+    } else {
+        // When not verifying, use a custom verifier that accepts all certs.
+        rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+    };
+
+    // Configure client certificate if provided.
+    let tls_config = match (config.get_ssl_cert(), config.get_ssl_key()) {
         (Some(ssl_cert), Some(ssl_key)) => {
-            builder.set_certificate(&*X509::from_pem(ssl_cert)?)?;
-            builder.set_private_key(&*PKey::private_key_from_pem(ssl_key)?)?;
+            let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(ssl_cert)
+                .collect::<Result<_, _>>()
+                .map_err(|e| {
+                    TlsError::Generic(anyhow::anyhow!("failed to parse client cert: {e}"))
+                })?;
+            let key = PrivateKeyDer::from_pem_slice(ssl_key).map_err(|e| {
+                TlsError::Generic(anyhow::anyhow!("failed to parse client key: {e}"))
+            })?;
+            builder.with_client_auth_cert(certs, key)?
         }
         (None, Some(_)) => {
             bail_generic!("must provide both sslcert and sslkey, but only provided sslkey")
@@ -74,26 +197,52 @@ pub fn make_tls(config: &tokio_postgres::Config) -> Result<MakeTlsConnector, Tls
         (Some(_), None) => {
             bail_generic!("must provide both sslcert and sslkey, but only provided sslcert")
         }
-        _ => {}
-    }
-    if let Some(ssl_root_cert) = config.get_ssl_root_cert() {
-        for cert in X509::stack_from_pem(ssl_root_cert)? {
-            builder.cert_store_mut().add_cert(cert)?;
-        }
+        _ => builder.with_no_client_auth(),
+    };
+
+    Ok(MakeRustlsConnect::new(tls_config))
+}
+
+/// A certificate verifier that accepts all certificates.
+/// Used when SslMode is Disable, Prefer, or Require without a root cert.
+#[derive(Debug)]
+struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
     }
 
-    let mut tls_connector = MakeTlsConnector::new(builder.build());
-
-    // Configure hostname verification
-    match (verify_mode, verify_hostname) {
-        (SslVerifyMode::PEER, false) => tls_connector.set_callback(|connect, _| {
-            connect.set_verify_hostname(false);
-            Ok(())
-        }),
-        _ => {}
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
     }
 
-    Ok(tls_connector)
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
 }
 
 pub struct Pkcs12Archive {
@@ -114,49 +263,31 @@ impl Drop for Pkcs12Archive {
     }
 }
 
-/// Constructs an identity from a PEM-formatted key and certificate using OpenSSL.
-pub fn pkcs12der_from_pem(
-    key: &[u8],
-    cert: &[u8],
-) -> Result<Pkcs12Archive, openssl::error::ErrorStack> {
+/// Constructs a PEM identity from a key and certificate.
+///
+/// Returns a `Pkcs12Archive` for backward compatibility with callers that
+/// expect the PKCS#12 DER + password format. The DER field now contains the
+/// concatenated PEM key+cert bytes, and the pass field is empty.
+pub fn pkcs12der_from_pem(key: &[u8], cert: &[u8]) -> Result<Pkcs12Archive, anyhow::Error> {
     let mut buf = Zeroizing::new(Vec::new());
     buf.extend(key);
     buf.push(b'\n');
     buf.extend(cert);
-    let pem = buf.as_slice();
-    let pkey = PKey::private_key_from_pem(pem)?;
-    let mut certs = Stack::new()?;
 
-    // `X509::stack_from_pem` in openssl as of at least versions <= 0.10.48
-    // does not guarantee that it will either error or return at least 1
-    // element; in fact, it doesn't if the `pem` is not a well-formed
-    // representation of a PEM file. For example, if the represented file
-    // contains a well-formed key but a malformed certificate.
-    //
-    // To circumvent this issue, if `X509::stack_from_pem` returns no
-    // certificates, rely on getting the error message from
-    // `X509::from_pem`.
-    let mut cert_iter = X509::stack_from_pem(pem)?.into_iter();
-    let cert = match cert_iter.next() {
-        Some(cert) => cert,
-        None => X509::from_pem(pem)?,
-    };
-    for cert in cert_iter {
-        certs.push(cert)?;
+    // Validate the key and cert can be parsed.
+    let _key = PrivateKeyDer::from_pem_slice(&buf)
+        .map_err(|e| anyhow::anyhow!("failed to parse private key PEM: {e}"))?;
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&buf)
+        .collect::<Result<_, _>>()
+        .map_err(|e| anyhow::anyhow!("failed to parse certificate PEM: {e}"))?;
+    if certs.is_empty() {
+        anyhow::bail!("no certificates found in PEM");
     }
-    // We build a PKCS #12 archive solely to have something to pass to
-    // `reqwest::Identity::from_pkcs12_der`, so the password and friendly
-    // name don't matter.
-    let pass = String::new();
-    let friendly_name = "";
-    let der = Pkcs12::builder()
-        .name(friendly_name)
-        .pkey(&pkey)
-        .cert(&cert)
-        .ca(certs)
-        .build2(&pass)?
-        .to_der()?;
-    Ok(Pkcs12Archive { der, pass })
+
+    Ok(Pkcs12Archive {
+        der: buf.to_vec(),
+        pass: String::new(),
+    })
 }
 
 #[cfg(test)]

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -9,6 +9,10 @@
 
 //! A tiny utility library for making TLS connectors.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use mz_ore::secure::{Zeroize, Zeroizing};
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::PKey;
@@ -16,7 +20,12 @@ use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use openssl::stack::Stack;
 use openssl::x509::X509;
 use postgres_openssl::MakeTlsConnector;
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_postgres::config::SslMode;
+use tokio_postgres::tls::ChannelBinding;
+use tokio_rustls::TlsConnector;
 
 macro_rules! bail_generic {
     ($err:expr $(,)?) => {
@@ -94,6 +103,226 @@ pub fn make_tls(config: &tokio_postgres::Config) -> Result<MakeTlsConnector, Tls
     }
 
     Ok(tls_connector)
+}
+
+/// Creates a rustls-based TLS connector for the given
+/// [`Config`](tokio_postgres::Config).
+///
+/// The rustls equivalent of [`make_tls`]. The two coexist while consumers
+/// migrate from openssl to rustls one at a time.
+pub fn make_tls_rustls(config: &tokio_postgres::Config) -> Result<MakeRustlsConnect, TlsError> {
+    let mut root_store = rustls::RootCertStore::empty();
+
+    // The mode dictates whether we verify peer certs and hostnames. By default, Postgres is
+    // pretty relaxed and recommends SslMode::VerifyCa or SslMode::VerifyFull for security.
+    //
+    // For more details, check out Table 33.1. SSL Mode Descriptions in
+    // https://postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION.
+    let verify_mode = match config.get_ssl_mode() {
+        SslMode::Disable | SslMode::Prefer => false,
+        // If a root CA file exists, the behavior of sslmode=require will be the same as
+        // that of verify-ca, meaning the server certificate is validated against the CA.
+        //
+        // For more details, check out the note about backwards compatibility in
+        // https://postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES.
+        SslMode::Require => config.get_ssl_root_cert().is_some(),
+        SslMode::VerifyCa | SslMode::VerifyFull => true,
+        _ => panic!("unexpected sslmode {:?}", config.get_ssl_mode()),
+    };
+
+    // Load root certificates if verification is needed.
+    if let Some(ssl_root_cert) = config.get_ssl_root_cert() {
+        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(ssl_root_cert)
+            .collect::<Result<_, _>>()
+            .map_err(|e| TlsError::Generic(anyhow::anyhow!("failed to parse root certs: {e}")))?;
+        for cert in certs {
+            root_store
+                .add(cert)
+                .map_err(|e| TlsError::Generic(anyhow::anyhow!("invalid root cert: {e}")))?;
+        }
+    }
+
+    let builder = if verify_mode {
+        rustls::ClientConfig::builder().with_root_certificates(root_store)
+    } else {
+        // When not verifying, use a custom verifier that accepts all certs.
+        rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+    };
+
+    // Configure client certificate if provided.
+    let tls_config = match (config.get_ssl_cert(), config.get_ssl_key()) {
+        (Some(ssl_cert), Some(ssl_key)) => {
+            let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(ssl_cert)
+                .collect::<Result<_, _>>()
+                .map_err(|e| {
+                    TlsError::Generic(anyhow::anyhow!("failed to parse client cert: {e}"))
+                })?;
+            let key = PrivateKeyDer::from_pem_slice(ssl_key).map_err(|e| {
+                TlsError::Generic(anyhow::anyhow!("failed to parse client key: {e}"))
+            })?;
+            builder.with_client_auth_cert(certs, key).map_err(|e| {
+                TlsError::Generic(anyhow::anyhow!("failed to configure client auth: {e}"))
+            })?
+        }
+        (None, Some(_)) => {
+            bail_generic!("must provide both sslcert and sslkey, but only provided sslkey")
+        }
+        (Some(_), None) => {
+            bail_generic!("must provide both sslcert and sslkey, but only provided sslcert")
+        }
+        _ => builder.with_no_client_auth(),
+    };
+
+    Ok(MakeRustlsConnect::new(tls_config))
+}
+
+/// Wrapper around `tokio_rustls::client::TlsStream` that implements
+/// `tokio_postgres::tls::TlsStream`.
+pub struct RustlsTlsStream<S>(tokio_rustls::client::TlsStream<S>);
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for RustlsTlsStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for RustlsTlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> tokio_postgres::tls::TlsStream for RustlsTlsStream<S> {
+    fn channel_binding(&self) -> ChannelBinding {
+        ChannelBinding::none()
+    }
+}
+
+/// A `MakeTlsConnect` implementation backed by rustls.
+#[derive(Clone)]
+pub struct MakeRustlsConnect {
+    config: Arc<rustls::ClientConfig>,
+}
+
+impl MakeRustlsConnect {
+    /// Creates a connector factory from the given client config.
+    pub fn new(config: rustls::ClientConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+impl<S> tokio_postgres::tls::MakeTlsConnect<S> for MakeRustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsTlsStream<S>;
+    type TlsConnect = RustlsConnect;
+    type Error = rustls_pki_types::InvalidDnsNameError;
+
+    fn make_tls_connect(&mut self, domain: &str) -> Result<Self::TlsConnect, Self::Error> {
+        // For Unix socket connections, tokio-postgres passes an empty string as
+        // the domain. Socket paths starting with "/" are also not valid DNS names.
+        // TLS is never negotiated over Unix sockets, so use a placeholder.
+        let server_name = if domain.is_empty() || domain.starts_with('/') {
+            ServerName::try_from("localhost").unwrap()
+        } else {
+            ServerName::try_from(domain.to_owned())?
+        };
+        Ok(RustlsConnect {
+            connector: TlsConnector::from(Arc::clone(&self.config)),
+            server_name,
+        })
+    }
+}
+
+/// A pending rustls TLS connection to a specific server.
+pub struct RustlsConnect {
+    connector: TlsConnector,
+    server_name: ServerName<'static>,
+}
+
+impl<S> tokio_postgres::tls::TlsConnect<S> for RustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsTlsStream<S>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
+
+    fn connect(self, stream: S) -> Self::Future {
+        Box::pin(async move {
+            let tls_stream = self.connector.connect(self.server_name, stream).await?;
+            Ok(RustlsTlsStream(tls_stream))
+        })
+    }
+}
+
+/// A certificate verifier that accepts all certificates.
+/// Used when SslMode is Disable, Prefer, or Require without a root cert.
+#[derive(Debug)]
+struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
 }
 
 pub struct Pkcs12Archive {

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -130,6 +130,19 @@ pub fn make_tls_rustls(config: &tokio_postgres::Config) -> Result<MakeRustlsConn
         _ => panic!("unexpected sslmode {:?}", config.get_ssl_mode()),
     };
 
+    // When verifying, seed the trust store with the platform's native roots.
+    // This matches the openssl connector, whose builder trusts the system
+    // default CA paths. Without it, verify modes with no explicit sslrootcert
+    // would reject every server certificate.
+    if verify_mode {
+        let native = rustls_native_certs::load_native_certs();
+        for error in &native.errors {
+            tracing::warn!("failed to load native root certs: {error}");
+        }
+        let (added, ignored) = root_store.add_parsable_certificates(native.certs);
+        tracing::debug!("loaded {added} native root certs, ignored {ignored}");
+    }
+
     // Load root certificates if verification is needed.
     if let Some(ssl_root_cert) = config.get_ssl_root_cert() {
         let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(ssl_root_cert)
@@ -218,7 +231,55 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for RustlsTlsStream<S> {
 
 impl<S: AsyncRead + AsyncWrite + Unpin> tokio_postgres::tls::TlsStream for RustlsTlsStream<S> {
     fn channel_binding(&self) -> ChannelBinding {
-        ChannelBinding::none()
+        let (_, session) = self.0.get_ref();
+        match session
+            .peer_certificates()
+            .and_then(|certs| certs.first())
+            .and_then(tls_server_end_point)
+        {
+            Some(hash) => ChannelBinding::tls_server_end_point(hash),
+            None => ChannelBinding::none(),
+        }
+    }
+}
+
+/// Computes the RFC 5929 `tls-server-end-point` channel binding data for a
+/// server certificate: a hash of the DER certificate using the hash function
+/// of its signature algorithm, with MD5 and SHA-1 upgraded to SHA-256.
+///
+/// Returns `None` when the signature algorithm has no well-defined hash
+/// function (e.g. Ed25519, RSASSA-PSS). The openssl connector also reports no
+/// channel binding for those, so this preserves parity.
+fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>> {
+    use sha2::{Digest, Sha256, Sha384, Sha512};
+    use x509_cert::der::Decode;
+    use x509_cert::der::oid::ObjectIdentifier;
+
+    const MD5_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.4");
+    const SHA1_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.5");
+    const SHA256_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
+    const SHA384_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12");
+    const SHA512_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
+    const SHA1_ECDSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.1");
+    const SHA256_ECDSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
+    const SHA384_ECDSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3");
+    const SHA512_ECDSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.4");
+
+    let parsed = x509_cert::Certificate::from_der(cert.as_ref()).ok()?;
+    let oid = parsed.signature_algorithm.oid;
+    if oid == MD5_RSA
+        || oid == SHA1_RSA
+        || oid == SHA256_RSA
+        || oid == SHA1_ECDSA
+        || oid == SHA256_ECDSA
+    {
+        Some(Sha256::digest(cert.as_ref()).to_vec())
+    } else if oid == SHA384_RSA || oid == SHA384_ECDSA {
+        Some(Sha384::digest(cert.as_ref()).to_vec())
+    } else if oid == SHA512_RSA || oid == SHA512_ECDSA {
+        Some(Sha512::digest(cert.as_ref()).to_vec())
+    } else {
+        None
     }
 }
 
@@ -399,7 +460,74 @@ pub fn pkcs12der_from_pem(
 
 #[cfg(test)]
 mod tests {
+    use openssl::asn1::Asn1Time;
+    use openssl::ec::{EcGroup, EcKey};
+    use openssl::hash::MessageDigest;
+    use openssl::nid::Nid;
+    use openssl::pkey::Private;
+    use openssl::rsa::Rsa;
+    use openssl::x509::X509NameBuilder;
+
     use super::*;
+
+    fn self_signed_der(key: &PKey<Private>, digest: MessageDigest) -> Vec<u8> {
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", "localhost").unwrap();
+        let name = name.build();
+        let mut builder = X509::builder().unwrap();
+        builder.set_version(2).unwrap();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(&name).unwrap();
+        builder.set_pubkey(key).unwrap();
+        builder
+            .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        builder.sign(key, digest).unwrap();
+        builder.build().to_der().unwrap()
+    }
+
+    /// Asserts that our `tls-server-end-point` hash of a cert signed with
+    /// `sign_digest` matches openssl's `X509_digest` with `expected`, which is
+    /// what postgres-openssl uses. `None` expects no channel binding.
+    fn check_end_point_parity(
+        key: &PKey<Private>,
+        sign_digest: MessageDigest,
+        expected: Option<MessageDigest>,
+    ) {
+        let der = self_signed_der(key, sign_digest);
+        let computed = tls_server_end_point(&CertificateDer::from(der.clone()));
+        let expected =
+            expected.map(|md| X509::from_der(&der).unwrap().digest(md).unwrap().to_vec());
+        assert_eq!(computed, expected);
+    }
+
+    #[mz_ore::test]
+    fn tls_server_end_point_digests() {
+        let rsa = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        check_end_point_parity(&rsa, MessageDigest::sha256(), Some(MessageDigest::sha256()));
+        check_end_point_parity(&rsa, MessageDigest::sha384(), Some(MessageDigest::sha384()));
+        check_end_point_parity(&rsa, MessageDigest::sha512(), Some(MessageDigest::sha512()));
+        // RFC 5929 upgrades SHA-1 to SHA-256.
+        check_end_point_parity(&rsa, MessageDigest::sha1(), Some(MessageDigest::sha256()));
+
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let ec = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+        check_end_point_parity(&ec, MessageDigest::sha256(), Some(MessageDigest::sha256()));
+
+        // Ed25519 has no hash in its signature algorithm, so no channel
+        // binding, matching openssl.
+        let ed = PKey::generate_ed25519().unwrap();
+        check_end_point_parity(&ed, MessageDigest::null(), None);
+    }
+
+    #[mz_ore::test]
+    fn tls_server_end_point_rejects_garbage() {
+        let garbage = CertificateDer::from(vec![0x30, 0x00]);
+        assert_eq!(tls_server_end_point(&garbage), None);
+    }
 
     #[mz_ore::test]
     fn pkcs12_archive_needs_drop() {

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -461,14 +461,244 @@ pub fn pkcs12der_from_pem(
 #[cfg(test)]
 mod tests {
     use openssl::asn1::Asn1Time;
+    use openssl::bn::{BigNum, MsbOption};
     use openssl::ec::{EcGroup, EcKey};
     use openssl::hash::MessageDigest;
     use openssl::nid::Nid;
     use openssl::pkey::Private;
     use openssl::rsa::Rsa;
     use openssl::x509::X509NameBuilder;
+    use openssl::x509::extension::{BasicConstraints, SubjectAlternativeName};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+    use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 
     use super::*;
+
+    /// A throwaway CA that can issue leaf certificates.
+    struct TestCa {
+        cert: X509,
+        key: PKey<Private>,
+    }
+
+    fn random_serial() -> openssl::asn1::Asn1Integer {
+        let mut bn = BigNum::new().unwrap();
+        bn.rand(64, MsbOption::MAYBE_ZERO, false).unwrap();
+        bn.to_asn1_integer().unwrap()
+    }
+
+    impl TestCa {
+        fn new() -> TestCa {
+            let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+            let mut name = X509NameBuilder::new().unwrap();
+            name.append_entry_by_text("CN", "mz-tls-util test CA")
+                .unwrap();
+            let name = name.build();
+            let mut builder = X509::builder().unwrap();
+            builder.set_version(2).unwrap();
+            builder.set_serial_number(&random_serial()).unwrap();
+            builder.set_subject_name(&name).unwrap();
+            builder.set_issuer_name(&name).unwrap();
+            builder.set_pubkey(&key).unwrap();
+            builder
+                .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+                .unwrap();
+            builder
+                .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+                .unwrap();
+            builder
+                .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
+                .unwrap();
+            builder.sign(&key, MessageDigest::sha256()).unwrap();
+            TestCa {
+                cert: builder.build(),
+                key,
+            }
+        }
+
+        /// Issues a leaf certificate, returning its PEM cert and PKCS#8 key.
+        fn issue(&self, cn: &str, dns_san: Option<&str>) -> (Vec<u8>, Vec<u8>) {
+            let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+            let mut name = X509NameBuilder::new().unwrap();
+            name.append_entry_by_text("CN", cn).unwrap();
+            let name = name.build();
+            let mut builder = X509::builder().unwrap();
+            builder.set_version(2).unwrap();
+            builder.set_serial_number(&random_serial()).unwrap();
+            builder.set_subject_name(&name).unwrap();
+            builder.set_issuer_name(self.cert.subject_name()).unwrap();
+            builder.set_pubkey(&key).unwrap();
+            builder
+                .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+                .unwrap();
+            builder
+                .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+                .unwrap();
+            if let Some(dns) = dns_san {
+                let san = SubjectAlternativeName::new()
+                    .dns(dns)
+                    .build(&builder.x509v3_context(Some(&self.cert), None))
+                    .unwrap();
+                builder.append_extension(san).unwrap();
+            }
+            builder.sign(&self.key, MessageDigest::sha256()).unwrap();
+            (
+                builder.build().to_pem().unwrap(),
+                key.private_key_to_pem_pkcs8().unwrap(),
+            )
+        }
+    }
+
+    /// Starts a TLS server on an ephemeral port. Each connection receives
+    /// "ok" once the handshake, including client certificate verification
+    /// when `client_ca_pem` is given, has completed on the server side.
+    async fn run_tls_server(
+        cert_pem: &[u8],
+        key_pem: &[u8],
+        client_ca_pem: Option<&[u8]>,
+    ) -> std::net::SocketAddr {
+        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_pem)
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let key = PrivateKeyDer::from_pem_slice(key_pem).unwrap();
+        let builder = rustls::ServerConfig::builder();
+        let config = match client_ca_pem {
+            Some(ca_pem) => {
+                let mut roots = rustls::RootCertStore::empty();
+                for cert in CertificateDer::pem_slice_iter(ca_pem) {
+                    roots.add(cert.unwrap()).unwrap();
+                }
+                let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots))
+                    .build()
+                    .unwrap();
+                builder.with_client_cert_verifier(verifier)
+            }
+            None => builder.with_no_client_auth(),
+        }
+        .with_single_cert(certs, key)
+        .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        mz_ore::task::spawn(|| "tls-test-server", async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let acceptor = acceptor.clone();
+                mz_ore::task::spawn(|| "tls-test-server-conn", async move {
+                    let mut tls = acceptor.accept(stream).await.unwrap();
+                    tls.write_all(b"ok").await.unwrap();
+                    tls.shutdown().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    /// Completes a TLS handshake for `host` via `make_tls_rustls`, returning
+    /// the established stream. Panics if certificate validation fails.
+    async fn rustls_connect(
+        config: &tokio_postgres::Config,
+        host: &str,
+        addr: impl tokio::net::ToSocketAddrs,
+    ) -> RustlsTlsStream<TcpStream> {
+        let mut make = make_tls_rustls(config).unwrap();
+        let connect = MakeTlsConnect::<TcpStream>::make_tls_connect(&mut make, host).unwrap();
+        let tcp = TcpStream::connect(addr).await.unwrap();
+        TlsConnect::<TcpStream>::connect(connect, tcp)
+            .await
+            .unwrap()
+    }
+
+    /// Completes a TLS handshake for `host` via the openssl `make_tls`,
+    /// returning the established stream. Panics if validation fails.
+    async fn openssl_connect(
+        config: &tokio_postgres::Config,
+        host: &str,
+        addr: impl tokio::net::ToSocketAddrs,
+    ) -> postgres_openssl::TlsStream<TcpStream> {
+        let mut make = make_tls(config).unwrap();
+        let connect = MakeTlsConnect::<TcpStream>::make_tls_connect(&mut make, host).unwrap();
+        let tcp = TcpStream::connect(addr).await.unwrap();
+        TlsConnect::<TcpStream>::connect(connect, tcp)
+            .await
+            .unwrap()
+    }
+
+    /// Reads the "ok" the test server sends after its side of the handshake,
+    /// including any client certificate verification, has succeeded.
+    async fn assert_server_ok<S: AsyncRead + AsyncWrite + Unpin>(mut tls: S) {
+        let mut buf = [0u8; 2];
+        tls.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"ok");
+    }
+
+    /// In verify modes with no explicit sslrootcert, both connectors must
+    /// trust CAs from the environment's default trust store (SSL_CERT_FILE).
+    /// Guards the native root loading in `make_tls_rustls`.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // uses the network and openssl FFI
+    async fn verify_full_trusts_default_store() {
+        let ca = TestCa::new();
+        let (server_cert, server_key) = ca.issue("server", Some("localhost"));
+
+        let mut ca_file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut ca_file, &ca.cert.to_pem().unwrap()).unwrap();
+        // SAFETY: env mutation is process global, but nextest gives each test
+        // its own process, which is how CI runs. Under plain `cargo test`
+        // this can race with other tests that read the environment.
+        unsafe { std::env::set_var("SSL_CERT_FILE", ca_file.path()) };
+
+        let addr = run_tls_server(&server_cert, &server_key, None).await;
+        let mut config = tokio_postgres::Config::new();
+        config.ssl_mode(SslMode::VerifyFull);
+
+        assert_server_ok(rustls_connect(&config, "localhost", addr).await).await;
+        assert_server_ok(openssl_connect(&config, "localhost", addr).await).await;
+    }
+
+    /// Both connectors must present the configured client certificate when
+    /// the server requires one.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // uses the network and openssl FFI
+    async fn client_certs_accepted() {
+        let ca = TestCa::new();
+        let (server_cert, server_key) = ca.issue("server", Some("localhost"));
+        let (client_cert, client_key) = ca.issue("client", None);
+        let ca_pem = ca.cert.to_pem().unwrap();
+
+        let addr = run_tls_server(&server_cert, &server_key, Some(&ca_pem)).await;
+        let mut config = tokio_postgres::Config::new();
+        config.ssl_mode(SslMode::VerifyFull);
+        config.ssl_root_cert(&ca_pem);
+        config.ssl_cert(&client_cert);
+        config.ssl_key(&client_key);
+
+        assert_server_ok(rustls_connect(&config, "localhost", addr).await).await;
+        assert_server_ok(openssl_connect(&config, "localhost", addr).await).await;
+    }
+
+    /// Validates the rustls connector against a real endpoint whose
+    /// certificate chains to a public CA, exercising the platform trust store
+    /// end to end. Needs external network access, so it only runs when the
+    /// Nightly pipeline sets MZ_TLS_UTIL_TEST_EXTERNAL_CAS.
+    ///
+    /// The openssl connector is deliberately not covered. Our vendored
+    /// openssl compiles its default trust store path to /usr/local/ssl, which
+    /// does not exist at runtime, so `make_tls` cannot validate public CAs
+    /// unless SSL_CERT_FILE points at a bundle.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // uses the network and openssl FFI
+    async fn external_public_ca_endpoint() {
+        if std::env::var_os("MZ_TLS_UTIL_TEST_EXTERNAL_CAS").is_none() {
+            return;
+        }
+        const HOST: &str = "s3.amazonaws.com";
+        let mut config = tokio_postgres::Config::new();
+        config.ssl_mode(SslMode::VerifyFull);
+        // Completing the handshake is the assertion. connect() fails if the
+        // chain does not validate against the platform trust store.
+        drop(rustls_connect(&config, HOST, (HOST, 443)).await);
+    }
 
     fn self_signed_der(key: &PKey<Private>, digest: MessageDigest) -> Vec<u8> {
         let mut name = X509NameBuilder::new().unwrap();


### PR DESCRIPTION
Part of the crypto migration from native-tls/OpenSSL to rustls/aws-lc-rs.

### Motivation

First PR of the TLS migration stack. Earlier iterations rewrote the shared TLS types in place, which could never pass CI standalone because consumers (balancerd, mz-debug, pgwire) still used the openssl API. This version is **additive**: the rustls machinery lands next to the openssl paths, and each later PR flips exactly one consumer.

This PR deliberately contains no FIPS machinery. It standardizes rustls on the aws-lc-rs provider, and the FIPS build story lands separately once the TLS stack swap is complete.

### Changes

- **ore**: new `crypto` feature installs the aws-lc-rs rustls `CryptoProvider` process-wide via `ctor`, so rustls configurations built anywhere in the process pick it up without selecting a provider explicitly. rustls `AsyncReady` impls added alongside the openssl one.
- **tls-util**: adds `make_tls_rustls` plus a rustls-backed `MakeTlsConnect` impl for tokio-postgres. Enables `mz-ore/crypto`, so linking tls-util guarantees the provider is installed. The openssl `make_tls` and PKCS#12 helpers are untouched.
- **pgwire-common**: `Conn::Ssl` now holds a `TlsStream` enum (`Openssl` | rustls `Server` | rustls `Client`). The `Openssl` variant is a migration bridge and is deleted by the final cleanup PR. SNI extraction is unified behind `TlsStream::server_name`.
- **pgwire, balancerd**: mechanical wraps in `TlsStream::Openssl` only. No behavior change.

Net diff: ~430 insertions, 17 deletions. No consumer changes TLS backend in this PR.

### Stack

This PR → #36086 (server-core/pgwire) and #36087 (postgres-util/postgres-client/ccsr) in parallel → #36088 (balancerd), #36089 (environmentd), #36090 (test infra) → final cleanup PR removes the openssl paths and the `TlsStream::Openssl` variant.

### Testing

Existing TLS behavior is unchanged (openssl paths untouched, verified by full workspace build + existing test suite in CI). The rustls machinery gains coverage as each consumer flips in its own PR.

Part of [SEC-218](https://linear.app/materializeinc/issue/SEC-218). Related to [SEC-192](https://linear.app/materializeinc/issue/SEC-192).
