### PR TITLE
Remove `memory_request` field from `ReplicaAllocation`

### DIFF
--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -181,7 +181,6 @@ impl ClusterReplicaSizeMap {
                         name,
                         ReplicaAllocation {
                             memory_limit: memory_limit.map(|gib| MemoryLimit(ByteSize::gib(gib))),
-                            memory_request: memory_limit.map(|gib| MemoryLimit(ByteSize::gib(gib))),
                             cpu_limit: None,
                             cpu_request: None,
                             disk_limit: None,
@@ -205,7 +204,6 @@ impl ClusterReplicaSizeMap {
                 format!("scale={scale},workers=1"),
                 ReplicaAllocation {
                     memory_limit: None,
-                    memory_request: None,
                     cpu_limit: None,
                     cpu_request: None,
                     disk_limit: None,
@@ -224,7 +222,6 @@ impl ClusterReplicaSizeMap {
                 format!("scale={scale},workers={scale}"),
                 ReplicaAllocation {
                     memory_limit: None,
-                    memory_request: None,
                     cpu_limit: None,
                     cpu_request: None,
                     disk_limit: None,
@@ -243,7 +240,6 @@ impl ClusterReplicaSizeMap {
                 format!("scale=1,workers=8,mem={scale}GiB"),
                 ReplicaAllocation {
                     memory_limit: Some(MemoryLimit(ByteSize(u64::cast_from(scale) * (1 << 30)))),
-                    memory_request: Some(MemoryLimit(ByteSize(u64::cast_from(scale) * (1 << 30)))),
                     cpu_limit: None,
                     cpu_request: None,
                     disk_limit: None,
@@ -263,7 +259,6 @@ impl ClusterReplicaSizeMap {
             "scale=2,workers=4".to_string(),
             ReplicaAllocation {
                 memory_limit: None,
-                memory_request: None,
                 cpu_limit: None,
                 cpu_request: None,
                 disk_limit: None,
@@ -282,7 +277,6 @@ impl ClusterReplicaSizeMap {
             "free".to_string(),
             ReplicaAllocation {
                 memory_limit: None,
-                memory_request: None,
                 cpu_limit: None,
                 cpu_request: None,
                 disk_limit: None,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -75,8 +75,6 @@ pub struct ReplicaConfig {
 pub struct ReplicaAllocation {
     /// The memory limit for each process in the replica.
     pub memory_limit: Option<MemoryLimit>,
-    /// The memory request for each process in the replica.
-    pub memory_request: Option<MemoryLimit>,
     /// The CPU limit for each process in the replica.
     pub cpu_limit: Option<CpuLimit>,
     /// The CPU limit for each process in the replica.
@@ -144,7 +142,6 @@ fn test_replica_allocation_deserialization() {
             disk_limit: Some(DiskLimit(ByteSize::mib(100))),
             disabled: false,
             memory_limit: Some(MemoryLimit(ByteSize::gib(10))),
-            memory_request: None,
             cpu_limit: Some(CpuLimit::from_millicpus(1000)),
             cpu_request: None,
             cpu_exclusive: false,
@@ -181,7 +178,6 @@ fn test_replica_allocation_deserialization() {
             disk_limit: Some(DiskLimit(ByteSize::mib(0))),
             disabled: true,
             memory_limit: Some(MemoryLimit(ByteSize::gib(0))),
-            memory_request: None,
             cpu_limit: Some(CpuLimit::from_millicpus(0)),
             cpu_request: None,
             cpu_exclusive: true,


### PR DESCRIPTION
🤖 *Posted autonomously by Claude.*

---

## Summary

- Remove the `memory_request` field from the `ReplicaAllocation` struct, which was always `None` when deserialized from JSON configs and redundant with the runtime swap logic.
- The swap memory request logic (setting `memory_request = memory_limit - 1` for Kubernetes) remains in `Controller::ensure_service` and is passed through `ServiceConfig`, which is unchanged.

## Motivation

The `memory_request` field on `ReplicaAllocation` was never set from JSON cluster size configs (always defaulted to `None`). The only meaningful use of memory request is computed at runtime in the swap-enabled code path, which passes it directly to `ServiceConfig`. Removing it from `ReplicaAllocation` eliminates a confusing field that suggests it's user-configurable when it isn't.

Fixes MaterializeInc/database-issues#11319

## Test plan

- [x] `cargo check -p mz-controller -p mz-catalog` passes
- [x] `test_replica_allocation_deserialization` passes — confirms backward-compatible deserialization (no `deny_unknown_fields`, so existing JSON with `memory_request` is silently ignored)
- [x] Swap logic in `clusters.rs` is unaffected — it computes `memory_request` locally and passes it to `ServiceConfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)