### PR TITLE
mcp: fix origin validation to use CORS allowlist instead of Origin/Host self-comparison

### DIFF
--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -782,6 +782,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         allowed_origins
     };
     let cors_allowed_origin = mz_http_util::build_cors_allowed_origin(&allowed_origins);
+    let cors_allowed_origin_list = allowed_origins.clone();
 
     // Configure controller.
     let entered = info_span!("environmentd::configure_controller").entered();
@@ -1087,6 +1088,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 external_login_password_mz_system: args.external_login_password_mz_system,
                 frontegg,
                 cors_allowed_origin,
+                cors_allowed_origin_list,
                 egress_addresses: args.announce_egress_address,
                 http_host_name: args.http_host_name,
                 internal_console_redirect_url: args.internal_console_redirect_url,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -150,6 +150,9 @@ pub struct HttpConfig {
     pub oidc_rx: Delayed<mz_authenticator::GenericOidcAuthenticator>,
     pub adapter_client_rx: Shared<Receiver<Client>>,
     pub allowed_origin: AllowOrigin,
+    /// Raw list of allowed CORS origins, used by the MCP endpoints for
+    /// server-side Origin validation to defend against DNS rebinding.
+    pub allowed_origin_list: Vec<HeaderValue>,
     pub active_connection_counter: ConnectionCounter,
     pub helm_chart_version: Option<String>,
     pub concurrent_webhook_req: Arc<tokio::sync::Semaphore>,
@@ -201,6 +204,7 @@ impl HttpServer {
             oidc_rx,
             adapter_client_rx,
             allowed_origin,
+            allowed_origin_list,
             active_connection_counter,
             helm_chart_version,
             concurrent_webhook_req,
@@ -497,15 +501,23 @@ impl HttpServer {
                 );
             }
 
+            // The MCP handlers perform a server-side Origin check against this
+            // allowlist to defend against DNS rebinding attacks (see
+            // database-issues#11311). The CorsLayer alone is not enough: in a
+            // DNS rebinding attack the browser considers the request
+            // same-origin, so no preflight fires and CORS enforcement is
+            // bypassed.
+            let mcp_allowed_origins = Arc::new(allowed_origin_list.clone());
             mcp_router = mcp_router
                 .layer(auth_middleware.clone())
                 .layer(Extension(adapter_client_rx.clone()))
                 .layer(Extension(active_connection_counter.clone()))
+                .layer(Extension(mcp_allowed_origins))
                 .layer(
                     CorsLayer::new()
                         .allow_methods(Method::POST)
-                        .allow_origin(AllowOrigin::mirror_request())
-                        .allow_headers(Any),
+                        .allow_origin(allowed_origin.clone())
+                        .allow_headers([AUTHORIZATION, CONTENT_TYPE]),
                 );
             router = router.merge(mcp_router);
         }

--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -23,12 +23,14 @@
 //!
 //! Data products are discovered via `mz_internal.mz_mcp_data_products` system view.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
+use axum::Extension;
 use axum::Json;
 use axum::response::IntoResponse;
-use http::{HeaderMap, StatusCode};
+use http::{HeaderMap, HeaderValue, StatusCode};
 use mz_adapter_types::dyncfgs::{
     ENABLE_MCP_AGENT, ENABLE_MCP_AGENT_QUERY_TOOL, ENABLE_MCP_DEVELOPER, MCP_MAX_RESPONSE_SIZE,
 };
