### PR TITLE
compute,storage: make more things not generic over the timestamp type

### DIFF
--- a/doc/developer/platform/compute-layer-q-n-a.md
+++ b/doc/developer/platform/compute-layer-q-n-a.md
@@ -18,7 +18,7 @@ This figure illustrates the compute networking stack, as well as the flow of com
 
 ### What is the set of commands that the COMPUTE layer responds to and what do these commands do at a high level?
 
-The set of available commands can be seen in `ComputeCommand<T>` at [`src/compute-client/src/command.rs`](/src/compute-client/src/command.rs). At a high level, there are commands to: (a) initialize a COMPUTE replica, (b) communicate to a replica that all command reconciliation during initialization has been completed, (c) create dataflows, (d) allow compactions of COMPUTE-managed collections to take place, (e) peek at arrangements, (f) cancel peeks. The types of responses to the commands are listed in `ComputeResponse` at [`src/compute-client/src/response.rs`](/src/compute-client/src/response.rs).
+The set of available commands can be seen in `ComputeCommand` at [`src/compute-client/src/command.rs`](/src/compute-client/src/command.rs). At a high level, there are commands to: (a) initialize a COMPUTE replica, (b) communicate to a replica that all command reconciliation during initialization has been completed, (c) create dataflows, (d) allow compactions of COMPUTE-managed collections to take place, (e) peek at arrangements, (f) cancel peeks. The types of responses to the commands are listed in `ComputeResponse` at [`src/compute-client/src/response.rs`](/src/compute-client/src/response.rs).
 
 ### What is the lifecycle of networking threads in a `computed` process? Do they farm out work to other threads?
 

--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -65,7 +65,7 @@ impl CompactionWindow {
     }
 }
 
