### PR TITLE
ci: Retry playwright install on transient apt failures

### DIFF
--- a/ci/test/console/e2e-prod.sh
+++ b/ci/test/console/e2e-prod.sh
@@ -44,7 +44,7 @@ corepack enable
 
 ci_collapsed_heading "Installing dependencies"
 retry yarn install --immutable --network-timeout 30000
-yarn playwright install --with-deps
+retry yarn playwright install --with-deps
 ci_collapsed_heading "Pulling Vercel production environment"
 npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
 mv .vercel/.env.production.local .vercel/.env.preview.local

--- a/ci/test/console/e2e.sh
+++ b/ci/test/console/e2e.sh
@@ -187,7 +187,7 @@ cd console
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 corepack enable
 retry yarn install --immutable --network-timeout 30000
-yarn playwright install --with-deps
+retry yarn playwright install --with-deps
 
 # --- Run tests ---
 


### PR DESCRIPTION
## Summary

- `yarn playwright install --with-deps` runs `apt-get update && apt-get install` internally, which occasionally fails when an Ubuntu mirror is mid-sync (e.g. `File has unexpected size (2401603 != 2401619). Mirror sync in progress?`).
- Wrap the install in the existing shlib `retry` helper — same pattern already used for `yarn install` in these scripts.
- Applies to both `ci/test/console/e2e.sh` and `ci/test/console/e2e-prod.sh`.

Observed in [build #120924, console-e2e-slash-prod](https://buildkite.com/materialize/test/builds/120924#019d96ee-6378-48c8-b91e-c12e89c2d86e).

## Test plan

- [ ] CI passes on this PR
- [ ] No regression in the happy path (install still works on the first attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)