@@ -378,10 +380,11 @@ pub async fn handle_mcp_method_not_allowed() -> impl IntoResponse {
 /// Agent endpoint: exposes user data products.
 pub async fn handle_mcp_agent(
     headers: HeaderMap,
+    Extension(allowed_origins): Extension<Arc<Vec<HeaderValue>>>,
     client: AuthedClient,
     Json(body): Json<McpRequest>,
 ) -> axum::response::Response {
-    if let Some(resp) = validate_origin(&headers) {
+    if let Some(resp) = validate_origin(&headers, &allowed_origins) {
         return resp;
     }
     handle_mcp_request(client, body, McpEndpointType::Agent)
@@ -392,10 +395,11 @@ pub async fn handle_mcp_agent(
 /// Developer endpoint: exposes system catalog (mz_*) only.
 pub async fn handle_mcp_developer(
     headers: HeaderMap,
+    Extension(allowed_origins): Extension<Arc<Vec<HeaderValue>>>,
     client: AuthedClient,
     Json(body): Json<McpRequest>,
 ) -> axum::response::Response {
-    if let Some(resp) = validate_origin(&headers) {
+    if let Some(resp) = validate_origin(&headers, &allowed_origins) {
         return resp;
     }
     handle_mcp_request(client, body, McpEndpointType::Developer)
@@ -403,38 +407,27 @@ pub async fn handle_mcp_developer(
         .into_response()
 }
 
-/// Validates the Origin header to prevent DNS rebinding attacks (MCP 2025-11-25).
-/// Returns Some(403) if the Origin is present but doesn't match the Host.
-/// Returns None if the Origin is absent (non-browser client) or valid.
-fn validate_origin(headers: &HeaderMap) -> Option<axum::response::Response> {
-    let origin = match headers.get(http::header::ORIGIN) {
-        Some(o) => o,
-        None => return None, // No Origin header = non-browser client, allow
-    };
-
-    let host = headers
-        .get(http::header::HOST)
-        .and_then(|h| h.to_str().ok());
-
-    let origin_str = origin.to_str().ok().unwrap_or("");
-
-    // Extract host portion from Origin (strip scheme)
-    let origin_host = origin_str
-        .strip_prefix("https://")
-        .or_else(|| origin_str.strip_prefix("http://"))
-        .unwrap_or(origin_str);
-
-    match host {
-        Some(h) if h == origin_host => None, // Origin matches Host
-        _ => {
-            warn!(
-                origin = origin_str,
-                host = ?host,
-                "MCP request rejected: Origin does not match Host",
-            );
-            Some(StatusCode::FORBIDDEN.into_response())
-        }
+/// Validates the Origin header against the CORS allowlist to prevent DNS
+/// rebinding attacks (MCP spec 2025-11-25). Returns Some(403) if Origin is
+/// present but not on the allowlist. Returns None if absent (non-browser
+/// client) or allowed.
+///
+/// Note: this server-side check is required in addition to the CorsLayer.
+/// CorsLayer only controls response headers and can be bypassed when the
+/// attacker arranges same-origin DNS rebinding (no preflight fires).
+fn validate_origin(
+    headers: &HeaderMap,
+    allowed: &[HeaderValue],
+) -> Option<axum::response::Response> {
+    let origin = headers.get(http::header::ORIGIN)?;
+    if mz_http_util::origin_is_allowed(origin, allowed) {
+        return None;
     }
+    warn!(
+        origin = ?origin,
+        "MCP request rejected: origin not in allowlist",
+    );
+    Some(StatusCode::FORBIDDEN.into_response())
 }
 
 async fn handle_mcp_request(
@@ -1664,46 +1657,6 @@ mod tests {
         assert!(safe_data_product_name("my_view, secrets").is_err());
         // SQL keywords after name are rejected by the parser
         assert!(safe_data_product_name("my_view WHERE 1=1 --").is_err());
-    }
-
-    // ── Origin validation tests ────────────────────────────────────────
-
-    #[mz_ore::test]
-    fn test_validate_origin_no_header() {
-        let headers = HeaderMap::new();
-        assert!(validate_origin(&headers).is_none(), "No Origin = allow");
-    }
-
-    #[mz_ore::test]
-    fn test_validate_origin_matching() {
-        let mut headers = HeaderMap::new();
-        headers.insert(http::header::ORIGIN, "https://example.com".parse().unwrap());
-        headers.insert(http::header::HOST, "example.com".parse().unwrap());
-        assert!(
-            validate_origin(&headers).is_none(),
-            "Matching Origin = allow"
-        );
-    }
-
-    #[mz_ore::test]
-    fn test_validate_origin_mismatch() {
-        let mut headers = HeaderMap::new();
-        headers.insert(http::header::ORIGIN, "https://evil.com".parse().unwrap());
-        headers.insert(http::header::HOST, "example.com".parse().unwrap());
-        assert!(
-            validate_origin(&headers).is_some(),
-            "Mismatched Origin = reject"
-        );
-    }
-
-    #[mz_ore::test]
-    fn test_validate_origin_no_host() {
-        let mut headers = HeaderMap::new();
-        headers.insert(http::header::ORIGIN, "https://example.com".parse().unwrap());
-        assert!(
-            validate_origin(&headers).is_some(),
-            "Origin with no Host = reject"
-        );
     }
 
     #[mz_ore::test]

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -13,6 +13,7 @@
 //! [differential dataflow]: ../differential_dataflow/index.html
 //! [timely dataflow]: ../timely/index.html
 
+use ::http::HeaderValue;
 use std::collections::BTreeMap;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
@@ -109,6 +110,11 @@ pub struct Config {
     /// Origins for which cross-origin resource sharing (CORS) for HTTP requests
     /// is permitted.
     pub cors_allowed_origin: AllowOrigin,
+    /// Raw list of allowed CORS origins. Retained alongside `cors_allowed_origin`
+    /// (which is the computed predicate) so that endpoints like MCP can perform
+    /// server-side Origin validation to defend against DNS rebinding attacks
+    /// (where same-origin requests bypass CORS enforcement).
+    pub cors_allowed_origin_list: Vec<HeaderValue>,
     /// Public IP addresses which the cloud environment has configured for
     /// egress.
     pub egress_addresses: Vec<IpNet>,
@@ -397,6 +403,7 @@ impl Listeners {
                 frontegg: config.frontegg.clone(),
                 oidc_rx: authenticator_oidc_rx.clone(),
                 allowed_origin: config.cors_allowed_origin.clone(),
+                allowed_origin_list: config.cors_allowed_origin_list.clone(),
                 concurrent_webhook_req: webhook_concurrency_limit.semaphore(),
                 metrics: metrics.clone(),
                 metrics_registry: metrics_registry.clone(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -876,6 +876,7 @@ impl Listeners {
                 now: config.now,
                 environment_id: config.environment_id,
                 cors_allowed_origin: AllowOrigin::list([]),
+                cors_allowed_origin_list: Vec::new(),
                 cluster_replica_sizes: ClusterReplicaSizeMap::for_tests(),
                 bootstrap_default_cluster_replica_size: config.default_cluster_replica_size,
                 bootstrap_default_cluster_replication_factor: config

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -156,6 +156,37 @@ pub async fn handle_tracing() -> impl IntoResponse {
     )
 }
 
+/// Returns true if `origin` matches any entry in `allowed`. Supports bare `*`
+/// (any origin), exact match, and wildcard subdomains (`*.example.com`).
+pub fn origin_is_allowed(origin: &HeaderValue, allowed: &[HeaderValue]) -> bool {
+    fn wildcard_origin_match(origin: &HeaderValue, wildcard: &[u8]) -> bool {
+        let Some(origin) = origin.to_str().ok() else {
+            return false;
+        };
+        let Ok(origin) = origin.parse::<Uri>() else {
+            return false;
+        };
+        let Some(host) = origin.host() else {
+            return false;
+        };
+
+        host.as_bytes().ends_with(wildcard)
+    }
+
+    if allowed.iter().any(|o| o.as_bytes() == b"*") {
+        return true;
+    }
+    for val in allowed {
+        if (val.as_bytes().starts_with(b"*.")
+            && wildcard_origin_match(origin, &val.as_bytes()[1..]))
+            || origin == val
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Construct a CORS policy to allow origins to query us via HTTP. If any bare
 /// '*' is passed, this allows any origin; otherwise, allows a list of origins,
 /// which can include wildcard subdomains. If the allowed origin starts with a

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1198,6 +1198,7 @@ impl<'a> RunnerInner<'a> {
             tls: None,
             frontegg: None,
             cors_allowed_origin: AllowOrigin::list([]),
+            cors_allowed_origin_list: Vec::new(),
             unsafe_mode: true,
             all_features: false,
             metrics_registry,


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/database-issues/issues/11311

The previous `validate_origin` function compared the request's Origin against its Host header, which doesn't prevent DNS rebinding.

Replacing the manual check with the existing `allowed_origin` CORS allowlist (built from `localhost`/`127.0.0.1`/`[::1]` defaults or `--cors-allowed-origin` flags), applied via `CorsLayer` on the MCP router. This matches the pattern used by the base router.

