### PR TITLE
Catalog implications: Hydrate plans in parse_item from the expression cache

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1394,7 +1394,7 @@ impl Catalog {
         let updates = self.storage().await.sync_to_current_updates().await?;
         let (builtin_table_updates, catalog_updates) = self
             .state
-            .apply_updates(updates, &mut state::LocalExpressionCache::Closed)
+            .apply_updates(updates, &mut state::InMemoryExpressionCache::Closed)
             .await;
         Ok((builtin_table_updates, catalog_updates))
     }
@@ -2256,7 +2256,7 @@ mod tests {
     use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
     use mz_sql::session::vars::{SystemVars, VarInput};
 
-    use crate::catalog::state::LocalExpressionCache;
+    use crate::catalog::state::InMemoryExpressionCache;
     use crate::catalog::{Catalog, Op};
     use crate::optimize::dataflows::{EvalTime, ExprPrep, ExprPrepOneShot};
     use crate::session::Session;
@@ -2590,7 +2590,7 @@ mod tests {
                     gid,
                     &create_sql,
                     &BTreeMap::new(),
-                    &mut LocalExpressionCache::Closed,
+                    &mut InMemoryExpressionCache::Closed,
                     None,
                 )
                 .expect("unable to parse view");

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -63,7 +63,7 @@ use mz_transform::notice::OptimizerNotice;
 use tracing::{info_span, warn};
 
 use crate::AdapterError;
-use crate::catalog::state::LocalExpressionCache;
+use crate::catalog::state::InMemoryExpressionCache;
 use crate::catalog::{BuiltinTableUpdate, CatalogState};
 use crate::coord::catalog_implications::parsed_state_updates::{self, ParsedStateUpdate};
 use crate::util::{index_sql, sort_topological};
@@ -102,7 +102,7 @@ impl CatalogState {
     pub(crate) async fn apply_updates(
         &mut self,
         updates: Vec<StateUpdate>,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> (
         Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
         Vec<ParsedStateUpdate>,
@@ -136,7 +136,7 @@ impl CatalogState {
                         ApplyState::new(update),
                         self,
                         &mut retractions,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                     )
                     .await;
                 apply_state = next_apply_state;
@@ -146,7 +146,7 @@ impl CatalogState {
 
             // Apply remaining state.
             let (builtin_table_update, catalog_update) = apply_state
-                .apply(self, &mut retractions, local_expression_cache)
+                .apply(self, &mut retractions, in_memory_expression_cache)
                 .await;
             builtin_table_updates.extend(builtin_table_update);
             catalog_updates.extend(catalog_update);
@@ -205,7 +205,7 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> Result<
         (
             Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
@@ -249,7 +249,7 @@ impl CatalogState {
                         state_update.kind,
                         state_update.diff,
                         retractions,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                     )?;
                 }
                 StateDiff::Addition => {
@@ -257,7 +257,7 @@ impl CatalogState {
                         state_update.kind.clone(),
                         state_update.diff,
                         retractions,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                     )?;
                     // We want the builtin table addition to match the state of
                     // the catalog after applying the update. So that we already
@@ -291,7 +291,7 @@ impl CatalogState {
         kind: StateUpdateKind,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> Result<(), CatalogError> {
         match kind {
             StateUpdateKind::Role(role) => {
@@ -336,14 +336,19 @@ impl CatalogState {
                     system_object_mapping,
                     diff,
                     retractions,
-                    local_expression_cache,
+                    in_memory_expression_cache,
                 );
             }
             StateUpdateKind::TemporaryItem(item) => {
-                self.apply_temporary_item_update(item, diff, retractions, local_expression_cache);
+                self.apply_temporary_item_update(
+                    item,
+                    diff,
+                    retractions,
+                    in_memory_expression_cache,
+                );
             }
             StateUpdateKind::Item(item) => {
-                self.apply_item_update(item, diff, retractions, local_expression_cache)?;
+                self.apply_item_update(item, diff, retractions, in_memory_expression_cache)?;
             }
             StateUpdateKind::Comment(comment) => {
                 self.apply_comment_update(comment, diff, retractions);
@@ -689,7 +694,7 @@ impl CatalogState {
         system_object_mapping: mz_catalog::durable::SystemObjectMapping,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) {
         let item_id = system_object_mapping.unique_identifier.catalog_id;
         let global_id = system_object_mapping.unique_identifier.global_id;
@@ -805,7 +810,7 @@ impl CatalogState {
                         None,
                         index.is_retained_metrics_object,
                         custom_logical_compaction_window,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                         None,
                     )
                     .unwrap_or_else(|e| {
@@ -952,7 +957,7 @@ impl CatalogState {
                         None,
                         mv.is_retained_metrics_object,
                         custom_logical_compaction_window,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                         None,
                     )
                     .unwrap_or_else(|e| {
@@ -1003,7 +1008,7 @@ impl CatalogState {
                         None,
                         false,
                         None,
-                        local_expression_cache,
+                        in_memory_expression_cache,
                         None,
                     )
                     .unwrap_or_else(|e| {
@@ -1047,7 +1052,7 @@ impl CatalogState {
         temporary_item: TemporaryItem,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) {
         match diff {
             StateDiff::Addition => {
@@ -1095,7 +1100,7 @@ impl CatalogState {
                                     global_id,
                                     &create_sql,
                                     &extra_versions,
-                                    local_expression_cache,
+                                    in_memory_expression_cache,
                                     Some(retraction.item),
                                 )
                                 .unwrap_or_else(|e| {
@@ -1124,7 +1129,7 @@ impl CatalogState {
                                 global_id,
                                 &create_sql,
                                 &extra_versions,
-                                local_expression_cache,
+                                in_memory_expression_cache,
                                 None,
                             )
                             .unwrap_or_else(|e| {
@@ -1165,7 +1170,7 @@ impl CatalogState {
         item: mz_catalog::durable::Item,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> Result<(), CatalogError> {
         match diff {
             StateDiff::Addition => {
@@ -1198,7 +1203,7 @@ impl CatalogState {
                                 global_id,
                                 &create_sql,
                                 &extra_versions,
-                                local_expression_cache,
+                                in_memory_expression_cache,
                                 Some(retraction.item),
                             )
                             .unwrap_or_else(|e| {
@@ -1222,7 +1227,7 @@ impl CatalogState {
                                 global_id,
                                 &create_sql,
                                 &extra_versions,
-                                local_expression_cache,
+                                in_memory_expression_cache,
                                 None,
                             )
                             .unwrap_or_else(|e| {
@@ -1668,7 +1673,7 @@ impl CatalogState {
         state: &mut CatalogState,
         builtin_views: Vec<(&'static BuiltinView, CatalogItemId, GlobalId)>,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         let mut builtin_table_updates = Vec::with_capacity(builtin_views.len());
         let (updates, additions): (Vec<_>, Vec<_>) =
@@ -1729,7 +1734,8 @@ impl CatalogState {
                     let span = info_span!(parent: None, "parse builtin view", name = view.name);
                     OpenTelemetryContext::obtain().attach_as_parent_to(&span);
                     let task_state = Arc::clone(&spawn_state);
-                    let cached_expr = local_expression_cache.remove_cached_expression(&global_id);
+                    let cached_expr =
+                        in_memory_expression_cache.remove_cached_expression(&global_id);
                     let handle = mz_ore::task::spawn_blocking(
                         || "parse view",
                         move || {
@@ -1758,13 +1764,13 @@ impl CatalogState {
             let (id, global_id, res) = selected;
             let mut insert_cached_expr = |cached_expr| {
                 if let Some(cached_expr) = cached_expr {
-                    local_expression_cache.insert_cached_expression(global_id, cached_expr);
+                    in_memory_expression_cache.insert_cached_expression(global_id, cached_expr);
                 }
             };
             match res {
                 Ok((item, uncached_expr)) => {
                     if let Some((uncached_expr, optimizer_features)) = uncached_expr {
-                        local_expression_cache.insert_uncached_expression(
+                        in_memory_expression_cache.insert_uncached_expression(
                             global_id,
                             uncached_expr,
                             optimizer_features,
@@ -2565,7 +2571,7 @@ impl ApplyState {
         self,
         state: &mut CatalogState,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> (
         Vec<BuiltinTableUpdate<&'static BuiltinTable>>,
         Vec<ParsedStateUpdate>,
@@ -2578,7 +2584,7 @@ impl ApplyState {
                     state,
                     builtin_view_additions,
                     retractions,
-                    local_expression_cache,
+                    in_memory_expression_cache,
                 )
                 .await;
                 state.system_configuration = restore;
@@ -2586,11 +2592,11 @@ impl ApplyState {
             }
             Self::Items(updates) => state.with_enable_for_item_parsing(|state| {
                 state
-                    .apply_updates_inner(updates, retractions, local_expression_cache)
+                    .apply_updates_inner(updates, retractions, in_memory_expression_cache)
                     .expect("corrupt catalog")
             }),
             Self::Updates(updates) => state
-                .apply_updates_inner(updates, retractions, local_expression_cache)
+                .apply_updates_inner(updates, retractions, in_memory_expression_cache)
                 .expect("corrupt catalog"),
         }
     }
@@ -2600,7 +2606,7 @@ impl ApplyState {
         next: Self,
         state: &mut CatalogState,
         retractions: &mut InProgressRetractions,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
     ) -> (
         Self,
         (
@@ -2633,7 +2639,7 @@ impl ApplyState {
             (apply_state, next_apply_state) => {
                 // Apply the current batch and start batching new apply state.
                 let updates = apply_state
-                    .apply(state, retractions, local_expression_cache)
+                    .apply(state, retractions, in_memory_expression_cache)
                     .await;
                 (next_apply_state, updates)
             }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::open::into_consolidatable_updates_startup;
-use crate::catalog::state::LocalExpressionCache;
+use crate::catalog::state::InMemoryExpressionCache;
 use crate::catalog::{BuiltinTableUpdate, CatalogState, ConnCatalog};
 use crate::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate;
 
@@ -129,7 +129,7 @@ pub(crate) struct MigrateResult {
 pub(crate) async fn migrate(
     state: &mut CatalogState,
     tx: &mut Transaction<'_>,
-    local_expr_cache: &mut LocalExpressionCache,
+    local_expr_cache: &mut InMemoryExpressionCache,
     item_updates: Vec<StateUpdate>,
     _now: NowFn,
     _boot_ts: Timestamp,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -64,7 +64,7 @@ use uuid::Uuid;
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::AdapterError;
 use crate::catalog::migrate::{self, get_migration_version, set_migration_version};
-use crate::catalog::state::LocalExpressionCache;
+use crate::catalog::state::InMemoryExpressionCache;
 use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogState, Config, is_reserved_name};
 
 pub struct InitializeStateResult {
@@ -305,7 +305,7 @@ impl Catalog {
         }
 
         let (builtin_table_update, _catalog_updates) = state
-            .apply_updates(pre_item_updates, &mut LocalExpressionCache::Closed)
+            .apply_updates(pre_item_updates, &mut InMemoryExpressionCache::Closed)
             .await;
         builtin_table_updates.extend(builtin_table_update);
 
@@ -395,7 +395,7 @@ impl Catalog {
         } else {
             (None, BTreeMap::new(), BTreeMap::new())
         };
-        let mut local_expr_cache = LocalExpressionCache::new(cached_local_exprs);
+        let mut local_expr_cache = InMemoryExpressionCache::new(cached_local_exprs);
         info!(
             "startup: coordinator init: catalog open: expr cache open complete in {:?}",
             expr_cache_start.elapsed()
@@ -658,7 +658,7 @@ impl Catalog {
 
         let updates = txn.get_and_commit_op_updates();
         let (builtin_updates, catalog_updates) = state
-            .apply_updates(updates, &mut LocalExpressionCache::Closed)
+            .apply_updates(updates, &mut InMemoryExpressionCache::Closed)
             .await;
         assert!(
             builtin_updates.is_empty(),

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -27,7 +27,7 @@ use mz_catalog::builtin::{
     BUILTINS, Builtin, BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BuiltinType,
 };
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogCollectionEntry, CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap,
@@ -185,30 +185,62 @@ pub struct CatalogState {
 /// statements when going back and forth between durable catalog operations and in-memory catalog
 /// operations.
 #[derive(Debug, Clone, Serialize)]
-pub(crate) enum LocalExpressionCache {
+pub(crate) enum InMemoryExpressionCache {
     /// The cache is being used.
     Open {
         /// The local expressions that were cached in the expression cache.
         cached_exprs: BTreeMap<GlobalId, LocalExpressions>,
         /// The local expressions that were NOT cached in the expression cache.
         uncached_exprs: BTreeMap<GlobalId, LocalExpressions>,
+        /// The global expressions pre-fetched from the expression cache for
+        /// items that are being created by the current catalog transaction.
+        /// Used by `parse_item_inner` to hydrate `optimized_plan`,
+        /// `physical_plan`, and `dataflow_metainfo` on newly-added Index /
+        /// MaterializedView items without having to go back
+        /// through the optimizer.
+        cached_global_exprs: BTreeMap<GlobalId, GlobalExpressions>,
     },
     /// The cache is not being used.
     Closed,
 }
 
-impl LocalExpressionCache {
+impl InMemoryExpressionCache {
     pub(super) fn new(cached_exprs: BTreeMap<GlobalId, LocalExpressions>) -> Self {
+        Self::new_with_globals(cached_exprs, BTreeMap::new())
+    }
+
+    pub(super) fn new_with_globals(
+        cached_exprs: BTreeMap<GlobalId, LocalExpressions>,
+        cached_global_exprs: BTreeMap<GlobalId, GlobalExpressions>,
+    ) -> Self {
         Self::Open {
             cached_exprs,
             uncached_exprs: BTreeMap::new(),
+            cached_global_exprs,
         }
     }
 
     pub(super) fn remove_cached_expression(&mut self, id: &GlobalId) -> Option<LocalExpressions> {
         match self {
-            LocalExpressionCache::Open { cached_exprs, .. } => cached_exprs.remove(id),
-            LocalExpressionCache::Closed => None,
+            InMemoryExpressionCache::Open { cached_exprs, .. } => cached_exprs.remove(id),
+            InMemoryExpressionCache::Closed => None,
+        }
+    }
+
+    /// Consumes and returns the pre-fetched global expression entry for `id`,
+    /// if any. Returns `None` if the cache is closed or the entry is absent
+    /// (expected cases: bootstrap with empty cache, cache miss, or non-plan-
+    /// bearing item kinds).
+    pub(super) fn remove_cached_global_expression(
+        &mut self,
+        id: &GlobalId,
+    ) -> Option<GlobalExpressions> {
+        match self {
+            InMemoryExpressionCache::Open {
+                cached_global_exprs,
+                ..
+            } => cached_global_exprs.remove(id),
+            InMemoryExpressionCache::Closed => None,
         }
     }
 
@@ -220,10 +252,10 @@ impl LocalExpressionCache {
         local_expressions: LocalExpressions,
     ) {
         match self {
-            LocalExpressionCache::Open { cached_exprs, .. } => {
+            InMemoryExpressionCache::Open { cached_exprs, .. } => {
                 cached_exprs.insert(id, local_expressions);
             }
-            LocalExpressionCache::Closed => {}
+            InMemoryExpressionCache::Closed => {}
         }
     }
 
@@ -236,7 +268,7 @@ impl LocalExpressionCache {
         optimizer_features: OptimizerFeatures,
     ) {
         match self {
-            LocalExpressionCache::Open { uncached_exprs, .. } => {
+            InMemoryExpressionCache::Open { uncached_exprs, .. } => {
                 let local_expr = LocalExpressions {
                     local_mir,
                     optimizer_features,
@@ -258,14 +290,14 @@ impl LocalExpressionCache {
                     Some(_) => {}
                 }
             }
-            LocalExpressionCache::Closed => {}
+            InMemoryExpressionCache::Closed => {}
         }
     }
 
     pub(super) fn into_uncached_exprs(self) -> BTreeMap<GlobalId, LocalExpressions> {
         match self {
-            LocalExpressionCache::Open { uncached_exprs, .. } => uncached_exprs,
-            LocalExpressionCache::Closed => BTreeMap::new(),
+            InMemoryExpressionCache::Open { uncached_exprs, .. } => uncached_exprs,
+            InMemoryExpressionCache::Closed => BTreeMap::new(),
         }
     }
 }
@@ -1037,7 +1069,7 @@ impl CatalogState {
         global_id: GlobalId,
         create_sql: &str,
         extra_versions: &BTreeMap<RelationVersion, GlobalId>,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
         previous_item: Option<CatalogItem>,
     ) -> Result<CatalogItem, AdapterError> {
         self.parse_item(
@@ -1047,7 +1079,7 @@ impl CatalogState {
             None,
             false,
             None,
-            local_expression_cache,
+            in_memory_expression_cache,
             previous_item,
         )
     }
@@ -1062,10 +1094,12 @@ impl CatalogState {
         pcx: Option<&PlanContext>,
         is_retained_metrics_object: bool,
         custom_logical_compaction_window: Option<CompactionWindow>,
-        local_expression_cache: &mut LocalExpressionCache,
+        in_memory_expression_cache: &mut InMemoryExpressionCache,
         previous_item: Option<CatalogItem>,
     ) -> Result<CatalogItem, AdapterError> {
-        let cached_expr = local_expression_cache.remove_cached_expression(&global_id);
+        let cached_expr = in_memory_expression_cache.remove_cached_expression(&global_id);
+        let cached_global_expr =
+            in_memory_expression_cache.remove_cached_global_expression(&global_id);
         match self.parse_item_inner(
             global_id,
             create_sql,
@@ -1076,19 +1110,48 @@ impl CatalogState {
             cached_expr,
             previous_item,
         ) {
-            Ok((item, uncached_expr)) => {
+            Ok((mut item, uncached_expr)) => {
                 if let Some((uncached_expr, optimizer_features)) = uncached_expr {
-                    local_expression_cache.insert_uncached_expression(
+                    in_memory_expression_cache.insert_uncached_expression(
                         global_id,
                         uncached_expr,
                         optimizer_features,
                     );
                 }
+                // If the global expression cache had a hit for this id
+                // (populated pre-transaction by `cache_expressions` in the
+                // sequencer `_finish` paths, or loaded at bootstrap), stamp
+                // the resulting optimized / physical / metainfo plans onto
+                // the freshly-built item. Using the durable cache as the
+                // source of truth for these plans lets the creation work
+                // that consumes them run in a different envd process than
+                // the one that ran the optimizer, which we will need for
+                // 0-downtime upgrades and multi-envd.
+                if let Some(global_expr) = cached_global_expr {
+                    let GlobalExpressions {
+                        global_mir,
+                        physical_plan,
+                        dataflow_metainfos,
+                        optimizer_features: _,
+                    } = global_expr;
+                    if let Some((optimized_plan, phys_plan, metainfo)) = item.plan_fields_mut() {
+                        *optimized_plan = Some(Arc::new(global_mir));
+                        *phys_plan = Some(Arc::new(physical_plan));
+                        *metainfo = Some(dataflow_metainfos);
+                    } else {
+                        // Other item kinds don't have plan fields; the
+                        // caller should not have put them in the map.
+                        mz_ore::soft_panic_or_log!(
+                            "unexpected cached global expression for non-plan-bearing \
+                             item {global_id}"
+                        );
+                    }
+                }
                 Ok(item)
             }
             Err((err, cached_expr)) => {
                 if let Some(local_expr) = cached_expr {
-                    local_expression_cache.insert_cached_expression(global_id, local_expr);
+                    in_memory_expression_cache.insert_cached_expression(global_id, local_expr);
                 }
                 Err(err)
             }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -28,7 +28,7 @@ use mz_audit_log::{
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::BuiltinLog;
 use mz_catalog::durable::{NetworkPolicy, Snapshot, Transaction};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{ExpressionCacheHandle, GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterConfig, DataSourceDesc, DefaultPrivileges, SourceReferences,
@@ -67,7 +67,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 
 use crate::AdapterError;
-use crate::catalog::state::LocalExpressionCache;
+use crate::catalog::state::InMemoryExpressionCache;
 use crate::catalog::{
     BuiltinTableUpdate, Catalog, CatalogState, UpdatePrivilegeVariant,
     catalog_type_to_audit_object_type, comment_id_to_audit_object_type, is_reserved_name,
@@ -469,6 +469,18 @@ impl Catalog {
             .await
             .unwrap_or_terminate("starting catalog transaction");
 
+        // Pre-fetch global expressions (optimized plan, physical plan,
+        // rendered notices) from the expression cache for any plan-bearing
+        // items (Index / MaterializedView) being created by
+        // this transaction. The sequencer `_finish` methods are expected to
+        // have `.await`ed `cache_expressions` before calling `transact`, so
+        // entries are guaranteed to be present in the cache's in-memory
+        // mirror by the time we read them here. The map is then threaded
+        // through `transact_inner` into `parse_item`, which uses it to stamp
+        // plan fields onto the freshly-built `CatalogItem`s.
+        let cached_global_exprs =
+            Self::prefetch_global_expressions(self.expr_cache_handle.as_ref(), &ops).await;
+
         let new_state = Self::transact_inner(
             TransactInnerMode::Commit,
             storage_collections,
@@ -481,6 +493,7 @@ impl Catalog {
             &mut audit_events,
             &mut tx,
             &self.state,
+            cached_global_exprs,
         )
         .await?;
 
@@ -553,6 +566,11 @@ impl Catalog {
         };
 
         // Process only the new ops against the accumulated state in dry-run mode.
+        // `transact_incremental_dry_run` (ALTER SINK 2-phase) does not produce
+        // `Op::CreateItem` for plan-bearing Index/MV/CT items, so there is
+        // nothing useful for `prefetch_global_expressions` to look up — pass
+        // an empty map. (Distinct from the preliminary-state apply inside
+        // `transact_inner`, which does pass the real `cached_global_exprs`.)
         let new_state = Self::transact_inner(
             TransactInnerMode::DryRun,
             None,
@@ -565,6 +583,7 @@ impl Catalog {
             &mut audit_events,
             &mut tx,
             base_state,
+            BTreeMap::new(),
         )
         .await?;
 
@@ -580,8 +599,57 @@ impl Catalog {
         Ok((state, new_snapshot))
     }
 
+    /// Pre-fetches global expressions (optimized plan, physical plan,
+    /// rendered metainfo) from the expression cache for every plan-bearing
+    /// item (Index / MaterializedView) being freshly created
+    /// by the given `ops`. Returns an empty map when the expression cache is
+    /// not configured or none of the ops create plan-bearing items.
+    ///
+    /// The returned map is consumed by `parse_item` (via `InMemoryExpressionCache`)
+    /// to hydrate `optimized_plan` / `physical_plan` / `dataflow_metainfo` on
+    /// the resulting catalog items.
+    ///
+    /// Correctness relies on the invariant that the sequencer `_finish`
+    /// methods have `.await`ed `cache_expressions` before reaching
+    /// `transact`, so the entry for each id is guaranteed to be visible in
+    /// the cache's in-memory mirror.
+    async fn prefetch_global_expressions(
+        expr_cache_handle: Option<&ExpressionCacheHandle>,
+        ops: &[Op],
+    ) -> BTreeMap<GlobalId, GlobalExpressions> {
+        let Some(handle) = expr_cache_handle else {
+            return BTreeMap::new();
+        };
+        let mut ids: BTreeSet<GlobalId> = BTreeSet::new();
+        for op in ops {
+            if let Op::CreateItem { item, .. } = op {
+                match item {
+                    CatalogItem::Index(index) => {
+                        ids.insert(index.global_id);
+                    }
+                    CatalogItem::MaterializedView(mv) => {
+                        ids.insert(mv.global_id_writes());
+                    }
+                    CatalogItem::Table(_)
+                    | CatalogItem::Source(_)
+                    | CatalogItem::Log(_)
+                    | CatalogItem::View(_)
+                    | CatalogItem::Sink(_)
+                    | CatalogItem::Type(_)
+                    | CatalogItem::Func(_)
+                    | CatalogItem::Secret(_)
+                    | CatalogItem::Connection(_) => {}
+                }
+            }
+        }
+        if ids.is_empty() {
+            return BTreeMap::new();
+        }
+        handle.get_global_expressions(ids).await
+    }
+
     /// Extracts optimized expressions from `Op::CreateItem` operations for views
-    /// and materialized views. These can be used to populate a `LocalExpressionCache`
+    /// and materialized views. These can be used to populate an `InMemoryExpressionCache`
     /// to avoid re-optimization during `apply_updates`.
     fn extract_expressions_from_ops(
         ops: &[Op],
@@ -646,6 +714,12 @@ impl Catalog {
         audit_events: &mut Vec<VersionedEvent>,
         tx: &mut Transaction<'_>,
         state: &CatalogState,
+        // Pre-fetched global expressions for plan-bearing items (Index / MV)
+        // being created by the ops. Populated by the caller
+        // from the expression cache. Consumed by `parse_item` to hydrate
+        // `optimized_plan` / `physical_plan` / `dataflow_metainfo` on the
+        // resulting catalog items.
+        cached_global_exprs: BTreeMap<GlobalId, GlobalExpressions>,
     ) -> Result<Option<CatalogState>, AdapterError> {
         // We come up with new catalog state, builtin state updates, and parsed
         // catalog updates (for deriving catalog implications) in two phases:
@@ -739,7 +813,10 @@ impl Catalog {
             if !op_updates.is_empty() {
                 // Clone the cache so each apply_updates call has access to cached expressions.
                 // The cache uses `remove` semantics, so we need a fresh clone for each call.
-                let mut local_expr_cache = LocalExpressionCache::new(cached_exprs.clone());
+                let mut local_expr_cache = InMemoryExpressionCache::new_with_globals(
+                    cached_exprs.clone(),
+                    cached_global_exprs.clone(),
+                );
                 let (_op_builtin_table_updates, _op_catalog_updates) = preliminary_state
                     .to_mut()
                     .apply_updates(op_updates.clone(), &mut local_expr_cache)
@@ -749,7 +826,10 @@ impl Catalog {
         }
 
         if !updates.is_empty() {
-            let mut local_expr_cache = LocalExpressionCache::new(cached_exprs.clone());
+            let mut local_expr_cache = InMemoryExpressionCache::new_with_globals(
+                cached_exprs.clone(),
+                cached_global_exprs,
+            );
             let (op_builtin_table_updates, op_catalog_updates) = state
                 .to_mut()
                 .apply_updates(updates.clone(), &mut local_expr_cache)
@@ -784,7 +864,10 @@ impl Catalog {
 
         let updates = tx.get_and_commit_op_updates();
         if !updates.is_empty() {
-            let mut local_expr_cache = LocalExpressionCache::new(cached_exprs.clone());
+            // No `cached_global_exprs` here: any plan-bearing items in the
+            // transaction were already hydrated by the earlier apply above,
+            // which consumed the pre-fetched globals.
+            let mut local_expr_cache = InMemoryExpressionCache::new(cached_exprs.clone());
             let (op_builtin_table_updates, op_catalog_updates) = state
                 .to_mut()
                 .apply_updates(updates.clone(), &mut local_expr_cache)

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -526,14 +526,6 @@ impl Coordinator {
         let transact_result = self
             .catalog_transact_with_side_effects(Some(ctx), ops, move |coord, _ctx| {
                 Box::pin(async move {
-                    // Save plan structures.
-                    coord
-                        .catalog_mut()
-                        .set_optimized_plan(global_id, global_mir_plan.df_desc().clone());
-                    coord
-                        .catalog_mut()
-                        .set_physical_plan(global_id, df_desc.clone());
-
                     let notice_builtin_updates_fut =
                         coord.persist_dataflow_metainfo(df_meta, global_id).await;
 

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -744,14 +744,6 @@ impl Coordinator {
         let transact_result = self
             .catalog_transact_with_side_effects(Some(ctx), ops, move |coord, _ctx| {
                 Box::pin(async move {
-                    // Save plan structures.
-                    coord
-                        .catalog_mut()
-                        .set_optimized_plan(global_id, global_mir_plan.df_desc().clone());
-                    coord
-                        .catalog_mut()
-                        .set_physical_plan(global_id, df_desc.clone());
-
                     let notice_builtin_updates_fut =
                         coord.persist_dataflow_metainfo(df_meta, global_id).await;
 

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -33,7 +33,7 @@ use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 #[derive(
@@ -376,6 +376,11 @@ enum CacheOperation {
         invalidate_ids: BTreeSet<GlobalId>,
         trigger: trigger::Trigger,
     },
+    /// See [`ExpressionCacheHandle::get_global_expressions`].
+    GetGlobalExpressions {
+        ids: BTreeSet<GlobalId>,
+        reply: oneshot::Sender<BTreeMap<GlobalId, GlobalExpressions>>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -396,6 +401,11 @@ impl ExpressionCacheHandle {
     ) {
         let (mut cache, local_expressions, global_expressions) =
             ExpressionCache::open(config).await;
+        // In-memory mirror of the durable global expressions, maintained by
+        // this task. Callers of [`ExpressionCacheHandle::get_global_expressions`]
+        // read from this mirror. Seeded from the initial `open` result and
+        // updated on every `Update` op.
+        let mut global_mirror = global_expressions.clone();
         let (tx, mut rx) = mpsc::unbounded_channel();
         spawn(|| "expression-cache-task", async move {
             loop {
@@ -407,6 +417,12 @@ impl ExpressionCacheHandle {
                             invalidate_ids,
                             trigger: _trigger,
                         } => {
+                            for id in &invalidate_ids {
+                                global_mirror.remove(id);
+                            }
+                            for (id, expr) in &new_global_expressions {
+                                global_mirror.insert(*id, expr.clone());
+                            }
                             cache
                                 .update(
                                     new_local_expressions,
@@ -414,6 +430,16 @@ impl ExpressionCacheHandle {
                                     invalidate_ids,
                                 )
                                 .await
+                        }
+                        CacheOperation::GetGlobalExpressions { ids, reply } => {
+                            let mut result = BTreeMap::new();
+                            for id in ids {
+                                if let Some(expr) = global_mirror.get(&id) {
+                                    result.insert(id, expr.clone());
+                                }
+                            }
+                            // If the reply send fails, the caller is gone; drop.
+                            let _ = reply.send(result);
                         }
                     }
                 }
@@ -439,6 +465,32 @@ impl ExpressionCacheHandle {
         // If the send fails, then we must be shutting down.
         let _ = self.tx.send(op);
         trigger_rx
+    }
+
+    /// Returns the best-effort in-memory snapshot of global expressions for
+    /// the given ids. Ids that are not in the cache are simply absent from
+    /// the returned map (no error).
+    ///
+    /// Used by the catalog-transaction path to hydrate newly-created items'
+    /// plan fields (`optimized_plan`, `physical_plan`, `dataflow_metainfo`)
+    /// in `parse_item`. Relies on the invariant that `cache_expressions` has
+    /// been `.await`ed before the transaction, so the entry for any newly-
+    /// created item is guaranteed to be in the in-memory mirror by the time
+    /// we read it here.
+    pub async fn get_global_expressions(
+        &self,
+        ids: BTreeSet<GlobalId>,
+    ) -> BTreeMap<GlobalId, GlobalExpressions> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let op = CacheOperation::GetGlobalExpressions {
+            ids,
+            reply: reply_tx,
+        };
+        if self.tx.send(op).is_err() {
+            // Task is gone; we must be shutting down.
+            return BTreeMap::new();
+        }
+        reply_rx.await.unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Followup to https://github.com/MaterializeInc/materialize/pull/35837

(Btw. I'm still planning to simplify how we handle plans on catalog objects by [making the plans non-optional](https://materializeinc.slack.com/archives/C08A62E0751/p1774627385747809?thread_ts=1774623679.171309&cid=C08A62E0751) at some point. That would eliminate the annoying differences we have between how the catalog handles locally-optimized plans vs. globally-optimized plans.)

Nightly:
- https://buildkite.com/materialize/nightly/builds/16132 (old)
- https://buildkite.com/materialize/nightly/builds/16370

---------

Makes the durable expression cache the source of truth for plans
(optimized MIR, physical LIR, and dataflow metainfo including
rendered optimizer notices) on newly-created Index /
MaterializedView items, rather than threading them
through an in-memory side-channel. This works across envd
processes, which we will need for 0-downtime upgrades and
eventually for running multiple envds at the same time.

Changes:

* `expr_cache.rs`: the cache task now maintains an in-memory
  mirror of `GlobalExpressions` (seeded from the `open` result and
  kept in sync on every `Update` op). Adds
  `ExpressionCacheHandle::get_global_expressions(ids)`, which
  returns the best-effort snapshot for the requested ids via a
  oneshot request/response channel — consistent with the existing
  single-writer design. Missing ids are simply absent from the
  map (no error).

* `catalog/transact.rs`: `Catalog::transact` pre-fetches
  `GlobalExpressions` for every plan-bearing `Op::CreateItem`
  (Index / MaterializedView) and threads the map
  through `transact_inner` into the `InMemoryExpressionCache`.
  Correctness relies on the sequencer `_finish` methods
  `.await`ing `cache_expressions` before reaching `transact`
  (see the "Move cache_expressions before the catalog
  transaction and await it" commit), so the entry for each id is
  guaranteed to be visible in the cache's in-memory mirror by the
  time we read it here. `transact_incremental_dry_run` passes an
  empty map (ALTER SINK dry-runs don't create new plan-bearing
  items).

* `catalog/state.rs`: `InMemoryExpressionCache::Open` gains a
  `cached_global_exprs` map with a matching
  `remove_cached_global_expression` accessor. After
  `parse_item_inner` succeeds, `parse_item` stamps the returned
  `optimized_plan` / `physical_plan` / `dataflow_metainfo` onto
  the freshly-built `CatalogItem` (MV / Index / CT).

* Removes now-redundant `set_optimized_plan` / `set_physical_plan`
  / `set_dataflow_metainfo` calls from all three `_finish` paths
  (`create_index.rs`, `create_materialized_view.rs`),
  since `parse_item` already stamps those fields from the cache
  entry the sequencer has just awaited.

`bootstrap_dataflow_plans` in `coord.rs` is intentionally kept
as-is: `parse_item` hydration covers the cache-hit case, but the
cache-miss path (cold start, version upgrade where the cache is
empty for the new version, `optimizer_features` drift) still
needs to re-optimize from `create_sql` and populate
`uncached_expressions` for the next writeback.