### PR TITLE
authenticator: Zeroize OidcClaims on drop, not just on explicit call

### DIFF
--- a/src/authenticator/src/oidc.rs
+++ b/src/authenticator/src/oidc.rs
@@ -193,8 +193,47 @@ impl Zeroize for OidcClaims {
             s.zeroize();
         }
         self.aud.clear();
-        // serde_json::Value doesn't implement Zeroize; clearing is best-effort.
-        self.unknown_claims.clear();
+        // serde_json::Value doesn't implement Zeroize; drain entries and
+        // zeroize keys/values before the backing allocations are freed.
+        while let Some((mut k, mut v)) = self.unknown_claims.pop_first() {
+            k.zeroize();
+            zeroize_json_value(&mut v);
+        }
+    }
+}
+
+impl Drop for OidcClaims {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// `OidcClaims` implements both `Zeroize` and `Drop` (which calls `zeroize()`),
+/// satisfying the `ZeroizeOnDrop` contract.
+impl ZeroizeOnDrop for OidcClaims {}
+
+fn zeroize_json_value(v: &mut serde_json::Value) {
+    use serde_json::Value;
+    match v {
+        Value::String(s) => s.zeroize(),
+        Value::Array(a) => {
+            for item in a.iter_mut() {
+                zeroize_json_value(item);
+            }
+            a.clear();
+        }
+        Value::Object(map) => {
+            let taken = std::mem::take(map);
+            for (mut k, mut nested) in taken {
+                k.zeroize();
+                zeroize_json_value(&mut nested);
+            }
+        }
+        Value::Number(_) => {
+            *v = Value::Number(serde_json::Number::from(0u8));
+        }
+        Value::Bool(b) => *b = false,
+        Value::Null => {}
     }
 }
 
@@ -594,6 +633,13 @@ mod tests {
         };
         claims.zeroize();
         assert!(claims.user.is_empty());
+    }
+
+    #[mz_ore::test]
+    fn oidc_claims_implements_zeroize_on_drop() {
+        fn assert_zod<T: ZeroizeOnDrop>() {}
+        assert_zod::<OidcClaims>();
+        assert_zod::<ValidatedClaims>();
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
Follow-up to #35704.

The existing `impl Zeroize for OidcClaims` was dead code in production: nothing in the runtime path called `.zeroize()` on it, and it did not implement `ZeroizeOnDrop` or a manual `Drop`. The only caller was the unit test.

In `validate_token`, `jsonwebtoken::decode::<OidcClaims>` produces a `TokenData` whose `claims` field holds the full JWT payload including `unknown_claims` (email, sub, groups, preferred_username, etc.). When `token_data` drops at the end of the function, none of that is zeroed — the sensitive data stays in freed heap memory.

Add `impl Drop` that calls `self.zeroize()` and an `unsafe impl ZeroizeOnDrop` so every `OidcClaims` instance is automatically zeroized when it goes out of scope. Add a compile-time regression test (`assert_zod::<OidcClaims>()`) to prevent silent removal of `ZeroizeOnDrop` in the future.