### PR TITLE
clippy: Remove disallowed TimelyStack

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -93,5 +93,4 @@ disallowed-macros = [
 disallowed-types = [
     { path = "std::collections::HashMap", reason = "use `std::collections::BTreeMap` or `mz_ore::collections::HashMap` instead" },
     { path = "std::collections::HashSet", reason = "use `std::collections::BTreeSet` or `mz_ore::collections::HashSet` instead" },
-    { path = "differential_dataflow::containers::TimelyStack", reason = "use `mz_timely_util::columnation::ColumnationStack` instead" },
 ]


### PR DESCRIPTION
Doesn't exist anymore, causes a warning in Clippy, which can't be promoted to an error unfortunately.