### PR TITLE
[COPY FROM pq] Dedupe pq map keys, choosing final one

### DIFF
--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -835,12 +835,24 @@ impl ColReader {
                 // Arrow's MapArray doesn't guarantee that keys are in sorted order, but Materialize's
                 // Datum::Map does, so we need to sort the keys here before packing them, or else
                 // many assumptions will break.
-                let kv_sorted = (start..end)
+                let mut kv_sorted = (start..end)
                     .map(|i| (keys.value(i), i))
-                    .sorted_by_key(|(k, _)| *k);
+                    .sorted_by_key(|(k, _)| *k)
+                    .peekable();
+
                 packer
                     .push_dict_with(|packer| {
-                        for (key, i) in kv_sorted {
+                        while let Some((key, i)) = kv_sorted.next() {
+                            // Parquet docs state that if there are duplicate keys, the last value
+                            // should be used, so skip duplicates here.
+                            //
+                            // sorted_by_key is a stable sort, so entries with duplicate keys will
+                            // maintain their original order, and we can pick the last one here.
+                            if let Some((next_key, _)) = kv_sorted.peek() {
+                                if key == *next_key {
+                                    continue;
+                                }
+                            }
                             packer.push(Datum::String(key));
                             values.read(i, packer)?;
                         }

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -685,6 +685,15 @@ fn build_parquet_unsorted_map_batch() -> Result<RecordBatch, anyhow::Error> {
     // Row 3: empty map
     map_builder.append(true).context("appending map row 3")?;
 
+    // Row 4: duplicate keys - should be deduped and the last one chosen by the reader
+    map_builder.keys().append_value("y");
+    map_builder.values().append_value("val_y");
+    map_builder.keys().append_value("y");
+    map_builder.values().append_value("val_y2");
+    map_builder.keys().append_value("y");
+    map_builder.values().append_value("val_y3");
+    map_builder.append(true).context("appending map row 4")?;
+
     let map_array = Arc::new(map_builder.finish());
 
     let schema = Arc::new(Schema::new(vec![
@@ -711,7 +720,7 @@ fn build_parquet_unsorted_map_batch() -> Result<RecordBatch, anyhow::Error> {
 
     let batch = RecordBatch::try_new(
         schema,
-        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4])), map_array],
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])), map_array],
     )
     .context("building record batch")?;
 

--- a/test/testdrive/copy-from-parquet-unsorted-map-keys.td
+++ b/test/testdrive/copy-from-parquet-unsorted-map-keys.td
@@ -39,6 +39,7 @@ ALTER SYSTEM SET enable_copy_from_remote = true;
 # Row 1: id=2, keys unsorted: {"b": "val_b", "a": "val_a"}
 # Row 2: id=3, single key (trivially sorted): {"x": "val_x"}
 # Row 3: id=4, empty map: {}
+# Row 4: id=5, duplicated keys: {"y": "val_y", "y": "val_y2", "y": "val_y3"}
 $ s3-upload-parquet-unsorted-map bucket=copyfroms3 key=parquet/unsorted_map.parquet
 
 > CREATE TABLE from_parquet (id int, map_col map[text => text]);
@@ -54,7 +55,8 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
   (1, '{a=>val_a,m=>val_m,z=>val_z}'),
   (2, '{a=>val_a,b=>val_b}'),
   (3, '{x=>val_x}'),
-  (4, '{}');
+  (4, '{}'),
+  (5, '{y=>val_y3}');
 
 # Verify that COPY FROM'd maps have keys in sorted order.
 # If the bug is present, keys will be in their original unsorted order
@@ -64,6 +66,7 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
 2 {a=>val_a,b=>val_b}
 3 {x=>val_x}
 4 {}
+5 {y=>val_y3}
 
 # Verify equality: maps from COPY FROM should equal maps inserted via SQL.
 # If unsorted, these will NOT match, demonstrating silent data corruption.
@@ -75,6 +78,7 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
 2 true
 3 true
 4 true
+5 true
 
 # Verify that a join on map_col works correctly.
 # If keys are unsorted, hash/equality is broken and this join will miss rows.
@@ -86,3 +90,4 @@ $ s3-set-presigned-url bucket=copyfroms3 key=parquet/unsorted_map.parquet var-na
 2
 3
 4
+5


### PR DESCRIPTION
https://github.com/MaterializeInc/database-issues/issues/11290#issue-4251375732

[Parquet docs state](https://parquet.apache.org/docs/file-format/types/logicaltypes/) that if there are duplicate keys in a map, then the final one is the actual value. This adds logic to dedupe entries with duplicate keys by skipping entries when the next one has an identical key, using the fact that the entries are sorted by this point to guarantee that identical keys will be adjacent. 

`sorted_by_key` is a stable sort function, meaning that entries with identical keys will retain their original ordering, allowing us to dedupe like this.

Updates `test/testdrive/copy-from-parquet-unsorted-map-keys.td` to test this functionality.