### PR TITLE
ci: Fix nightlies / release qualification (2026-04-18)

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -143,7 +143,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
-            args: [--scenario=UserTablesLarge, --actions=200000]
+            args: [--scenario=UserTablesLarge, --actions=100000]
 
     - id: zippy-debezium-postgres-long
       label: "Longer Zippy Debezium Postgres"

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -215,16 +215,30 @@ class ScenarioRunner:
             }
         )
 
-    def run_query(self, query: str, fetch: bool = False, **params) -> list | None:
+    def run_query(
+        self, query: str, fetch: bool = False, retries: int = 5, **params
+    ) -> list | None:
         query = dedent(query).strip()
         if "CREATE SECRET" not in query:
             print(f"> {query} {params or ''}")
-        with self.connection as cur:
-            cur.execute(query.encode(), params)
-            if fetch:
-                return cur.fetchall()
-            else:
-                return None
+        for retry in range(retries + 1):
+            try:
+                with self.connection as cur:
+                    cur.execute(query.encode(), params)
+                    if fetch:
+                        return cur.fetchall()
+                    else:
+                        return None
+            except (
+                InterfaceError,
+                OperationalError,
+                psycopg.errors.SystemError,
+            ) as e:
+                if retry >= retries:
+                    raise
+                print(f"Retryable error (attempt {retry + 1}/{retries}): {e}")
+                time.sleep(5 * (retry + 1))
+        return None
 
     def measure(
         self,

--- a/test/pg-cdc/alter-table-after-source-2.td
+++ b/test/pg-cdc/alter-table-after-source-2.td
@@ -219,6 +219,10 @@ contains:table was truncated
 #
 # Drop table
 
+# TODO: Reenable when https://github.com/MaterializeInc/database-issues/issues/9571 is fixed
+$ skip-if
+SELECT true
+
 > SELECT * from drop_table;
 1 1
 
@@ -228,3 +232,5 @@ DROP TABLE drop_table;
 # Table is dropped
 ! SELECT * FROM drop_table;
 regex:(table was dropped|incompatible schema change)
+
+$ skip-end

--- a/test/sqlancer/Dockerfile
+++ b/test/sqlancer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
 # TODO: Put this back when merged: https://github.com/sqlancer/sqlancer/pull/1307 & DQP
 RUN git clone https://github.com/MaterializeInc/sqlancer \
     && cd sqlancer \
-    && git checkout d631c696e909fa70bf837faf005299faa2086d93 \
+    && git checkout 970f3439fd9abc9719960991fc816a2342426015 \
     && rm -rf .git \
     && mvn package -DskipTests
 # RUN git clone --depth=1 --single-branch https://github.com/sqlancer/sqlancer \

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -28,7 +28,7 @@ from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.sqlsmith import known_errors
 
-TOTAL_MEMORY = 8
+TOTAL_MEMORY = 16
 NUM_SERVERS = 2
 MZ_SERVERS = [f"mz_{i + 1}" for i in range(NUM_SERVERS)]
 


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/16127#019d9dc7-ec49-4644-accb-8727a7f5d37e and https://buildkite.com/materialize/release-qualification/builds/1196 and all other RQ runs in v26.20

Test runs: https://buildkite.com/materialize/nightly/builds/16128 & https://buildkite.com/materialize/release-qualification/builds/1199