### PR TITLE
mcp: expose all RBAC-accessible views as data products without requiring indexes or comments

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -542,9 +542,10 @@ each materialized view with a refresh strategy other than `on-commit`.
 
 ## `mz_mcp_data_products`
 
-The `mz_mcp_data_products` view lists data products (i.e., indexed materialized
-views) that are available through the Model Context Protocol (MCP) server and
-that the current user can access. This is a lightweight discovery view. Use
+The `mz_mcp_data_products` view lists data products (materialized views)
+that are available through the Model Context Protocol (MCP) server and
+that the current user has SELECT access on. Indexes and comments are optional
+enrichment. This is a lightweight discovery view. Use
 [`mz_mcp_data_product_details`](#mz_mcp_data_product_details) for full column
 schema information.
 
@@ -552,8 +553,8 @@ schema information.
 | Field         | Type     | Meaning                                                                                  |
 | ------------- | -------- | ---------------------------------------------------------------------------------------- |
 | `object_name` | [`text`] | Fully qualified object name (database.schema.name).                                      |
-| `cluster`     | [`text`] | Cluster where the index is hosted.                                                       |
-| `description` | [`text`] | Index comment (used as data product description).                                        |
+| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. The object can be read from any cluster. |
+| `description` | [`text`] | Index comment if available, otherwise object comment. Used as data product description.   |
 
 ## `mz_mcp_data_product_details`
 
@@ -564,8 +565,8 @@ with a JSON Schema describing each data product's columns and types.
 | Field         | Type     | Meaning                                                                                  |
 | ------------- | -------- | ---------------------------------------------------------------------------------------- |
 | `object_name` | [`text`] | Fully qualified object name (database.schema.name).                                      |
-| `cluster`     | [`text`] | Cluster where the index is hosted.                                                       |
-| `description` | [`text`] | Index comment (used as data product description).                                        |
+| `cluster`     | [`text`] | Cluster where the object computes or its index is hosted. The object can be read from any cluster. |
+| `description` | [`text`] | Index comment if available, otherwise object comment. Used as data product description.   |
 | `schema`      | [`jsonb`]| JSON Schema describing the object's columns and types.                                   |
 
 ## `mz_object_dependencies`

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -11622,16 +11622,18 @@ FROM
 
 /// Lightweight data product discovery for MCP (Model Context Protocol).
 ///
-/// Lists indexed views with comments that the current user has privileges on.
+/// Lists materialized views that the current user has SELECT privileges on.
+/// Indexes and comments are optional enrichment — any MV accessible via RBAC
+/// appears as a data product.
 /// Used by the `get_data_products` and `read_data_product` MCP tools.
-/// Does not include schema details — use `mz_mcp_data_product_details` for that.
+/// Does not include schema details: use `mz_mcp_data_product_details` for that.
 pub static MZ_MCP_DATA_PRODUCTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
     name: "mz_mcp_data_products",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::VIEW_MZ_MCP_DATA_PRODUCTS_OID,
     desc: RelationDesc::builder()
         .with_column("object_name", SqlScalarType::String.nullable(false))
-        .with_column("cluster", SqlScalarType::String.nullable(false))
+        .with_column("cluster", SqlScalarType::String.nullable(true))
         .with_column("description", SqlScalarType::String.nullable(true))
         .with_key(vec![0, 1, 2])
         .finish(),
@@ -11640,43 +11642,49 @@ pub static MZ_MCP_DATA_PRODUCTS: LazyLock<BuiltinView> = LazyLock::new(|| Builti
             "object_name",
             "Fully qualified object name (database.schema.name).",
         ),
-        ("cluster", "Cluster where the index is hosted."),
+        (
+            "cluster",
+            "Cluster where the object computes or its index is hosted. The object can be read from any cluster.",
+        ),
         (
             "description",
-            "Index comment (used as data product description).",
+            "Index comment if available, otherwise object comment. Used as data product description.",
         ),
     ]),
     sql: r#"
 SELECT DISTINCT
     '"' || op.database || '"."' || op.schema || '"."' || op.name || '"' AS object_name,
-    c.name AS cluster,
-    cts.comment AS description
+    COALESCE(c_idx.name, c_obj.name) AS cluster,
+    COALESCE(cts_idx.comment, cts_obj.comment) AS description
 FROM mz_internal.mz_show_my_object_privileges op
 JOIN mz_objects o ON op.name = o.name AND op.object_type = o.type
 JOIN mz_schemas s ON s.name = op.schema AND s.id = o.schema_id
 JOIN mz_databases d ON d.name = op.database AND d.id = s.database_id
