### PR TITLE
adapter: Convert many recoverable panics to query errors

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -34,7 +34,8 @@ use crate::ast::{AstInfo, Ident, OrderByExpr, Query, UnresolvedItemName, Value};
 /// inappropriate type, like `WHERE 1` or `SELECT 1=1`, as necessary.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Expr<T: AstInfo> {
-    /// Identifier e.g. table name or column name
+    /// Identifier e.g. table name or column name. The parser always
+    /// constructs this with a non-empty `Vec`.
     Identifier(Vec<Ident>),
     /// Qualified wildcard, e.g. `alias.*` or `schema.table.*`.
     QualifiedWildcard(Vec<Ident>),

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -109,6 +109,12 @@ macro_rules! bail_never_supported {
     };
 }
 
+macro_rules! bail_internal {
+    ($($e:expr),* $(,)?) => {
+        return Err(crate::plan::error::PlanError::Internal(format!($($e),*)).into())
+    }
+}
+
 // TODO(benesch): delete these macros once we use structured errors everywhere.
 macro_rules! sql_bail {
     ($($e:expr),* $(,)?) => {

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -109,9 +109,21 @@ macro_rules! bail_never_supported {
     };
 }
 
+/// Returns a `PlanError::Internal` from the current function. Prefer this over
+/// `sql_bail!` whenever the situation reflects a Materialize bug rather than a
+/// user error (e.g., an invariant that is supposed to be enforced by the
+/// parser, name resolution, or purification).
 macro_rules! bail_internal {
     ($($e:expr),* $(,)?) => {
         return Err(crate::plan::error::PlanError::Internal(format!($($e),*)).into())
+    }
+}
+
+/// Constructs a `PlanError::Internal`. Prefer this over `sql_err!` whenever the
+/// situation reflects a Materialize bug rather than a user error.
+macro_rules! internal_err {
+    ($($e:expr),* $(,)?) => {
+        crate::plan::error::PlanError::Internal(format!($($e),*))
     }
 }
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -474,7 +474,7 @@ pub fn create_statement(
                 .retain(|o| o.name != mz_sql_parser::ast::CreateConnectionOptionName::Validate);
         }
 
-        _ => unreachable!(),
+        _ => sql_bail!("unexpected statement type for normalization"),
     }
 
     Ok(stmt.to_ast_string_stable())

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -474,7 +474,7 @@ pub fn create_statement(
                 .retain(|o| o.name != mz_sql_parser::ast::CreateConnectionOptionName::Validate);
         }
 
