### PR TITLE
terraform: bump Kubernetes version to 1.34 in AWS and Azure test configs

### DIFF
--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -31,7 +31,7 @@ module "eks" {
   source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=main"
 
   name_prefix                              = var.name_prefix
-  cluster_version                          = "1.32"
+  cluster_version                          = "1.34"
   vpc_id                                   = module.networking.vpc_id
   private_subnet_ids                       = module.networking.private_subnet_ids
   cluster_enabled_log_types                = ["api", "audit"]

--- a/test/terraform/aws-upgrade/main.tf
+++ b/test/terraform/aws-upgrade/main.tf
@@ -31,7 +31,7 @@ module "eks" {
   source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=main"
 
   name_prefix                              = var.name_prefix
-  cluster_version                          = "1.32"
+  cluster_version                          = "1.34"
   vpc_id                                   = module.networking.vpc_id
   private_subnet_ids                       = module.networking.private_subnet_ids
   cluster_enabled_log_types                = ["api", "audit"]

--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -21,7 +21,7 @@ locals {
   }
 
   aks_config = {
-    kubernetes_version         = "1.32"
+    kubernetes_version         = "1.34"
     service_cidr               = "20.1.0.0/16"
     enable_azure_monitor       = false
     log_analytics_workspace_id = null


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/materialize-terraform-self-managed/issues/191

As per this PR here too: https://github.com/MaterializeInc/materialize-terraform-self-managed/pull/180