### PR TITLE
orchestratord: version-gate pod security context UID/GID for distroless

### DIFF
--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -655,7 +655,7 @@ pub mod v1alpha1 {
     }
 }
 
-fn parse_image_ref(image_ref: &str) -> Option<Version> {
+pub fn parse_image_ref(image_ref: &str) -> Option<Version> {
     image_ref
         .rsplit_once(':')
         .and_then(|(_repo, tag)| tag.strip_prefix('v'))

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -1619,7 +1619,14 @@ pub mod v1 {
 }
 
 pub fn parse_image_ref(image_ref: &str) -> Option<Version> {
+    // Strip any `@sha256:...` digest first. Otherwise the digest's `:`
+    // separator is mistaken for the tag separator, so a digest-pinned ref like
+    // `env:v26.32.0@sha256:...` parses the digest hex as the tag and fails,
+    // silently falling into the parse-failure path of every version gate.
     image_ref
+        .split('@')
+        .next()
+        .unwrap_or(image_ref)
         .rsplit_once(':')
         .and_then(|(_repo, tag)| tag.strip_prefix('v'))
         .and_then(|tag| {
@@ -1677,9 +1684,17 @@ mod tests {
             "materialize/environmentd:v0.146.0-dev.0--pr.g5a05a9e4ba873be8adaa528644aaae6e4c7cd29b"
                 .to_owned();
         assert!(mz.meets_minimum_version(&Version::parse("0.146.0-dev.0").unwrap()));
+        // Digest-pinned tag: the `@sha256:` digest must be stripped before
+        // parsing, or the tag is lost and the gate silently returns true.
+        mz.spec.environmentd_image_ref = "materialize/environmentd:v0.35.0@sha256:abc".to_owned();
+        assert!(mz.meets_minimum_version(&Version::parse("0.34.0").unwrap()));
 
         // false cases
         mz.spec.environmentd_image_ref = "materialize/environmentd:v0.34.0-dev".to_owned();
+        assert!(!mz.meets_minimum_version(&Version::parse("0.34.0").unwrap()));
+        // Digest-pinned old tag stays below the gate rather than falling into
+        // the parse-failure (assume-newest) path.
+        mz.spec.environmentd_image_ref = "materialize/environmentd:v0.33.0@sha256:abc".to_owned();
         assert!(!mz.meets_minimum_version(&Version::parse("0.34.0").unwrap()));
         mz.spec.environmentd_image_ref = "materialize/environmentd:v0.33.0".to_owned();
         assert!(!mz.meets_minimum_version(&Version::parse("0.34.0").unwrap()));

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -1618,7 +1618,7 @@ pub mod v1 {
     }
 }
 
-fn parse_image_ref(image_ref: &str) -> Option<Version> {
+pub fn parse_image_ref(image_ref: &str) -> Option<Version> {
     image_ref
         .rsplit_once(':')
         .and_then(|(_repo, tag)| tag.strip_prefix('v'))

--- a/src/orchestratord/src/controller/balancer.rs
+++ b/src/orchestratord/src/controller/balancer.rs
@@ -41,6 +41,7 @@ use mz_cloud_resources::crd::{
     ManagedResource,
     balancer::v1alpha1::{Balancer, Routing},
     generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
+    materialize::parse_image_ref,
 };
 use mz_orchestrator_kubernetes::KubernetesImagePullPolicy;
 use mz_ore::{cli::KeyValueArg, instrument};
@@ -157,6 +158,32 @@ impl Context {
             CertificatePrivateKeyAlgorithm::Ecdsa,
             Some(256),
         )
+    }
+
+    fn pod_uid_gid(image_ref: &str) -> i64 {
+        // Distroless images (v26.19+) run as the `nonroot` user (uid/gid 65534).
+        // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
+        // Note: balancerd transitioned to distroless one release earlier than
+        // environmentd/clusterd (which use V26_20_0 in generation.rs).
+        static V26_19_0: std::sync::LazyLock<semver::Version> =
+            std::sync::LazyLock::new(|| semver::Version {
+                major: 26,
+                minor: 19,
+                patch: 0,
+                pre: semver::Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+                build: semver::BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+            });
+        let is_distroless = match parse_image_ref(image_ref) {
+            Some(v) => v.cmp_precedence(&V26_19_0).is_ge(),
+            None => {
+                tracing::warn!(
+                    image_ref,
+                    "failed to parse balancerd image ref; assuming distroless"
+                );
+                true
+            }
+        };
+        if is_distroless { 65534 } else { 999 }
     }
 
     fn create_deployment_object(&self, balancer: &Balancer) -> anyhow::Result<Deployment> {
@@ -388,12 +415,15 @@ impl Context {
                     ),
                     affinity: self.config.balancerd_affinity.clone(),
                     tolerations: self.config.balancerd_tolerations.clone(),
-                    security_context: Some(PodSecurityContext {
-                        fs_group: Some(999),
-                        run_as_user: Some(999),
-                        run_as_group: Some(999),
-                        ..Default::default()
-                    }),
+                    security_context: {
+                        let uid_gid = Self::pod_uid_gid(&balancer.spec.balancerd_image_ref);
+                        Some(PodSecurityContext {
+                            fs_group: Some(uid_gid),
+                            run_as_user: Some(uid_gid),
+                            run_as_group: Some(uid_gid),
+                            ..Default::default()
+                        })
+                    },
                     scheduler_name: self.config.scheduler_name.clone(),
                     volumes: Some(volumes),
                     ..Default::default()
@@ -594,5 +624,30 @@ impl k8s_controller::Context for Context {
         self.sync_deployment_status(&client, balancer).await?;
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_pod_uid_gid() {
+        // Boundary: v26.19.0 is the first distroless version
+        assert_eq!(Context::pod_uid_gid("materialize/balancerd:v26.18.0"), 999);
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.19.0"),
+            65534
+        );
+        // Pre-release below threshold gets Ubuntu
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.19.0-dev"),
+            999
+        );
+        // Unparseable refs assume distroless
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd@sha256:abc"),
+            65534
+        );
     }
 }

--- a/src/orchestratord/src/controller/balancer.rs
+++ b/src/orchestratord/src/controller/balancer.rs
@@ -165,7 +165,7 @@ impl Context {
         // Distroless images (v26.18+) run as the `nonroot` user (uid/gid 65534).
         // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
         // Note: balancerd transitioned to distroless earlier than
-        // environmentd/clusterd (which use V26_28_0 in generation.rs).
+        // environmentd/clusterd (which use V26_32_0 in generation.rs).
         // Verified against release history: balancerd's ci/Dockerfile switched
         // to distroless-prod-base in v26.18.0 (prod-base in v26.17.x).
         static V26_18_0: std::sync::LazyLock<semver::Version> =

--- a/src/orchestratord/src/controller/balancer.rs
+++ b/src/orchestratord/src/controller/balancer.rs
@@ -162,7 +162,7 @@ impl Context {
     }
 
     fn pod_uid_gid(image_ref: &str) -> i64 {
-        // Distroless balancerd (v26.18.0+) runs as `nonroot` (uid/gid 65534).
+        // Distroless balancerd (v26.18.0+) runs as `nonroot` (uid/gid 65532).
         // Older Ubuntu-based images run as `materialize` (uid/gid 999).
         static V26_18_0: std::sync::LazyLock<semver::Version> =
             std::sync::LazyLock::new(|| semver::Version {
@@ -182,7 +182,7 @@ impl Context {
                 true
             }
         };
-        if is_distroless { 65534 } else { 999 }
+        if is_distroless { 65532 } else { 999 }
     }
 
     fn create_deployment_object(&self, balancer: &Balancer) -> anyhow::Result<Deployment> {
@@ -640,17 +640,27 @@ mod tests {
         assert_eq!(Context::pod_uid_gid("materialize/balancerd:v26.17.0"), 999);
         assert_eq!(
             Context::pod_uid_gid("materialize/balancerd:v26.18.0"),
-            65534
+            65532
         );
         // Pre-release below threshold gets Ubuntu
         assert_eq!(
             Context::pod_uid_gid("materialize/balancerd:v26.18.0-dev"),
             999
         );
+        // Digest-pinned refs keep their tag's classification: an old
+        // tag stays on the Ubuntu path even with a digest appended.
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.17.0@sha256:abc"),
+            999
+        );
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.18.0@sha256:abc"),
+            65532
+        );
         // Unparseable refs assume distroless
         assert_eq!(
             Context::pod_uid_gid("materialize/balancerd@sha256:abc"),
-            65534
+            65532
         );
     }
 }

--- a/src/orchestratord/src/controller/balancer.rs
+++ b/src/orchestratord/src/controller/balancer.rs
@@ -162,12 +162,8 @@ impl Context {
     }
 
     fn pod_uid_gid(image_ref: &str) -> i64 {
-        // Distroless images (v26.18+) run as the `nonroot` user (uid/gid 65534).
-        // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
-        // Note: balancerd transitioned to distroless earlier than
-        // environmentd/clusterd (which use V26_32_0 in generation.rs).
-        // Verified against release history: balancerd's ci/Dockerfile switched
-        // to distroless-prod-base in v26.18.0 (prod-base in v26.17.x).
+        // Distroless balancerd (v26.18.0+) runs as `nonroot` (uid/gid 65534).
+        // Older Ubuntu-based images run as `materialize` (uid/gid 999).
         static V26_18_0: std::sync::LazyLock<semver::Version> =
             std::sync::LazyLock::new(|| semver::Version {
                 major: 26,

--- a/src/orchestratord/src/controller/balancer.rs
+++ b/src/orchestratord/src/controller/balancer.rs
@@ -42,6 +42,7 @@ use mz_cloud_resources::crd::{
     ManagedResource,
     balancer::v1alpha1::{Balancer, Routing},
     generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
+    materialize::parse_image_ref,
 };
 use mz_orchestrator_kubernetes::KubernetesImagePullPolicy;
 use mz_ore::{cli::KeyValueArg, instrument};
@@ -158,6 +159,34 @@ impl Context {
             CertificatePrivateKeyAlgorithm::Ecdsa,
             Some(256),
         )
+    }
+
+    fn pod_uid_gid(image_ref: &str) -> i64 {
+        // Distroless images (v26.18+) run as the `nonroot` user (uid/gid 65534).
+        // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
+        // Note: balancerd transitioned to distroless earlier than
+        // environmentd/clusterd (which use V26_28_0 in generation.rs).
+        // Verified against release history: balancerd's ci/Dockerfile switched
+        // to distroless-prod-base in v26.18.0 (prod-base in v26.17.x).
+        static V26_18_0: std::sync::LazyLock<semver::Version> =
+            std::sync::LazyLock::new(|| semver::Version {
+                major: 26,
+                minor: 18,
+                patch: 0,
+                pre: semver::Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+                build: semver::BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+            });
+        let is_distroless = match parse_image_ref(image_ref) {
+            Some(v) => v.cmp_precedence(&V26_18_0).is_ge(),
+            None => {
+                tracing::warn!(
+                    image_ref,
+                    "failed to parse balancerd image ref; assuming distroless"
+                );
+                true
+            }
+        };
+        if is_distroless { 65534 } else { 999 }
     }
 
     fn create_deployment_object(&self, balancer: &Balancer) -> anyhow::Result<Deployment> {
@@ -392,12 +421,15 @@ impl Context {
                     ),
                     affinity: self.config.balancerd_affinity.clone(),
                     tolerations: self.config.balancerd_tolerations.clone(),
-                    security_context: Some(PodSecurityContext {
-                        fs_group: Some(999),
-                        run_as_user: Some(999),
-                        run_as_group: Some(999),
-                        ..Default::default()
-                    }),
+                    security_context: {
+                        let uid_gid = Self::pod_uid_gid(&balancer.spec.balancerd_image_ref);
+                        Some(PodSecurityContext {
+                            fs_group: Some(uid_gid),
+                            run_as_user: Some(uid_gid),
+                            run_as_group: Some(uid_gid),
+                            ..Default::default()
+                        })
+                    },
                     scheduler_name: self.config.scheduler_name.clone(),
                     volumes: Some(volumes),
                     ..Default::default()
@@ -599,5 +631,30 @@ impl k8s_controller::Context for Context {
         self.sync_deployment_status(&client, balancer).await?;
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_pod_uid_gid() {
+        // Boundary: v26.18.0 is the first distroless balancerd version
+        assert_eq!(Context::pod_uid_gid("materialize/balancerd:v26.17.0"), 999);
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.18.0"),
+            65534
+        );
+        // Pre-release below threshold gets Ubuntu
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd:v26.18.0-dev"),
+            999
+        );
+        // Unparseable refs assume distroless
+        assert_eq!(
+            Context::pod_uid_gid("materialize/balancerd@sha256:abc"),
+            65534
+        );
     }
 }

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -81,6 +81,17 @@ static V26_1_0: LazyLock<Version> = LazyLock::new(|| Version {
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
 });
 
+/// Minimum version for distroless environmentd/clusterd images (nonroot
+/// uid/gid 65534). Balancerd transitioned one release earlier at V26_19_0
+/// (see balancer.rs).
+static V26_20_0: LazyLock<Version> = LazyLock::new(|| Version {
+    major: 26,
+    minor: 20,
+    patch: 0,
+    pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+    build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+});
+
 /// Describes the status of a deployment.
 ///
 /// This is a simplified representation of `DeploymentState`, suitable for
@@ -864,8 +875,23 @@ fn create_environmentd_statefulset_object(
             ephemeral_volume_class
         ));
     }
-    // The `materialize` user used by clusterd always has gid 999.
-    args.push("--orchestrator-kubernetes-service-fs-group=999".to_string());
+    // Distroless images (v26.20+) run as the `nonroot` user (uid/gid 65534).
+    // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
+    // This value is used for both the environmentd pod security context and
+    // the --orchestrator-kubernetes-service-fs-group arg (which controls
+    // clusterd pod security contexts). Both transition at the same version.
+    // Note: Kubernetes fsGroup re-chowns volume contents on mount, so
+    // existing PVCs with UID 999 files will be migrated automatically
+    // (may add startup latency for large volumes).
+    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_20_0) {
+        65534
+    } else {
+        999
+    };
+    args.push(format!(
+        "--orchestrator-kubernetes-service-fs-group={}",
+        service_fs_group
+    ));
 
     // Add system_param configmap
     // This feature was enabled in 0.163 but did not have testing until after 0.164.
@@ -1218,9 +1244,9 @@ fn create_environmentd_statefulset_object(
             service_account_name: Some(mz.service_account_name()),
             volumes: Some(volumes),
             security_context: Some(PodSecurityContext {
-                fs_group: Some(999),
-                run_as_user: Some(999),
-                run_as_group: Some(999),
+                fs_group: Some(service_fs_group),
+                run_as_user: Some(service_fs_group),
+                run_as_group: Some(service_fs_group),
                 ..Default::default()
             }),
             tolerations,

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -95,9 +95,9 @@ static PER_ROUTE_GROUP_ROLES_VERSION: LazyLock<Version> = LazyLock::new(|| Versi
 /// Minimum version for distroless environmentd/clusterd images (nonroot
 /// uid/gid 65534). Balancerd transitioned earlier at V26_18_0 (see
 /// balancer.rs).
-static V26_32_0: LazyLock<Version> = LazyLock::new(|| Version {
+static V26_33_0: LazyLock<Version> = LazyLock::new(|| Version {
     major: 26,
-    minor: 32,
+    minor: 33,
     patch: 0,
     pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
@@ -898,7 +898,7 @@ fn create_environmentd_statefulset_object(
             ephemeral_volume_class
         ));
     }
-    // Distroless environmentd/clusterd (v26.32.0+) run as `nonroot` (uid/gid
+    // Distroless environmentd/clusterd (v26.33.0+) run as `nonroot` (uid/gid
     // 65534). Older images run as `materialize` (999). This sets both the
     // environmentd pod security context and the
     // --orchestrator-kubernetes-service-fs-group arg controlling clusterd
@@ -906,7 +906,7 @@ fn create_environmentd_statefulset_object(
     // NOTE: fsGroup re-chowns volume contents on mount, so existing PVCs with
     // uid-999 files migrate automatically (may add startup latency on large
     // volumes).
-    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_32_0) {
+    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_33_0) {
         65534
     } else {
         999

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -92,6 +92,17 @@ static PER_ROUTE_GROUP_ROLES_VERSION: LazyLock<Version> = LazyLock::new(|| Versi
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
 });
 
+/// Minimum version for distroless environmentd/clusterd images (nonroot
+/// uid/gid 65534). Balancerd transitioned earlier at V26_18_0 (see
+/// balancer.rs).
+static V26_28_0: LazyLock<Version> = LazyLock::new(|| Version {
+    major: 26,
+    minor: 28,
+    patch: 0,
+    pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+    build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+});
+
 /// Describes the status of a deployment.
 ///
 /// This is a simplified representation of `DeploymentState`, suitable for
@@ -887,8 +898,23 @@ fn create_environmentd_statefulset_object(
             ephemeral_volume_class
         ));
     }
-    // The `materialize` user used by clusterd always has gid 999.
-    args.push("--orchestrator-kubernetes-service-fs-group=999".to_string());
+    // Distroless images (v26.28+) run as the `nonroot` user (uid/gid 65534).
+    // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
+    // This value is used for both the environmentd pod security context and
+    // the --orchestrator-kubernetes-service-fs-group arg (which controls
+    // clusterd pod security contexts). Both transition at the same version.
+    // Note: Kubernetes fsGroup re-chowns volume contents on mount, so
+    // existing PVCs with UID 999 files will be migrated automatically
+    // (may add startup latency for large volumes).
+    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_28_0) {
+        65534
+    } else {
+        999
+    };
+    args.push(format!(
+        "--orchestrator-kubernetes-service-fs-group={}",
+        service_fs_group
+    ));
 
     // Add system_param configmap
     // This feature was enabled in 0.163 but did not have testing until after 0.164.
@@ -1241,9 +1267,9 @@ fn create_environmentd_statefulset_object(
             service_account_name: Some(mz.service_account_name()),
             volumes: Some(volumes),
             security_context: Some(PodSecurityContext {
-                fs_group: Some(999),
-                run_as_user: Some(999),
-                run_as_group: Some(999),
+                fs_group: Some(service_fs_group),
+                run_as_user: Some(service_fs_group),
+                run_as_group: Some(service_fs_group),
                 ..Default::default()
             }),
             tolerations,

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -93,7 +93,7 @@ static PER_ROUTE_GROUP_ROLES_VERSION: LazyLock<Version> = LazyLock::new(|| Versi
 });
 
 /// Minimum version for distroless environmentd/clusterd images (nonroot
-/// uid/gid 65534). Balancerd transitioned earlier at V26_18_0 (see
+/// uid/gid 65532). Balancerd transitioned earlier at V26_18_0 (see
 /// balancer.rs).
 static V26_33_0: LazyLock<Version> = LazyLock::new(|| Version {
     major: 26,
@@ -899,7 +899,7 @@ fn create_environmentd_statefulset_object(
         ));
     }
     // Distroless environmentd/clusterd (v26.33.0+) run as `nonroot` (uid/gid
-    // 65534). Older images run as `materialize` (999). This sets both the
+    // 65532). Older images run as `materialize` (999). This sets both the
     // environmentd pod security context and the
     // --orchestrator-kubernetes-service-fs-group arg controlling clusterd
     // pods, so both transition together.
@@ -907,7 +907,7 @@ fn create_environmentd_statefulset_object(
     // uid-999 files migrate automatically (may add startup latency on large
     // volumes).
     let service_fs_group: i64 = if mz.meets_minimum_version(&V26_33_0) {
-        65534
+        65532
     } else {
         999
     };

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -95,9 +95,9 @@ static PER_ROUTE_GROUP_ROLES_VERSION: LazyLock<Version> = LazyLock::new(|| Versi
 /// Minimum version for distroless environmentd/clusterd images (nonroot
 /// uid/gid 65534). Balancerd transitioned earlier at V26_18_0 (see
 /// balancer.rs).
-static V26_28_0: LazyLock<Version> = LazyLock::new(|| Version {
+static V26_32_0: LazyLock<Version> = LazyLock::new(|| Version {
     major: 26,
-    minor: 28,
+    minor: 32,
     patch: 0,
     pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
     build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
@@ -906,7 +906,7 @@ fn create_environmentd_statefulset_object(
     // Note: Kubernetes fsGroup re-chowns volume contents on mount, so
     // existing PVCs with UID 999 files will be migrated automatically
     // (may add startup latency for large volumes).
-    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_28_0) {
+    let service_fs_group: i64 = if mz.meets_minimum_version(&V26_32_0) {
         65534
     } else {
         999

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -898,14 +898,14 @@ fn create_environmentd_statefulset_object(
             ephemeral_volume_class
         ));
     }
-    // Distroless images (v26.28+) run as the `nonroot` user (uid/gid 65534).
-    // Older Ubuntu-based images use the `materialize` user (uid/gid 999).
-    // This value is used for both the environmentd pod security context and
-    // the --orchestrator-kubernetes-service-fs-group arg (which controls
-    // clusterd pod security contexts). Both transition at the same version.
-    // Note: Kubernetes fsGroup re-chowns volume contents on mount, so
-    // existing PVCs with UID 999 files will be migrated automatically
-    // (may add startup latency for large volumes).
+    // Distroless environmentd/clusterd (v26.32.0+) run as `nonroot` (uid/gid
+    // 65534). Older images run as `materialize` (999). This sets both the
+    // environmentd pod security context and the
+    // --orchestrator-kubernetes-service-fs-group arg controlling clusterd
+    // pods, so both transition together.
+    // NOTE: fsGroup re-chowns volume contents on mount, so existing PVCs with
+    // uid-999 files migrate automatically (may add startup latency on large
+    // volumes).
     let service_fs_group: i64 = if mz.meets_minimum_version(&V26_32_0) {
         65534
     } else {


### PR DESCRIPTION
## Summary

Distroless images run as nonroot (uid/gid 65534) instead of root. This version-gates the pod security context in orchestratord so each Materialize version gets the matching `runAsUser`/`runAsGroup`, avoiding UID mismatches during rolling upgrades.

Gates: balancerd `V26_18_0` (already distroless), environmentd/clusterd `V26_33_0`. The env/clusterd gate must equal the release #36099 ships in; see the coordination comment below.

## Test plan

- [x] `cargo test -p mz-orchestratord` passes
- [ ] Pods for new versions get nonroot uid/gid, old versions keep root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
