### PR TITLE
sql: int2vector to array cast is not eliminable

### DIFF
--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -18,7 +18,6 @@ use crate::scalar::func::stringify_datum;
     sqlname = "int2vectortoarray",
     is_monotone = true,
     introduces_nulls = false,
-    is_eliminable_cast = true,
     output_type_expr = SqlScalarType::Array(Box::from(SqlScalarType::Int16))
         .nullable(input_type.nullable)
 )]

--- a/test/sqllogictest/int2vector.slt
+++ b/test/sqllogictest/int2vector.slt
@@ -186,7 +186,7 @@ SELECT CASE WHEN c2 = 5 THEN c0 ELSE c1 END FROM t1;
 ----
 Explained Query:
   Project (#3)
-    Map (case when (#2{c2} = 5) then #0{c0} else arraytoarray(#1{c1}) end)
+    Map (case when (#2{c2} = 5) then #0{c0} else arraytoarray(int2vectortoarray(#1{c1})) end)
       ReadStorage materialize.public.t1
 
 Source materialize.public.t1


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/database-issues/issues/11318

Follow-up to #36144. Unlucky that Nightly didn't catch it when I ran it on that PR, but then on main SQLancer++ failed in 2/2 runs!

Nightly run: https://buildkite.com/materialize/nightly/builds/16137