-        _ => sql_bail!("unexpected statement type for normalization"),
+        _ => bail_internal!("unexpected statement type for normalization"),
     }
 
     Ok(stmt.to_ast_string_stable())

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -306,6 +306,7 @@ pub enum PlanError {
     UntilReadyTimeoutRequired,
     SubsourceResolutionError(ExternalReferenceResolutionError),
     Replan(String),
+    Internal(String),
     NetworkPolicyLockoutError,
     NetworkPolicyInUse,
     /// Expected a constant expression that evaluates without an error to a non-null value.
@@ -868,6 +869,7 @@ impl fmt::Display for PlanError {
             },
             Self::SubsourceResolutionError(e) => write!(f, "{}", e),
             Self::Replan(msg) => write!(f, "internal error while replanning, please contact support: {msg}"),
+            Self::Internal(msg) => write!(f, "internal error: {msg}"),
             Self::NetworkPolicyLockoutError => write!(f, "policy would block current session IP"),
             Self::NetworkPolicyInUse => write!(f, "network policy is currently in use"),
             Self::UntilReadyTimeoutRequired => {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2015,7 +2015,7 @@ fn plan_set_expr(
             ) -> Result<(HirRelationExpr, Scope), PlanError> {
                 let rows = vec![plan.row.iter().collect::<Vec<_>>()];
                 let desc = desc.relation_desc.ok_or_else(|| {
-                    sql_err!("internal error: statement description missing relation descriptor")
+                    PlanError::Internal("statement description missing relation descriptor".into())
                 })?;
                 let scope = Scope::from_source(None, desc.iter_names());
                 let expr = HirRelationExpr::constant(rows, desc.into_typ());
@@ -4100,24 +4100,24 @@ fn plan_expr_inner<'a>(
         Expr::MapSubquery(query) => plan_map_subquery(ecx, query),
         Expr::ArraySubquery(query) => plan_array_subquery(ecx, query),
         Expr::Collate { expr, collation } => plan_collate(ecx, expr, collation),
-        Expr::Nested(_) => sql_bail!("internal error: Expr::Nested should have been desugared"),
+        Expr::Nested(_) => bail_internal!("Expr::Nested should have been desugared"),
         Expr::InSubquery { .. } => {
-            sql_bail!("internal error: Expr::InSubquery should have been desugared")
+            bail_internal!("Expr::InSubquery should have been desugared")
         }
         Expr::AnyExpr { .. } => {
-            sql_bail!("internal error: Expr::AnyExpr should have been desugared")
+            bail_internal!("Expr::AnyExpr should have been desugared")
         }
         Expr::AllExpr { .. } => {
-            sql_bail!("internal error: Expr::AllExpr should have been desugared")
+            bail_internal!("Expr::AllExpr should have been desugared")
         }
         Expr::AnySubquery { .. } => {
-            sql_bail!("internal error: Expr::AnySubquery should have been desugared")
+            bail_internal!("Expr::AnySubquery should have been desugared")
         }
         Expr::AllSubquery { .. } => {
-            sql_bail!("internal error: Expr::AllSubquery should have been desugared")
+            bail_internal!("Expr::AllSubquery should have been desugared")
         }
         Expr::Between { .. } => {
-            sql_bail!("internal error: Expr::Between should have been desugared")
+            bail_internal!("Expr::Between should have been desugared")
         }
     }
 }
@@ -5176,7 +5176,7 @@ fn plan_aggregate_common(
 
     let impls = match resolve_func(ecx, name, args)? {
         Func::Aggregate(impls) => impls,
-        _ => sql_bail!("internal error: plan_aggregate_common called on non-aggregate function"),
+        _ => bail_internal!("plan_aggregate_common called on non-aggregate function"),
     };
 
     // We follow PostgreSQL's rule here for mapping `count(*)` into the
@@ -5268,7 +5268,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, 
     let col_name = normalize::column_name(
         names
             .pop()
-            .ok_or_else(|| sql_err!("internal error: empty identifier"))?,
+            .ok_or_else(|| PlanError::Internal("empty identifier".into()))?,
     );
 
     // If the name is qualified, it must refer to a column in a table.
@@ -5549,7 +5549,7 @@ fn plan_function<'a>(
     };
 
     if over.is_some() {
-        sql_bail!("internal error: OVER clause should have been handled");
+        bail_internal!("OVER clause should have been handled by the window function path above");
     }
 
     if *distinct {
@@ -6037,7 +6037,7 @@ pub fn scalar_type_from_sql(
         ResolvedDataType::Named { id, modifiers, .. } => {
             scalar_type_from_catalog(scx.catalog, *id, modifiers)
         }
-        ResolvedDataType::Error => sql_bail!("internal error: unresolved data type"),
+        ResolvedDataType::Error => bail_internal!("should have been caught in name resolution"),
     }
 }
 
@@ -6633,7 +6633,7 @@ impl<'a> QueryContext<'a> {
 
                 Ok((expr, scope))
             }
-            ResolvedItemName::Error => sql_bail!("internal error: unresolved item name"),
+            ResolvedItemName::Error => bail_internal!("should have been caught in name resolution"),
         }
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2015,7 +2015,7 @@ fn plan_set_expr(
             ) -> Result<(HirRelationExpr, Scope), PlanError> {
                 let rows = vec![plan.row.iter().collect::<Vec<_>>()];
                 let desc = desc.relation_desc.ok_or_else(|| {
-                    PlanError::Internal("statement description missing relation descriptor".into())
+                    internal_err!("statement description missing relation descriptor")
                 })?;
                 let scope = Scope::from_source(None, desc.iter_names());
                 let expr = HirRelationExpr::constant(rows, desc.into_typ());

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3493,7 +3493,7 @@ fn invent_column_name(
     ecx: &ExprContext,
     expr: &Expr<Aug>,
     table_func_names: &BTreeMap<String, Ident>,
-) -> Option<ColumnName> {
+) -> Result<Option<ColumnName>, PlanError> {
     // We follow PostgreSQL exactly here, which has some complicated rules
     // around "high" and "low" quality names. Low quality names override other
     // low quality names but not high quality names.
@@ -3510,15 +3510,15 @@ fn invent_column_name(
         ecx: &ExprContext,
         expr: &Expr<Aug>,
         table_func_names: &BTreeMap<String, Ident>,
-    ) -> Option<(ColumnName, NameQuality)> {
-        match expr {
+    ) -> Result<Option<(ColumnName, NameQuality)>, PlanError> {
+        Ok(match expr {
             Expr::Identifier(names) => {
                 if let [name] = names.as_slice() {
                     if let Some(table_func_name) = table_func_names.get(name.as_str()) {
-                        return Some((
+                        return Ok(Some((
                             normalize::column_name(table_func_name.clone()),
                             NameQuality::High,
-                        ));
+                        )));
                     }
                 }
                 names
@@ -3539,7 +3539,11 @@ fn invent_column_name(
                         full_name,
                         ..
                     } => (&qualifiers.schema_spec, full_name.item.clone()),
-                    _ => return None,
+                    // Name resolution should have rejected anything other than
+                    // `Item` for a function call.
+                    _ => {
+                        bail_internal!("function name did not resolve to an item: {:?}", func.name)
+                    }
                 };
 
                 if schema == &SchemaSpecifier::from(ecx.qcx.scx.catalog.get_mz_internal_schema_id())
@@ -3559,15 +3563,16 @@ fn invent_column_name(
             Expr::Array { .. } => Some(("array".into(), NameQuality::High)),
             Expr::List { .. } => Some(("list".into(), NameQuality::High)),
             Expr::Map { .. } | Expr::MapSubquery(_) => Some(("map".into(), NameQuality::High)),
-            Expr::Cast { expr, data_type } => match invent(ecx, expr, table_func_names) {
+            Expr::Cast { expr, data_type } => match invent(ecx, expr, table_func_names)? {
                 Some((name, NameQuality::High)) => Some((name, NameQuality::High)),
                 _ => Some((data_type.unqualified_item_name().into(), NameQuality::Low)),
             },
             Expr::Case { else_result, .. } => {
-                match else_result
-                    .as_ref()
-                    .and_then(|else_result| invent(ecx, else_result, table_func_names))
-                {
+                let inner = match else_result.as_ref() {
+                    Some(else_result) => invent(ecx, else_result, table_func_names)?,
+                    None => None,
+                };
+                match inner {
                     Some((name, NameQuality::High)) => Some((name, NameQuality::High)),
                     _ => Some(("case".into(), NameQuality::Low)),
                 }
@@ -3576,13 +3581,19 @@ fn invent_column_name(
                 Some((normalize::column_name(field.clone()), NameQuality::High))
             }
             Expr::Exists { .. } => Some(("exists".into(), NameQuality::High)),
-            Expr::Subscript { expr, .. } => invent(ecx, expr, table_func_names),
+            Expr::Subscript { expr, .. } => invent(ecx, expr, table_func_names)?,
             Expr::Subquery(query) | Expr::ListSubquery(query) | Expr::ArraySubquery(query) => {
                 // A bit silly to have to plan the query here just to get its column
                 // name, since we throw away the planned expression, but fixing this
                 // requires a separate semantic analysis phase.
-                let (_expr, scope) =
-                    plan_nested_query(&mut ecx.derived_query_context(), query).ok()?;
+                //
+                // We deliberately swallow planning errors here: if the subquery
+                // doesn't plan, we just don't invent a name for it; the real
+                // planning attempt elsewhere will surface the error.
+                let Ok((_expr, scope)) = plan_nested_query(&mut ecx.derived_query_context(), query)
+                else {
+                    return Ok(None);
+                };
                 scope
                     .items
                     .first()
@@ -3590,10 +3601,10 @@ fn invent_column_name(
             }
             Expr::Row { .. } => Some(("row".into(), NameQuality::High)),
             _ => None,
-        }
+        })
     }
 
-    invent(ecx, expr, table_func_names).map(|(name, _quality)| name)
+    Ok(invent(ecx, expr, table_func_names)?.map(|(name, _quality)| name))
 }
 
 #[derive(Debug)]
@@ -3712,11 +3723,11 @@ fn expand_select_item<'a>(
             Ok(items)
         }
         SelectItem::Expr { expr, alias } => {
-            let name = alias
-                .clone()
-                .map(normalize::column_name)
-                .or_else(|| invent_column_name(ecx, expr, table_func_names))
-                .unwrap_or_else(|| UNKNOWN_COLUMN_NAME.into());
+            let name = match alias.clone().map(normalize::column_name) {
+                Some(name) => name,
+                None => invent_column_name(ecx, expr, table_func_names)?
+                    .unwrap_or_else(|| UNKNOWN_COLUMN_NAME.into()),
+            };
             Ok(vec![(ExpandedSelectItem::Expr(Cow::Borrowed(expr)), name)])
         }
     }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5282,11 +5282,12 @@ fn plan_aggregate_common(
 
 fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, PlanError> {
     let mut names = names.to_vec();
-    let col_name = normalize::column_name(
-        names
-            .pop()
-            .ok_or_else(|| PlanError::Internal("empty identifier".into()))?,
-    );
+    // The parser guarantees that an `Expr::Identifier` is constructed with a
+    // non-empty list of name parts, so an empty list here is an internal bug.
+    let Some(last) = names.pop() else {
+        bail_internal!("empty identifier");
+    };
+    let col_name = normalize::column_name(last);
 
     // If the name is qualified, it must refer to a column in a table.
     if !names.is_empty() {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -241,7 +241,9 @@ pub fn plan_insert_query(
             table_name.full_name_str()
         );
     }
-    let desc = table.relation_desc().expect("table has desc");
+    let desc = table
+        .relation_desc()
+        .ok_or_else(|| sql_err!("item does not have a relation description"))?;
     let mut defaults = table
         .writable_table_details()
         .ok_or_else(|| {
@@ -633,7 +635,9 @@ pub fn plan_copy_from_rows(
         transform_ast::transform(&scx, default)?;
     }
 
-    let desc = table.relation_desc().expect("table has desc");
+    let desc = table
+        .relation_desc()
+        .ok_or_else(|| sql_err!("item does not have a relation description"))?;
     let column_types = columns
         .iter()
         .map(|x| desc.get_type(x).clone())
@@ -2010,7 +2014,9 @@ fn plan_set_expr(
                 desc: StatementDesc,
             ) -> Result<(HirRelationExpr, Scope), PlanError> {
                 let rows = vec![plan.row.iter().collect::<Vec<_>>()];
-                let desc = desc.relation_desc.expect("must exist");
+                let desc = desc.relation_desc.ok_or_else(|| {
+                    sql_err!("internal error: statement description missing relation descriptor")
+                })?;
                 let scope = Scope::from_source(None, desc.iter_names());
                 let expr = HirRelationExpr::constant(rows, desc.into_typ());
                 Ok((expr, scope))
@@ -3533,7 +3539,7 @@ fn invent_column_name(
                         full_name,
                         ..
                     } => (&qualifiers.schema_spec, full_name.item.clone()),
-                    _ => unreachable!(),
+                    _ => return None,
                 };
 
                 if schema == &SchemaSpecifier::from(ecx.qcx.scx.catalog.get_mz_internal_schema_id())
@@ -4094,13 +4100,25 @@ fn plan_expr_inner<'a>(
         Expr::MapSubquery(query) => plan_map_subquery(ecx, query),
         Expr::ArraySubquery(query) => plan_array_subquery(ecx, query),
         Expr::Collate { expr, collation } => plan_collate(ecx, expr, collation),
-        Expr::Nested(_) => unreachable!("Expr::Nested not desugared"),
-        Expr::InSubquery { .. } => unreachable!("Expr::InSubquery not desugared"),
-        Expr::AnyExpr { .. } => unreachable!("Expr::AnyExpr not desugared"),
-        Expr::AllExpr { .. } => unreachable!("Expr::AllExpr not desugared"),
-        Expr::AnySubquery { .. } => unreachable!("Expr::AnySubquery not desugared"),
-        Expr::AllSubquery { .. } => unreachable!("Expr::AllSubquery not desugared"),
-        Expr::Between { .. } => unreachable!("Expr::Between not desugared"),
+        Expr::Nested(_) => sql_bail!("internal error: Expr::Nested should have been desugared"),
+        Expr::InSubquery { .. } => {
+            sql_bail!("internal error: Expr::InSubquery should have been desugared")
+        }
+        Expr::AnyExpr { .. } => {
+            sql_bail!("internal error: Expr::AnyExpr should have been desugared")
+        }
+        Expr::AllExpr { .. } => {
+            sql_bail!("internal error: Expr::AllExpr should have been desugared")
+        }
+        Expr::AnySubquery { .. } => {
+            sql_bail!("internal error: Expr::AnySubquery should have been desugared")
+        }
+        Expr::AllSubquery { .. } => {
+            sql_bail!("internal error: Expr::AllSubquery should have been desugared")
+        }
+        Expr::Between { .. } => {
+            sql_bail!("internal error: Expr::Between should have been desugared")
+        }
     }
 }
 
@@ -5158,7 +5176,7 @@ fn plan_aggregate_common(
 
     let impls = match resolve_func(ecx, name, args)? {
         Func::Aggregate(impls) => impls,
-        _ => unreachable!("plan_aggregate_common called on non-aggregate function,"),
+        _ => sql_bail!("internal error: plan_aggregate_common called on non-aggregate function"),
     };
 
     // We follow PostgreSQL's rule here for mapping `count(*)` into the
@@ -5178,7 +5196,8 @@ fn plan_aggregate_common(
                     ecx.qcx
                         .scx
                         .humanize_resolved_name(name)
-                        .expect("name actually resolved")
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|_| "<unknown>".into())
                 );
             }
             let args = plan_exprs(ecx, args)?;
@@ -5246,7 +5265,11 @@ fn plan_aggregate_common(
 
 fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, PlanError> {
     let mut names = names.to_vec();
-    let col_name = normalize::column_name(names.pop().unwrap());
+    let col_name = normalize::column_name(
+        names
+            .pop()
+            .ok_or_else(|| sql_err!("internal error: empty identifier"))?,
+    );
 
     // If the name is qualified, it must refer to a column in a table.
     if !names.is_empty() {
@@ -5526,7 +5549,7 @@ fn plan_function<'a>(
     };
 
     if over.is_some() {
-        unreachable!("If there is an OVER clause, we should have returned already above.");
+        sql_bail!("internal error: OVER clause should have been handled");
     }
 
     if *distinct {
@@ -5535,7 +5558,8 @@ fn plan_function<'a>(
             ecx.qcx
                 .scx
                 .humanize_resolved_name(name)
-                .expect("already resolved")
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "<unknown>".into())
         );
     }
     if filter.is_some() {
@@ -5544,7 +5568,8 @@ fn plan_function<'a>(
             ecx.qcx
                 .scx
                 .humanize_resolved_name(name)
-                .expect("already resolved")
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "<unknown>".into())
         );
     }
 
@@ -5555,7 +5580,8 @@ fn plan_function<'a>(
                 ecx.qcx
                     .scx
                     .humanize_resolved_name(name)
-                    .expect("already resolved")
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|_| "<unknown>".into())
             )
         }
         FunctionArgs::Args { args, order_by } => {
@@ -5565,7 +5591,8 @@ fn plan_function<'a>(
                     ecx.qcx
                         .scx
                         .humanize_resolved_name(name)
-                        .expect("already resolved")
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|_| "<unknown>".into())
                 );
             }
             plan_exprs(ecx, args)?
