### PR TITLE
dbt: retry deploy_promote atomic swap only on concurrent-DDL conflicts

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Automatically retry the atomic swap transaction in `deploy_promote` when
+  it is aborted by a concurrent-DDL conflict (Materialize SQLSTATE 40001).
+  Retries are capped by the new `max_retries` argument (default: 3) and
+  each retry waits `retry_backoff` seconds (default: 1.0). Errors that are
+  not concurrent-DDL conflicts, for example, permission, syntax, or
+  missing-object errors, are raised immediately and are not retried.
+
 ## 1.9.7 - 2026-03-16
 
 * Reduce catalog server load during

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -376,8 +376,11 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
             try:
                 with handle.cursor() as cursor:
                     cursor.execute("ROLLBACK")
-            except psycopg2.Error:
-                pass
+            except psycopg2.Error as rollback_err:
+                logger.debug(
+                    f"ROLLBACK after aborted swap failed (connection may be "
+                    f"broken): {rollback_err}"
+                )
             if getattr(e, "pgcode", None) == self._DDL_CONFLICT_SQLSTATE:
                 logger.info(f"Atomic swap aborted by concurrent DDL: {e}")
                 return False

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
 import dbt_common.exceptions
+import psycopg2
 from dbt_common.contracts.constraints import (
     ColumnLevelConstraint,
     ConstraintType,
@@ -34,6 +35,7 @@ from dbt.adapters.capability import (
     CapabilitySupport,
     Support,
 )
+from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.materialize.connections import MaterializeConnectionManager
 from dbt.adapters.materialize.exceptions import (
     RefreshIntervalConfigError,
@@ -43,6 +45,8 @@ from dbt.adapters.materialize.relation import MaterializeRelation
 from dbt.adapters.postgres.column import PostgresColumn
 from dbt.adapters.postgres.impl import PostgresAdapter, SQLAdapter
 from dbt.adapters.sql.impl import LIST_RELATIONS_MACRO_NAME
+
+logger = AdapterLogger("Materialize")
 
 
 # types in ./misc/dbt-materialize need to import generic types from typing
@@ -337,6 +341,47 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
         self.connections.execute(f"drop view {view_name}")
 
         return columns
+
+    # SQLSTATE raised by Materialize when a DDL transaction is aborted because
+    # another session modified the catalog concurrently. See
+    # `AdapterError::DDLTransactionRace` in `src/adapter/src/error.rs`.
+    _DDL_CONFLICT_SQLSTATE = "40001"
+
+    @available
+    def try_atomic_swap(self, swap_sql: str) -> bool:
+        """Execute a multi-statement atomic swap as a single transaction.
+
+        Returns True on success. Returns False if the transaction failed due
+        to a concurrent-DDL conflict (SQLSTATE 40001), which callers may
+        retry. Any other error, including permission, syntax, or missing
+        object errors, is raised immediately so it is surfaced to the user
+        without retry noise.
+
+        This reaches down to the raw psycopg2 connection rather than going
+        through dbt's `add_query`/`run_query` because we need the original
+        `pgcode` to classify the failure: dbt's wrapper converts psycopg2
+        errors into `DbtDatabaseError` and drops the SQLSTATE, leaving no
+        reliable way to tell a retryable DDL conflict apart from a
+        permissions or syntax error.
+        """
+        connection = self.connections.get_thread_connection()
+        handle = connection.handle
+        try:
+            with handle.cursor() as cursor:
+                cursor.execute(swap_sql)
+            return True
+        except psycopg2.Error as e:
+            # The server has already aborted the transaction on error, but
+            # send a ROLLBACK to explicitly exit the transaction block.
+            try:
+                with handle.cursor() as cursor:
+                    cursor.execute("ROLLBACK")
+            except psycopg2.Error:
+                pass
+            if getattr(e, "pgcode", None) == self._DDL_CONFLICT_SQLSTATE:
+                logger.info(f"Atomic swap aborted by concurrent DDL: {e}")
+                return False
+            raise
 
     @available
     def generate_final_cluster_name(

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -38,6 +38,8 @@
     atomic swap transaction when it is aborted by a concurrent-DDL conflict
     (Materialize SQLSTATE 40001). Other errors (permissions, syntax, missing
     objects) are surfaced immediately and are not retried. Default: 3.
+    Values below zero produce zero attempts and raise the retry-exhausted
+    error immediately.
   - `retry_backoff` (number, optional): Seconds to sleep before each retry
     of the atomic swap. Gives concurrent DDL a chance to complete before
     retrying. Default: 1.0.
@@ -110,10 +112,10 @@
     {% set ns = namespace(success=False) %}
     {% for attempt in range(max_retries + 1) %}
         {% if attempt > 0 %}
+            {{ log("Retrying atomic swap (attempt " ~ (attempt + 1) ~ " of " ~ (max_retries + 1) ~ ") due to concurrent-DDL conflict", info=True) }}
             {% if retry_backoff > 0 %}
                 {% do adapter.sleep(retry_backoff) %}
             {% endif %}
-            {{ log("Retrying atomic swap (attempt " ~ (attempt + 1) ~ " of " ~ (max_retries + 1) ~ ") due to concurrent-DDL conflict", info=True) }}
         {% endif %}
 
         {% if adapter.try_atomic_swap(swap_sql) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_promote(wait=False, poll_interval=15, lag_threshold='1s', dry_run=False) %}
+{% macro deploy_promote(wait=False, poll_interval=15, lag_threshold='1s', dry_run=False, max_retries=3, retry_backoff=1.0) %}
 {#
   Performs atomic deployment of current dbt targets to production,
   based on the deployment configuration specified in the dbt_project.yml file.
@@ -34,6 +34,13 @@
   - `dry_run` (boolean, optional): When `true`, prints out the sequence of
     commands dbt would execute without actually promoting the deployment, for
     validation.
+  - `max_retries` (integer, optional): Maximum number of times to retry the
+    atomic swap transaction when it is aborted by a concurrent-DDL conflict
+    (Materialize SQLSTATE 40001). Other errors (permissions, syntax, missing
+    objects) are surfaced immediately and are not retried. Default: 3.
+  - `retry_backoff` (number, optional): Seconds to sleep before each retry
+    of the atomic swap. Gives concurrent DDL a chance to complete before
+    retrying. Default: 1.0.
 
   ## Returns
   None: This macro performs deployment actions but does not return a value.
@@ -81,24 +88,47 @@
 {% endif %}
 
 {% if not dry_run %}
-    {% call statement('swap', fetch_result=True, auto_begin=False) -%}
-    BEGIN;
-
+    {# Build the ordered list of ALTER ... SWAP statements. Schemas are
+       swapped before clusters so that cluster renames don't strand objects
+       referencing the old schema name. #}
+    {% set swap_statements = [] %}
     {% for schema in schemas %}
         {% set deploy_schema = schema ~ "_dbt_deploy" %}
         {{ log("Swapping schemas " ~ schema ~ " and " ~ deploy_schema, info=True) }}
-        ALTER SCHEMA {{ adapter.quote(schema) }} SWAP WITH {{ adapter.quote(deploy_schema) }};
+        {% do swap_statements.append("ALTER SCHEMA " ~ adapter.quote(schema) ~ " SWAP WITH " ~ adapter.quote(deploy_schema)) %}
     {% endfor %}
 
     {% for cluster in clusters %}
         {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
         {% set origin_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=False) %}
         {{ log("Swapping clusters " ~ origin_cluster ~ " and " ~ deploy_cluster, info=True) }}
-        ALTER CLUSTER {{ adapter.quote(origin_cluster) }} SWAP WITH {{ adapter.quote(deploy_cluster) }};
+        {% do swap_statements.append("ALTER CLUSTER " ~ adapter.quote(origin_cluster) ~ " SWAP WITH " ~ adapter.quote(deploy_cluster)) %}
     {% endfor %}
 
-    COMMIT;
-    {%- endcall %}
+    {% set swap_sql = "BEGIN; " ~ (swap_statements | join("; ")) ~ "; COMMIT;" %}
+
+    {% set ns = namespace(success=False) %}
+    {% for attempt in range(max_retries + 1) %}
+        {% if attempt > 0 %}
+            {% if retry_backoff > 0 %}
+                {% do adapter.sleep(retry_backoff) %}
+            {% endif %}
+            {{ log("Retrying atomic swap (attempt " ~ (attempt + 1) ~ " of " ~ (max_retries + 1) ~ ") due to concurrent-DDL conflict", info=True) }}
+        {% endif %}
+
+        {% if adapter.try_atomic_swap(swap_sql) %}
+            {% if attempt > 0 %}
+                {{ log("Atomic swap succeeded on attempt " ~ (attempt + 1), info=True) }}
+            {% endif %}
+            {% set ns.success = True %}
+            {% break %}
+        {% endif %}
+    {% endfor %}
+
+    {% if not ns.success %}
+        {{ exceptions.raise_compiler_error("Atomic swap transaction failed after " ~ (max_retries + 1) ~ " attempts due to concurrent-DDL conflicts. Consider increasing max_retries or reducing concurrent DDL activity during the deploy.") }}
+    {% endif %}
+
     {{ tag_deployed_schemas(schemas) }}
 {% else %}
     {{ log("Starting dry run...", info=True) }}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import threading
 import time
 
+import psycopg2
 import pytest
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 from fixtures import (
     test_materialized_view,
     test_materialized_view_deploy,
@@ -1107,6 +1110,241 @@ class TestEndToEndDeployment:
         ), "Sink's view ID should be different after deployment"
 
         run_dbt(["run-operation", "deploy_cleanup", "--vars", project_config])
+
+
+# Test-only macro that exposes `adapter.try_atomic_swap` directly so we can
+# assert on its error classification without needing to reproduce exotic
+# server-side conditions.
+_test_try_atomic_swap_macro = """
+{% macro _test_try_atomic_swap(swap_sql) %}
+    {% set ok = adapter.try_atomic_swap(swap_sql) %}
+    {{ log("try_atomic_swap returned: " ~ ok, info=True) }}
+{% endmacro %}
+"""
+
+
+class TestDeployPromoteRetry:
+    """Covers the retry behavior in deploy_promote.
+
+    The atomic swap should retry on Materialize's concurrent-DDL conflict
+    (SQLSTATE 40001) and raise all other errors immediately.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "vars": {
+                "deployment": {
+                    "default": {
+                        "clusters": ["prod"],
+                        "schemas": ["prod"],
+                    }
+                },
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"_test_try_atomic_swap.sql": _test_try_atomic_swap_macro}
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS prod CASCADE")
+        project.run_sql("DROP CLUSTER IF EXISTS prod_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS prod CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS prod_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS concurrent_probe CASCADE")
+
+    def test_try_atomic_swap_raises_syntax_errors_immediately(self, project):
+        """A syntax error is not a DDL conflict and must surface to the user
+        right away rather than being silently retried."""
+        with pytest.raises(Exception) as excinfo:
+            run_dbt(
+                [
+                    "run-operation",
+                    "_test_try_atomic_swap",
+                    "--args",
+                    "{swap_sql: 'NOT VALID SQL'}",
+                ],
+            )
+        # Must not be disguised as a retry-exhausted error from deploy_promote.
+        assert (
+            "failed after" not in str(excinfo.value).lower()
+        ), "syntax error should not be masked by a retry-exhausted message"
+
+    def test_try_atomic_swap_raises_missing_object_errors_immediately(self, project):
+        """A missing-object error is not a DDL conflict and must raise
+        immediately, not be retried as if it were one."""
+        with pytest.raises(Exception) as excinfo:
+            run_dbt(
+                [
+                    "run-operation",
+                    "_test_try_atomic_swap",
+                    "--args",
+                    "{swap_sql: 'ALTER SCHEMA does_not_exist_xyz SWAP WITH also_missing_xyz'}",
+                ],
+            )
+        assert (
+            "failed after" not in str(excinfo.value).lower()
+        ), "missing-object error should not be masked by a retry-exhausted message"
+
+    def test_deploy_promote_succeeds_under_concurrent_ddl(self, project):
+        """Injects continuous concurrent DDL on a second connection while
+        deploy_promote runs. The swap transaction should hit at least one
+        conflict and then succeed on retry. Asserts both the final state
+        and that the retry path actually fired, so a regression that
+        silently drops the retry loop would be caught."""
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA prod_dbt_deploy")
+
+        before_schemas = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_schemas WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+        before_clusters = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_clusters WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+
+        stop = threading.Event()
+
+        def churn_ddl():
+            conn = psycopg2.connect(
+                host=os.environ.get("DBT_HOST", "localhost"),
+                port=int(os.environ.get("DBT_PORT", 6875)),
+                user="materialize",
+                password="password",
+                dbname="materialize",
+            )
+            conn.autocommit = True
+            try:
+                with conn.cursor() as cur:
+                    while not stop.is_set():
+                        try:
+                            cur.execute("CREATE SCHEMA IF NOT EXISTS concurrent_probe")
+                            cur.execute("DROP SCHEMA IF EXISTS concurrent_probe")
+                        except psycopg2.Error:
+                            pass
+            finally:
+                conn.close()
+
+        churn = threading.Thread(target=churn_ddl, daemon=True)
+        churn.start()
+        try:
+            # Use retry_backoff=0 so the test runs quickly even across many
+            # retries, and max_retries high enough that we'll almost
+            # certainly catch a conflict window.
+            _, log_output = run_dbt_and_capture(
+                [
+                    "run-operation",
+                    "deploy_promote",
+                    "--args",
+                    "{max_retries: 50, retry_backoff: 0}",
+                ]
+            )
+        finally:
+            stop.set()
+            churn.join(timeout=5)
+
+        after_schemas = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_schemas WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+        after_clusters = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_clusters WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+
+        # Schemas and clusters should have swapped identities.
+        assert before_schemas["prod"] == after_schemas["prod_dbt_deploy"]
+        assert before_schemas["prod_dbt_deploy"] == after_schemas["prod"]
+        assert before_clusters["prod"] == after_clusters["prod_dbt_deploy"]
+        assert before_clusters["prod_dbt_deploy"] == after_clusters["prod"]
+
+        # The retry path must have fired at least once. If the churn thread
+        # was unlucky and never raced, this assertion will fail — retry
+        # `max_retries` high enough that the race window is reliably hit.
+        assert (
+            "Retrying atomic swap" in log_output
+        ), "concurrent DDL should have forced at least one retry"
+
+    def test_deploy_promote_happy_path_logs_swap_lines(self, project):
+        """Regression guard: the user-visible "Swapping schemas/clusters"
+        log lines must still fire on a happy-path swap. Without these,
+        customers have no feedback during the deploy."""
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA prod_dbt_deploy")
+
+        _, log_output = run_dbt_and_capture(["run-operation", "deploy_promote"])
+        assert "Swapping schemas prod and prod_dbt_deploy" in log_output, log_output
+        assert "Swapping clusters prod and prod_dbt_deploy" in log_output, log_output
+        # No retries should have happened on the happy path.
+        assert "Retrying atomic swap" not in log_output, log_output
+
+    def test_deploy_promote_max_retries_zero_succeeds_without_conflict(self, project):
+        """Sanity check that `max_retries=0` still permits a successful
+        swap — the retry loop must execute exactly one attempt, not zero."""
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA prod_dbt_deploy")
+
+        before_schemas = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_schemas WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+        run_dbt(
+            [
+                "run-operation",
+                "deploy_promote",
+                "--args",
+                "{max_retries: 0}",
+            ]
+        )
+        after_schemas = dict(
+            project.run_sql(
+                "SELECT name, id FROM mz_schemas WHERE name IN ('prod', 'prod_dbt_deploy')",
+                fetch="all",
+            )
+        )
+        assert before_schemas["prod"] == after_schemas["prod_dbt_deploy"]
+        assert before_schemas["prod_dbt_deploy"] == after_schemas["prod"]
+
+    def test_deploy_promote_raises_retry_exhausted_error(self, project):
+        """Pins down the retry-exhausted failure path. With `max_retries=-1`
+        the retry loop executes zero attempts and must raise the
+        exhaustion error; this covers the branch deterministically without
+        having to race concurrent DDL."""
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA prod_dbt_deploy")
+
+        _, log_output = run_dbt_and_capture(
+            [
+                "run-operation",
+                "deploy_promote",
+                "--args",
+                "{max_retries: -1}",
+            ],
+            expect_pass=False,
+        )
+        assert "failed after" in log_output, log_output
+        assert "attempts" in log_output, log_output
 
 
 def run_with_retry(project, sql, expected_count, retries=5, delay=3, fetch="one"):

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -1158,35 +1158,47 @@ class TestDeployPromoteRetry:
     def test_try_atomic_swap_raises_syntax_errors_immediately(self, project):
         """A syntax error is not a DDL conflict and must surface to the user
         right away rather than being silently retried."""
-        with pytest.raises(Exception) as excinfo:
-            run_dbt(
-                [
-                    "run-operation",
-                    "_test_try_atomic_swap",
-                    "--args",
-                    "{swap_sql: 'NOT VALID SQL'}",
-                ],
-            )
+        _, log_output = run_dbt_and_capture(
+            [
+                "run-operation",
+                "_test_try_atomic_swap",
+                "--args",
+                "{swap_sql: 'NOT VALID SQL'}",
+            ],
+            expect_pass=False,
+        )
+        msg = log_output.lower()
         # Must not be disguised as a retry-exhausted error from deploy_promote.
         assert (
-            "failed after" not in str(excinfo.value).lower()
-        ), "syntax error should not be masked by a retry-exhausted message"
+            "failed after" not in msg
+        ), f"syntax error should not be masked by a retry-exhausted message; got: {msg}"
+        # The original syntax error must actually surface. Materialize phrases
+        # parser errors as "Unexpected keyword ..."; match either that or the
+        # generic "syntax" wording.
+        assert (
+            "unexpected" in msg or "syntax" in msg
+        ), f"expected the underlying syntax error to surface; got: {msg}"
 
     def test_try_atomic_swap_raises_missing_object_errors_immediately(self, project):
         """A missing-object error is not a DDL conflict and must raise
         immediately, not be retried as if it were one."""
-        with pytest.raises(Exception) as excinfo:
-            run_dbt(
-                [
-                    "run-operation",
-                    "_test_try_atomic_swap",
-                    "--args",
-                    "{swap_sql: 'ALTER SCHEMA does_not_exist_xyz SWAP WITH also_missing_xyz'}",
-                ],
-            )
+        _, log_output = run_dbt_and_capture(
+            [
+                "run-operation",
+                "_test_try_atomic_swap",
+                "--args",
+                "{swap_sql: 'ALTER SCHEMA does_not_exist_xyz SWAP WITH also_missing_xyz'}",
+            ],
+            expect_pass=False,
+        )
+        msg = log_output.lower()
         assert (
-            "failed after" not in str(excinfo.value).lower()
-        ), "missing-object error should not be masked by a retry-exhausted message"
+            "failed after" not in msg
+        ), f"missing-object error should not be masked by a retry-exhausted message; got: {msg}"
+        # The original missing-object error must actually surface.
+        assert (
+            "does_not_exist_xyz" in msg or "unknown schema" in msg or "not found" in msg
+        ), f"expected the underlying missing-object error to surface; got: {msg}"
 
     def test_deploy_promote_succeeds_under_concurrent_ddl(self, project):
         """Injects continuous concurrent DDL on a second connection while
@@ -1237,15 +1249,17 @@ class TestDeployPromoteRetry:
         churn = threading.Thread(target=churn_ddl, daemon=True)
         churn.start()
         try:
-            # Use retry_backoff=0 so the test runs quickly even across many
-            # retries, and max_retries high enough that we'll almost
-            # certainly catch a conflict window.
+            # `retry_backoff` has to be non-zero: with continuous concurrent
+            # DDL and zero backoff, each swap retry races the churn thread
+            # with no quiet window and loses every time. A short backoff
+            # gives the swap a reliable window between churn DDLs. Keep
+            # `max_retries * retry_backoff` modest so CI time stays bounded.
             _, log_output = run_dbt_and_capture(
                 [
                     "run-operation",
                     "deploy_promote",
                     "--args",
-                    "{max_retries: 50, retry_backoff: 0}",
+                    "{max_retries: 20, retry_backoff: 0.1}",
                 ]
             )
         finally:


### PR DESCRIPTION
Supersedes #33275 (closing it). Fixes customer issue CS-382 where `ALTER SWAP` in `dbt deploy` fails with DDL interrupt errors if there is concurrent DDL on the catalog.

Fixes: https://linear.app/materializeinc/issue/CS-382/ddl-interrupt-errors-during-alter-swap-in-dbt-deploy

The previous approach tried to add retries in Jinja using `{% try %}/{% except %}`, but Jinja2 does not support that syntax and it would also have retried unrelated errors, potentially hiding real failures.

This PR moves the retry logic to Python by adding `MaterializeAdapter.try_atomic_swap(sql)`, which classifies psycopg2 errors by SQLSTATE. It only retries on `40001` (DDL transaction race) and raises everything else immediately. The `deploy_promote.sql` macro now loops over this with a configurable `max_retries` (default 3), while keeping the existing log messages. Integration tests cover immediate failures for syntax and missing objects, as well as successful deploys under concurrent DDL. A CHANGELOG entry is included.