### PR TITLE
rocksdb: fix 'occured' -> 'occurred' in doc comment

### DIFF
--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -64,7 +64,7 @@ pub enum Error {
     #[error("failed to cleanup in time")]
     CleanupTimeout(#[from] tokio::time::error::Elapsed),
 
-    /// An error occured with a provided value.
+    /// An error occurred with a provided value.
     #[error("error with value: {0}")]
     ValueError(String),
 }


### PR DESCRIPTION
Doc comment in `src/rocksdb/src/lib.rs` line 67 reads `An error occured with a provided value`. Fixed to `occurred`. Comment-only change.