-impl From<CompactionWindow> for ReadPolicy<Timestamp> {
+impl From<CompactionWindow> for ReadPolicy {
     fn from(value: CompactionWindow) -> Self {
         let time = match value {
             CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3493,7 +3493,7 @@ impl Coordinator {
     /// This method expects all storage collections and dataflow plans to be available, so it must
     /// run after [`Coordinator::bootstrap_storage_collections`] and
     /// [`Coordinator::bootstrap_dataflow_plans`].
-    async fn bootstrap_dataflow_as_ofs(&mut self) -> BTreeMap<GlobalId, ReadHold<Timestamp>> {
+    async fn bootstrap_dataflow_as_ofs(&mut self) -> BTreeMap<GlobalId, ReadHold> {
         let mut catalog_ids = Vec::new();
         let mut dataflows = Vec::new();
         let mut read_policies = BTreeMap::new();

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -90,11 +90,7 @@ pub enum PeekResponseUnary {
 
 #[derive(Clone, Debug)]
 pub struct PeekDataflowPlan {
-    pub(crate) desc: DataflowDescription<
-        mz_compute_types::plan::Plan<mz_repr::Timestamp>,
-        (),
-        mz_repr::Timestamp,
-    >,
+    pub(crate) desc: DataflowDescription<mz_compute_types::plan::Plan, ()>,
     pub(crate) id: GlobalId,
     key: Vec<MirScalarExpr>,
     permutation: Vec<usize>,
@@ -103,11 +99,7 @@ pub struct PeekDataflowPlan {
 
 impl PeekDataflowPlan {
     pub fn new(
-        desc: DataflowDescription<
-            mz_compute_types::plan::Plan<mz_repr::Timestamp>,
-            (),
-            mz_repr::Timestamp,
-        >,
+        desc: DataflowDescription<mz_compute_types::plan::Plan, ()>,
         id: GlobalId,
         typ: &SqlRelationType,
     ) -> Self {

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -42,8 +42,8 @@ use crate::util::ResultExt;
 /// relinquishes the associated read capabilities.
 #[derive(Debug, Default, Clone)]
 pub struct ReadHolds {
-    pub storage_holds: BTreeMap<GlobalId, ReadHold<Timestamp>>,
-    pub compute_holds: BTreeMap<(ComputeInstanceId, GlobalId), ReadHold<Timestamp>>,
+    pub storage_holds: BTreeMap<GlobalId, ReadHold>,
+    pub compute_holds: BTreeMap<(ComputeInstanceId, GlobalId), ReadHold>,
 }
 
 impl ReadHolds {

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -308,10 +308,7 @@ impl crate::coord::Coordinator {
         }
     }
 
-    pub(crate) fn update_storage_read_policies(
-        &self,
-        policies: Vec<(CatalogItemId, ReadPolicy<Timestamp>)>,
-    ) {
+    pub(crate) fn update_storage_read_policies(&self, policies: Vec<(CatalogItemId, ReadPolicy)>) {
         let policies = policies
             .into_iter()
             .map(|(item_id, policy)| {
@@ -330,7 +327,7 @@ impl crate::coord::Coordinator {
 
     pub(crate) fn update_compute_read_policies(
         &self,
-        mut policies: Vec<(ComputeInstanceId, CatalogItemId, ReadPolicy<Timestamp>)>,
+        mut policies: Vec<(ComputeInstanceId, CatalogItemId, ReadPolicy)>,
     ) {
         policies.sort_by_key(|&(cluster_id, _, _)| cluster_id);
         for (cluster_id, group) in &policies
@@ -357,7 +354,7 @@ impl crate::coord::Coordinator {
         &self,
         compute_instance: ComputeInstanceId,
         item_id: CatalogItemId,
-        base_policy: ReadPolicy<Timestamp>,
+        base_policy: ReadPolicy,
     ) {
         self.update_compute_read_policies(vec![(compute_instance, item_id, base_policy)])
     }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -104,7 +104,7 @@ pub fn run(
     storage_collections: &dyn StorageCollections,
     current_time: Timestamp,
     read_only_mode: bool,
-) -> BTreeMap<GlobalId, ReadHold<Timestamp>> {
+) -> BTreeMap<GlobalId, ReadHold> {
     // Get read holds for the storage inputs of the dataflows.
     // This ensures that storage frontiers don't advance past the selected as-ofs.
     let mut storage_read_holds = BTreeMap::new();
@@ -427,7 +427,7 @@ impl<'a> Context<'a> {
     /// not be able to hydrate successfully.
     fn apply_upstream_storage_constraints(
         &self,
-        storage_read_holds: &BTreeMap<GlobalId, ReadHold<Timestamp>>,
+        storage_read_holds: &BTreeMap<GlobalId, ReadHold>,
     ) {
         // Apply direct constraints from storage inputs.
         for (id, collection) in &self.collections {
@@ -1034,7 +1034,7 @@ mod tests {
         fn acquire_read_holds(
             &self,
             desired_holds: Vec<GlobalId>,
-        ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing> {
+        ) -> Result<Vec<ReadHold>, CollectionMissing> {
             let mut holds = Vec::with_capacity(desired_holds.len());
             for id in desired_holds {
                 let (read, _write) = self.0.get(&id).ok_or(CollectionMissing(id))?;

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -100,7 +100,7 @@ use tracing::{info, warn};
 /// with the compute controller.
 pub fn run(
     dataflows: &mut [DataflowDescription<Plan, ()>],
-    read_policies: &BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
+    read_policies: &BTreeMap<GlobalId, ReadPolicy>,
     storage_collections: &dyn StorageCollections,
     current_time: Timestamp,
     read_only_mode: bool,
@@ -321,7 +321,7 @@ impl Constraint<'_> {
 struct Collection<'a> {
     storage_inputs: Vec<GlobalId>,
     compute_inputs: Vec<GlobalId>,
-    read_policy: Option<&'a ReadPolicy<Timestamp>>,
+    read_policy: Option<&'a ReadPolicy>,
     /// The currently known as-of bounds.
     ///
     /// Shared between collections exported by the same dataflow.
@@ -342,7 +342,7 @@ impl<'a> Context<'a> {
     fn new(
         dataflows: &[DataflowDescription<Plan, ()>],
         storage_collections: &'a dyn StorageCollections,
-        read_policies: &'a BTreeMap<GlobalId, ReadPolicy<Timestamp>>,
+        read_policies: &'a BTreeMap<GlobalId, ReadPolicy>,
         current_time: Timestamp,
     ) -> Self {
         // Construct initial collection state for each dataflow export. Dataflows might have their
@@ -1027,7 +1027,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn set_read_policies(&self, _policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
+        fn set_read_policies(&self, _policies: Vec<(GlobalId, ReadPolicy)>) {
             unimplemented!()
         }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -943,7 +943,7 @@ impl ComputeController {
     pub fn set_read_policy(
         &self,
         instance_id: ComputeInstanceId,
-        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
+        policies: Vec<(GlobalId, ReadPolicy)>,
     ) -> Result<(), ReadPolicyError> {
         use ReadPolicyError::*;
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -968,7 +968,7 @@ impl ComputeController {
         &self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
-    ) -> Result<ReadHold<Timestamp>, CollectionUpdateError> {
+    ) -> Result<ReadHold, CollectionUpdateError> {
         let read_hold = self
             .instance(instance_id)?
             .acquire_read_hold(collection_id)?;
@@ -1114,10 +1114,7 @@ impl InstanceState {
     }
 
     /// Acquires a [`ReadHold`] for the identified compute collection.
-    pub fn acquire_read_hold(
-        &self,
-        id: GlobalId,
-    ) -> Result<ReadHold<Timestamp>, CollectionMissing> {
+    pub fn acquire_read_hold(&self, id: GlobalId) -> Result<ReadHold, CollectionMissing> {
         // We acquire read holds at the earliest possible time rather than returning a copy
         // of the implied read hold. This is so that in `create_dataflow` we can acquire read holds
         // on compute dependencies at frontiers that are held back by other read holds the caller

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1724,7 +1724,7 @@ impl Instance {
     #[mz_ore::instrument(level = "debug")]
     pub fn set_read_policy(
         &mut self,
-        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
+        policies: Vec<(GlobalId, ReadPolicy)>,
     ) -> Result<(), ReadPolicyError> {
         // Do error checking upfront, to avoid introducing inconsistencies between a collection's
         // `implied_capability` and `read_capabilities`.
@@ -2411,7 +2411,7 @@ struct CollectionState {
     /// If `None`, the collection is a write-only collection (i.e. a sink). For write-only
     /// collections, the `implied_read_hold` is only required for maintaining read holds on the
     /// inputs, so we can immediately downgrade it to the `write_frontier`.
-    read_policy: Option<ReadPolicy<Timestamp>>,
+    read_policy: Option<ReadPolicy>,
 
     /// Storage identifiers on which this collection depends, and read holds this collection
     /// requires on them.

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -208,7 +208,7 @@ pub(super) struct Instance {
     ///
     /// Copies of this sender are given to [`ReadHold`]s that are created in
     /// [`CollectionState::new`].
-    read_hold_tx: read_holds::ChangeTx<Timestamp>,
+    read_hold_tx: read_holds::ChangeTx,
     /// A sender for responses from replicas.
     replica_tx: mz_ore::channel::InstrumentedUnboundedSender<ReplicaResponse, IntCounter>,
     /// A receiver for responses from replicas.
@@ -277,9 +277,9 @@ impl Instance {
         id: GlobalId,
         as_of: Antichain<Timestamp>,
         shared: SharedCollectionState,
-        storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
-        compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
-        replica_input_read_holds: Vec<ReadHold<Timestamp>>,
+        storage_dependencies: BTreeMap<GlobalId, ReadHold>,
+        compute_dependencies: BTreeMap<GlobalId, ReadHold>,
+        replica_input_read_holds: Vec<ReadHold>,
         write_only: bool,
         storage_sink: bool,
         initial_as_of: Option<Antichain<Timestamp>>,
@@ -885,7 +885,7 @@ impl Instance {
         dyncfg: Arc<ConfigSet>,
         command_rx: mpsc::UnboundedReceiver<Command>,
         response_tx: mpsc::UnboundedSender<ComputeControllerResponse>,
-        read_hold_tx: read_holds::ChangeTx<Timestamp>,
+        read_hold_tx: read_holds::ChangeTx,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
         read_only: bool,
     ) -> Self {
@@ -1269,7 +1269,7 @@ impl Instance {
     pub fn create_dataflow(
         &mut self,
         dataflow: DataflowDescription<mz_compute_types::plan::Plan, ()>,
-        import_read_holds: Vec<ReadHold<Timestamp>>,
+        import_read_holds: Vec<ReadHold>,
         mut shared_collection_state: BTreeMap<GlobalId, SharedCollectionState>,
         target_replica: Option<ReplicaId>,
     ) -> Result<(), DataflowCreationError> {
@@ -1628,7 +1628,7 @@ impl Instance {
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
-        mut read_hold: ReadHold<Timestamp>,
+        mut read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
     ) -> Result<(), PeekError> {
@@ -2327,10 +2327,7 @@ impl Instance {
     ///
     /// This mirrors the logic used by the controller-side `InstanceState::acquire_read_hold`,
     /// but executes on the instance task itself.
-    pub(super) fn acquire_read_hold(
-        &self,
-        id: GlobalId,
-    ) -> Result<ReadHold<Timestamp>, CollectionMissing> {
+    pub(super) fn acquire_read_hold(&self, id: GlobalId) -> Result<ReadHold, CollectionMissing> {
         // Similarly to InstanceState::acquire_read_hold and StorageCollections::acquire_read_holds,
         // we acquire read holds at the earliest possible time rather than returning a copy
         // of the implied read hold. This is so that dependents can acquire read holds on
@@ -2400,7 +2397,7 @@ struct CollectionState {
     /// `read_policy`. It also ensures that read holds on the collection's dependencies are kept at
     /// some time not greater than the collection's `write_frontier`, guaranteeing that the
     /// collection's next outputs can always be computed without skipping times.
-    implied_read_hold: ReadHold<Timestamp>,
+    implied_read_hold: ReadHold,
     /// A read hold held to enable dataflow warmup.
     ///
     /// Dataflow warmup is an optimization that allows dataflows to immediately start hydrating
@@ -2408,7 +2405,7 @@ struct CollectionState {
     /// By installing a read capability derived from the write frontiers of the collection's
     /// inputs, we ensure that the as-of of new dataflows installed for the collection is at a time
     /// that is immediately available, so hydration can begin immediately too.
-    warmup_read_hold: ReadHold<Timestamp>,
+    warmup_read_hold: ReadHold,
     /// The policy to use to downgrade `self.implied_read_hold`.
     ///
     /// If `None`, the collection is a write-only collection (i.e. a sink). For write-only
@@ -2418,10 +2415,10 @@ struct CollectionState {
 
     /// Storage identifiers on which this collection depends, and read holds this collection
     /// requires on them.
-    storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+    storage_dependencies: BTreeMap<GlobalId, ReadHold>,
     /// Compute identifiers on which this collection depends, and read holds this collection
     /// requires on them.
-    compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
+    compute_dependencies: BTreeMap<GlobalId, ReadHold>,
 
     /// Introspection state associated with this collection.
     introspection: CollectionIntrospection,
@@ -2450,9 +2447,9 @@ impl CollectionState {
         collection_id: GlobalId,
         as_of: Antichain<Timestamp>,
         shared: SharedCollectionState,
-        storage_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
-        compute_dependencies: BTreeMap<GlobalId, ReadHold<Timestamp>>,
-        read_hold_tx: read_holds::ChangeTx<Timestamp>,
+        storage_dependencies: BTreeMap<GlobalId, ReadHold>,
+        compute_dependencies: BTreeMap<GlobalId, ReadHold>,
+        read_hold_tx: read_holds::ChangeTx,
         introspection: CollectionIntrospection,
     ) -> Self {
         // A collection is not readable before the `as_of`.
@@ -2505,7 +2502,7 @@ impl CollectionState {
     fn new_log_collection(
         id: GlobalId,
         shared: SharedCollectionState,
-        read_hold_tx: read_holds::ChangeTx<Timestamp>,
+        read_hold_tx: read_holds::ChangeTx,
         introspection_tx: mpsc::UnboundedSender<IntrospectionUpdates>,
     ) -> Self {
         let since = Antichain::from_elem(Timestamp::MIN);
@@ -2943,7 +2940,7 @@ struct PendingPeek {
     /// Used to track peek durations.
     requested_at: Instant,
     /// The read hold installed to serve this peek.
-    read_hold: ReadHold<Timestamp>,
+    read_hold: ReadHold,
     /// The channel to send peek results.
     peek_response_tx: oneshot::Sender<PeekResponse>,
     /// An optional limit of the peek's result size.
@@ -3014,7 +3011,7 @@ impl ReplicaState {
         &mut self,
         id: GlobalId,
         as_of: Antichain<Timestamp>,
-        input_read_holds: Vec<ReadHold<Timestamp>>,
+        input_read_holds: Vec<ReadHold>,
     ) {
         let metrics = self.metrics.for_collection(id);
         let introspection = ReplicaCollectionIntrospection::new(
@@ -3114,7 +3111,7 @@ struct ReplicaCollectionState {
     /// These read holds are kept to ensure that the replica is able to read from storage inputs at
     /// all times it hasn't read yet. We only need to install read holds for storage inputs since
     /// compaction of compute inputs is implicitly held back by Timely/DD.
-    input_read_holds: Vec<ReadHold<Timestamp>>,
+    input_read_holds: Vec<ReadHold>,
 
     /// Maximum frontier wallclock lag since the last `WallclockLagHistory` introspection update.
     ///
@@ -3127,7 +3124,7 @@ impl ReplicaCollectionState {
         metrics: Option<ReplicaCollectionMetrics>,
         as_of: Antichain<Timestamp>,
         introspection: ReplicaCollectionIntrospection,
-        input_read_holds: Vec<ReadHold<Timestamp>>,
+        input_read_holds: Vec<ReadHold>,
     ) -> Self {
         Self {
             write_frontier: as_of.clone(),

--- a/src/compute-client/src/controller/instance_client.rs
+++ b/src/compute-client/src/controller/instance_client.rs
@@ -101,11 +101,11 @@ pub struct InstanceClient {
     command_tx: mpsc::UnboundedSender<Command>,
     /// A sender for read hold changes for collections installed on the instance.
     #[derivative(Debug = "ignore")]
-    read_hold_tx: read_holds::ChangeTx<Timestamp>,
+    read_hold_tx: read_holds::ChangeTx,
 }
 
 impl InstanceClient {
-    pub(super) fn read_hold_tx(&self) -> read_holds::ChangeTx<Timestamp> {
+    pub(super) fn read_hold_tx(&self) -> read_holds::ChangeTx {
         Arc::clone(&self.read_hold_tx)
     }
 
@@ -163,7 +163,7 @@ impl InstanceClient {
     ) -> Self {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
 
-        let read_hold_tx: read_holds::ChangeTx<_> = {
+        let read_hold_tx: read_holds::ChangeTx = {
             let command_tx = command_tx.clone();
             Arc::new(move |id, change: ChangeBatch<_>| {
                 let cmd: Command = {
@@ -205,8 +205,7 @@ impl InstanceClient {
     pub async fn acquire_read_holds_and_collection_write_frontiers(
         &self,
         ids: Vec<GlobalId>,
-    ) -> Result<Vec<(GlobalId, ReadHold<Timestamp>, Antichain<Timestamp>)>, AcquireReadHoldsError>
-    {
+    ) -> Result<Vec<(GlobalId, ReadHold, Antichain<Timestamp>)>, AcquireReadHoldsError> {
         self.call_sync(move |i| {
             let mut result = Vec::new();
             for id in ids.into_iter() {
@@ -233,7 +232,7 @@ impl InstanceClient {
         result_desc: RelationDesc,
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
-        target_read_hold: ReadHold<Timestamp>,
+        target_read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
     ) -> Result<(), PeekError> {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -18,7 +18,7 @@ use mz_dyncfg::ConfigUpdates;
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_types::PersistLocation;
-use mz_repr::{GlobalId, RelationDesc, Row};
+use mz_repr::{GlobalId, RelationDesc, Row, Timestamp};
 use mz_service::params::GrpcClientParameters;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_tracing::params::TracingParameters;
@@ -35,7 +35,7 @@ use crate::logging::LoggingConfig;
 ///
 /// [Protocol Stages]: super#protocol-stages
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum ComputeCommand<T = mz_repr::Timestamp> {
+pub enum ComputeCommand {
     /// `Hello` is the first command sent to a replica after a connection was established. It
     /// provides the replica with meta information about the connection.
     ///
@@ -141,7 +141,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`Frontiers`]: super::response::ComputeResponse::Frontiers
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     /// [`CopyToResponse`]: super::response::ComputeResponse::CopyToResponse
-    CreateDataflow(Box<DataflowDescription<RenderPlan<T>, CollectionMetadata, T>>),
+    CreateDataflow(Box<DataflowDescription<RenderPlan<Timestamp>, CollectionMetadata, Timestamp>>),
 
     /// `Schedule` allows the replica to start computation for a compute collection.
     ///
@@ -210,7 +210,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         /// TODO(database-issues#7533): Add documentation.
         id: GlobalId,
         /// TODO(database-issues#7533): Add documentation.
-        frontier: Antichain<T>,
+        frontier: Antichain<Timestamp>,
     },
 
     /// `Peek` instructs the replica to perform a peek on a collection: either an index or a
@@ -241,7 +241,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`Rows`]: super::response::PeekResponse::Rows
     /// [`Error`]: super::response::PeekResponse::Error
     /// [`Canceled`]: super::response::PeekResponse::Canceled
-    Peek(Box<Peek<T>>),
+    Peek(Box<Peek>),
 
     /// `CancelPeek` instructs the replica to cancel the identified pending peek.
     ///
@@ -417,7 +417,7 @@ impl PeekTarget {
 /// the dataflow runners are responsible for ensuring that they can
 /// correctly answer the `Peek`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Peek<T = mz_repr::Timestamp> {
+pub struct Peek {
     /// Target-specific metadata.
     pub target: PeekTarget,
     /// The relation description for the rows returned by this peek, before
@@ -432,7 +432,7 @@ pub struct Peek<T = mz_repr::Timestamp> {
     /// Used in responses and cancellation requests.
     pub uuid: Uuid,
     /// The logical timestamp at which the collection is queried.
-    pub timestamp: T,
+    pub timestamp: Timestamp,
     /// Actions to apply to the result set before returning them.
     pub finishing: RowSetFinishing,
     /// Linear operation to apply in-line on each result.

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -141,7 +141,7 @@ pub enum ComputeCommand {
     /// [`Frontiers`]: super::response::ComputeResponse::Frontiers
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     /// [`CopyToResponse`]: super::response::ComputeResponse::CopyToResponse
-    CreateDataflow(Box<DataflowDescription<RenderPlan<Timestamp>, CollectionMetadata, Timestamp>>),
+    CreateDataflow(Box<DataflowDescription<RenderPlan, CollectionMetadata>>),
 
     /// `Schedule` allows the replica to start computation for a compute collection.
     ///

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -16,7 +16,7 @@ use mz_expr::{CollectionPlan, MirRelationExpr, MirScalarExpr, OptimizedMirRelati
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_or_log;
 use mz_repr::refresh_schedule::RefreshSchedule;
-use mz_repr::{GlobalId, ReprRelationType, SqlRelationType};
+use mz_repr::{GlobalId, ReprRelationType, SqlRelationType, Timestamp};
 use mz_storage_types::time_dependence::TimeDependence;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
@@ -28,9 +28,9 @@ use crate::sources::{SourceInstanceArguments, SourceInstanceDesc};
 
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
+pub struct DataflowDescription<P, S: 'static = ()> {
     /// Sources instantiations made available to the dataflow pair with monotonicity information.
-    pub source_imports: BTreeMap<GlobalId, SourceImport<S, T>>,
+    pub source_imports: BTreeMap<GlobalId, SourceImport<S>>,
     /// Indexes made available to the dataflow.
     /// (id of index, import)
     pub index_imports: BTreeMap<GlobalId, IndexImport>,
@@ -43,23 +43,23 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
     pub index_exports: BTreeMap<GlobalId, (IndexDesc, ReprRelationType)>,
     /// sinks to be created
     /// (id of new sink, description of sink)
-    pub sink_exports: BTreeMap<GlobalId, ComputeSinkDesc<S, T>>,
+    pub sink_exports: BTreeMap<GlobalId, ComputeSinkDesc<S>>,
     /// An optional frontier to which inputs should be advanced.
     ///
     /// If this is set, it should override the default setting determined by
     /// the upper bound of `since` frontiers contributing to the dataflow.
     /// It is an error for this to be set to a frontier not beyond that default.
-    pub as_of: Option<Antichain<T>>,
+    pub as_of: Option<Antichain<Timestamp>>,
     /// Frontier beyond which the dataflow should not execute.
     /// Specifically, updates at times greater or equal to this frontier are suppressed.
     /// This is often set to `as_of + 1` to enable "batch" computations.
     /// Note that frontier advancements might still happen to times that are after the `until`,
     /// only data is suppressed. (This is consistent with how frontier advancements can also
     /// happen before the `as_of`.)
-    pub until: Antichain<T>,
+    pub until: Antichain<Timestamp>,
     /// The initial as_of when the collection is first created. Filled only for materialized views.
     /// Note that this doesn't change upon restarts.
-    pub initial_storage_as_of: Option<Antichain<T>>,
+    pub initial_storage_as_of: Option<Antichain<Timestamp>>,
     /// The schedule of REFRESH materialized views.
     pub refresh_schedule: Option<RefreshSchedule>,
     /// Human-readable name
@@ -68,7 +68,7 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
     pub time_dependence: Option<TimeDependence>,
 }
 
-impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
+impl<P, S> DataflowDescription<P, S> {
     /// Tests if the dataflow refers to a single timestamp, namely
     /// that `as_of` has a single coordinate and that the `until`
     /// value corresponds to the `as_of` value plus one, or `as_of`
@@ -103,7 +103,7 @@ impl<P, S> DataflowDescription<P, S, mz_repr::Timestamp> {
     }
 }
 
-impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
+impl DataflowDescription<Plan, ()> {
     /// Check invariants expected to be true about `DataflowDescription`s.
     pub fn check_invariants(&self) -> Result<(), String> {
         let mut plans: Vec<_> = self.objects_to_build.iter().map(|o| &o.plan).collect();
@@ -123,7 +123,7 @@ impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
     }
 }
 
-impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
+impl DataflowDescription<OptimizedMirRelationExpr, ()> {
     /// Imports a previously exported index.
     ///
     /// This method makes available an index previously exported as `id`, identified
@@ -198,7 +198,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     }
 
     /// Exports as `id` a sink described by `description`.
-    pub fn export_sink(&mut self, id: GlobalId, description: ComputeSinkDesc<(), T>) {
+    pub fn export_sink(&mut self, id: GlobalId, description: ComputeSinkDesc<()>) {
         self.sink_exports.insert(id, description);
     }
 
@@ -254,7 +254,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     }
 }
 
-impl<P, S, T> DataflowDescription<P, S, T> {
+impl<P, S> DataflowDescription<P, S> {
     /// Creates a new dataflow description with a human-readable name.
     pub fn new(name: String) -> Self {
         Self {
@@ -295,12 +295,12 @@ impl<P, S, T> DataflowDescription<P, S, T> {
     /// Generally, one should consider setting `as_of` at least to the `since`
     /// frontiers of contributing data sources and as aggressively as the
     /// computation permits.
-    pub fn set_as_of(&mut self, as_of: Antichain<T>) {
+    pub fn set_as_of(&mut self, as_of: Antichain<Timestamp>) {
         self.as_of = Some(as_of);
     }
 
     /// Records the initial `as_of` of the storage collection associated with a materialized view.
-    pub fn set_initial_as_of(&mut self, initial_as_of: Antichain<T>) {
+    pub fn set_initial_as_of(&mut self, initial_as_of: Antichain<Timestamp>) {
         self.initial_storage_as_of = Some(initial_as_of);
     }
 
@@ -419,7 +419,7 @@ impl<P, S, T> DataflowDescription<P, S, T> {
     }
 }
 
-impl<P, S, T> DataflowDescription<P, S, T>
+impl<P, S> DataflowDescription<P, S>
 where
     P: CollectionPlan,
 {
@@ -488,10 +488,9 @@ where
     }
 }
 
-impl<S, T> DataflowDescription<RenderPlan, S, T>
+impl<S> DataflowDescription<RenderPlan, S>
 where
     S: Clone + PartialEq,
-    T: Clone + timely::PartialOrder,
 {
     /// Determine if a dataflow description is compatible with this dataflow description.
     ///
@@ -611,7 +610,7 @@ pub struct IndexImport {
 
 /// Information about an imported source, and how it will be used by the dataflow.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct SourceImport<S: 'static = (), T = mz_repr::Timestamp> {
+pub struct SourceImport<S: 'static = ()> {
     /// Description of the source instance to import.
     pub desc: SourceInstanceDesc<S>,
     /// Whether the source will supply monotonic data.
@@ -619,7 +618,7 @@ pub struct SourceImport<S: 'static = (), T = mz_repr::Timestamp> {
     /// Whether this import must include the snapshot data.
     pub with_snapshot: bool,
     /// The initial known upper frontier for the source.
-    pub upper: Antichain<T>,
+    pub upper: Antichain<Timestamp>,
 }
 
 /// An association of a global identifier to an expression.

--- a/src/compute-types/src/explain.rs
+++ b/src/compute-types/src/explain.rs
@@ -152,7 +152,7 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
 }
 
 /// TODO(database-issues#7533): Add documentation.
-pub fn export_ids_for<P, S, T>(dd: &DataflowDescription<P, S, T>) -> BTreeMap<GlobalId, GlobalId> {
+pub fn export_ids_for<P, S>(dd: &DataflowDescription<P, S>) -> BTreeMap<GlobalId, GlobalId> {
     let mut map = BTreeMap::<GlobalId, GlobalId>::default();
 
     // Dataflows created from a `CREATE MATERIALIZED VIEW` have:

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -469,7 +469,7 @@ pub enum GetPlan {
     Collection(MapFilterProject),
 }
 
-impl<T: timely::progress::Timestamp> Plan<T> {
+impl Plan {
     /// Convert the dataflow description into one that uses render plans.
     #[mz_ore::instrument(
         target = "optimizer",
@@ -704,7 +704,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         // a single-time dataflow.
         assert!(dataflow.is_single_time());
 
-        let transform = transform::RelaxMustConsolidate::<T>::new();
+        let transform = transform::RelaxMustConsolidate::new();
         for build_desc in dataflow.objects_to_build.iter_mut() {
             transform
                 .transform(config, &mut build_desc.plan)

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -23,7 +23,7 @@ use mz_ore::str::Indent;
 use mz_repr::explain::text::text_string_at;
 use mz_repr::explain::{DummyHumanizer, ExplainConfig, ExprHumanizer, PlanRenderingContext};
 use mz_repr::optimize::OptimizerFeatures;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use serde::{Deserialize, Serialize};
 
 use crate::dataflows::DataflowDescription;
@@ -140,20 +140,20 @@ impl std::fmt::Display for LirId {
 
 /// A rendering plan with as much conditional logic as possible removed.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct Plan<T = mz_repr::Timestamp> {
+pub struct Plan {
     /// A dataflow-local identifier.
     pub lir_id: LirId,
     /// The underlying operator.
-    pub node: PlanNode<T>,
+    pub node: PlanNode,
 }
 
 /// The actual AST node of the `Plan`.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum PlanNode<T = mz_repr::Timestamp> {
+pub enum PlanNode {
     /// A collection containing a pre-determined collection.
     Constant {
         /// Explicit update triples for the collection.
-        rows: Result<Vec<(Row, T, Diff)>, EvalError>,
+        rows: Result<Vec<(Row, Timestamp, Diff)>, EvalError>,
     },
     /// A reference to a bound collection.
     ///
@@ -186,10 +186,10 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// The local identifier to be used, available to `body` as `Id::Local(id)`.
         id: LocalId,
         /// The collection that should be bound to `id`.
-        value: Box<Plan<T>>,
+        value: Box<Plan>,
         /// The collection that results, which is allowed to contain `Get` stages
         /// that reference `Id::Local(id)`.
-        body: Box<Plan<T>>,
+        body: Box<Plan>,
     },
     /// Binds `values` to `ids`, evaluates them potentially recursively, and returns `body`.
     ///
@@ -201,12 +201,12 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// The local identifiers to be used, available to `body` as `Id::Local(id)`.
         ids: Vec<LocalId>,
         /// The collection that should be bound to `id`.
-        values: Vec<Plan<T>>,
+        values: Vec<Plan>,
         /// Maximum number of iterations. See further info on the MIR `LetRec`.
         limits: Vec<Option<LetRecLimit>>,
         /// The collection that results, which is allowed to contain `Get` stages
         /// that reference `Id::Local(id)`.
-        body: Box<Plan<T>>,
+        body: Box<Plan>,
     },
     /// Map, Filter, and Project operators.
     ///
@@ -215,7 +215,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// and sometimes reduce stages are not able to absorb this operator.
     Mfp {
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// Linear operator to apply to each record.
         mfp: MapFilterProject,
         /// Whether the input is from an arrangement, and if so,
@@ -239,7 +239,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// if any
         input_key: Option<Vec<MirScalarExpr>>,
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// Expressions that for each row prepare the arguments to `func`.
         exprs: Vec<MirScalarExpr>,
         /// The variable-record emitting function.
@@ -254,7 +254,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// strategy we will use, and any pushed down per-record work.
     Join {
         /// An ordered list of inputs that will be joined.
-        inputs: Vec<Plan<T>>,
+        inputs: Vec<Plan>,
         /// Detailed information about the implementation of the join.
         ///
         /// This includes information about the implementation strategy, but also
@@ -268,7 +268,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// if any
         input_key: Option<Vec<MirScalarExpr>>,
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// A plan for changing input records into key, value pairs.
         key_val_plan: KeyValPlan,
         /// A plan for performing the reduce.
@@ -287,7 +287,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// Key-based "Top K" operator, retaining the first K records in each group.
     TopK {
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// A plan for performing the Top-K.
         ///
         /// The implementation of reduction has several different strategies based
@@ -298,7 +298,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// Inverts the sign of each update.
     Negate {
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
     },
     /// Filters records that accumulate negatively.
     ///
@@ -306,7 +306,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// resources proportional to the number of records with non-zero accumulation.
     Threshold {
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// A plan for performing the threshold.
         ///
         /// The implementation of reduction has several different strategies based
@@ -322,7 +322,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     /// implementing the "distinct" operator.
     Union {
         /// The input collections
-        inputs: Vec<Plan<T>>,
+        inputs: Vec<Plan>,
         /// Whether to consolidate the output, e.g., cancel negated records.
         consolidate_output: bool,
     },
@@ -336,7 +336,7 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
         /// The key that must be used to access the input.
         input_key: Option<Vec<MirScalarExpr>>,
         /// The input collection.
-        input: Box<Plan<T>>,
+        input: Box<Plan>,
         /// The MFP that must be applied to the input.
         input_mfp: MapFilterProject,
         /// A list of arrangement keys, and possibly a raw collection,
@@ -346,9 +346,9 @@ pub enum PlanNode<T = mz_repr::Timestamp> {
     },
 }
 
-impl<T> PlanNode<T> {
+impl PlanNode {
     /// Iterates through references to child expressions.
-    pub fn children(&self) -> impl Iterator<Item = &Plan<T>> {
+    pub fn children(&self) -> impl Iterator<Item = &Plan> {
         let mut first = None;
         let mut second = None;
         let mut rest = None;
@@ -387,7 +387,7 @@ impl<T> PlanNode<T> {
     }
 
     /// Iterates through mutable references to child expressions.
-    pub fn children_mut(&mut self) -> impl Iterator<Item = &mut Plan<T>> {
+    pub fn children_mut(&mut self) -> impl Iterator<Item = &mut Plan> {
         let mut first = None;
         let mut second = None;
         let mut rest = None;
@@ -426,9 +426,9 @@ impl<T> PlanNode<T> {
     }
 }
 
-impl<T> PlanNode<T> {
+impl PlanNode {
     /// Attach an `lir_id` to a `PlanNode` to make a complete `Plan`.
-    pub fn as_plan(self, lir_id: LirId) -> Plan<T> {
+    pub fn as_plan(self, lir_id: LirId) -> Plan {
         Plan { lir_id, node: self }
     }
 }
@@ -704,7 +704,7 @@ impl Plan {
         // a single-time dataflow.
         assert!(dataflow.is_single_time());
 
-        let transform = transform::RelaxMustConsolidate::new();
+        let transform = transform::RelaxMustConsolidate;
         for build_desc in dataflow.objects_to_build.iter_mut() {
             transform
                 .transform(config, &mut build_desc.plan)
@@ -715,7 +715,7 @@ impl Plan {
     }
 }
 
-impl<T> CollectionPlan for PlanNode<T> {
+impl CollectionPlan for PlanNode {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         match self {
             PlanNode::Constant { rows: _ } => (),
@@ -793,7 +793,7 @@ impl<T> CollectionPlan for PlanNode<T> {
     }
 }
 
-impl<T> CollectionPlan for Plan<T> {
+impl CollectionPlan for Plan {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         self.node.depends_on_into(out);
     }

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -25,7 +25,7 @@ use mz_expr::{
 use mz_ore::cast::CastFrom;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_ore::{assert_none, soft_panic_or_log};
-use mz_repr::{Diff, Row};
+use mz_repr::{Diff, Row, Timestamp};
 
 use crate::plan::join::JoinPlan;
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
@@ -47,7 +47,7 @@ use crate::plan::{AvailableCollections, GetPlan, Plan, PlanNode};
 /// [tagless final encoding]: <https://okmij.org/ftp/tagless-final/>
 ///
 /// TODO(database-issues#7446): align this with the `Plan` structure
-pub trait Interpreter<T = mz_repr::Timestamp> {
+pub trait Interpreter {
     /// TODO(database-issues#7533): Add documentation.
     type Domain: Debug + Sized;
 
@@ -55,7 +55,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
     fn constant(
         &self,
         ctx: &Context<Self::Domain>,
-        rows: &Result<Vec<(Row, T, Diff)>, EvalError>,
+        rows: &Result<Vec<(Row, Timestamp, Diff)>, EvalError>,
     ) -> Self::Domain;
 
     /// TODO(database-issues#7533): Add documentation.
@@ -212,17 +212,17 @@ const MAX_LET_REC_ITERATIONS: u64 = 100;
 /// A wrapper for a recursive fold invocation over a [Plan] that cannot
 /// mutate its input.
 #[allow(missing_debug_implementations)]
-pub struct Fold<I, T>
+pub struct Fold<I>
 where
-    I: Interpreter<T>,
+    I: Interpreter,
 {
     interpret: I,
     ctx: Context<I::Domain>,
 }
 
-impl<I, T> Fold<I, T>
+impl<I> Fold<I>
 where
-    I: Interpreter<T>,
+    I: Interpreter,
     I::Domain: BoundedLattice + Clone,
 {
     /// TODO(database-issues#7533): Add documentation.
@@ -238,13 +238,13 @@ where
     /// Runs an abstract interpreter over the given `expr` in a bottom-up
     /// manner, keeping the `ctx` field of the enclosing field up to date, and
     /// returns the final result for the entire `expr`.
-    pub fn apply(&mut self, expr: &Plan<T>) -> Result<I::Domain, RecursionLimitError> {
+    pub fn apply(&mut self, expr: &Plan) -> Result<I::Domain, RecursionLimitError> {
         self.apply_rec(expr, &RecursionGuard::with_limit(RECURSION_LIMIT))
     }
 
     fn apply_rec(
         &mut self,
-        expr: &Plan<T>,
+        expr: &Plan,
         rg: &RecursionGuard,
     ) -> Result<I::Domain, RecursionLimitError> {
         use PlanNode::*;
@@ -460,20 +460,20 @@ where
 /// A wrapper for a recursive fold invocation over a [Plan] that can
 /// mutate its input.
 #[allow(missing_debug_implementations)]
-pub struct FoldMut<I, T, Action>
+pub struct FoldMut<I, Action>
 where
-    I: Interpreter<T>,
+    I: Interpreter,
 {
     interpret: I,
     action: Action,
     ctx: Context<I::Domain>,
 }
 
-impl<I, T, A> FoldMut<I, T, A>
+impl<I, A> FoldMut<I, A>
 where
-    I: Interpreter<T>,
+    I: Interpreter,
     I::Domain: BoundedLattice + Clone,
-    A: FnMut(&mut Plan<T>, &I::Domain, &[I::Domain]),
+    A: FnMut(&mut Plan, &I::Domain, &[I::Domain]),
 {
     /// TODO(database-issues#7533): Add documentation.
     pub fn new(interpreter: I, action: A) -> Self {
@@ -493,13 +493,13 @@ where
     /// At each step, the current `expr` is passed along with the interpretation
     /// result of itself and its children to an `action` callback that can
     /// optionally mutate it.
-    pub fn apply(&mut self, expr: &mut Plan<T>) -> Result<I::Domain, RecursionLimitError> {
+    pub fn apply(&mut self, expr: &mut Plan) -> Result<I::Domain, RecursionLimitError> {
         self.apply_rec(expr, &RecursionGuard::with_limit(RECURSION_LIMIT))
     }
 
     fn apply_rec(
         &mut self,
-        expr: &mut Plan<T>,
+        expr: &mut Plan,
         rg: &RecursionGuard,
     ) -> Result<I::Domain, RecursionLimitError> {
         use PlanNode::*;

--- a/src/compute-types/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-types/src/plan/interpret/physically_monotonic.rs
@@ -12,11 +12,10 @@
 
 use std::cmp::Reverse;
 use std::collections::BTreeSet;
-use std::marker::PhantomData;
 
 use differential_dataflow::lattice::Lattice;
 use mz_expr::{EvalError, Id, MapFilterProject, MirScalarExpr, TableFunc};
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use timely::PartialOrder;
 
 use crate::plan::interpret::{BoundedLattice, Context, Interpreter};
@@ -70,29 +69,25 @@ impl PartialOrder for PhysicallyMonotonic {
 /// of retractions in a stream, enables us to disable forced consolidation
 /// whenever possible.
 #[derive(Debug)]
-pub struct SingleTimeMonotonic<'a, T = mz_repr::Timestamp> {
+pub struct SingleTimeMonotonic<'a> {
     monotonic_ids: &'a BTreeSet<GlobalId>,
-    _phantom: PhantomData<T>,
 }
 
-impl<'a, T> SingleTimeMonotonic<'a, T> {
+impl<'a> SingleTimeMonotonic<'a> {
     /// Instantiates an interpreter for single-time physical monotonicity
     /// analysis.
     pub fn new(monotonic_ids: &'a BTreeSet<GlobalId>) -> Self {
-        SingleTimeMonotonic {
-            monotonic_ids,
-            _phantom: Default::default(),
-        }
+        SingleTimeMonotonic { monotonic_ids }
     }
 }
 
-impl<T> Interpreter<T> for SingleTimeMonotonic<'_, T> {
+impl Interpreter for SingleTimeMonotonic<'_> {
     type Domain = PhysicallyMonotonic;
 
     fn constant(
         &self,
         _ctx: &Context<Self::Domain>,
-        rows: &Result<Vec<(Row, T, Diff)>, EvalError>,
+        rows: &Result<Vec<(Row, Timestamp, Diff)>, EvalError>,
     ) -> Self::Domain {
         // A constant is physically monotonic iff the constant is an `EvalError`
         // or all its rows have `Diff` values greater than zero.

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -19,9 +19,8 @@ use mz_expr::{
     OptimizedMirRelationExpr, TableFunc, permutation_for_arrangement,
 };
 use mz_ore::{assert_none, soft_assert_eq_or_log, soft_panic_or_log};
-use mz_repr::GlobalId;
 use mz_repr::optimize::OptimizerFeatures;
-use timely::progress::Timestamp;
+use mz_repr::{GlobalId, Timestamp};
 
 use crate::dataflows::{BuildDesc, DataflowDescription, IndexImport};
 use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
@@ -65,10 +64,10 @@ impl Context {
         id
     }
 
-    pub fn lower<T: Timestamp>(
+    pub fn lower(
         mut self,
         desc: DataflowDescription<OptimizedMirRelationExpr>,
-    ) -> Result<DataflowDescription<Plan<T>>, String> {
+    ) -> Result<DataflowDescription<Plan>, String> {
         // Sources might provide arranged forms of their data, in the future.
         // Indexes provide arranged forms of their data.
         for IndexImport {
@@ -141,10 +140,10 @@ impl Context {
     ///
     /// An empty list of arrangement keys indicates that only a `Collection` stream can
     /// be assumed to exist.
-    fn lower_mir_expr<T: Timestamp>(
+    fn lower_mir_expr(
         &mut self,
         expr: &MirRelationExpr,
-    ) -> Result<(Plan<T>, AvailableCollections), String> {
+    ) -> Result<(Plan, AvailableCollections), String> {
         // This function is recursive and can overflow its stack, so grow it if
         // needed. The growth here is unbounded. Our general solution for this problem
         // is to use [`ore::stack::RecursionGuard`] to additionally limit the stack
@@ -157,13 +156,10 @@ impl Context {
         mz_ore::stack::maybe_grow(|| self.lower_mir_expr_stack_safe(expr))
     }
 
-    fn lower_mir_expr_stack_safe<T>(
+    fn lower_mir_expr_stack_safe(
         &mut self,
         expr: &MirRelationExpr,
-    ) -> Result<(Plan<T>, AvailableCollections), String>
-    where
-        T: Timestamp,
-    {
+    ) -> Result<(Plan, AvailableCollections), String> {
         // Extract a maximally large MapFilterProject from `expr`.
         // We will then try and push this in to the resulting expression.
         //
@@ -190,7 +186,7 @@ impl Context {
                 let node = PlanNode::Constant {
                     rows: rows.clone().map(|rows| {
                         rows.into_iter()
-                            .map(|(row, diff)| (row, T::minimum(), diff))
+                            .map(|(row, diff)| (row, Timestamp::MIN, diff))
                             .collect()
                     }),
                 };
@@ -981,7 +977,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
     /// originally on top of the `Reduce`. This MFP, or a part of it, might be fused into the
     /// `Reduce`, in which case `mfp_on_top` is mutated to be the residual MFP, i.e., what was not
     /// fused.
-    fn lower_reduce<T: Timestamp>(
+    fn lower_reduce(
         &mut self,
         input: &MirRelationExpr,
         group_key: &Vec<MirScalarExpr>,
@@ -990,7 +986,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
         expected_group_size: &Option<u64>,
         mfp_on_top: &mut MapFilterProject,
         fused_unnest_list: bool,
-    ) -> Result<(Plan<T>, AvailableCollections), String> {
+    ) -> Result<(Plan, AvailableCollections), String> {
         let input_arity = input.arity();
         let (input, keys) = self.lower_mir_expr(input)?;
         let (input_key, permutation_and_new_arity) =
@@ -1048,13 +1044,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
 
     /// Replace the plan with another one
     /// that has the collection in some additional forms.
-    pub fn arrange_by<T>(
+    pub fn arrange_by(
         &mut self,
-        plan: Plan<T>,
+        plan: Plan,
         collections: AvailableCollections,
         old_collections: &AvailableCollections,
         arity: usize,
-    ) -> Plan<T> {
+    ) -> Plan {
         if let Plan {
             node:
                 PlanNode::ArrangeBy {

--- a/src/compute-types/src/plan/render_plan.rs
+++ b/src/compute-types/src/plan/render_plan.rs
@@ -19,7 +19,7 @@ use mz_expr::{
 };
 use mz_ore::soft_assert_or_log;
 use mz_repr::explain::{CompactScalars, ExprHumanizer};
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use serde::{Deserialize, Serialize};
 
 use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
@@ -38,11 +38,11 @@ use crate::plan::{AvailableCollections, GetPlan, LirId, Plan, PlanNode};
 ///
 /// A [`RenderPlan`] can be constructed from a [`Plan`] using the corresponding [`TryFrom`] impl.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct RenderPlan<T = mz_repr::Timestamp> {
+pub struct RenderPlan {
     /// Stages of bindings to render in order.
-    pub binds: Vec<BindStage<T>>,
+    pub binds: Vec<BindStage>,
     /// The binding-free body.
-    pub body: LetFreePlan<T>,
+    pub body: LetFreePlan,
 }
 
 /// A set of bindings to render in order.
@@ -55,29 +55,29 @@ pub struct RenderPlan<T = mz_repr::Timestamp> {
 /// Rec bindings in `recs` are rendered second. Each one has access to _all_ Let and Rec bindings
 /// in the same stage, including itself, as well as any bindings from previous stages.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct BindStage<T = mz_repr::Timestamp> {
+pub struct BindStage {
     /// Non-recursive bindings.
-    pub lets: Vec<LetBind<T>>,
+    pub lets: Vec<LetBind>,
     /// Potentially recursive bindings.
-    pub recs: Vec<RecBind<T>>,
+    pub recs: Vec<RecBind>,
 }
 
 /// Binds a collection to a [`LocalId`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct LetBind<T = mz_repr::Timestamp> {
+pub struct LetBind {
     /// The identifier through which the collection can be referenced.
     pub id: LocalId,
     /// The collection that is bound to `id`.
-    pub value: LetFreePlan<T>,
+    pub value: LetFreePlan,
 }
 
 /// Binds a potentially recursively defined collection to a [`LocalId`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct RecBind<T = mz_repr::Timestamp> {
+pub struct RecBind {
     /// The identifier through which the collection can be referenced.
     pub id: LocalId,
     /// The collection that is bound to `id`.
-    pub value: RenderPlan<T>,
+    pub value: RenderPlan,
     /// Limits imposed on recursive iteration.
     pub limit: Option<LetRecLimit>,
 }
@@ -97,9 +97,9 @@ pub struct RecBind<T = mz_repr::Timestamp> {
 /// The implementation of [`LetFreePlan`] must ensure that all its methods uphold these invariants
 /// and that users are not able to break them.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct LetFreePlan<T = mz_repr::Timestamp> {
+pub struct LetFreePlan {
     /// The nodes in the plan.
-    nodes: BTreeMap<LirId, Node<T>>,
+    nodes: BTreeMap<LirId, Node>,
     /// The ID of the root node.
     root: LirId,
     /// The topological order of nodes (dependencies before dependants).
@@ -108,9 +108,9 @@ pub struct LetFreePlan<T = mz_repr::Timestamp> {
 
 /// A node of a [`RenderPlan`], comprising an [`Expr`] and some metadata.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Node<T = mz_repr::Timestamp> {
+pub struct Node {
     /// The relation expression for this node.
-    pub expr: Expr<T>,
+    pub expr: Expr,
     /// The [`LirId`] of the parent of this node (for tree reconstruction).
     pub parent: Option<LirId>,
     /// The nesting level of this node (for pretty printing).
@@ -124,11 +124,11 @@ pub struct Node<T = mz_repr::Timestamp> {
 ///  * The `Let` and `LetRec` variants are removed.
 ///  * The `lir_id` fields are removed.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum Expr<T = mz_repr::Timestamp> {
+pub enum Expr {
     /// A collection containing a pre-determined collection.
     Constant {
         /// Explicit update triples for the collection.
-        rows: Result<Vec<(Row, T, Diff)>, EvalError>,
+        rows: Result<Vec<(Row, Timestamp, Diff)>, EvalError>,
     },
     /// A reference to a bound collection.
     ///
@@ -276,7 +276,7 @@ pub enum Expr<T = mz_repr::Timestamp> {
     },
 }
 
-impl<T> TryFrom<Plan<T>> for RenderPlan<T> {
+impl TryFrom<Plan> for RenderPlan {
     /// The only error is "invalid input plan".
     type Error = ();
 
@@ -299,7 +299,7 @@ impl<T> TryFrom<Plan<T>> for RenderPlan<T> {
     /// ```
     ///
     /// Input [`Plan`]s that do not satisfy this requirement will result in errors.
-    fn try_from(mut plan: Plan<T>) -> Result<Self, Self::Error> {
+    fn try_from(mut plan: Plan) -> Result<Self, Self::Error> {
         use PlanNode::{Let, LetRec};
 
         // Peel off stages of bindings. Each stage is constructed of an arbitrary amount of leading
@@ -338,14 +338,14 @@ impl<T> TryFrom<Plan<T>> for RenderPlan<T> {
     }
 }
 
-impl<T> TryFrom<Plan<T>> for LetFreePlan<T> {
+impl TryFrom<Plan> for LetFreePlan {
     /// The only error is "invalid input plan".
     type Error = ();
 
     /// Convert the given [`Plan`] into a [`LetFreePlan`].
     ///
     /// Returns an error if the given [`Plan`] contains `Let` or `LetRec` nodes.
-    fn try_from(plan: Plan<T>) -> Result<Self, Self::Error> {
+    fn try_from(plan: Plan) -> Result<Self, Self::Error> {
         use Expr::*;
 
         // The strategy is to walk walk through the `Plan` in right-to-left pre-order and for each
@@ -355,9 +355,9 @@ impl<T> TryFrom<Plan<T>> for LetFreePlan<T> {
         let root = plan.lir_id;
 
         // Stack of nodes to flatten, with their parent id and nesting.
-        let mut todo: Vec<(Plan<T>, Option<LirId>, u8)> = vec![(plan, None, 0)];
+        let mut todo: Vec<(Plan, Option<LirId>, u8)> = vec![(plan, None, 0)];
         // `RenderPlan` nodes produced so far.
-        let mut nodes: BTreeMap<LirId, Node<T>> = Default::default();
+        let mut nodes: BTreeMap<LirId, Node> = Default::default();
         // A list remembering the order in which nodes were flattened.
         // Because nodes are flatten in right-to-left pre-order, reversing this list at the end
         // yields a valid topological order.
@@ -524,7 +524,7 @@ impl<T> TryFrom<Plan<T>> for LetFreePlan<T> {
     }
 }
 
-impl<T> CollectionPlan for RenderPlan<T> {
+impl CollectionPlan for RenderPlan {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         for stage in &self.binds {
             for LetBind { value, .. } in &stage.lets {
@@ -539,7 +539,7 @@ impl<T> CollectionPlan for RenderPlan<T> {
     }
 }
 
-impl<T> CollectionPlan for LetFreePlan<T> {
+impl CollectionPlan for LetFreePlan {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         for Node { expr, .. } in self.nodes.values() {
             if let Expr::Get { id, .. } = expr {
@@ -551,7 +551,7 @@ impl<T> CollectionPlan for LetFreePlan<T> {
     }
 }
 
-impl<T> RenderPlan<T> {
+impl RenderPlan {
     /// Return whether the plan contains recursion.
     pub fn is_recursive(&self) -> bool {
         self.binds.iter().any(|b| !b.recs.is_empty())
@@ -589,7 +589,7 @@ impl<T> RenderPlan<T> {
     }
 }
 
-impl<T> LetFreePlan<T> {
+impl LetFreePlan {
     /// Return the ID of the root node.
     pub fn root_id(&self) -> LirId {
         self.root
@@ -600,7 +600,7 @@ impl<T> LetFreePlan<T> {
     ///
     /// This allows consuming the plan without being required to uphold the [`LetFreePlan`]
     /// invariants.
-    pub fn destruct(self) -> (BTreeMap<LirId, Node<T>>, LirId, Vec<LirId>) {
+    pub fn destruct(self) -> (BTreeMap<LirId, Node>, LirId, Vec<LirId>) {
         (self.nodes, self.root, self.topological_order)
     }
 
@@ -634,7 +634,7 @@ impl<T> LetFreePlan<T> {
     }
 }
 
-impl<T: Clone> RenderPlan<T> {
+impl RenderPlan {
     /// Partitions the plan into `parts` many disjoint pieces.
     ///
     /// This is used to partition `PlanNode::Constant` stages so that the work
@@ -668,7 +668,7 @@ impl<T: Clone> RenderPlan<T> {
     }
 }
 
-impl<T: Clone> BindStage<T> {
+impl BindStage {
     /// Partitions the stage into `parts` many disjoint pieces.
     ///
     /// This is used to partition `PlanNode::Constant` stages so that the work
@@ -699,7 +699,7 @@ impl<T: Clone> BindStage<T> {
     }
 }
 
-impl<T: Clone> LetFreePlan<T> {
+impl LetFreePlan {
     /// Partitions the plan into `parts` many disjoint pieces.
     ///
     /// This is used to partition `PlanNode::Constant` stages so that the work
@@ -732,7 +732,7 @@ impl<T: Clone> LetFreePlan<T> {
     }
 }
 
-impl<T: Clone> Expr<T> {
+impl Expr {
     /// Partitions the expr into `parts` many disjoint pieces.
     ///
     /// This is used to partition `PlanNode::Constant` stages so that the work
@@ -771,7 +771,7 @@ impl<T: Clone> Expr<T> {
     }
 }
 
-impl<T> Expr<T> {
+impl Expr {
     /// Renders a single [`Expr`] as a string.
     ///
     /// Typically of the format "{ExprName}::{Detail} {input LirID} ({options})"
@@ -787,23 +787,23 @@ impl<T> Expr<T> {
 ///
 /// Invariant: the [`std::fmt::Display`] instance should produce a single line for a given expr.
 #[derive(Debug)]
-pub struct RenderPlanExprHumanizer<'a, T> {
+pub struct RenderPlanExprHumanizer<'a> {
     /// The [`Expr`] to be rendered.
-    expr: &'a Expr<T>,
+    expr: &'a Expr,
     /// Humanization information.
     humanizer: &'a dyn ExprHumanizer,
 }
 
-impl<'a, T> RenderPlanExprHumanizer<'a, T> {
+impl<'a> RenderPlanExprHumanizer<'a> {
     /// Creates a [`RenderPlanExprHumanizer`] (which simply holds the references).
     ///
     /// Use the [`std::fmt::Display`] instance.
-    pub fn new(expr: &'a Expr<T>, humanizer: &'a dyn ExprHumanizer) -> Self {
+    pub fn new(expr: &'a Expr, humanizer: &'a dyn ExprHumanizer) -> Self {
         Self { expr, humanizer }
     }
 }
 
-impl<'a, T> std::fmt::Display for RenderPlanExprHumanizer<'a, T> {
+impl<'a> std::fmt::Display for RenderPlanExprHumanizer<'a> {
     // NOTE: This code needs to be kept in sync with `Plan::fmt_default_text`.
     //
     // This code determines what you see in `mz_lir_mapping`; that other code

--- a/src/compute-types/src/plan/transform/api.rs
+++ b/src/compute-types/src/plan/transform/api.rs
@@ -26,7 +26,7 @@ pub struct TransformConfig {
 }
 
 /// A transform for [crate::plan::Plan] nodes.
-pub trait Transform<T = mz_repr::Timestamp> {
+pub trait Transform {
     /// TODO(database-issues#7533): Add documentation.
     fn name(&self) -> &'static str;
 
@@ -39,7 +39,7 @@ pub trait Transform<T = mz_repr::Timestamp> {
     fn transform(
         &self,
         config: &TransformConfig,
-        plan: &mut Plan<T>,
+        plan: &mut Plan,
     ) -> Result<(), RecursionLimitError> {
         let _span = tracing::span!(target: "optimizer",
             tracing::Level::TRACE,
@@ -54,19 +54,19 @@ pub trait Transform<T = mz_repr::Timestamp> {
     fn do_transform(
         &self,
         config: &TransformConfig,
-        plan: &mut Plan<T>,
+        plan: &mut Plan,
     ) -> Result<(), RecursionLimitError>;
 }
 
 /// TODO(database-issues#7533): Add documentation.
-pub trait BottomUpTransform<T = mz_repr::Timestamp> {
+pub trait BottomUpTransform {
     /// A type representing analysis information to be associated with each
     /// sub-term and exposed to the transformation action callback.
     type Info: BoundedLattice + Clone;
 
     /// A type responsible for synthesizing the [Self::Info] associated with
     /// each sub-term.
-    type Interpreter<'a>: Interpreter<T, Domain = Self::Info>;
+    type Interpreter<'a>: Interpreter<Domain = Self::Info>;
 
     /// The name for this transform.
     fn name(&self) -> &'static str;
@@ -76,12 +76,12 @@ pub trait BottomUpTransform<T = mz_repr::Timestamp> {
 
     /// A callback for manipulating the root of the given [Plan] using the
     /// [Self::Info] derived for itself and its children.
-    fn action(plan: &mut Plan<T>, plan_info: &Self::Info, input_infos: &[Self::Info]);
+    fn action(plan: &mut Plan, plan_info: &Self::Info, input_infos: &[Self::Info]);
 }
 
-impl<A, T> Transform<T> for A
+impl<A> Transform for A
 where
-    A: BottomUpTransform<T>,
+    A: BottomUpTransform,
 {
     fn name(&self) -> &'static str {
         self.name()
@@ -90,7 +90,7 @@ where
     fn do_transform(
         &self,
         config: &TransformConfig,
-        plan: &mut Plan<T>,
+        plan: &mut Plan,
     ) -> Result<(), RecursionLimitError> {
         let mut fold = FoldMut::new(Self::interpreter(config), Self::action);
         fold.apply(plan).map(|_| ())

--- a/src/compute-types/src/plan/transform/relax_must_consolidate.rs
+++ b/src/compute-types/src/plan/transform/relax_must_consolidate.rs
@@ -10,8 +10,6 @@
 //! Placeholder module for an [crate::plan::transform::Transform] that infers
 //! physical monotonicity.
 
-use std::marker::PhantomData;
-
 use crate::plan::interpret::{PhysicallyMonotonic, SingleTimeMonotonic};
 use crate::plan::reduce::{HierarchicalPlan, MonotonicPlan};
 use crate::plan::top_k::{MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan};
@@ -22,23 +20,12 @@ use crate::plan::{Plan, PlanNode, ReducePlan};
 /// analysis and refines, as appropriate, the setting of the `must_consolidate`
 /// flag in monotonic `Plan` nodes with forced consolidation.
 #[derive(Debug)]
-pub struct RelaxMustConsolidate<T = mz_repr::Timestamp> {
-    _phantom: PhantomData<T>,
-}
-
-impl<T> RelaxMustConsolidate<T> {
-    /// TODO(database-issues#7533): Add documentation.
-    pub fn new() -> Self {
-        RelaxMustConsolidate {
-            _phantom: Default::default(),
-        }
-    }
-}
-
-impl<T> BottomUpTransform<T> for RelaxMustConsolidate<T> {
+pub struct RelaxMustConsolidate;
+ 
+impl BottomUpTransform for RelaxMustConsolidate {
     type Info = PhysicallyMonotonic;
 
-    type Interpreter<'a> = SingleTimeMonotonic<'a, T>;
+    type Interpreter<'a> = SingleTimeMonotonic<'a>;
 
     fn name(&self) -> &'static str {
         "must_consolidate relaxation"
@@ -48,7 +35,7 @@ impl<T> BottomUpTransform<T> for RelaxMustConsolidate<T> {
         SingleTimeMonotonic::new(&config.monotonic_ids)
     }
 
-    fn action(plan: &mut Plan<T>, _plan_info: &Self::Info, input_infos: &[Self::Info]) {
+    fn action(plan: &mut Plan, _plan_info: &Self::Info, input_infos: &[Self::Info]) {
         // Look at `input_infos` and type of `Plan` node and refine the `must_consolidate` flag.
         // Note that the LIR nodes we care about have a single input.
         match (&mut plan.node, input_infos) {

--- a/src/compute-types/src/plan/transform/relax_must_consolidate.rs
+++ b/src/compute-types/src/plan/transform/relax_must_consolidate.rs
@@ -21,7 +21,7 @@ use crate::plan::{Plan, PlanNode, ReducePlan};
 /// flag in monotonic `Plan` nodes with forced consolidation.
 #[derive(Debug)]
 pub struct RelaxMustConsolidate;
- 
+
 impl BottomUpTransform for RelaxMustConsolidate {
     type Info = PhysicallyMonotonic;
 

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -19,7 +19,7 @@ use timely::progress::Antichain;
 
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ComputeSinkDesc<S: 'static = (), T = Timestamp> {
+pub struct ComputeSinkDesc<S: 'static = ()> {
     /// TODO(database-issues#7533): Add documentation.
     pub from: GlobalId,
     /// TODO(database-issues#7533): Add documentation.
@@ -29,7 +29,7 @@ pub struct ComputeSinkDesc<S: 'static = (), T = Timestamp> {
     /// TODO(database-issues#7533): Add documentation.
     pub with_snapshot: bool,
     /// TODO(database-issues#7533): Add documentation.
-    pub up_to: Antichain<T>,
+    pub up_to: Antichain<Timestamp>,
     /// TODO(database-issues#7533): Add documentation.
     pub non_null_assertions: Vec<usize>,
     /// TODO(database-issues#7533): Add documentation.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1087,8 +1087,8 @@ impl<'a> ActiveComputeState<'a> {
     pub fn determine_dataflow_expiration(
         &self,
         time_dependence: &TimeDependence,
-        until: &Antichain<mz_repr::Timestamp>,
-    ) -> Antichain<mz_repr::Timestamp> {
+        until: &Antichain<Timestamp>,
+    ) -> Antichain<Timestamp> {
         // Evaluate time dependence with respect to the expiration time.
         // * Step time forward to ensure the expiration time is different to the moment a dataflow
         //   can legitimately jump to.
@@ -1098,7 +1098,7 @@ impl<'a> ActiveComputeState<'a> {
             .replica_expiration
             .iter()
             .filter_map(|t| time_dependence.apply(*t))
-            .filter_map(|t| mz_repr::Timestamp::try_step_forward(&t))
+            .filter_map(|t| Timestamp::try_step_forward(&t))
             .filter(|expiration| !until.less_equal(expiration));
         Antichain::from_iter(iter)
     }
@@ -1523,7 +1523,7 @@ impl IndexPeek {
 
     /// Collects data for a known-complete peek from the ok stream.
     fn collect_ok_finished_data<Tr>(
-        peek: &Peek<Timestamp>,
+        peek: &Peek,
         oks_handle: &mut Tr,
         max_result_size: u64,
         peek_stash_eligible: bool,
@@ -1535,7 +1535,7 @@ impl IndexPeek {
                 Key<'a>: ToDatumIter + Eq,
                 KeyContainer: BatchContainer<Owned = Row>,
                 Val<'a>: ToDatumIter,
-                TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
+                TimeGat<'a>: PartialOrder<Timestamp>,
                 DiffGat<'a> = &'a Diff,
             >,
     {

--- a/src/compute/src/render/continual_task.rs
+++ b/src/compute/src/render/continual_task.rs
@@ -317,7 +317,7 @@ impl ContinualTaskSourceTransformer {
 }
 
 impl<'scope> ContinualTaskCtx<'scope> {
-    pub fn new<P, S>(dataflow: &DataflowDescription<P, S, Timestamp>) -> Self {
+    pub fn new<P, S>(dataflow: &DataflowDescription<P, S>) -> Self {
         let mut name = None;
         let mut ct_inputs = BTreeSet::new();
         let mut ct_outputs = BTreeSet::new();

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -770,7 +770,7 @@ pub struct ExportState {
     pub read_holds: [ReadHold; 2],
 
     /// The policy to use to downgrade `self.read_capability`.
-    pub read_policy: ReadPolicy<Timestamp>,
+    pub read_policy: ReadPolicy,
 
     /// Reported write frontier.
     pub write_frontier: Antichain<Timestamp>,
@@ -782,7 +782,7 @@ impl ExportState {
         read_hold: ReadHold,
         self_hold: ReadHold,
         write_frontier: Antichain<Timestamp>,
-        read_policy: ReadPolicy<Timestamp>,
+        read_policy: ReadPolicy,
     ) -> Self {
         let mut dependency_since = Antichain::from_elem(Timestamp::MIN);
         for read_hold in [&read_hold, &self_hold] {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -767,7 +767,7 @@ pub struct ExportState {
     /// The read holds that this export has on its dependencies (its input and itself). When
     /// the upper of the export changes, we downgrade this, which in turn
     /// downgrades holds we have on our dependencies' sinces.
-    pub read_holds: [ReadHold<Timestamp>; 2],
+    pub read_holds: [ReadHold; 2],
 
     /// The policy to use to downgrade `self.read_capability`.
     pub read_policy: ReadPolicy<Timestamp>,
@@ -779,8 +779,8 @@ pub struct ExportState {
 impl ExportState {
     pub fn new(
         cluster_id: StorageInstanceId,
-        read_hold: ReadHold<Timestamp>,
-        self_hold: ReadHold<Timestamp>,
+        read_hold: ReadHold,
+        self_hold: ReadHold,
         write_frontier: Antichain<Timestamp>,
         read_policy: ReadPolicy<Timestamp>,
     ) -> Self {
@@ -804,7 +804,7 @@ impl ExportState {
     }
 
     /// Returns the cluster to which the export is bound.
-    pub fn input_hold(&self) -> &ReadHold<Timestamp> {
+    pub fn input_hold(&self) -> &ReadHold {
         &self.read_holds[0]
     }
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -282,7 +282,7 @@ pub trait StorageCollections: Debug + Sync {
     ///
     /// Identifiers not present in `policies` retain their existing read
     /// policies.
-    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>);
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy)>);
 
     /// Acquires and returns the earliest possible read holds for the specified
     /// collections.
@@ -1120,7 +1120,7 @@ impl StorageCollectionsImpl {
     fn set_read_policies_inner(
         &self,
         collections: &mut BTreeMap<GlobalId, CollectionState>,
-        policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>,
+        policies: Vec<(GlobalId, ReadPolicy)>,
     ) {
         trace!("set_read_policies: {:?}", policies);
 
@@ -2203,7 +2203,7 @@ impl StorageCollections for StorageCollectionsImpl {
         self.synchronize_finalized_shards(storage_metadata);
     }
 
-    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy)>) {
         let mut collections = self.collections.lock().expect("lock poisoned");
 
         if tracing::enabled!(tracing::Level::TRACE) {
@@ -2497,7 +2497,7 @@ struct CollectionState {
     pub implied_capability: Antichain<Timestamp>,
 
     /// The policy to use to downgrade `self.implied_capability`.
-    pub read_policy: ReadPolicy<Timestamp>,
+    pub read_policy: ReadPolicy,
 
     /// Storage identifiers on which this collection depends.
     pub storage_dependencies: Vec<GlobalId>,

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -289,7 +289,7 @@ pub trait StorageCollections: Debug + Sync {
     fn acquire_read_holds(
         &self,
         desired_holds: Vec<GlobalId>,
-    ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing>;
+    ) -> Result<Vec<ReadHold>, CollectionMissing>;
 
     /// Get the time dependence for a storage collection. Returns no value if unknown or if
     /// the object isn't managed by storage.
@@ -2238,7 +2238,7 @@ impl StorageCollections for StorageCollectionsImpl {
     fn acquire_read_holds(
         &self,
         desired_holds: Vec<GlobalId>,
-    ) -> Result<Vec<ReadHold<Timestamp>>, CollectionMissing> {
+    ) -> Result<Vec<ReadHold>, CollectionMissing> {
         if desired_holds.is_empty() {
             return Ok(vec![]);
         }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2837,7 +2837,7 @@ where
     // This is really only used when dropping things, where we set the
     // ReadPolicy to the empty Antichain.
     #[instrument(level = "debug")]
-    fn set_hold_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy<Timestamp>)>) {
+    fn set_hold_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy)>) {
         let mut read_capability_changes = BTreeMap::default();
 
         for (id, policy) in policies.into_iter() {
@@ -3936,7 +3936,7 @@ struct IngestionState {
     /// This is a _storage-controller-internal_ policy used to derive its
     /// personal read hold on the collection. It should not be confused with any
     /// read policies that the adapter might install at [StorageCollections].
-    pub hold_policy: ReadPolicy<Timestamp>,
+    pub hold_policy: ReadPolicy,
 
     /// The ID of the instance in which the ingestion is running.
     pub instance_id: StorageInstanceId,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3925,7 +3925,7 @@ struct IngestionState {
     pub derived_since: Antichain<Timestamp>,
 
     /// Holds that this ingestion (or ingestion export) has on its dependencies.
-    pub dependency_read_holds: Vec<ReadHold<Timestamp>>,
+    pub dependency_read_holds: Vec<ReadHold>,
 
     /// Reported write frontier.
     pub write_frontier: Antichain<Timestamp>,

--- a/src/storage-types/src/read_holds.rs
+++ b/src/storage-types/src/read_holds.rs
@@ -10,15 +10,18 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Timestamp};
 use thiserror::Error;
 use timely::PartialOrder;
-use timely::progress::{Antichain, ChangeBatch, Timestamp as TimelyTimestamp};
+use timely::progress::{Antichain, ChangeBatch};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::error::SendError;
 
-pub type ChangeTx<T> = Arc<
-    dyn Fn(GlobalId, ChangeBatch<T>) -> Result<(), SendError<(GlobalId, ChangeBatch<T>)>>
+pub type ChangeTx = Arc<
+    dyn Fn(
+            GlobalId,
+            ChangeBatch<Timestamp>,
+        ) -> Result<(), SendError<(GlobalId, ChangeBatch<Timestamp>)>>
         + Send
         + Sync,
 >;
@@ -29,18 +32,18 @@ pub type ChangeTx<T> = Arc<
 ///
 /// This [ReadHold] is safe to drop. The installed read hold will be returned to
 /// the issuer behind the scenes.
-pub struct ReadHold<T: TimelyTimestamp> {
+pub struct ReadHold {
     /// Identifies that collection that we have a hold on.
     id: GlobalId,
 
     /// The times at which we hold.
-    since: Antichain<T>,
+    since: Antichain<Timestamp>,
 
     /// For communicating changes to this read hold back to whoever issued it.
-    change_tx: ChangeTx<T>,
+    change_tx: ChangeTx,
 }
 
-impl<T: TimelyTimestamp> Debug for ReadHold<T> {
+impl Debug for ReadHold {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReadHold")
             .field("id", &self.id)
@@ -51,19 +54,19 @@ impl<T: TimelyTimestamp> Debug for ReadHold<T> {
 
 /// Errors for manipulating read holds.
 #[derive(Error, Debug)]
-pub enum ReadHoldDowngradeError<T> {
+pub enum ReadHoldDowngradeError {
     /// The new frontier is not beyond the current since.
     #[error("since violation: new frontier {frontier:?} is not beyond current since {since:?}")]
     SinceViolation {
         /// The frontier to downgrade to.
-        frontier: Antichain<T>,
+        frontier: Antichain<Timestamp>,
         /// The since of the collection.
-        since: Antichain<T>,
+        since: Antichain<Timestamp>,
     },
 }
 
-impl<T: TimelyTimestamp> ReadHold<T> {
-    pub fn new(id: GlobalId, since: Antichain<T>, change_tx: ChangeTx<T>) -> Self {
+impl ReadHold {
+    pub fn new(id: GlobalId, since: Antichain<Timestamp>, change_tx: ChangeTx) -> Self {
         Self {
             id,
             since,
@@ -73,8 +76,8 @@ impl<T: TimelyTimestamp> ReadHold<T> {
 
     pub fn with_channel(
         id: GlobalId,
-        since: Antichain<T>,
-        channel_tx: UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+        since: Antichain<Timestamp>,
+        channel_tx: UnboundedSender<(GlobalId, ChangeBatch<Timestamp>)>,
     ) -> Self {
         let tx = Arc::new(move |id, changes| channel_tx.send((id, changes)));
         Self::new(id, since, tx)
@@ -89,7 +92,7 @@ impl<T: TimelyTimestamp> ReadHold<T> {
     /// of the collection identified by `id`. This does not mean that the
     /// overall since of the collection is what we report here. Only that it is
     /// _at least_ held back to the reported frontier by this read hold.
-    pub fn since(&self) -> &Antichain<T> {
+    pub fn since(&self) -> &Antichain<Timestamp> {
         &self.since
     }
 
@@ -99,7 +102,7 @@ impl<T: TimelyTimestamp> ReadHold<T> {
     ///
     /// Panics when trying to merge a [ReadHold] for a different collection
     /// (different [GlobalId]).
-    pub fn merge_assign(&mut self, mut other: ReadHold<T>) {
+    pub fn merge_assign(&mut self, mut other: ReadHold) {
         assert_eq!(
             self.id, other.id,
             "can only merge ReadHolds for the same ID"
@@ -134,8 +137,8 @@ impl<T: TimelyTimestamp> ReadHold<T> {
     /// holding.
     pub fn try_downgrade(
         &mut self,
-        frontier: Antichain<T>,
-    ) -> Result<(), ReadHoldDowngradeError<T>> {
+        frontier: Antichain<Timestamp>,
+    ) -> Result<(), ReadHoldDowngradeError> {
         if PartialOrder::less_than(&frontier, &self.since) {
             return Err(ReadHoldDowngradeError::SinceViolation {
                 frontier,
@@ -164,7 +167,7 @@ impl<T: TimelyTimestamp> ReadHold<T> {
     }
 }
 
-impl<T: TimelyTimestamp> Clone for ReadHold<T> {
+impl Clone for ReadHold {
     fn clone(&self) -> Self {
         if self.id.is_user() {
             tracing::trace!("cloning ReadHold on {}: {:?}", self.id, self.since);
@@ -194,7 +197,7 @@ impl<T: TimelyTimestamp> Clone for ReadHold<T> {
     }
 }
 
-impl<T: TimelyTimestamp> Drop for ReadHold<T> {
+impl Drop for ReadHold {
     fn drop(&mut self) {
         if self.id.is_user() {
             tracing::trace!("dropping ReadHold on {}: {:?}", self.id, self.since);

--- a/src/storage-types/src/read_policy.rs
+++ b/src/storage-types/src/read_policy.rs
@@ -11,10 +11,10 @@ use std::sync::Arc;
 
 use derivative::Derivative;
 use itertools::Itertools;
-use mz_repr::TimestampManipulation;
+use mz_repr::Timestamp;
 use serde::Serialize;
+use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
-use timely::progress::{Antichain, Timestamp};
 
 /// Compaction policies for collections maintained by `Controller`.
 ///
@@ -22,13 +22,13 @@ use timely::progress::{Antichain, Timestamp};
 /// because it is fundamental to both storage and compute.
 #[derive(Clone, Derivative, Serialize)]
 #[derivative(Debug)]
-pub enum ReadPolicy<T> {
+pub enum ReadPolicy {
     /// No-one has yet requested a `ReadPolicy` from us, which means that we can
     /// still change the implied_capability/the collection since if we need
     /// to.
-    NoPolicy { initial_since: Antichain<T> },
+    NoPolicy { initial_since: Antichain<Timestamp> },
     /// Maintain the collection as valid from this frontier onward.
-    ValidFrom(Antichain<T>),
+    ValidFrom(Antichain<Timestamp>),
     /// Maintain the collection as valid from a function of the write frontier.
     ///
     /// This function will only be re-evaluated when the write frontier changes.
@@ -39,51 +39,40 @@ pub enum ReadPolicy<T> {
     LagWriteFrontier(
         #[derivative(Debug = "ignore")]
         #[serde(skip)]
-        Arc<dyn Fn(AntichainRef<T>) -> Antichain<T> + Send + Sync>,
+        Arc<dyn Fn(AntichainRef<Timestamp>) -> Antichain<Timestamp> + Send + Sync>,
     ),
     /// Allows one to express multiple read policies, taking the least of
     /// the resulting frontiers.
-    Multiple(Vec<ReadPolicy<T>>),
+    Multiple(Vec<ReadPolicy>),
 }
 
-impl<T> ReadPolicy<T>
-where
-    T: Timestamp + TimestampManipulation,
-{
+impl ReadPolicy {
     /// Creates a read policy that lags the write frontier "by one".
     pub fn step_back() -> Self {
         Self::LagWriteFrontier(Arc::new(move |upper| {
             if upper.is_empty() {
-                Antichain::from_elem(Timestamp::minimum())
+                Antichain::from_elem(Timestamp::MIN)
             } else {
                 let stepped_back = upper
                     .to_owned()
                     .into_iter()
-                    .map(|time| {
-                        if time == T::minimum() {
-                            time
-                        } else {
-                            time.step_back().unwrap()
-                        }
-                    })
+                    .map(|t| t.step_back().unwrap_or(Timestamp::MIN))
                     .collect_vec();
                 stepped_back.into()
             }
         }))
     }
-}
 
-impl ReadPolicy<mz_repr::Timestamp> {
     /// Creates a read policy that lags the write frontier by the indicated amount, rounded down to (at most) the specified value.
     /// The rounding down is done to reduce the number of changes the capability undergoes.
-    pub fn lag_writes_by(lag: mz_repr::Timestamp, max_granularity: mz_repr::Timestamp) -> Self {
+    pub fn lag_writes_by(lag: Timestamp, max_granularity: Timestamp) -> Self {
         Self::LagWriteFrontier(Arc::new(move |upper| {
             if upper.is_empty() {
-                Antichain::from_elem(Timestamp::minimum())
+                Antichain::from_elem(Timestamp::MIN)
             } else {
                 // Subtract the lag from the time, and then round down to a multiple of `granularity` to cut chatter.
                 let mut time = upper[0];
-                if lag != mz_repr::Timestamp::default() {
+                if lag != Timestamp::default() {
                     time = time.saturating_sub(lag);
                     // It makes little sense to refuse to compact if the user genuinely
                     // sets a smaller compaction window than the default, so honor it here.
@@ -94,10 +83,8 @@ impl ReadPolicy<mz_repr::Timestamp> {
             }
         }))
     }
-}
 
-impl<T: Timestamp> ReadPolicy<T> {
-    pub fn frontier(&self, write_frontier: AntichainRef<T>) -> Antichain<T> {
+    pub fn frontier(&self, write_frontier: AntichainRef<Timestamp>) -> Antichain<Timestamp> {
         match self {
             ReadPolicy::NoPolicy { initial_since } => initial_since.clone(),
             ReadPolicy::ValidFrom(frontier) => frontier.clone(),


### PR DESCRIPTION
This PR advances the effort of removing unneeded timestamp genericity from the code base. It focuses on occurrences in `mz-compute-client`, `mz-compute-types`, and `mz-storage-types`. See individual commits.