-JOIN mz_indexes i ON i.on_id = o.id
-JOIN mz_clusters c ON c.id = i.cluster_id
-JOIN mz_internal.mz_show_my_cluster_privileges cp ON cp.name = c.name
-LEFT JOIN mz_internal.mz_comments cts ON cts.id = i.id AND cts.object_sub_id IS NULL
+LEFT JOIN mz_indexes i ON i.on_id = o.id
+LEFT JOIN mz_clusters c_idx ON c_idx.id = i.cluster_id
+LEFT JOIN mz_clusters c_obj ON c_obj.id = o.cluster_id
+LEFT JOIN mz_internal.mz_comments cts_idx ON cts_idx.id = i.id AND cts_idx.object_sub_id IS NULL
+LEFT JOIN mz_internal.mz_comments cts_obj ON cts_obj.id = o.id AND cts_obj.object_sub_id IS NULL
 WHERE op.privilege_type = 'SELECT'
-  AND cp.privilege_type = 'USAGE'
+  AND o.type = 'materialized-view'
+  AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
 "#,
     access: vec![PUBLIC_SELECT],
 });
 
 /// Full data product details with JSON Schema for MCP agents.
 ///
-/// Extends `mz_mcp_data_products` with column types, index keys, and column
-/// comments, formatted as a JSON Schema object. Used by the
-/// `get_data_product_details` MCP tool.
+/// Extends `mz_mcp_data_products` with column types, index keys (when
+/// available), and column comments, formatted as a JSON Schema object.
+/// Used by the `get_data_product_details` MCP tool. Indexes and comments
+/// are optional enrichment.
 pub static MZ_MCP_DATA_PRODUCT_DETAILS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
     name: "mz_mcp_data_product_details",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::VIEW_MZ_MCP_DATA_PRODUCT_DETAILS_OID,
     desc: RelationDesc::builder()
         .with_column("object_name", SqlScalarType::String.nullable(false))
-        .with_column("cluster", SqlScalarType::String.nullable(false))
+        .with_column("cluster", SqlScalarType::String.nullable(true))
         .with_column("description", SqlScalarType::String.nullable(true))
         .with_column("schema", SqlScalarType::Jsonb.nullable(false))
         .with_key(vec![0, 1, 2])
@@ -11686,10 +11694,13 @@ pub static MZ_MCP_DATA_PRODUCT_DETAILS: LazyLock<BuiltinView> = LazyLock::new(||
             "object_name",
             "Fully qualified object name (database.schema.name).",
         ),
