### PR TITLE
Select as of at least an object list

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -594,6 +594,44 @@ impl Coordinator {
         oracle_read_ts
     }
 
+    /// Resolves `QueryWhen::AtLeastFrontierOf` by reading the current write
+    /// frontiers of the named storage collections and converting to the
+    /// equivalent `AtLeastTimestamp`. Errors if any named collection has not
+    /// yet produced any output (write frontier is `[T::minimum()]` or empty),
+    /// since there is no readable timestamp to constrain against.
+    fn resolve_frontier_of(&self, when: &QueryWhen) -> Result<Option<QueryWhen>, AdapterError> {
+        let QueryWhen::AtLeastFrontierOf(item_ids) = when else {
+            return Ok(None);
+        };
+        let mut max_ts: Option<Timestamp> = None;
+        for item_id in item_ids {
+            let entry = self.catalog().get_entry(item_id);
+            let gid = entry.latest_global_id();
+            let (_since, upper) =
+                self.controller
+                    .storage
+                    .collection_frontiers(gid)
+                    .map_err(|_| {
+                        AdapterError::Internal(format!(
+                            "AS OF AT LEAST FRONTIER OF: no storage collection for {}",
+                            entry.name().item,
+                        ))
+                    })?;
+            let readable = upper.as_option().and_then(|upper| upper.step_back());
+            let Some(readable) = readable else {
+                return Err(AdapterError::Unstructured(anyhow::anyhow!(
+                    "AS OF AT LEAST FRONTIER OF: {} has no readable timestamp yet \
+                     (collection is unhydrated or closed)",
+                    entry.name().item,
+                )));
+            };
+            max_ts = Some(max_ts.map_or(readable, |cur| cur.max(readable)));
+        }
+        // `item_ids` was non-empty because we matched `AtLeastFrontierOf`, but
+        // the list could in principle be empty; treat that as no constraint.
+        Ok(max_ts.map(QueryWhen::AtLeastTimestamp))
+    }
+
     /// Determines the timestamp for a query, acquires read holds that ensure the
     /// query remains executable at that time, and returns those.
     /// The caller is responsible for eventually dropping those read holds.
