### PR TITLE
mcp: extend test version regex to match -rc.N suffix

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4969,7 +4969,7 @@ fn test_webhook_request_compression() {
 
 /// Helper to set up an MCP test server and run datadriven tests.
 fn run_mcp_datadriven(testdata_path: &str, harness: test_util::TestHarness) {
-    let version_re = Regex::new(r#"\d+\.\d+\.\d+(\.\d+)?(-dev(\.\d+)?)?"#).unwrap();
+    let version_re = Regex::new(r#"\d+\.\d+\.\d+(\.\d+)?(-(dev|rc)(\.\d+)?)?"#).unwrap();
 
     datadriven::walk(testdata_path, |f| {
         let server = harness.clone().start_blocking();


### PR DESCRIPTION
### Motivation

The MCP datadriven tests in `src/environmentd/tests/server.rs` strip version
strings to `<VERSION>` for stable expected output. The regex handled `-dev.N`
but not `-rc.N`:

Caught by [test/121029](https://buildkite.com/materialize/test/builds/121029) (v26.21.0-rc.1) on `test_mcp_agent` and `test_mcp_developer`.

### Tips for reviewer

- One-line change to the regex; behavior on `main` and `-dev` builds is unchanged.
- After this lands on `main`, it should be cherry-picked onto the v26.21.0-rc.1 release branch so RC qualification can complete green. Earlier RC branches (v26.20, v26.19, v26.18) likely also need the cherry-pick if any further qualification work is planned on them.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] If this PR evolves an existing `$T ⇔ Proto$T` mapping (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. (N/A)
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR. (N/A)
- [x] If this PR includes major user-facing behavior changes, I have pinged the relevant PM to schedule a changelog post. (N/A — test-only fix)