-        ("cluster", "Cluster where the index is hosted."),
+        (
+            "cluster",
+            "Cluster where the object computes or its index is hosted. The object can be read from any cluster.",
+        ),
         (
             "description",
-            "Index comment (used as data product description).",
+            "Index comment if available, otherwise object comment. Used as data product description.",
         ),
         (
             "schema",
@@ -11700,8 +11711,8 @@ pub static MZ_MCP_DATA_PRODUCT_DETAILS: LazyLock<BuiltinView> = LazyLock::new(||
 SELECT * FROM (
     SELECT
         '"' || op.database || '"."' || op.schema || '"."' || op.name || '"' AS object_name,
-        c.name AS cluster,
-        cts.comment AS description,
+        COALESCE(c_idx.name, c_obj.name) AS cluster,
+        COALESCE(cts_idx.comment, cts_obj.comment) AS description,
         COALESCE(jsonb_build_object(
         'type', 'object',
         'required', jsonb_agg(distinct ccol.name) FILTER (WHERE ccol.position = ic.on_position),
@@ -11761,15 +11772,17 @@ FROM mz_internal.mz_show_my_object_privileges op
 JOIN mz_objects o ON op.name = o.name AND op.object_type = o.type
 JOIN mz_schemas s ON s.name = op.schema AND s.id = o.schema_id
 JOIN mz_databases d ON d.name = op.database AND d.id = s.database_id
-JOIN mz_indexes i ON i.on_id = o.id
-JOIN mz_index_columns ic ON i.id = ic.index_id
 JOIN mz_columns ccol ON ccol.id = o.id
-JOIN mz_clusters c ON c.id = i.cluster_id
-JOIN mz_internal.mz_show_my_cluster_privileges cp ON cp.name = c.name
-LEFT JOIN mz_internal.mz_comments cts ON cts.id = i.id AND cts.object_sub_id IS NULL
+LEFT JOIN mz_indexes i ON i.on_id = o.id
+LEFT JOIN mz_index_columns ic ON i.id = ic.index_id
+LEFT JOIN mz_clusters c_idx ON c_idx.id = i.cluster_id
+LEFT JOIN mz_clusters c_obj ON c_obj.id = o.cluster_id
+LEFT JOIN mz_internal.mz_comments cts_idx ON cts_idx.id = i.id AND cts_idx.object_sub_id IS NULL
+LEFT JOIN mz_internal.mz_comments cts_obj ON cts_obj.id = o.id AND cts_obj.object_sub_id IS NULL
 LEFT JOIN mz_internal.mz_comments cts_col ON cts_col.id = o.id AND cts_col.object_sub_id = ccol.position
 WHERE op.privilege_type = 'SELECT'
-  AND cp.privilege_type = 'USAGE'
+  AND o.type = 'materialized-view'
+  AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
 GROUP BY 1, 2, 3
 )
 "#,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5144,10 +5144,10 @@ fn test_mcp_agent_with_data_product() {
             ))
             .unwrap();
 
-        // Create a view and an index on it.
+        // Create a materialized view and an index on it.
         super_user
             .batch_execute(
-                "CREATE VIEW test_products AS SELECT 1::int AS id, 'widget'::text AS name",
+                "CREATE MATERIALIZED VIEW test_products IN CLUSTER quickstart AS SELECT 1::int AS id, 'widget'::text AS name",
             )
             .unwrap();
         super_user
@@ -5155,7 +5155,7 @@ fn test_mcp_agent_with_data_product() {
                 "CREATE INDEX test_products_idx IN CLUSTER quickstart ON test_products (id)",
             )
             .unwrap();
-        // Comment on the index makes it show up as a data product.
+        // Comment on the index enriches the data product description.
         super_user
             .batch_execute("COMMENT ON INDEX test_products_idx IS 'A test data product for integration testing'")
             .unwrap();
@@ -5477,11 +5477,9 @@ fn test_mcp_agent_runtime_flag_toggle() {
     );
 }
 
-/// Tests that the MCP agent endpoint respects RBAC: data products are only visible
-/// to users with both SELECT on the view and USAGE on the cluster.
-///
-/// The `mz_mcp_data_products` view joins `mz_show_my_object_privileges` (SELECT) and
-/// `mz_show_my_cluster_privileges` (USAGE) — both must be satisfied for a product to appear.
+/// Tests that the MCP agent endpoint respects RBAC: data products are visible
+/// to any user with SELECT on the view. Cluster USAGE is not required for
+/// discovery — the view appears with a NULL cluster if no accessible index exists.
 #[mz_ore::test]
 fn test_mcp_agent_rbac() {
     let server = test_util::TestHarness::default()
@@ -5521,18 +5519,9 @@ fn test_mcp_agent_rbac() {
         ))
         .unwrap();
 
-    // Create a dedicated cluster with no PUBLIC USAGE grant so we can control
-    // USAGE precisely (quickstart grants USAGE to PUBLIC by default).
+    // Create a data product: a materialized view (no index or comment required).
     super_user
-        .batch_execute("CREATE CLUSTER rbac_cluster REPLICAS (r1 (SIZE 'scale=1,workers=1'))")
-        .unwrap();
-
-    // Create a data product: view + index on the dedicated cluster.
-    super_user
-        .batch_execute("CREATE VIEW rbac_product AS SELECT 1::int AS id, 'secret'::text AS payload")
-        .unwrap();
-    super_user
-        .batch_execute("CREATE INDEX rbac_product_idx IN CLUSTER rbac_cluster ON rbac_product (id)")
+        .batch_execute("CREATE MATERIALIZED VIEW rbac_product IN CLUSTER quickstart AS SELECT 1::int AS id, 'secret'::text AS payload")
         .unwrap();
 
     let get_products = serde_json::json!({
@@ -5560,7 +5549,7 @@ fn test_mcp_agent_rbac() {
             .unwrap_or(false)
     };
 
-    // 1. No SELECT, no USAGE → product NOT visible.
+    // 1. No SELECT → product NOT visible.
     let (status, body) = mcp_post(&agents_url, get_products.clone());
     assert_eq!(status, StatusCode::OK);
     assert!(
@@ -5568,7 +5557,7 @@ fn test_mcp_agent_rbac() {
         "product should not be visible with no privileges"
     );
 
-    // 2. Grant SELECT on view only (no cluster USAGE) → still NOT visible.
+    // 2. Grant SELECT on view → product NOW visible (no index or cluster USAGE needed).
     super_user
         .batch_execute(&format!(
             "GRANT SELECT ON rbac_product TO {}",
@@ -5578,22 +5567,8 @@ fn test_mcp_agent_rbac() {
     let (status, body) = mcp_post(&agents_url, get_products.clone());
     assert_eq!(status, StatusCode::OK);
     assert!(
-        !products_visible(&body),
-        "product should not be visible with SELECT but no cluster USAGE"
-    );
-
-    // 3. Also grant USAGE on rbac_cluster → product NOW visible.
-    super_user
-        .batch_execute(&format!(
-            "GRANT USAGE ON CLUSTER rbac_cluster TO {}",
-            &HTTP_DEFAULT_USER.name
-        ))
-        .unwrap();
-    let (status, body) = mcp_post(&agents_url, get_products.clone());
-    assert_eq!(status, StatusCode::OK);
-    assert!(
         products_visible(&body),
-        "product should be visible with both SELECT and cluster USAGE"
+        "product should be visible with just SELECT (no index required)"
     );
 
     // Capture the fully-qualified product name for subsequent tests.
@@ -5615,7 +5590,7 @@ fn test_mcp_agent_rbac() {
         .unwrap()
         .to_string();
 
-    // 4. Revoke SELECT → product disappears.
+    // 3. Revoke SELECT → product disappears.
     super_user
         .batch_execute(&format!(
             "REVOKE SELECT ON rbac_product FROM {}",
@@ -5629,9 +5604,7 @@ fn test_mcp_agent_rbac() {
         "product should disappear after revoking SELECT"
     );
 
-    // 5. read_data_product by name while lacking SELECT → DataProductNotFound.
-    //    The query fails with a privilege error, which is translated into
-    //    DataProductNotFound so callers get a clean, actionable message.
+    // 4. read_data_product by name while lacking SELECT → DataProductNotFound.
     let (status, body) = mcp_post(
         &agents_url,
         serde_json::json!({
@@ -5650,7 +5623,7 @@ fn test_mcp_agent_rbac() {
         "read_data_product should fail with not-found when SELECT is revoked"
     );
 
-    // 6. Re-grant SELECT → visible again.
+    // 5. Re-grant SELECT → visible again.
     super_user
         .batch_execute(&format!(
             "GRANT SELECT ON rbac_product TO {}",
@@ -5662,39 +5635,6 @@ fn test_mcp_agent_rbac() {
     assert!(
         products_visible(&body),
         "product should reappear after re-granting SELECT"
-    );
-
-    // 7. Revoke cluster USAGE → product disappears again.
-    super_user
-        .batch_execute(&format!(
-            "REVOKE USAGE ON CLUSTER rbac_cluster FROM {}",
-            &HTTP_DEFAULT_USER.name
-        ))
-        .unwrap();
-    let (status, body) = mcp_post(&agents_url, get_products.clone());
-    assert_eq!(status, StatusCode::OK);
-    assert!(
-        !products_visible(&body),
-        "product should disappear after revoking cluster USAGE"
-    );
-
-    // 8. get_data_product_details by name while invisible → DataProductNotFound.
-    let (status, body) = mcp_post(
-        &agents_url,
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {"name": "get_data_product_details", "arguments": {"name": product_name}}
-        }),
-    );
-    assert_eq!(status, StatusCode::OK);
-    assert!(
-        body["error"]["message"]
-            .as_str()
-            .unwrap_or("")
-            .contains("Data product not found"),
-        "get_data_product_details should fail with not-found when cluster USAGE is revoked"
     );
 }
 

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -317,15 +317,15 @@ query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_mcp_data_products' ORDER BY position
 ----
 object_name  text  Fully␠qualified␠object␠name␠(database.schema.name).
-cluster  text  Cluster␠where␠the␠index␠is␠hosted.
-description  text  Index␠comment␠(used␠as␠data␠product␠description).
+cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠The␠object␠can␠be␠read␠from␠any␠cluster.
+description  text  Index␠comment␠if␠available,␠otherwise␠object␠comment.␠Used␠as␠data␠product␠description.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_mcp_data_product_details' ORDER BY position
 ----
 object_name  text  Fully␠qualified␠object␠name␠(database.schema.name).
-cluster  text  Cluster␠where␠the␠index␠is␠hosted.
-description  text  Index␠comment␠(used␠as␠data␠product␠description).
+cluster  text  Cluster␠where␠the␠object␠computes␠or␠its␠index␠is␠hosted.␠The␠object␠can␠be␠read␠from␠any␠cluster.
+description  text  Index␠comment␠if␠available,␠otherwise␠object␠comment.␠Used␠as␠data␠product␠description.
 schema  jsonb  JSON␠Schema␠describing␠the␠object's␠columns␠and␠types.
 
 query TTT


### PR DESCRIPTION
Fixes: https://linear.app/materializeinc/issue/DEX-23/mcp-agent-expose-all-rbac-accessible-views-as-data-products-without