@@ -608,6 +646,11 @@ impl Coordinator {
         oracle_read_ts: Option<Timestamp>,
         real_time_recency_ts: Option<mz_repr::Timestamp>,
     ) -> Result<(TimestampDetermination, ReadHolds), AdapterError> {
+        // Resolve `AS OF AT LEAST FRONTIER OF <names>` into a concrete
+        // `AtLeastTimestamp` using current write frontiers. This must happen
+        // here rather than at plan time because the frontiers move.
+        let resolved_when = self.resolve_frontier_of(when)?;
+        let when = resolved_when.as_ref().unwrap_or(when);
         let isolation_level = session.vars().transaction_isolation();
         let (det, read_holds) = self.determine_timestamp_for(
             session,

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -197,6 +197,7 @@ Foreign
 Format
 Forward
 From
+Frontier
 Full
 Fullname
 Function

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -5191,6 +5191,10 @@ impl_display!(AlterSystemResetAllStatement);
 pub enum AsOf<T: AstInfo> {
     At(Expr<T>),
     AtLeast(Expr<T>),
+    /// Timestamp is derived from the write frontiers of the named objects at
+    /// sequencing time: the maximum over `frontier - 1` across all names.
+    /// Only sources, tables, and materialized views are permitted.
+    AtLeastFrontierOf(Vec<T::ItemName>),
 }
 
 impl<T: AstInfo> AstDisplay for AsOf<T> {
@@ -5201,6 +5205,10 @@ impl<T: AstInfo> AstDisplay for AsOf<T> {
             AsOf::AtLeast(expr) => {
                 f.write_str("AT LEAST ");
                 f.write_node(expr);
+            }
+            AsOf::AtLeastFrontierOf(names) => {
+                f.write_str("AT LEAST FRONTIER OF ");
+                f.write_node(&display::comma_separated(names));
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -8712,6 +8712,10 @@ impl<'a> Parser<'a> {
         if self.parse_keyword(AS) {
             self.expect_keyword(OF)?;
             if self.parse_keywords(&[AT, LEAST]) {
+                if self.parse_keywords(&[FRONTIER, OF]) {
+                    let names = self.parse_comma_separated(Parser::parse_raw_name)?;
+                    return Ok(Some(AsOf::AtLeastFrontierOf(names)));
+                }
                 match self.parse_expr() {
                     Ok(expr) => Ok(Some(AsOf::AtLeast(expr))),
                     Err(e) => self.expected(

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1488,6 +1488,11 @@ SELECT * FROM data AS OF AT LEAST 5
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(AtLeast(Value(Number("5")))) })
 
+parse-statement roundtrip
+SELECT * FROM data AS OF AT LEAST FRONTIER OF foo, bar.baz
+----
+SELECT * FROM data AS OF AT LEAST FRONTIER OF foo, bar.baz
+
 # Query hints
 parse-statement
 SELECT * FROM foo OPTIONS (bar = 7)

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -671,11 +671,14 @@ impl Pretty {
     }
 
     fn doc_as_of<'a, T: AstInfo>(&'a self, v: &'a AsOf<T>) -> RcDoc<'a> {
-        let (title, expr) = match v {
-            AsOf::At(expr) => ("AS OF", expr),
-            AsOf::AtLeast(expr) => ("AS OF AT LEAST", expr),
-        };
-        nest_title(title, self.doc_expr(expr))
+        match v {
+            AsOf::At(expr) => nest_title("AS OF", self.doc_expr(expr)),
+            AsOf::AtLeast(expr) => nest_title("AS OF AT LEAST", self.doc_expr(expr)),
+            AsOf::AtLeastFrontierOf(names) => nest_title(
+                "AS OF AT LEAST FRONTIER OF",
+                comma_separate(|n| self.doc_display_pass(n), names),
+            ),
+        }
     }
 
     pub(crate) fn doc_create_view<'a, T: AstInfo>(

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1936,6 +1936,11 @@ pub enum QueryWhen {
     /// Same as Immediately, but will also advance to at least the specified
     /// expression.
     AtLeastTimestamp(Timestamp),
+    /// Same as Immediately, but will also advance to at least the largest
+    /// readable timestamp (i.e. write frontier minus one) across the named
+    /// objects. The list is resolved to concrete frontiers by the sequencer
+    /// at query time.
+    AtLeastFrontierOf(Vec<CatalogItemId>),
 }
 
 impl QueryWhen {
@@ -1943,7 +1948,9 @@ impl QueryWhen {
     pub fn advance_to_timestamp(&self) -> Option<Timestamp> {
         match self {
             QueryWhen::AtTimestamp(t) | QueryWhen::AtLeastTimestamp(t) => Some(t.clone()),
-            QueryWhen::Immediately | QueryWhen::FreshestTableWrite => None,
+            QueryWhen::Immediately
+            | QueryWhen::FreshestTableWrite
+            | QueryWhen::AtLeastFrontierOf(_) => None,
         }
     }
     /// Returns whether the candidate's upper bound is constrained.
@@ -1954,7 +1961,8 @@ impl QueryWhen {
             QueryWhen::AtTimestamp(_) => true,
             QueryWhen::AtLeastTimestamp(_)
             | QueryWhen::Immediately
-            | QueryWhen::FreshestTableWrite => false,
+            | QueryWhen::FreshestTableWrite
+            | QueryWhen::AtLeastFrontierOf(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the since.
@@ -1962,7 +1970,8 @@ impl QueryWhen {
         match self {
             QueryWhen::Immediately
             | QueryWhen::AtLeastTimestamp(_)
-            | QueryWhen::FreshestTableWrite => true,
+            | QueryWhen::FreshestTableWrite
+            | QueryWhen::AtLeastFrontierOf(_) => true,
             QueryWhen::AtTimestamp(_) => false,
         }
     }
@@ -1972,7 +1981,8 @@ impl QueryWhen {
             QueryWhen::Immediately => true,
             QueryWhen::FreshestTableWrite
             | QueryWhen::AtTimestamp(_)
-            | QueryWhen::AtLeastTimestamp(_) => false,
+            | QueryWhen::AtLeastTimestamp(_)
+            | QueryWhen::AtLeastFrontierOf(_) => false,
         }
     }
 
@@ -1980,23 +1990,28 @@ impl QueryWhen {
     pub fn can_advance_to_timeline_ts(&self) -> bool {
         match self {
             QueryWhen::Immediately | QueryWhen::FreshestTableWrite => true,
-            QueryWhen::AtTimestamp(_) | QueryWhen::AtLeastTimestamp(_) => false,
+            QueryWhen::AtTimestamp(_)
+            | QueryWhen::AtLeastTimestamp(_)
+            | QueryWhen::AtLeastFrontierOf(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the timeline's timestamp.
     pub fn must_advance_to_timeline_ts(&self) -> bool {
         match self {
             QueryWhen::FreshestTableWrite => true,
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) | QueryWhen::AtTimestamp(_) => {
-                false
-            }
+            QueryWhen::Immediately
+            | QueryWhen::AtLeastTimestamp(_)
+            | QueryWhen::AtTimestamp(_)
+            | QueryWhen::AtLeastFrontierOf(_) => false,
         }
     }
     /// Returns whether the selected timestamp should be tracked within the current transaction.
     pub fn is_transactional(&self) -> bool {
         match self {
             QueryWhen::Immediately | QueryWhen::FreshestTableWrite => true,
-            QueryWhen::AtLeastTimestamp(_) | QueryWhen::AtTimestamp(_) => false,
+            QueryWhen::AtLeastTimestamp(_)
+            | QueryWhen::AtTimestamp(_)
+            | QueryWhen::AtLeastFrontierOf(_) => false,
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1057,6 +1057,35 @@ pub fn plan_as_of(
         Some(as_of) => match as_of {
             AsOf::At(expr) => Ok(QueryWhen::AtTimestamp(plan_as_of_or_up_to(scx, expr)?)),
             AsOf::AtLeast(expr) => Ok(QueryWhen::AtLeastTimestamp(plan_as_of_or_up_to(scx, expr)?)),
+            AsOf::AtLeastFrontierOf(names) => {
+                let mut ids = Vec::with_capacity(names.len());
+                for name in names {
+                    let id = match &name {
+                        ResolvedItemName::Item { id, .. } => *id,
+                        ResolvedItemName::Cte { .. }
+                        | ResolvedItemName::ContinualTask { .. }
+                        | ResolvedItemName::Error => sql_bail!(
+                            "AS OF AT LEAST FRONTIER OF requires a source, table, \
+                             or materialized view; got {}",
+                            name.full_name_str(),
+                        ),
+                    };
+                    let item = scx.get_item(&id);
+                    match item.item_type() {
+                        CatalogItemType::Source
+                        | CatalogItemType::Table
+                        | CatalogItemType::MaterializedView => {}
+                        other => sql_bail!(
+                            "AS OF AT LEAST FRONTIER OF does not support {} {}; \
+                             only sources, tables, and materialized views are supported",
+                            other,
+                            name.full_name_str(),
+                        ),
+                    }
+                    ids.push(id);
+                }
+                Ok(QueryWhen::AtLeastFrontierOf(ids))
+            }
         },
     }
 }


### PR DESCRIPTION
Claude wrote this in a voice that sounds like I pretended to write it. I didn't write it. -Frank

  `AS OF AT LEAST FRONTIER OF <objects>` — RFC / eyes-wanted                                
                                                                                          
  Extends the `SELECT ... AS OF AT LEAST <timestamp>` surface to accept a list of object
  names instead of a literal timestamp:                                                   

```sql                                                            
  SELECT * FROM v AS OF AT LEAST FRONTIER OF src_a, src_b, mv_c;                          
  SUBSCRIBE v AS OF AT LEAST FRONTIER OF src_a;                                           
```
  Motivation                                                                              
                                                                                          
  A user (or tool) has observed some set of upstream objects and wants their next read to 
  be at least as fresh as what they already saw. Today they'd have to query mz_frontiers
  themselves, do frontier - 1 arithmetic, and feed the literal back in — racy and awkward.
   This lets the system do it in a single statement.        

  Semantics: take max(upper.step_back()) across the named objects as the AT LEAST lower   
  bound for timestamp selection. "Readable timestamp" = write frontier minus one.
                                                                                          
  Scope                                                     

  Only sources, tables, and materialized views are accepted. Indexes and other compute    
  objects are rejected at plan time — keeps the frontier lookup to the storage controller
  and sidesteps cross-cluster considerations for a first cut. We can revisit if there's   
  demand.                                                   

  Error behavior

  If any named object has no readable timestamp yet (write frontier is [T::minimum()] or  
  empty), the query errors rather than silently ignoring that input. Rationale: the whole
  framing is "be at least as fresh as the user's observation," which is meaningless for an
   object the user couldn't have observed. Happy to soften this to "skip with warning" if
  reviewers prefer.

  Implementation sketch

  - Parser: new AsOf::AtLeastFrontierOf(Vec<ItemName>) variant; FRONTIER added as a       
  non-reserved keyword.
  - Plan: new QueryWhen::AtLeastFrontierOf(Vec<CatalogItemId>) — resolution is deferred to
   sequencing time because frontiers move. Planner rejects non-storage item types with a  
  clear message.
  - Sequencer (Coordinator::resolve_frontier_of in timestamp_selection.rs): at            
  determine_timestamp entry, reads write frontiers via                                    
  controller.storage.collection_frontiers, computes the max readable timestamp, and
  substitutes in an ordinary AtLeastTimestamp before delegating to the existing           
  timestamp-selection path. This means the new variant reuses all existing read-hold,
  linearizability, and timeline-selection machinery unchanged.

  Things I'd like feedback on

  1. Surface syntax: AT LEAST FRONTIER OF <names> vs. something shorter like AT LEAST OF  
  <names> or introducing a function (frontier_of(...)) that could compose with AT LEAST 
  <expr>. The function form is more uniform but requires plumbing catalog lookups through 
  expression evaluation.                                    
  2. Unhydrated → error vs. skip: above.
  3. Tables with multiple GlobalIds: I use latest_global_id() — i.e. "freshest on the     
  current schema." Alternative is to take the max across global_ids(), though older shards
   should be strictly behind.                                                             
  4. Interaction with AS OF AT LEAST <expr>: currently you choose one or the other. Worth 
  supporting both simultaneously (AT LEAST <expr> AND FRONTIER OF <names>)? Probably yes  
  eventually, no for this PR.
  5. Strict-serializable isolation: the resolved timestamp flows through the existing     
  oracle path, so real-time bounds should be respected by construction. But confirmation  
  from someone who owns that invariant would be welcome.
                                                                                          
  Testing                                                   

  Compiles clean and parser tests pass. No e2e tests yet — will add testdrive coverage    
  (happy path, unhydrated error, unsupported object type, subscribe) before merging.
  Hand-testing locally is the immediate next step.  

Edit from @ggevay: Linear: https://linear.app/materializeinc/project/select-as-of-at-least-c7835ea23d60/overview