### PR TITLE
skills: capture pr_checklist.yml guidance in mz-commit and mz-pr-review

### DIFF
--- a/.claude/skills/mz-commit/SKILL.md
+++ b/.claude/skills/mz-commit/SKILL.md
@@ -37,6 +37,16 @@ Mention which tests were added or modified in the pull request description, but 
 To auto-close issues, include `Fixes database-issues#NNNN`.
 Add release notes for user-visible changes (should complete "This release will...").
 
+## Pre-merge checklist
+
+Before asking for review, verify:
+
+* **Trigger CI**: For non-trivial changes, kick off additional test suites at `https://ci.dev.materialize.com/trigger/<PR-number>`.
+* **Design doc**: The PR description references an up-to-date design doc, or the change is small enough not to require one ([template](doc/developer/design/00000000_template.md), [guidelines](doc/developer/design/README.md)).
+* **User-visible changes**: If the change is user-visible per `doc/developer/guide-changes.md`, include a release note in the description ("This release will…") and ping the relevant PM.
+* **`T-proto` label**: If the diff evolves a `$T ⇔ Proto$T` encoding in a potentially backwards-incompatible way, add the `T-proto` label. Proto encoding breakage can silently corrupt persisted data on upgrade.
+* **Cloud companion PR**: If the change affects cloud orchestration or cloud-side tests, open a companion cloud PR tagged `release-blocker`. Ask in `#team-cloud` on Slack if uncertain.
+
 ## Cargo.lock discipline
 
 Never regenerate the entire Cargo.lock — bare `cargo update` bumps every semver-compatible dep and introduces unrelated breakage (e.g., `os_info` pulling in `objc2` on macOS, `chrono-tz` changing timezone data, `serde_path_to_error` changing error formats).

--- a/.claude/skills/mz-pr-review/SKILL.md
+++ b/.claude/skills/mz-pr-review/SKILL.md
@@ -70,8 +70,14 @@ The overall developer guide for reviewing changes is defined in `doc/developer/g
 - No unrelated formatting changes in untouched code.
 - New public items should have doc comments.
 
-### Release notes
-- Any user-visible change to stable APIs needs a release note (imperative, "This release will…").
+### PR metadata
+
+These are the author's responsibility but easy to miss — flag them during review if absent:
+
+- **Release notes and PM notification**: User-visible changes need a release note in the description ("This release will…") and PM notification. Check `doc/developer/guide-changes.md` if uncertain what qualifies.
+- **Design doc**: Significant changes should reference a design doc in the PR description.
+- **`T-proto` label**: If the diff changes a `$T ⇔ Proto$T` encoding, verify the `T-proto` label is set. Missing it means broken binary encoding can slip into a release unnoticed.
+- **Cloud companion PR**: If the change touches cloud orchestration or cloud-side tests, look for a companion cloud PR tagged `release-blocker`.
 
 ## One semantic change rule
 
@@ -83,3 +89,4 @@ The PR should do one thing. If it spans multiple CODEOWNERS areas (e.g. sql-pars
 - Use **nit:** for preferences where reasonable people could disagree.
 - If the PR improves overall codebase health and blocking items are addressed, say so.
 - Do NOT make any changes — this is read-only review.
+- Don't flag issues that `cargo clippy`, `bin/lint`, or `bin/fmt` would catch — those are enforced by CI. Focus on what automated tooling cannot catch: design decisions, missing tests, documentation gaps, and the PR metadata items above.


### PR DESCRIPTION
## Summary

Captures the pre-merge guidance that previously lived in the `pr_checklist.yml` GitHub Actions comment (removed in #36063), splitting it between the two skills that authors and reviewers actually consult.

- **mz-commit** — new Pre-merge checklist section covering: trigger-CI link for non-trivial changes, design doc requirement, user-visible change handling (release notes + PM ping), `T-proto` label for proto encoding changes, and cloud companion PR for cloud-affecting changes.
- **mz-pr-review** — the thin Release notes section is replaced with a richer PR metadata section covering the same author-side items so reviewers can flag them when missing. Also adds a rule directing reviewers away from issues that `cargo clippy` / `bin/lint` / `bin/fmt` already enforce.

## Test plan

- [ ] Skim mz-commit/SKILL.md and mz-pr-review/SKILL.md for clarity and accuracy of the new sections
- [ ] Confirm the T-proto, design doc, cloud companion PR, and trigger-ci details match current project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
