### PR TITLE
tls-util: zeroize sensitive data in consumers, not just Pkcs12Archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,6 +5960,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -16,6 +16,7 @@ openssl.workspace = true
 reqwest.workspace = true
 mz-tls-util = { path = "../tls-util" }
 proptest.workspace = true
+zeroize.workspace = true
 proptest-derive.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -12,6 +12,7 @@
 use serde::{Deserialize, Serialize};
 
 use mz_tls_util::pkcs12der_from_pem;
+use zeroize::Zeroize;
 
 /// A [Serde][serde]-enabled wrapper around [`reqwest::Identity`].
 ///
@@ -22,14 +23,24 @@ pub struct Identity {
     pass: String,
 }
 
+impl Zeroize for Identity {
+    fn zeroize(&mut self) {
+        self.der.zeroize();
+        self.pass.zeroize();
+    }
+}
+
+impl Drop for Identity {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
 impl Identity {
     /// Constructs an identity from a PEM-formatted key and certificate using OpenSSL.
     pub fn from_pem(key: &[u8], cert: &[u8]) -> Result<Self, openssl::error::ErrorStack> {
-        let mut archive = pkcs12der_from_pem(key, cert)?;
-        Ok(Identity {
-            der: std::mem::take(&mut archive.der),
-            pass: std::mem::take(&mut archive.pass),
-        })
+        let (der, pass) = pkcs12der_from_pem(key, cert)?.into_parts();
+        Ok(Identity { der, pass })
     }
 
     /// Wraps [`reqwest::Identity::from_pkcs12_der`].

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -2006,9 +2006,8 @@ impl MySqlConnection<InlinedConnection> {
                 .read_string_in_task_if(in_task, identity.key)
                 .await?;
             let cert = identity.cert.get_string(in_task, secrets_reader).await?;
-            let mut archive = mz_tls_util::pkcs12der_from_pem(key.as_bytes(), cert.as_bytes())?;
-            let der = std::mem::take(&mut archive.der);
-            let pass = std::mem::take(&mut archive.pass);
+            let (der, pass) =
+                mz_tls_util::pkcs12der_from_pem(key.as_bytes(), cert.as_bytes())?.into_parts();
 
             // Add client identity to SSLOpts
             ssl_opts = ssl_opts.map(|opts| {

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -114,6 +114,15 @@ impl Drop for Pkcs12Archive {
     }
 }
 
+impl Pkcs12Archive {
+    pub fn into_parts(self) -> (Vec<u8>, String) {
+        let mut md = std::mem::ManuallyDrop::new(self);
+        let der = std::mem::take(&mut md.der);
+        let pass = std::mem::take(&mut md.pass);
+        (der, pass)
+    }
+}
+
 /// Constructs an identity from a PEM-formatted key and certificate using OpenSSL.
 pub fn pkcs12der_from_pem(
     key: &[u8],


### PR DESCRIPTION
The std::mem::take pattern moved der/pass out of Pkcs12Archive into types that didn't zeroize on drop, so the archive's Drop only zeroed empty fields. Fix by adding Pkcs12Archive::into_parts() to cleanly consume the archive, and implementing Zeroize + Drop on ccsr::Identity so the actual sensitive data is zeroized when dropped.

Follow-up to 16c15ae7