### PR TITLE
catalog: fix wrong unique key on mz_dataflow_global_ids

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6473,7 +6473,7 @@ pub static MZ_DATAFLOW_GLOBAL_IDS: LazyLock<BuiltinView> = LazyLock::new(|| Buil
     desc: RelationDesc::builder()
         .with_column("id", SqlScalarType::UInt64.nullable(false))
         .with_column("global_id", SqlScalarType::String.nullable(false))
-        .with_key(vec![0])
+        .with_key(vec![0, 1])
         .finish(),
     column_comments: BTreeMap::from_iter([
         ("id", "The dataflow ID."),

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -382,7 +382,7 @@ impl LogVariant {
                 .with_column("id", SqlScalarType::UInt64.nullable(false))
                 .with_column("worker_id", SqlScalarType::UInt64.nullable(false))
                 .with_column("global_id", SqlScalarType::String.nullable(false))
-                .with_key(vec![0, 1])
+                .with_key(vec![0, 1, 2])
                 .finish(),
 
             LogVariant::Compute(ComputeLog::PrometheusMetrics) => RelationDesc::builder()

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -203,6 +203,7 @@ bar  mz_cluster_prometheus_metrics  mz_cluster_prometheus_metrics_u7_primary_idx
 bar  mz_cluster_prometheus_metrics  mz_cluster_prometheus_metrics_u7_primary_idx  3  labels  NULL  false
 bar  mz_compute_dataflow_global_ids_per_worker  mz_compute_dataflow_global_ids_per_worker_u7_primary_idx  1  id  NULL  false
 bar  mz_compute_dataflow_global_ids_per_worker  mz_compute_dataflow_global_ids_per_worker_u7_primary_idx  2  worker_id  NULL  false
+bar  mz_compute_dataflow_global_ids_per_worker  mz_compute_dataflow_global_ids_per_worker_u7_primary_idx  3  global_id  NULL  false
 bar  mz_compute_error_counts_raw  mz_compute_error_counts_raw_u7_primary_idx  1  export_id  NULL  false
 bar  mz_compute_error_counts_raw  mz_compute_error_counts_raw_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_compute_exports_per_worker  mz_compute_exports_per_worker_u7_primary_idx  1  export_id  NULL  false

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -51,7 +51,7 @@ mz_cluster_replicas_ind  CREATE␠INDEX␠"mz_cluster_replicas_ind"␠IN␠CLUST
 mz_clusters_ind  CREATE␠INDEX␠"mz_clusters_ind"␠IN␠CLUSTER␠[s2]␠ON␠[s499␠AS␠"mz_catalog"."mz_clusters"]␠("id")
 mz_columns_ind  CREATE␠INDEX␠"mz_columns_ind"␠IN␠CLUSTER␠[s2]␠ON␠[s472␠AS␠"mz_catalog"."mz_columns"]␠("name")
 mz_comments_ind  CREATE␠INDEX␠"mz_comments_ind"␠IN␠CLUSTER␠[s2]␠ON␠[s522␠AS␠"mz_internal"."mz_comments"]␠("id")
-mz_compute_dataflow_global_ids_per_worker_s2_primary_idx  CREATE␠INDEX␠"mz_compute_dataflow_global_ids_per_worker_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_compute_dataflow_global_ids_per_worker"␠("id",␠"worker_id")
+mz_compute_dataflow_global_ids_per_worker_s2_primary_idx  CREATE␠INDEX␠"mz_compute_dataflow_global_ids_per_worker_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_compute_dataflow_global_ids_per_worker"␠("id",␠"worker_id",␠"global_id")
 mz_compute_dependencies_ind  CREATE␠INDEX␠"mz_compute_dependencies_ind"␠IN␠CLUSTER␠[s2]␠ON␠[s724␠AS␠"mz_internal"."mz_compute_dependencies"]␠("dependency_id")
 mz_compute_error_counts_raw_s2_primary_idx  CREATE␠INDEX␠"mz_compute_error_counts_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_compute_error_counts_raw"␠("export_id",␠"worker_id")
 mz_compute_exports_per_worker_s2_primary_idx  CREATE␠INDEX␠"mz_compute_exports_per_worker_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_compute_exports_per_worker"␠("export_id",␠"worker_id")

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -309,7 +309,7 @@ mz_clusters_ind                                             mz_clusters         
 mz_columns_ind                                              mz_columns                                   mz_catalog_server    {name}                                      ""
 mz_comments_ind                                             mz_comments                                  mz_catalog_server    {id}                                        ""
 mz_compute_dependencies_ind                                 mz_compute_dependencies                      mz_catalog_server    {dependency_id}                             ""
-mz_compute_dataflow_global_ids_per_worker_s2_primary_idx   mz_compute_dataflow_global_ids_per_worker     mz_catalog_server    {id,worker_id}                             ""
+mz_compute_dataflow_global_ids_per_worker_s2_primary_idx   mz_compute_dataflow_global_ids_per_worker     mz_catalog_server    {id,worker_id,global_id}                   ""
 mz_compute_error_counts_raw_s2_primary_idx                  mz_compute_error_counts_raw                  mz_catalog_server    {export_id,worker_id}                       ""
 mz_compute_exports_per_worker_s2_primary_idx                mz_compute_exports_per_worker                mz_catalog_server    {export_id,worker_id}                       ""
 mz_compute_frontiers_per_worker_s2_primary_idx              mz_compute_frontiers_per_worker              mz_catalog_server    {export_id,worker_id}                       ""

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -576,5 +576,38 @@ idx3_div_by_zero 3
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 
+# Regression test for database-issues#11314: mz_dataflow_global_ids
+# declared a false unique key on `id`, which caused the optimizer to
+# drop `DISTINCT id` and return the wrong number of dataflows when a
+# single dataflow hosts multiple global IDs (e.g. an index that inlines
+# a view).
+
+> CREATE TABLE t_gid (x INT NOT NULL, y INT, z TEXT)
+> CREATE VIEW v_gid AS
+    SELECT t1.x, t1.z AS z1, t2.z AS z2
+    FROM t_gid AS t1, t_gid AS t2
+    WHERE t1.x = t2.y
+> CREATE INDEX v_gid_idx ON v_gid (x)
+
+# The index dataflow hosts two global IDs (the view and the index).
+> SELECT COUNT(*)
+  FROM mz_introspection.mz_dataflow_global_ids dgi
+  JOIN mz_introspection.mz_compute_exports ce ON dgi.id = ce.dataflow_id
+  JOIN mz_objects o ON ce.export_id = o.id
+  WHERE o.name = 'v_gid_idx'
+2
+
+# `DISTINCT id` must collapse those two rows to one.
+> SELECT COUNT(*) FROM (
+    SELECT DISTINCT dgi.id
+    FROM mz_introspection.mz_dataflow_global_ids dgi
+    JOIN mz_introspection.mz_compute_exports ce ON dgi.id = ce.dataflow_id
+    JOIN mz_objects o ON ce.export_id = o.id
+    WHERE o.name = 'v_gid_idx'
+  )
+1
+
+> DROP TABLE t_gid CASCADE
+
 # Cleanup.
 > DROP CLUSTER test CASCADE


### PR DESCRIPTION
A single dataflow may host multiple `GlobalId`s (view + index in the same dataflow, for example), so `id` alone is not a unique key for either the `mz_dataflow_global_ids` view or the underlying `mz_compute_dataflow_global_ids_per_worker` log source.
The false key declarations let the optimizer drop `DISTINCT` on `id`, producing wrong results.

Repro:

```sql
CREATE TABLE t(x INT NOT NULL, y INT, z TEXT);
CREATE VIEW v AS
  SELECT t1.x, t1.z AS z1, t2.z AS z2
  FROM t AS t1, t AS t2
  WHERE t1.x = t2.y;
CREATE INDEX v_idx ON v(x);
SELECT mz_unsafe.mz_sleep(8);
SELECT COUNT(*) FROM (SELECT DISTINCT id FROM mz_internal.mz_dataflow_global_ids);
```

Returns 2 despite there being exactly one dataflow ID.

Fix the view key to `(id, global_id)` and the log source key to `(id, worker_id, global_id)`.
Includes a testdrive regression test in `introspection-sources.td` that reproduces the scenario.
The regression was introduced by #35889 and shipped in v26.20.

Fixes https://github.com/MaterializeInc/database-issues/issues/11314