@@ -6010,7 +6037,7 @@ pub fn scalar_type_from_sql(
         ResolvedDataType::Named { id, modifiers, .. } => {
             scalar_type_from_catalog(scx.catalog, *id, modifiers)
         }
-        ResolvedDataType::Error => unreachable!("should have been caught in name resolution"),
+        ResolvedDataType::Error => sql_bail!("internal error: unresolved data type"),
     }
 }
 
@@ -6606,7 +6633,7 @@ impl<'a> QueryContext<'a> {
 
                 Ok((expr, scope))
             }
-            ResolvedItemName::Error => unreachable!("should have been caught in name resolution"),
+            ResolvedItemName::Error => sql_bail!("internal error: unresolved item name"),
         }
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5149,6 +5149,16 @@ fn plan_function_order_by(
     Ok((order_by_exprs, col_orders))
 }
 
+/// Returns a human-readable rendering of `name`, falling back to a debug
+/// dump of the `ResolvedItemName` if humanization fails. Used to construct
+/// user-facing error messages on already-failing paths, where we'd rather
+/// surface the raw resolved name than emit a useless `<unknown>` placeholder.
+fn humanize_or_debug(scx: &StatementContext, name: &ResolvedItemName) -> String {
+    scx.humanize_resolved_name(name)
+        .map(|n| n.to_string())
+        .unwrap_or_else(|_| format!("<error when trying to humanize `{name:?}`>"))
+}
+
 /// Common part of the planning of windowed and non-windowed aggregation functions.
 fn plan_aggregate_common(
     ecx: &ExprContext,
@@ -5193,11 +5203,7 @@ fn plan_aggregate_common(
             if args.is_empty() {
                 sql_bail!(
                     "{}(*) must be used to call a parameterless aggregate function",
-                    ecx.qcx
-                        .scx
-                        .humanize_resolved_name(name)
-                        .map(|n| n.to_string())
-                        .unwrap_or_else(|_| "<unknown>".into())
+                    humanize_or_debug(ecx.qcx.scx, name)
                 );
             }
             let args = plan_exprs(ecx, args)?;
@@ -5555,21 +5561,13 @@ fn plan_function<'a>(
     if *distinct {
         sql_bail!(
             "DISTINCT specified, but {} is not an aggregate function",
-            ecx.qcx
-                .scx
-                .humanize_resolved_name(name)
-                .map(|n| n.to_string())
-                .unwrap_or_else(|_| "<unknown>".into())
+            humanize_or_debug(ecx.qcx.scx, name)
         );
     }
     if filter.is_some() {
         sql_bail!(
             "FILTER specified, but {} is not an aggregate function",
-            ecx.qcx
-                .scx
-                .humanize_resolved_name(name)
-                .map(|n| n.to_string())
-                .unwrap_or_else(|_| "<unknown>".into())
+            humanize_or_debug(ecx.qcx.scx, name)
         );
     }
 
@@ -5577,22 +5575,14 @@ fn plan_function<'a>(
         FunctionArgs::Star => {
             sql_bail!(
                 "* argument is invalid with non-aggregate function {}",
-                ecx.qcx
-                    .scx
-                    .humanize_resolved_name(name)
-                    .map(|n| n.to_string())
-                    .unwrap_or_else(|_| "<unknown>".into())
+                humanize_or_debug(ecx.qcx.scx, name)
             )
         }
         FunctionArgs::Args { args, order_by } => {
             if !order_by.is_empty() {
                 sql_bail!(
                     "ORDER BY specified, but {} is not an aggregate function",
-                    ecx.qcx
-                        .scx
-                        .humanize_resolved_name(name)
-                        .map(|n| n.to_string())
-                        .unwrap_or_else(|_| "<unknown>".into())
+                    humanize_or_debug(ecx.qcx.scx, name)
                 );
             }
             plan_exprs(ecx, args)?

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -79,6 +79,7 @@ pub fn plan_alter_owner(
         (ObjectType::NetworkPolicy, UnresolvedObjectName::NetworkPolicy(name)) => {
             plan_alter_network_policy_owner(scx, if_exists, name, new_owner.id)
         }
+        // The parser should have rejected this.
         (ObjectType::Role, UnresolvedObjectName::Role(_)) => {
             sql_bail!("cannot ALTER OWNER of a role")
         }
@@ -99,6 +100,7 @@ pub fn plan_alter_owner(
             | name @ UnresolvedObjectName::NetworkPolicy(_)
             | name @ UnresolvedObjectName::Role(_),
         ) => {
+            // The parser should not have produced this combination.
             sql_bail!("invalid object type '{object_type}' for ALTER OWNER with name {name}")
         }
         (object_type, UnresolvedObjectName::Item(name)) => {
@@ -506,6 +508,7 @@ fn plan_update_privilege(
                     let mut ids = Vec::with_capacity(names.len());
                     for name in names {
                         ids.push(
+                            // Name resolution should have rejected invalid objects.
                             name.try_into()
                                 .map_err(|e| sql_err!("invalid object name: {}", e))?,
                         );

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -81,7 +81,7 @@ pub fn plan_alter_owner(
         }
         // The parser should have rejected this.
         (ObjectType::Role, UnresolvedObjectName::Role(_)) => {
-            sql_bail!("cannot ALTER OWNER of a role")
+            bail_internal!("cannot ALTER OWNER of a role")
         }
         (
             object_type @ ObjectType::Cluster
@@ -101,7 +101,7 @@ pub fn plan_alter_owner(
             | name @ UnresolvedObjectName::Role(_),
         ) => {
             // The parser should not have produced this combination.
-            sql_bail!("invalid object type '{object_type}' for ALTER OWNER with name {name}")
+            bail_internal!("invalid object type '{object_type}' for ALTER OWNER with name {name}")
         }
         (object_type, UnresolvedObjectName::Item(name)) => {
             plan_alter_item_owner(scx, object_type, if_exists, name, new_owner.id)
@@ -510,7 +510,7 @@ fn plan_update_privilege(
                         ids.push(
                             // Name resolution should have rejected invalid objects.
                             name.try_into()
-                                .map_err(|e| sql_err!("invalid object name: {}", e))?,
+                                .map_err(|e| internal_err!("invalid object name: {}", e))?,
                         );
                     }
                     ids

--- a/src/sql/src/plan/statement/acl.rs
+++ b/src/sql/src/plan/statement/acl.rs
@@ -79,7 +79,9 @@ pub fn plan_alter_owner(
         (ObjectType::NetworkPolicy, UnresolvedObjectName::NetworkPolicy(name)) => {
             plan_alter_network_policy_owner(scx, if_exists, name, new_owner.id)
         }
-        (ObjectType::Role, UnresolvedObjectName::Role(_)) => unreachable!("rejected by the parser"),
+        (ObjectType::Role, UnresolvedObjectName::Role(_)) => {
+            sql_bail!("cannot ALTER OWNER of a role")
+        }
         (
             object_type @ ObjectType::Cluster
             | object_type @ ObjectType::ClusterReplica
@@ -97,7 +99,7 @@ pub fn plan_alter_owner(
             | name @ UnresolvedObjectName::NetworkPolicy(_)
             | name @ UnresolvedObjectName::Role(_),
         ) => {
-            unreachable!("parser set the wrong object type '{object_type:?}' for name {name:?}")
+            sql_bail!("invalid object type '{object_type}' for ALTER OWNER with name {name}")
         }
         (object_type, UnresolvedObjectName::Item(name)) => {
             plan_alter_item_owner(scx, object_type, if_exists, name, new_owner.id)
@@ -500,13 +502,16 @@ fn plan_update_privilege(
                     .map(|item_id| item_id.into())
                     .filter(|object_id| object_type_filter(object_id, &object_type, scx))
                     .collect(),
-                GrantTargetSpecificationInner::Objects { names } => names
-                    .into_iter()
-                    .map(|name| {
-                        name.try_into()
-                            .expect("name resolution should handle invalid objects")
-                    })
-                    .collect(),
+                GrantTargetSpecificationInner::Objects { names } => {
+                    let mut ids = Vec::with_capacity(names.len());
+                    for name in names {
+                        ids.push(
+                            name.try_into()
+                                .map_err(|e| sql_err!("invalid object name: {}", e))?,
+                        );
+                    }
+                    ids
+                }
             };
             let target_ids = object_ids.into_iter().map(|id| id.into()).collect();
             (SystemObjectType::Object(object_type), target_ids)
@@ -580,7 +585,7 @@ fn plan_update_privilege(
             SystemObjectId::Object(object_id) => scx
                 .catalog
                 .get_owner_id(object_id)
-                .expect("cannot revoke privileges on objects without owners"),
+                .ok_or_else(|| sql_err!("cannot revoke privileges on objects without owners"))?,
             SystemObjectId::System => scx.catalog.mz_system_role_id(),
         };
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1117,7 +1117,7 @@ fn plan_mysql_source_connection(
     } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| sql_err!("internal error: MySQL source missing details"))?;
+        .ok_or_else(|| PlanError::Internal("MySQL source missing details".into()))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details = ProtoMySqlSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
     let details = MySqlSourceDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
@@ -1144,7 +1144,7 @@ fn plan_sqlserver_source_connection(
     let SqlServerConfigOptionExtracted { details, .. } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| sql_err!("internal error: SQL Server source missing details"))?;
+        .ok_or_else(|| PlanError::Internal("SQL Server source missing details".into()))?;
     let extras = hex::decode(details)
         .map_err(|e| sql_err!("{e}"))
         .and_then(|raw| ProtoSqlServerSourceExtras::decode(&*raw).map_err(|e| sql_err!("{e}")))
@@ -1177,7 +1177,7 @@ fn plan_postgres_source_connection(
     } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| sql_err!("internal error: Postgres source missing details"))?;
+        .ok_or_else(|| PlanError::Internal("Postgres source missing details".into()))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details =
         ProtoPostgresSourcePublicationDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -1186,6 +1186,7 @@ fn plan_postgres_source_connection(
     Ok(PostgresSourceConnection {
         connection: connection_item.id(),
         connection_id: connection_item.id(),
+        // Validated during purification.
         publication: publication.ok_or_else(|| sql_err!("PUBLICATION option is required"))?,
         publication_details,
     })
@@ -1212,6 +1213,7 @@ fn plan_kafka_source_connection(
         start_offset,
         seen: _,
     }: KafkaSourceConfigOptionExtracted = options.clone().try_into()?;
+    // Validated during purification.
     let topic = topic.ok_or_else(|| sql_err!("TOPIC option is required"))?;
     let mut start_offsets = BTreeMap::new();
     if let Some(offsets) = start_offset {
@@ -1606,6 +1608,10 @@ pub fn plan_create_subsource(
         seen: _,
     } = with_options.clone().try_into()?;
 
+    // This invariant is enforced during purification; we are responsible for
+    // creating the AST for subsources as a response to CREATE SOURCE
+    // statements, so this would fire in integration testing if we failed to
+    // uphold it.
     if !(progress ^ (external_reference.is_some() && of_source.is_some())) {
         sql_bail!("CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option");
     }
@@ -1634,7 +1640,7 @@ pub fn plan_create_subsource(
         // created during the purification process.
         let details = details
             .as_ref()
-            .ok_or_else(|| sql_err!("internal error: source-export subsource missing details"))?;
+            .ok_or_else(|| PlanError::Internal("source-export subsource missing details".into()))?;
         let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
         let details =
             ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -1773,7 +1779,7 @@ pub fn plan_create_table_from_source(
     // created during the purification process.
     let details = details
         .as_ref()
-        .ok_or_else(|| sql_err!("internal error: source-export missing details"))?;
+        .ok_or_else(|| PlanError::Internal("source-export missing details".into()))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details =
         ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -1916,7 +1922,7 @@ pub fn plan_create_table_from_source(
         if matches!(columns, TableFromSourceColumns::Defined(_)) || !constraints.is_empty() {
             let columns = match columns {
                 TableFromSourceColumns::Defined(columns) => columns,
-                _ => sql_bail!("internal error: expected column definitions to be present"),
+                _ => bail_internal!("expected column definitions to be present"),
             };
             let desc = plan_source_export_desc(scx, name, columns, constraints)?;
             (None, desc)
@@ -1970,6 +1976,7 @@ pub fn plan_create_table_from_source(
 
     let data_source = DataSourceDesc::IngestionExport {
         ingestion_id,
+        // Populated during purification.
         external_reference: external_reference
             .as_ref()
             .ok_or_else(|| sql_err!("EXTERNAL REFERENCE is required"))?
@@ -5340,7 +5347,7 @@ pub fn plan_drop_objects(
     }: DropObjectsStatement,
 ) -> Result<Plan, PlanError> {
     if object_type == mz_sql_parser::ast::ObjectType::Func {
-        sql_bail!("DROP FUNCTION is not supported");
+        bail_unsupported!("DROP FUNCTION");
     }
     let object_type = object_type.into();
 
@@ -6761,7 +6768,7 @@ pub fn plan_alter_object_swap(
             plan_alter_cluster_swap(scx, name_a, name_b, if_exists, gen_temp_suffix)
         }
         (ObjectType::Schema | ObjectType::Cluster, _, _) => {
-            sql_bail!("internal error: name type does not match object type for ALTER SWAP")
+            bail_internal!("name type does not match object type for ALTER SWAP")
         }
         (
             ObjectType::Table
@@ -7209,10 +7216,10 @@ pub fn plan_alter_sink(
             let create_sql = item.create_sql();
             let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
             let [stmt]: [StatementParseResult; 1] = stmts.try_into().map_err(|_| {
-                sql_err!("internal error: create SQL of sink was not exactly one statement")
+                PlanError::Internal("create SQL of sink was not exactly one statement".into())
             })?;
             let Statement::CreateSink(stmt) = stmt.ast else {
-                sql_bail!("internal error: create SQL of sink is not a CREATE SINK statement");
+                bail_internal!("create SQL of sink is not a CREATE SINK statement");
             };
 
             // Then resolve and swap the resolved from relation to the new one
@@ -7221,7 +7228,7 @@ pub fn plan_alter_sink(
 
             // Finally re-plan the modified create sink statement to verify the new configuration is valid
             let Plan::CreateSink(mut plan) = plan_sink(scx, stmt)? else {
-                sql_bail!("internal error: plan_sink did not produce a CreateSink plan");
+                bail_internal!("plan_sink did not produce a CreateSink plan");
             };
 
             plan.sink.version += 1;
@@ -7638,7 +7645,7 @@ pub fn plan_comment(
                 }
                 (CommentObjectId::Type(*id), None)
             }
-            ResolvedDataType::Error => sql_bail!("internal error: unresolved data type"),
+            ResolvedDataType::Error => bail_internal!("unresolved data type"),
         },
         CommentObjectType::Column { name } => {
             let (item, pos) = scx.get_column_by_resolved_name(name)?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1187,7 +1187,7 @@ fn plan_postgres_source_connection(
         connection: connection_item.id(),
         connection_id: connection_item.id(),
         // Validated during purification.
-        publication: publication.ok_or_else(|| sql_err!("PUBLICATION option is required"))?,
+        publication: publication.ok_or_else(|| internal_err!("PUBLICATION option is required"))?,
         publication_details,
     })
 }
@@ -1214,7 +1214,7 @@ fn plan_kafka_source_connection(
         seen: _,
     }: KafkaSourceConfigOptionExtracted = options.clone().try_into()?;
     // Validated during purification.
-    let topic = topic.ok_or_else(|| sql_err!("TOPIC option is required"))?;
+    let topic = topic.ok_or_else(|| internal_err!("TOPIC option is required"))?;
     let mut start_offsets = BTreeMap::new();
     if let Some(offsets) = start_offset {
         for (part, offset) in offsets.iter().enumerate() {
@@ -1613,7 +1613,9 @@ pub fn plan_create_subsource(
     // statements, so this would fire in integration testing if we failed to
     // uphold it.
     if !(progress ^ (external_reference.is_some() && of_source.is_some())) {
-        sql_bail!("CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option");
+        bail_internal!(
+            "CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option"
+        );
     }
 
     let desc = plan_source_export_desc(scx, name, columns, constraints)?;
@@ -6421,7 +6423,9 @@ pub fn plan_alter_object_rename(
             plan_alter_schema_rename(scx, name, to_item_name, if_exists)
         }
         (object_type, name) => {
-            sql_bail!("invalid object type '{object_type}' for ALTER RENAME with name {name}")
+            // The earlier dispatch + name resolution should make this
+            // combination impossible.
+            bail_internal!("invalid object type '{object_type}' for ALTER RENAME with name {name}")
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1186,7 +1186,7 @@ fn plan_postgres_source_connection(
     Ok(PostgresSourceConnection {
         connection: connection_item.id(),
         connection_id: connection_item.id(),
-        publication: publication.expect("validated exists during purification"),
+        publication: publication.ok_or_else(|| sql_err!("PUBLICATION option is required"))?,
         publication_details,
     })
 }
@@ -1212,7 +1212,7 @@ fn plan_kafka_source_connection(
         start_offset,
         seen: _,
     }: KafkaSourceConfigOptionExtracted = options.clone().try_into()?;
-    let topic = topic.expect("validated exists during purification");
+    let topic = topic.ok_or_else(|| sql_err!("TOPIC option is required"))?;
     let mut start_offsets = BTreeMap::new();
     if let Some(offsets) = start_offset {
         for (part, offset) in offsets.iter().enumerate() {
@@ -1606,14 +1606,9 @@ pub fn plan_create_subsource(
         seen: _,
     } = with_options.clone().try_into()?;
 
-    // This invariant is enforced during purification; we are responsible for
-    // creating the AST for subsources as a response to CREATE SOURCE
-    // statements, so this would fire in integration testing if we failed to
-    // uphold it.
-    assert!(
-        progress ^ (external_reference.is_some() && of_source.is_some()),
-        "CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option"
-    );
+    if !(progress ^ (external_reference.is_some() && of_source.is_some())) {
+        sql_bail!("CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option");
+    }
 
     let desc = plan_source_export_desc(scx, name, columns, constraints)?;
 
@@ -1631,7 +1626,9 @@ pub fn plan_create_subsource(
         // This is a subsource with the "natural" dependency order, i.e. it is
         // not a legacy subsource with the inverted structure.
         let ingestion_id = *source_reference.item_id();
-        let external_reference = external_reference.unwrap();
+        let external_reference = external_reference.ok_or_else(|| {
+            sql_err!("CREATE SUBSOURCE with REFERENCES requires EXTERNAL REFERENCE option")
+        })?;
 
         // Decode the details option stored on the subsource statement, which contains information
         // created during the purification process.
@@ -1703,7 +1700,7 @@ pub fn plan_create_subsource(
     } else if progress {
         DataSourceDesc::Progress
     } else {
-        panic!("subsources must specify one of `external_reference`, `progress`, or `references`")
+        sql_bail!("CREATE SUBSOURCE must specify one of PROGRESS or REFERENCES option")
     };
 
     let if_not_exists = *if_not_exists;
@@ -1906,7 +1903,10 @@ pub fn plan_create_table_from_source(
         }
     };
 
-    let source_connection = &source_item.source_desc()?.expect("is source").connection;
+    let source_connection = &source_item
+        .source_desc()?
+        .ok_or_else(|| sql_err!("item is not a source"))?
+        .connection;
 
     // Some source-types (e.g. postgres, mysql, multi-output load-gen sources) define a value_schema
     // during purification and define the `columns` and `constraints` fields for the statement,
@@ -1916,7 +1916,7 @@ pub fn plan_create_table_from_source(
         if matches!(columns, TableFromSourceColumns::Defined(_)) || !constraints.is_empty() {
             let columns = match columns {
                 TableFromSourceColumns::Defined(columns) => columns,
-                _ => unreachable!(),
+                _ => sql_bail!("internal error: expected column definitions to be present"),
             };
             let desc = plan_source_export_desc(scx, name, columns, constraints)?;
             (None, desc)
@@ -1972,7 +1972,7 @@ pub fn plan_create_table_from_source(
         ingestion_id,
         external_reference: external_reference
             .as_ref()
-            .expect("populated in purification")
+            .ok_or_else(|| sql_err!("EXTERNAL REFERENCE is required"))?
             .clone(),
         details,
         data_config: SourceExportDataConfig { envelope, encoding },
@@ -2362,7 +2362,7 @@ fn get_encoding_inner(
                             confluent_wire_format: true,
                         }
                     } else {
-                        unreachable!("CSR seed resolution should already have been called: Avro")
+                        sql_bail!("Avro CSR seed resolution has not been performed")
                     }
                 }
             };
@@ -2439,7 +2439,7 @@ fn get_encoding_inner(
                     }
                     value
                 } else {
-                    unreachable!("CSR seed resolution should already have been called: Proto")
+                    sql_bail!("Protobuf CSR seed resolution has not been performed")
                 }
             }
             ProtobufSchema::InlineSchema {
@@ -3231,7 +3231,9 @@ fn plan_sink(
         bail_unsupported!("creating a sink directly on a catalog object");
     }
 
-    let desc = from.relation_desc().expect("item type checked above");
+    let desc = from
+        .relation_desc()
+        .ok_or_else(|| sql_err!("item does not have a relation description"))?;
     let key_indices = match &connection {
         CreateSinkConnection::Kafka { key: Some(key), .. }
         | CreateSinkConnection::Iceberg { key: Some(key), .. } => {
@@ -3598,7 +3600,7 @@ impl std::convert::TryFrom<Vec<CsrConfigOption<Aug>>> for CsrConfigOptionExtract
                         DocOnIdentifier::Type(ResolvedItemName::Item { id, .. }) => {
                             DocTarget::Type(id)
                         }
-                        _ => unreachable!(),
+                        _ => sql_bail!("invalid DOC ON identifier"),
                     };
 
                     match doc_on.for_schema {
@@ -4035,7 +4037,9 @@ pub fn plan_create_index(
         }
     }
 
-    let on_desc = on.relation_desc().expect("item type checked above");
+    let on_desc = on
+        .relation_desc()
+        .ok_or_else(|| sql_err!("item does not have a relation description"))?;
 
     let filled_key_parts = match key_parts {
         Some(kp) => kp.to_vec(),
@@ -5335,11 +5339,9 @@ pub fn plan_drop_objects(
         cascade,
     }: DropObjectsStatement,
 ) -> Result<Plan, PlanError> {
-    assert_ne!(
-        object_type,
-        mz_sql_parser::ast::ObjectType::Func,
-        "rejected in parser"
-    );
+    if object_type == mz_sql_parser::ast::ObjectType::Func {
+        sql_bail!("DROP FUNCTION is not supported");
+    }
     let object_type = object_type.into();
 
     let mut referenced_ids = Vec::new();
@@ -6237,9 +6239,12 @@ pub fn plan_alter_cluster(
                 // The `DISK` option is a no-op for legacy cluster sizes and was never allowed for
                 // `cc` sizes. The long term plan is to phase out the legacy sizes, at which point
                 // we'll be able to remove the `DISK` option entirely.
-                let size = size.as_deref().unwrap_or_else(|| {
-                    cluster.managed_size().expect("cluster known to be managed")
-                });
+                let size = match size.as_deref() {
+                    Some(s) => s,
+                    None => cluster
+                        .managed_size()
+                        .ok_or_else(|| sql_err!("cluster is not managed"))?,
+                };
                 if scx.catalog.is_cluster_size_cc(size) {
                     sql_bail!(
                         "DISK option not supported for modern cluster sizes because disk is always enabled"
@@ -6409,7 +6414,7 @@ pub fn plan_alter_object_rename(
             plan_alter_schema_rename(scx, name, to_item_name, if_exists)
         }
         (object_type, name) => {
-            unreachable!("parser set the wrong object type '{object_type:?}' for name {name:?}")
+            sql_bail!("invalid object type '{object_type}' for ALTER RENAME with name {name}")
         }
     }
 }
@@ -6756,7 +6761,7 @@ pub fn plan_alter_object_swap(
             plan_alter_cluster_swap(scx, name_a, name_b, if_exists, gen_temp_suffix)
         }
         (ObjectType::Schema | ObjectType::Cluster, _, _) => {
-            unreachable!("parser ensures name type matches object type")
+            sql_bail!("internal error: name type does not match object type for ALTER SWAP")
         }
         (
             ObjectType::Table
@@ -7076,7 +7081,7 @@ pub fn plan_alter_connection(
         .map(|action: &AlterConnectionAction<Aug>| match action {
             AlterConnectionAction::SetOption(option) => option.name.clone(),
             AlterConnectionAction::DropOption(name) => name.clone(),
-            AlterConnectionAction::RotateKeys => unreachable!(),
+            AlterConnectionAction::RotateKeys => unreachable!("RotateKeys is handled separately"),
         })
         .collect();
 
@@ -7093,7 +7098,7 @@ pub fn plan_alter_connection(
         actions.into_iter().partition_map(|action| match action {
             AlterConnectionAction::SetOption(option) => Either::Left(option),
             AlterConnectionAction::DropOption(name) => Either::Right(name),
-            AlterConnectionAction::RotateKeys => unreachable!(),
+            AlterConnectionAction::RotateKeys => unreachable!("RotateKeys is handled separately"),
         });
 
     let set_options: BTreeMap<_, _> = set_options_vec
@@ -7203,11 +7208,11 @@ pub fn plan_alter_sink(
             // First we reconstruct the original CREATE SINK statement
             let create_sql = item.create_sql();
             let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
-            let [stmt]: [StatementParseResult; 1] = stmts
-                .try_into()
-                .expect("create sql of sink was not exactly one statement");
+            let [stmt]: [StatementParseResult; 1] = stmts.try_into().map_err(|_| {
+                sql_err!("internal error: create SQL of sink was not exactly one statement")
+            })?;
             let Statement::CreateSink(stmt) = stmt.ast else {
-                unreachable!("invalid create SQL for sink item");
+                sql_bail!("internal error: create SQL of sink is not a CREATE SINK statement");
             };
 
             // Then resolve and swap the resolved from relation to the new one
@@ -7216,7 +7221,7 @@ pub fn plan_alter_sink(
 
             // Finally re-plan the modified create sink statement to verify the new configuration is valid
             let Plan::CreateSink(mut plan) = plan_sink(scx, stmt)? else {
-                unreachable!("invalid plan for CREATE SINK statement");
+                sql_bail!("internal error: plan_sink did not produce a CreateSink plan");
             };
 
             plan.sink.version += 1;
@@ -7272,7 +7277,9 @@ pub fn plan_alter_source(
     match action {
         AlterSourceAction::SetOptions(options) => {
             let mut options = options.into_iter();
-            let option = options.next().unwrap();
+            let option = options
+                .next()
+                .ok_or_else(|| sql_err!("ALTER SOURCE SET requires at least one option"))?;
             if option.name == CreateSourceOptionName::RetainHistory {
                 if options.next().is_some() {
                     sql_bail!("RETAIN HISTORY must be only option");
@@ -7300,7 +7307,9 @@ pub fn plan_alter_source(
         }
         AlterSourceAction::ResetOptions(reset) => {
             let mut options = reset.into_iter();
-            let option = options.next().unwrap();
+            let option = options
+                .next()
+                .ok_or_else(|| sql_err!("ALTER SOURCE RESET requires at least one option"))?;
             if option == CreateSourceOptionName::RetainHistory {
                 if options.next().is_some() {
                     sql_bail!("RETAIN HISTORY must be only option");
@@ -7328,10 +7337,10 @@ pub fn plan_alter_source(
             sql_bail!("ALTER SOURCE...DROP SUBSOURCE no longer supported; use DROP SOURCE")
         }
         AlterSourceAction::AddSubsources { .. } => {
-            unreachable!("ALTER SOURCE...ADD SUBSOURCE must be purified")
+            sql_bail!("ALTER SOURCE...ADD SUBSOURCE must be purified before planning")
         }
         AlterSourceAction::RefreshReferences => {
-            unreachable!("ALTER SOURCE...REFRESH REFERENCES must be purified")
+            sql_bail!("ALTER SOURCE...REFRESH REFERENCES must be purified before planning")
         }
     };
 }
@@ -7440,7 +7449,10 @@ pub fn plan_alter_table_add_column(
                 // Always add columns to the latest version of the item.
                 let item_name = scx.catalog.resolve_full_name(item.name());
                 let item = item.at_version(RelationVersionSelector::Latest);
-                let desc = item.relation_desc().expect("table has desc").into_owned();
+                let desc = item
+                    .relation_desc()
+                    .ok_or_else(|| sql_err!("item does not have a relation description"))?
+                    .into_owned();
                 (item.id(), item_name, desc)
             }
             None => {
@@ -7511,7 +7523,7 @@ pub fn plan_alter_materialized_view_apply_replacement(
     };
 
     let replacement = resolve_item_or_type(scx, object_type, replacement_name, false)?
-        .expect("if_exists not set");
+        .ok_or_else(|| sql_err!("replacement materialized view does not exist"))?;
 
     if replacement.replacement_target() != Some(mv.id()) {
         return Err(PlanError::InvalidReplacement {
@@ -7605,7 +7617,7 @@ pub fn plan_comment(
                         CommentObjectType::Source { .. } => ObjectType::Source,
                         CommentObjectType::Sink { .. } => ObjectType::Sink,
                         CommentObjectType::Secret { .. } => ObjectType::Secret,
-                        _ => unreachable!("these are the only types we match on"),
+                        _ => sql_bail!("cannot comment on this object type"),
                     };
 
                     return Err(PlanError::InvalidObjectType {
@@ -7626,7 +7638,7 @@ pub fn plan_comment(
                 }
                 (CommentObjectId::Type(*id), None)
             }
-            ResolvedDataType::Error => unreachable!("should have been caught in name resolution"),
+            ResolvedDataType::Error => sql_bail!("internal error: unresolved data type"),
         },
         CommentObjectType::Column { name } => {
             let (item, pos) = scx.get_column_by_resolved_name(name)?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -18,7 +18,7 @@ use std::iter;
 use std::num::NonZeroU32;
 use std::time::Duration;
 
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use mz_adapter_types::compaction::{CompactionWindow, DEFAULT_LOGICAL_COMPACTION_WINDOW_DURATION};
 use mz_adapter_types::dyncfgs::ENABLE_MULTI_REPLICA_SOURCES;
 use mz_arrow_util::builder::ArrowBuilder;
@@ -7090,11 +7090,13 @@ pub fn plan_alter_connection(
     let specified_options: BTreeSet<_> = actions
         .iter()
         .map(|action: &AlterConnectionAction<Aug>| match action {
-            AlterConnectionAction::SetOption(option) => option.name.clone(),
-            AlterConnectionAction::DropOption(name) => name.clone(),
-            AlterConnectionAction::RotateKeys => unreachable!("RotateKeys is handled separately"),
+            AlterConnectionAction::SetOption(option) => Ok(option.name.clone()),
+            AlterConnectionAction::DropOption(name) => Ok(name.clone()),
+            AlterConnectionAction::RotateKeys => {
+                Err(internal_err!("RotateKeys is handled separately above"))
+            }
         })
-        .collect();
+        .collect::<Result<_, PlanError>>()?;
 
     for invalid in INALTERABLE_OPTIONS {
         if specified_options.contains(invalid) {
@@ -7104,13 +7106,20 @@ pub fn plan_alter_connection(
 
     connection::validate_options_per_connection_type(connection_type, specified_options)?;
 
-    // Partition operations into set and drop
-    let (set_options_vec, mut drop_options): (Vec<_>, BTreeSet<_>) =
-        actions.into_iter().partition_map(|action| match action {
-            AlterConnectionAction::SetOption(option) => Either::Left(option),
-            AlterConnectionAction::DropOption(name) => Either::Right(name),
-            AlterConnectionAction::RotateKeys => unreachable!("RotateKeys is handled separately"),
-        });
+    // Partition operations into set and drop.
+    let mut set_options_vec: Vec<_> = Vec::new();
+    let mut drop_options: BTreeSet<_> = BTreeSet::new();
+    for action in actions {
+        match action {
+            AlterConnectionAction::SetOption(option) => set_options_vec.push(option),
+            AlterConnectionAction::DropOption(name) => {
+                drop_options.insert(name);
+            }
+            AlterConnectionAction::RotateKeys => {
+                bail_internal!("RotateKeys is handled separately above")
+            }
+        }
+    }
 
     let set_options: BTreeMap<_, _> = set_options_vec
         .clone()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1117,7 +1117,7 @@ fn plan_mysql_source_connection(
     } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| PlanError::Internal("MySQL source missing details".into()))?;
+        .ok_or_else(|| internal_err!("MySQL source missing details"))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details = ProtoMySqlSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
     let details = MySqlSourceDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
@@ -1144,7 +1144,7 @@ fn plan_sqlserver_source_connection(
     let SqlServerConfigOptionExtracted { details, .. } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| PlanError::Internal("SQL Server source missing details".into()))?;
+        .ok_or_else(|| internal_err!("SQL Server source missing details"))?;
     let extras = hex::decode(details)
         .map_err(|e| sql_err!("{e}"))
         .and_then(|raw| ProtoSqlServerSourceExtras::decode(&*raw).map_err(|e| sql_err!("{e}")))
@@ -1177,7 +1177,7 @@ fn plan_postgres_source_connection(
     } = options.clone().try_into()?;
     let details = details
         .as_ref()
-        .ok_or_else(|| PlanError::Internal("Postgres source missing details".into()))?;
+        .ok_or_else(|| internal_err!("Postgres source missing details"))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details =
         ProtoPostgresSourcePublicationDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -1642,7 +1642,7 @@ pub fn plan_create_subsource(
         // created during the purification process.
         let details = details
             .as_ref()
-            .ok_or_else(|| PlanError::Internal("source-export subsource missing details".into()))?;
+            .ok_or_else(|| internal_err!("source-export subsource missing details"))?;
         let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
         let details =
             ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -1781,7 +1781,7 @@ pub fn plan_create_table_from_source(
     // created during the purification process.
     let details = details
         .as_ref()
-        .ok_or_else(|| PlanError::Internal("source-export missing details".into()))?;
+        .ok_or_else(|| internal_err!("source-export missing details"))?;
     let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
     let details =
         ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
@@ -7219,9 +7219,9 @@ pub fn plan_alter_sink(
             // First we reconstruct the original CREATE SINK statement
             let create_sql = item.create_sql();
             let stmts = mz_sql_parser::parser::parse_statements(create_sql)?;
-            let [stmt]: [StatementParseResult; 1] = stmts.try_into().map_err(|_| {
-                PlanError::Internal("create SQL of sink was not exactly one statement".into())
-            })?;
+            let [stmt]: [StatementParseResult; 1] = stmts
+                .try_into()
+                .map_err(|_| internal_err!("create SQL of sink was not exactly one statement"))?;
             let Statement::CreateSink(stmt) = stmt.ast else {
                 bail_internal!("create SQL of sink is not a CREATE SINK statement");
             };

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -876,7 +876,7 @@ pub fn plan_explain_schema(
                 "EXPLAIN SCHEMA is only available for Kafka sinks with Avro schemas"
             ),
         },
-        _ => unreachable!("plan_create_sink returns a CreateSinkPlan"),
+        _ => sql_bail!("internal error: plan_sink did not produce a CreateSink plan"),
     }
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -876,7 +876,7 @@ pub fn plan_explain_schema(
                 "EXPLAIN SCHEMA is only available for Kafka sinks with Avro schemas"
             ),
         },
-        _ => sql_bail!("internal error: plan_sink did not produce a CreateSink plan"),
+        _ => bail_internal!("plan_sink did not produce a CreateSink plan"),
     }
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -328,7 +328,7 @@ pub fn show_schemas<'a>(
             None => sql_bail!("no database specified and no active database"),
         },
         Some(ResolvedDatabaseName::Error) => {
-            sql_bail!("internal error: unresolved database name")
+            bail_internal!("unresolved database name")
         }
     };
     let query = format!(
@@ -988,14 +988,11 @@ impl<'a> ShowSelect<'a> {
         query: String,
     ) -> Result<(ShowSelect<'a>, ResolvedIds), PlanError> {
         let stmts = parse::parse(&query).map_err(|e| {
-            sql_err!(
-                "internal error: failed to parse generated SHOW query: {}",
-                e
-            )
+            PlanError::Internal(format!("failed to parse generated SHOW query: {}", e))
         })?;
         let stmt = match stmts.into_element().ast {
             Statement::Select(select) => select,
-            _ => sql_bail!("internal error: generated SHOW query was not a SELECT statement"),
+            _ => bail_internal!("generated SHOW query was not a SELECT statement"),
         };
         let (mut stmt, new_resolved_ids) = names::resolve(scx.catalog, stmt)?;
         transform_ast::transform(scx, &mut stmt)?;

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -16,7 +16,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 
-use mz_ore::assert_none;
 use mz_ore::collections::CollectionExt;
 use mz_repr::{CatalogItemId, Datum, RelationDesc, Row, SqlScalarType};
 use mz_sql_parser::ast::display::{AstDisplay, FormatMode};
@@ -329,7 +328,7 @@ pub fn show_schemas<'a>(
             None => sql_bail!("no database specified and no active database"),
         },
         Some(ResolvedDatabaseName::Error) => {
-            unreachable!("should have been handled in name resolution")
+            sql_bail!("internal error: unresolved database name")
         }
     };
     let query = format!(
@@ -379,15 +378,21 @@ pub fn show_objects<'a>(
         ShowObjectType::Type => show_types(scx, from, filter),
         ShowObjectType::Object => show_all_objects(scx, from, filter),
         ShowObjectType::Role => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_roles(scx, filter)
         }
         ShowObjectType::Cluster => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_clusters(scx, filter)
         }
         ShowObjectType::ClusterReplica => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_cluster_replicas(scx, filter)
         }
         ShowObjectType::Secret => show_secrets(scx, from, filter),
@@ -400,27 +405,39 @@ pub fn show_objects<'a>(
             on_object,
         } => show_indexes(scx, from, on_object, in_cluster, filter),
         ShowObjectType::Database => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_databases(scx, filter)
         }
         ShowObjectType::Schema { from: db_from } => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_schemas(scx, db_from, filter)
         }
         ShowObjectType::Privileges { object_type, role } => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::DefaultPrivileges { object_type, role } => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_default_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::RoleMembership { role } => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_role_membership(scx, role, filter)
         }
         ShowObjectType::NetworkPolicy => {
-            assert_none!(from, "parser should reject from");
+            if from.is_some() {
+                sql_bail!("FROM not supported for this SHOW command");
+            }
             show_network_policies(scx, filter)
         }
     }
@@ -970,10 +987,15 @@ impl<'a> ShowSelect<'a> {
         scx: &'a StatementContext,
         query: String,
     ) -> Result<(ShowSelect<'a>, ResolvedIds), PlanError> {
-        let stmts = parse::parse(&query).expect("ShowSelect::new called with invalid SQL");
+        let stmts = parse::parse(&query).map_err(|e| {
+            sql_err!(
+                "internal error: failed to parse generated SHOW query: {}",
+                e
+            )
+        })?;
         let stmt = match stmts.into_element().ast {
             Statement::Select(select) => select,
-            _ => panic!("ShowSelect::new called with non-SELECT statement"),
+            _ => sql_bail!("internal error: generated SHOW query was not a SELECT statement"),
         };
         let (mut stmt, new_resolved_ids) = names::resolve(scx.catalog, stmt)?;
         transform_ast::transform(scx, &mut stmt)?;

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -361,6 +361,16 @@ pub fn show_network_policies<'a>(
     )
 }
 
+/// Ensures that the `FROM` clause was not provided for `SHOW` commands that
+/// don't accept it. The parser is supposed to reject such cases, so this is an
+/// internal-only invariant.
+fn ensure_no_from<T>(from: Option<T>) -> Result<(), PlanError> {
+    if from.is_some() {
+        bail_internal!("FROM not supported for this SHOW command");
+    }
+    Ok(())
+}
+
 pub fn show_objects<'a>(
     scx: &'a StatementContext<'a>,
     ShowObjectsStatement {
@@ -378,21 +388,15 @@ pub fn show_objects<'a>(
         ShowObjectType::Type => show_types(scx, from, filter),
         ShowObjectType::Object => show_all_objects(scx, from, filter),
         ShowObjectType::Role => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_roles(scx, filter)
         }
         ShowObjectType::Cluster => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_clusters(scx, filter)
         }
         ShowObjectType::ClusterReplica => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_cluster_replicas(scx, filter)
         }
         ShowObjectType::Secret => show_secrets(scx, from, filter),
@@ -405,39 +409,27 @@ pub fn show_objects<'a>(
             on_object,
         } => show_indexes(scx, from, on_object, in_cluster, filter),
         ShowObjectType::Database => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_databases(scx, filter)
         }
         ShowObjectType::Schema { from: db_from } => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_schemas(scx, db_from, filter)
         }
         ShowObjectType::Privileges { object_type, role } => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::DefaultPrivileges { object_type, role } => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_default_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::RoleMembership { role } => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_role_membership(scx, role, filter)
         }
         ShowObjectType::NetworkPolicy => {
-            if from.is_some() {
-                sql_bail!("FROM not supported for this SHOW command");
-            }
+            ensure_no_from(from)?;
             show_network_policies(scx, filter)
         }
     }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -979,9 +979,8 @@ impl<'a> ShowSelect<'a> {
         scx: &'a StatementContext,
         query: String,
     ) -> Result<(ShowSelect<'a>, ResolvedIds), PlanError> {
-        let stmts = parse::parse(&query).map_err(|e| {
-            PlanError::Internal(format!("failed to parse generated SHOW query: {}", e))
-        })?;
+        let stmts = parse::parse(&query)
+            .map_err(|e| internal_err!("failed to parse generated SHOW query: {}", e))?;
         let stmt = match stmts.into_element().ast {
             Statement::Select(select) => select,
             _ => bail_internal!("generated SHOW query was not a SELECT statement"),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -311,7 +311,7 @@ pub async fn purify_statement(
             None,
         ),
         o => (
-            Err(sql_err!(
+            Err(internal_err!(
                 "unexpected statement type in purification: {:?}",
                 o
             )),
@@ -1627,7 +1627,9 @@ async fn purify_alter_source_add_subsources(
                     Some(WithOptionValue::Sequence(normalized_excl_columns));
             }
         }
-        _ => sql_bail!("source does not support ALTER SOURCE...ADD SUBSOURCE"),
+        // The source kind was already established earlier in this function;
+        // reaching this catch-all is an internal invariant violation.
+        _ => bail_internal!("source does not support ALTER SOURCE...ADD SUBSOURCE"),
     };
 
     Ok(PurifiedStatement::PurifiedAlterSourceAddSubsources {
@@ -2067,7 +2069,11 @@ async fn purify_create_table_from_source(
             }
             match columns {
                 TableFromSourceColumns::Defined(_) => {
-                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                    // Purification is what populates the `Defined` variant;
+                    // reaching this is an internal invariant violation.
+                    bail_internal!(
+                        "column definitions cannot be explicitly set for this source type"
+                    )
                 }
                 TableFromSourceColumns::NotSpecified => {
                     *columns = TableFromSourceColumns::Defined(gen_columns);
@@ -2123,7 +2129,11 @@ async fn purify_create_table_from_source(
             }
             match columns {
                 TableFromSourceColumns::Defined(_) => {
-                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                    // Purification is what populates the `Defined` variant;
+                    // reaching this is an internal invariant violation.
+                    bail_internal!(
+                        "column definitions cannot be explicitly set for this source type"
+                    )
                 }
                 TableFromSourceColumns::NotSpecified => {
                     *columns = TableFromSourceColumns::Defined(gen_columns);
@@ -2187,7 +2197,11 @@ async fn purify_create_table_from_source(
                     sql_bail!("columns cannot be named for SQL Server sources")
                 }
                 TableFromSourceColumns::Defined(_) => {
-                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                    // Purification is what populates the `Defined` variant;
+                    // reaching this is an internal invariant violation.
+                    bail_internal!(
+                        "column definitions cannot be explicitly set for this source type"
+                    )
                 }
             }
 
@@ -2210,7 +2224,9 @@ async fn purify_create_table_from_source(
             if let Some(desc) = desc {
                 let (gen_columns, gen_constraints) = scx.relation_desc_into_table_defs(&desc)?;
                 match columns {
-                    TableFromSourceColumns::Defined(_) => sql_bail!(
+                    // Purification is what populates the `Defined` variant;
+                    // reaching this is an internal invariant violation.
+                    TableFromSourceColumns::Defined(_) => bail_internal!(
                         "column definitions cannot be explicitly set for this source type"
                     ),
                     TableFromSourceColumns::NotSpecified => {
@@ -2413,7 +2429,7 @@ pub fn generate_subsource_statements(
             // producing data––we'll need to understand the schema
             // of the output here.
             if !subsources.is_empty() {
-                sql_bail!("Kafka sources do not produce data-bearing subsources");
+                bail_internal!("Kafka sources do not produce data-bearing subsources");
             }
             vec![]
         }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -310,7 +310,13 @@ pub async fn purify_statement(
             purify_create_table_from_source(catalog, stmt, storage_configuration).await,
             None,
         ),
-        o => unreachable!("{:?} does not need to be purified", o),
+        o => (
+            Err(sql_err!(
+                "unexpected statement type in purification: {:?}",
+                o
+            )),
+            None,
+        ),
     }
 }
 
@@ -1161,8 +1167,10 @@ async fn purify_create_source(
                     .all_references()
                     .iter()
                     .any(|r| {
-                        r.load_generator_output().expect("is loadgen")
-                            != &LoadGeneratorOutput::Default
+                        matches!(
+                            r.load_generator_output(),
+                            Some(output) if output != &LoadGeneratorOutput::Default
+                        )
                     });
 
             match external_references {
@@ -1194,12 +1202,12 @@ async fn purify_create_source(
                                     table: export
                                         .meta
                                         .load_generator_desc()
-                                        .expect("is loadgen")
+                                        .ok_or_else(|| sql_err!("internal error: expected load generator source reference"))?
                                         .clone(),
                                     output: export
                                         .meta
                                         .load_generator_output()
-                                        .expect("is loadgen")
+                                        .ok_or_else(|| sql_err!("internal error: expected load generator source reference"))?
                                         .clone(),
                                 },
                             },
@@ -1241,10 +1249,15 @@ async fn purify_create_source(
         let name = match progress_subsource {
             Some(name) => match name {
                 DeferredItemName::Deferred(name) => name.clone(),
-                DeferredItemName::Named(_) => unreachable!("already checked for this value"),
+                DeferredItemName::Named(_) => {
+                    sql_bail!("progress subsource name cannot be a resolved name")
+                }
             },
             None => {
-                let (item, prefix) = source_name.0.split_last().unwrap();
+                let (item, prefix) = source_name
+                    .0
+                    .split_last()
+                    .ok_or_else(|| sql_err!("source name must have at least one component"))?;
                 let item_name =
                     Ident::try_generate_name(item.to_string(), "_progress", |candidate| {
                         let mut suggested_name = prefix.to_vec();
@@ -1605,7 +1618,7 @@ async fn purify_alter_source_add_subsources(
                     Some(WithOptionValue::Sequence(normalized_excl_columns));
             }
         }
-        _ => unreachable!(),
+        _ => sql_bail!("source does not support ALTER SOURCE...ADD SUBSOURCE"),
     };
 
     Ok(PurifiedStatement::PurifiedAlterSourceAddSubsources {
@@ -1946,12 +1959,16 @@ async fn purify_create_table_from_source(
                     table: export
                         .meta
                         .load_generator_desc()
-                        .expect("is loadgen")
+                        .ok_or_else(|| {
+                            sql_err!("internal error: expected load generator source reference")
+                        })?
                         .clone(),
                     output: export
                         .meta
                         .load_generator_output()
-                        .expect("is loadgen")
+                        .ok_or_else(|| {
+                            sql_err!("internal error: expected load generator source reference")
+                        })?
                         .clone(),
                 },
             }
@@ -2040,7 +2057,9 @@ async fn purify_create_table_from_source(
                 }
             }
             match columns {
-                TableFromSourceColumns::Defined(_) => unreachable!(),
+                TableFromSourceColumns::Defined(_) => {
+                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                }
                 TableFromSourceColumns::NotSpecified => {
                     *columns = TableFromSourceColumns::Defined(gen_columns);
                     *constraints = gen_constraints;
@@ -2094,7 +2113,9 @@ async fn purify_create_table_from_source(
                 }
             }
             match columns {
-                TableFromSourceColumns::Defined(_) => unreachable!(),
+                TableFromSourceColumns::Defined(_) => {
+                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                }
                 TableFromSourceColumns::NotSpecified => {
                     *columns = TableFromSourceColumns::Defined(gen_columns);
                     *constraints = gen_constraints;
@@ -2156,7 +2177,9 @@ async fn purify_create_table_from_source(
                 TableFromSourceColumns::Named(_) => {
                     sql_bail!("columns cannot be named for SQL Server sources")
                 }
-                TableFromSourceColumns::Defined(_) => unreachable!(),
+                TableFromSourceColumns::Defined(_) => {
+                    sql_bail!("column definitions cannot be explicitly set for this source type")
+                }
             }
 
             with_options.push(TableFromSourceOption {
@@ -2169,7 +2192,7 @@ async fn purify_create_table_from_source(
         PurifiedExportDetails::LoadGenerator { .. } => {
             let (desc, output) = match purified_export.details {
                 PurifiedExportDetails::LoadGenerator { table, output } => (table, output),
-                _ => unreachable!("purified export details must be load generator"),
+                _ => sql_bail!("internal error: purified export details must be load generator"),
             };
             // We only determine the table description for multi-output load generator sources here,
             // whereas single-output load generators will have their relation description
@@ -2178,7 +2201,9 @@ async fn purify_create_table_from_source(
             if let Some(desc) = desc {
                 let (gen_columns, gen_constraints) = scx.relation_desc_into_table_defs(&desc)?;
                 match columns {
-                    TableFromSourceColumns::Defined(_) => unreachable!(),
+                    TableFromSourceColumns::Defined(_) => sql_bail!(
+                        "column definitions cannot be explicitly set for this source type"
+                    ),
                     TableFromSourceColumns::NotSpecified => {
                         *columns = TableFromSourceColumns::Defined(gen_columns);
                         *constraints = gen_constraints;
@@ -2303,7 +2328,10 @@ pub fn generate_subsource_statements(
     if subsources.is_empty() {
         return Ok(vec![]);
     }
-    let (_, purified_export) = subsources.iter().next().unwrap();
+    let (_, purified_export) = subsources
+        .iter()
+        .next()
+        .ok_or_else(|| sql_err!("internal error: expected at least one subsource"))?;
 
     let statements = match &purified_export.details {
         PurifiedExportDetails::Postgres { .. } => {
@@ -2328,10 +2356,13 @@ pub fn generate_subsource_statements(
             for (subsource_name, purified_export) in subsources {
                 let (desc, output) = match purified_export.details {
                     PurifiedExportDetails::LoadGenerator { table, output } => (table, output),
-                    _ => unreachable!("purified export details must be load generator"),
+                    _ => {
+                        sql_bail!("internal error: purified export details must be load generator")
+                    }
                 };
-                let desc =
-                    desc.expect("subsources cannot be generated for single-output load generators");
+                let desc = desc.ok_or_else(|| {
+                    sql_err!("internal error: subsources cannot be generated for single-output load generators")
+                })?;
 
                 let (columns, table_constraints) = scx.relation_desc_into_table_defs(&desc)?;
                 let details = SourceExportStatementDetails::LoadGenerator { output };
@@ -2370,10 +2401,9 @@ pub fn generate_subsource_statements(
             // TODO: as part of database-issues#8322, Kafka sources will begin
             // producing data––we'll need to understand the schema
             // of the output here.
-            assert!(
-                subsources.is_empty(),
-                "Kafka sources do not produce data-bearing subsources"
-            );
+            if !subsources.is_empty() {
+                sql_bail!("Kafka sources do not produce data-bearing subsources");
+            }
             vec![]
         }
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1203,8 +1203,8 @@ async fn purify_create_source(
                                         .meta
                                         .load_generator_desc()
                                         .ok_or_else(|| {
-                                            PlanError::Internal(
-                                                "expected load generator source reference".into(),
+                                            internal_err!(
+                                                "expected load generator source reference"
                                             )
                                         })?
                                         .clone(),
@@ -1212,8 +1212,8 @@ async fn purify_create_source(
                                         .meta
                                         .load_generator_output()
                                         .ok_or_else(|| {
-                                            PlanError::Internal(
-                                                "expected load generator source reference".into(),
+                                            internal_err!(
+                                                "expected load generator source reference"
                                             )
                                         })?
                                         .clone(),
@@ -1970,16 +1970,12 @@ async fn purify_create_table_from_source(
                     table: export
                         .meta
                         .load_generator_desc()
-                        .ok_or_else(|| {
-                            PlanError::Internal("expected load generator source reference".into())
-                        })?
+                        .ok_or_else(|| internal_err!("expected load generator source reference"))?
                         .clone(),
                     output: export
                         .meta
                         .load_generator_output()
-                        .ok_or_else(|| {
-                            PlanError::Internal("expected load generator source reference".into())
-                        })?
+                        .ok_or_else(|| internal_err!("expected load generator source reference"))?
                         .clone(),
                 },
             }
@@ -2356,7 +2352,7 @@ pub fn generate_subsource_statements(
     let (_, purified_export) = subsources
         .iter()
         .next()
-        .ok_or_else(|| PlanError::Internal("expected at least one subsource".into()))?;
+        .ok_or_else(|| internal_err!("expected at least one subsource"))?;
 
     let statements = match &purified_export.details {
         PurifiedExportDetails::Postgres { .. } => {
@@ -2386,8 +2382,8 @@ pub fn generate_subsource_statements(
                     }
                 };
                 let desc = desc.ok_or_else(|| {
-                    PlanError::Internal(
-                        "subsources cannot be generated for single-output load generators".into(),
+                    internal_err!(
+                        "subsources cannot be generated for single-output load generators"
                     )
                 })?;
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1202,12 +1202,20 @@ async fn purify_create_source(
                                     table: export
                                         .meta
                                         .load_generator_desc()
-                                        .ok_or_else(|| sql_err!("internal error: expected load generator source reference"))?
+                                        .ok_or_else(|| {
+                                            PlanError::Internal(
+                                                "expected load generator source reference".into(),
+                                            )
+                                        })?
                                         .clone(),
                                     output: export
                                         .meta
                                         .load_generator_output()
-                                        .ok_or_else(|| sql_err!("internal error: expected load generator source reference"))?
+                                        .ok_or_else(|| {
+                                            PlanError::Internal(
+                                                "expected load generator source reference".into(),
+                                            )
+                                        })?
                                         .clone(),
                                 },
                             },
@@ -1249,6 +1257,7 @@ async fn purify_create_source(
         let name = match progress_subsource {
             Some(name) => match name {
                 DeferredItemName::Deferred(name) => name.clone(),
+                // Already checked for this value above.
                 DeferredItemName::Named(_) => {
                     sql_bail!("progress subsource name cannot be a resolved name")
                 }
@@ -1960,14 +1969,14 @@ async fn purify_create_table_from_source(
                         .meta
                         .load_generator_desc()
                         .ok_or_else(|| {
-                            sql_err!("internal error: expected load generator source reference")
+                            PlanError::Internal("expected load generator source reference".into())
                         })?
                         .clone(),
                     output: export
                         .meta
                         .load_generator_output()
                         .ok_or_else(|| {
-                            sql_err!("internal error: expected load generator source reference")
+                            PlanError::Internal("expected load generator source reference".into())
                         })?
                         .clone(),
                 },
@@ -2192,7 +2201,7 @@ async fn purify_create_table_from_source(
         PurifiedExportDetails::LoadGenerator { .. } => {
             let (desc, output) = match purified_export.details {
                 PurifiedExportDetails::LoadGenerator { table, output } => (table, output),
-                _ => sql_bail!("internal error: purified export details must be load generator"),
+                _ => bail_internal!("purified export details must be load generator"),
             };
             // We only determine the table description for multi-output load generator sources here,
             // whereas single-output load generators will have their relation description
@@ -2331,7 +2340,7 @@ pub fn generate_subsource_statements(
     let (_, purified_export) = subsources
         .iter()
         .next()
-        .ok_or_else(|| sql_err!("internal error: expected at least one subsource"))?;
+        .ok_or_else(|| PlanError::Internal("expected at least one subsource".into()))?;
 
     let statements = match &purified_export.details {
         PurifiedExportDetails::Postgres { .. } => {
@@ -2357,11 +2366,13 @@ pub fn generate_subsource_statements(
                 let (desc, output) = match purified_export.details {
                     PurifiedExportDetails::LoadGenerator { table, output } => (table, output),
                     _ => {
-                        sql_bail!("internal error: purified export details must be load generator")
+                        bail_internal!("purified export details must be load generator")
                     }
                 };
                 let desc = desc.ok_or_else(|| {
-                    sql_err!("internal error: subsources cannot be generated for single-output load generators")
+                    PlanError::Internal(
+                        "subsources cannot be generated for single-output load generators".into(),
+                    )
                 })?;
 
                 let (columns, table_constraints) = scx.relation_desc_into_table_defs(&desc)?;

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -132,9 +132,7 @@ pub(super) fn generate_source_export_statement_values(
         initial_gtid_set,
     } = purified_export.details
     else {
-        return Err(sql_err!(
-            "internal error: purified export details must be mysql"
-        ));
+        bail_internal!("purified export details must be mysql");
     };
 
     // Figure out the schema of the subsource

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -132,7 +132,9 @@ pub(super) fn generate_source_export_statement_values(
         initial_gtid_set,
     } = purified_export.details
     else {
-        unreachable!("purified export details must be mysql")
+        return Err(sql_err!(
+            "internal error: purified export details must be mysql"
+        ));
     };
 
     // Figure out the schema of the subsource

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -230,7 +230,9 @@ pub(super) fn generate_source_export_statement_values(
         exclude_columns,
     } = purified_export.details
     else {
-        unreachable!("purified export details must be postgres")
+        return Err(sql_err!(
+            "internal error: purified export details must be postgres"
+        ));
     };
 
     let text_column_set = BTreeSet::from_iter(text_columns.iter().flatten().map(Ident::as_str));

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -230,9 +230,7 @@ pub(super) fn generate_source_export_statement_values(
         exclude_columns,
     } = purified_export.details
     else {
-        return Err(sql_err!(
-            "internal error: purified export details must be postgres"
-        ));
+        bail_internal!("purified export details must be postgres");
     };
 
     let text_column_set = BTreeSet::from_iter(text_columns.iter().flatten().map(Ident::as_str));

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -410,7 +410,9 @@ pub(super) fn generate_source_export_statement_values(
         initial_lsn,
     } = purified_export.details
     else {
-        unreachable!("purified export details must be SQL Server")
+        return Err(sql_err!(
+            "internal error: purified export details must be SQL Server"
+        ));
     };
 
     // Filter out columns that the user wanted to exclude.

--- a/src/sql/src/pure/sql_server.rs
+++ b/src/sql/src/pure/sql_server.rs
@@ -410,9 +410,7 @@ pub(super) fn generate_source_export_statement_values(
         initial_lsn,
     } = purified_export.details
     else {
-        return Err(sql_err!(
-            "internal error: purified export details must be SQL Server"
-        ));
+        bail_internal!("purified export details must be SQL Server");
     };
 
     // Filter out columns that the user wanted to exclude.


### PR DESCRIPTION
When a query is bad, even because of a bug from our side, we shouldn't bring down `environmentd` but fail the query.