### PR TITLE
Source Versioning docs for MySQL

### DIFF
--- a/doc/user/content/headless/mysql-considerations.md
+++ b/doc/user/content/headless/mysql-considerations.md
@@ -3,11 +3,20 @@ headless: true
 ---
 ### Schema changes
 
-{{% include-headless "/headless/schema-changes-in-progress" %}}
-
 Materialize supports schema changes in the upstream database as follows:
 
-#### Compatible schema changes
+#### Compatible schema changes (Legacy syntax)
+
+{{< note >}}
+
+This section refer to the legacy [`CREATE SOURCE ... FOR
+...`](/sql/create-source/mysql/) that creates subsources as part of the `CREATE
+SOURCE` operation.  To be able to handle the upstream column additions and
+drops, use [`CREATE SOURCE (New Syntax)`](/sql/create-source/mysql-v2/) and
+[`CREATE TABLE FROM SOURCE`](/sql/create-table) instead.  For details, see
+[MySQL: Source versioning guide](/ingest-data/mysql/source-versioning/).
+
+{{< /note >}}
 
 {{% include-from-yaml data="mysql_source_details"
 name="mysql-compatible-schema-changes-legacy" %}}

--- a/doc/user/content/headless/mysql-ingest-guides.md
+++ b/doc/user/content/headless/mysql-ingest-guides.md
@@ -1,0 +1,8 @@
+---
+headless: true
+---
+- [Amazon Aurora for MySQL](/ingest-data/mysql/amazon-aurora/)
+- [Amazon RDS for MySQL](/ingest-data/mysql/amazon-rds/)
+- [Azure DB for MySQL](/ingest-data/mysql/azure-db/)
+- [Google Cloud SQL for MySQL](/ingest-data/mysql/google-cloud-sql/)
+- [Self-hosted MySQL](/ingest-data/mysql/self-hosted/)

--- a/doc/user/content/headless/source-versioning-snapshotting-note.md
+++ b/doc/user/content/headless/source-versioning-snapshotting-note.md
@@ -1,0 +1,8 @@
+---
+headless: true
+---
+During the snapshotting, the data ingestion for the existing tables for the same
+source is temporarily blocked. As such, if possible, you can resize the cluster
+to speed up the snapshotting process and once the process finishes, resize the
+cluster for steady-state. You can monitor the snapshot progress on the overview
+page for the source in the Materialize console.

--- a/doc/user/content/ingest-data/debezium.md
+++ b/doc/user/content/ingest-data/debezium.md
@@ -7,31 +7,22 @@ aliases:
   - /connect-sources/debezium/
 ---
 
-You can use [Debezium](https://debezium.io/) to propagate Change Data Capture
-(CDC) data to Materialize from databases that are not supported via native
-connectors. For PostgreSQL and MySQL databases, we **strongly recommend** using
-the native [PostgreSQL](/sql/create-source/postgres/) and [MySQL](/sql/create-source/mysql/)
-sources instead.
+For databases that are not natively supported, like Oracle or MongoDB, you can
+use [Debezium](https://debezium.io/) to propagate Change Data Capture (CDC) data
+to Materialize.
 
 | Database   | Natively supported? | Integration guide                                                                              |
 |------------|---------------------| ---------------------------------------------------------------------------------------------- |
-| PostgreSQL | ✓                   | {{% ingest-data/postgres-native-support %}}                                                    |
-| MySQL      | ✓                   | {{% ingest-data/mysql-native-support %}}                                                       |
-| SQL Server | ✓                   | {{% ingest-data/sql-server-native-support %}}                                                  |
 | Oracle     |                     | [Kafka + Debezium](https://debezium.io/documentation/reference/stable/connectors/oracle.html)  |
 | MongoDB    |                     | [Kafka + Debezium](/ingest-data/mongodb/) |
-
-### Using Debezium
-
-For databases that are not yet natively supported, like Oracle, SQL Server, or
-MongoDB, you can use [Debezium](https://debezium.io/) to propagate Change Data
-Capture (CDC) data to Materialize.
-
-{{< debezium-json >}}
 
 Debezium captures row-level changes resulting from `INSERT`, `UPDATE`, and
 `DELETE` operations in the upstream database and publishes them as events to
 Kafka (and other Kafka API-compatible brokers) using Kafka Connect-compatible
-connectors. For more details on CDC support in Materialize, check the
+connectors.
+
+{{< debezium-json >}}
+
+For more details on CDC support in Materialize, check the
 [Kafka source](/sql/create-source/kafka/#debezium-envelope) reference
 documentation.

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -11,8 +11,8 @@ menu:
 
 ## Change Data Capture (CDC)
 
-Materialize supports MySQL as a real-time data source. The [MySQL source](/sql/create-source/mysql/)
-uses MySQL's [binlog replication protocol](/sql/create-source/mysql/#change-data-capture)
+Materialize supports MySQL as a real-time data source. The [MySQL source](/sql/create-source/mysql-v2/)
+uses MySQL's [binlog replication protocol](/sql/create-source/mysql-v2/#change-data-capture)
 to **continually ingest changes** resulting from CRUD operations in the upstream
 database. The native support for MySQL Change Data Capture (CDC) in Materialize
 gives you the following benefits:

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -42,13 +42,11 @@ and [PlanetScale](https://planetscale.com/) are currently **not supported**.
 The MySQL source requires **MySQL 8.0.1+** and is compatible with most common
 MySQL hosted services.
 
-| Integration guides                       |
-| ---------------------------------------- |
-| {{% ingest-data/mysql-native-support %}} |
+## Integration guides
 
-If there is a hosted service or MySQL distribution that is not listed above but
-you would like to use with Materialize, please submit a [feature request](https://github.com/MaterializeInc/materialize/discussions/new?category=feature-requests&labels=A-integration)
-or reach out in the Materialize [Community Slack](https://materialize.com/s/chat).
+To help you get started, the following integration guides are available:
+
+{{% include-headless "/headless/mysql-ingest-guides" %}}
 
 ## Considerations
 

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -3,33 +3,33 @@ title: "MySQL"
 description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
 disable_list: true
 menu:
-  main:
-    parent: 'ingest-data'
-    identifier: 'mysql'
-    weight: 5
+    main:
+        parent: "ingest-data"
+        identifier: "mysql"
+        weight: 5
 ---
 
 ## Change Data Capture (CDC)
 
-Materialize supports MySQL as a real-time data source. The [MySQL source](/sql/create-source/mysql-v2/)
+Materialize supports MySQL (8.0.1+) as a real-time data source. The [MySQL source](/sql/create-source/mysql-v2/)
 uses MySQL's [binlog replication protocol](/sql/create-source/mysql-v2/#change-data-capture)
 to **continually ingest changes** resulting from CRUD operations in the upstream
 database. The native support for MySQL Change Data Capture (CDC) in Materialize
 gives you the following benefits:
 
-* **No additional infrastructure:** Ingest MySQL change data into Materialize in
-    real-time with no architectural changes or additional operational overhead.
-    In particular, you **do not need to deploy Kafka and Debezium** for MySQL
-    CDC.
+- **No additional infrastructure:** Ingest MySQL change data into Materialize in
+  real-time with no architectural changes or additional operational overhead.
+  In particular, you **do not need to deploy Kafka and Debezium** for MySQL
+  CDC.
 
-* **Transactional consistency:** The MySQL source ensures that transactions in
-    the upstream MySQL database are respected downstream. Materialize will
-    **never show partial results** based on partially replicated transactions.
+- **Transactional consistency:** The MySQL source ensures that transactions in
+  the upstream MySQL database are respected downstream. Materialize will
+  **never show partial results** based on partially replicated transactions.
 
-* **Incrementally updated materialized views:** Materialized views are **not
-    supported in MySQL**, so you can use Materialize as a
-    read-replica to build views on top of your MySQL data that are efficiently
-    maintained and always up-to-date.
+- **Incrementally updated materialized views:** Materialized views are **not
+  supported in MySQL**, so you can use Materialize as a
+  read-replica to build views on top of your MySQL data that are efficiently
+  maintained and always up-to-date.
 
 ## Supported versions and services
 
@@ -39,12 +39,12 @@ source out-of-the-box. [MariaDB](https://mariadb.org/), [Vitess](https://vitess.
 and [PlanetScale](https://planetscale.com/) are currently **not supported**.
 {{< /note >}}
 
-The MySQL source requires **MySQL 5.7+** and is compatible with most common
+The MySQL source requires **MySQL 8.0.1+** and is compatible with most common
 MySQL hosted services.
 
-| Integration guides                          |
-| ------------------------------------------- |
-| {{% ingest-data/mysql-native-support %}}    |
+| Integration guides                       |
+| ---------------------------------------- |
+| {{% ingest-data/mysql-native-support %}} |
 
 If there is a hosted service or MySQL distribution that is not listed above but
 you would like to use with Materialize, please submit a [feature request](https://github.com/MaterializeInc/materialize/discussions/new?category=feature-requests&labels=A-integration)

--- a/doc/user/content/ingest-data/mysql/amazon-aurora.md
+++ b/doc/user/content/ingest-data/mysql/amazon-aurora.md
@@ -385,11 +385,7 @@ your networking configuration.
 
 ### 3. Start ingesting data
 
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="ingest-data-step" %}}
 
 [//]: # "TODO(morsapaes) Replace these Step 6. and 7. with guidance using the
 new progress metrics in mz_source_statistics + console monitoring, when

--- a/doc/user/content/ingest-data/mysql/amazon-aurora.md
+++ b/doc/user/content/ingest-data/mysql/amazon-aurora.md
@@ -2,11 +2,11 @@
 title: "Ingest data from Amazon Aurora"
 description: "How to stream data from Amazon Aurora for MySQL to Materialize"
 menu:
-  main:
-    parent: "mysql"
-    name: "Amazon Aurora"
-    identifier: "mysql-amazon-aurora"
-    weight: 10
+    main:
+        parent: "mysql"
+        name: "Amazon Aurora"
+        identifier: "mysql-amazon-aurora"
+        weight: 10
 ---
 
 This page shows you how to stream data from [Amazon Aurora MySQL](https://aws.amazon.com/rds/aurora/)
@@ -30,15 +30,15 @@ as Aurora Serverless v2.
 {{</ note >}}
 
 1. Before creating a source in Materialize, you **must** configure Amazon Aurora
-   MySQL for GTID-based binlog replication. Ensure the upstream MySQL database  has been configured for GTID-based binlog replication:
+   MySQL for GTID-based binlog replication. Ensure the upstream MySQL database has been configured for GTID-based binlog replication:
 
-   {{% mysql-direct/ingesting-data/mysql-configs
-      gtid_mode_note="In the AWS console, this parameter appears as `gtid-mode`."
-      binlog_format_note=" "
-   %}}
+    {{% mysql-direct/ingesting-data/mysql-configs
+        gtid_mode_note="In the AWS console, this parameter appears as `gtid-mode`."
+        binlog_format_note=" "
+     %}}
 
-   For guidance on enabling GTID-based binlog replication in Aurora, see the
-   [Amazon Aurora MySQL
+    For guidance on enabling GTID-based binlog replication in Aurora, see the
+    [Amazon Aurora MySQL
     documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/mysql-replication-gtid.html).
 
 1. In addition to the step above, you **must** also ensure that
@@ -46,20 +46,20 @@ as Aurora Serverless v2.
    reasonable value. To check the current value of the `binlog retention hours`
    configuration parameter, connect to your RDS instance and run:
 
-   ```mysql
-   CALL mysql.rds_show_configuration;
-   ```
+    ```mysql
+    CALL mysql.rds_show_configuration;
+    ```
 
-   If the value returned is `NULL`, or less than `168` (i.e. 7 days), run:
+    If the value returned is `NULL`, or less than `168` (i.e. 7 days), run:
 
-   ```mysql
-   CALL mysql.rds_set_configuration('binlog retention hours', 168);
-   ```
+    ```mysql
+    CALL mysql.rds_set_configuration('binlog retention hours', 168);
+    ```
 
-   Although 7 days is a reasonable retention period, we recommend using the
-   default MySQL retention period (30 days) in order to not compromise
-   Materialize’s ability to resume replication in case of failures or
-   restarts.
+    Although 7 days is a reasonable retention period, we recommend using the
+    default MySQL retention period (30 days) in order to not compromise
+    Materialize’s ability to resume replication in case of failures or
+    restarts.
 
 1. To validate that all configuration parameters are set to the expected values
    after the above configuration changes, run:
@@ -77,7 +77,8 @@ as Aurora Serverless v2.
       'binlog_row_image',
       'gtid_mode',
       'enforce_gtid_consistency',
-      'replica_preserve_commit_order'
+      'replica_preserve_commit_order',
+      'binlog_row_metadata' -- must be "FULL" to use new CREATE SOURCE syntax
     );
     ```
 
@@ -101,15 +102,15 @@ There are various ways to configure your database's network to allow Materialize
 to connect:
 
 - **Allow Materialize IPs:** If your database is publicly accessible, you can
-    configure your database's security group to allow connections from a set of
-    static Materialize IP addresses.
+  configure your database's security group to allow connections from a set of
+  static Materialize IP addresses.
 
 - **Use AWS PrivateLink**: If your database is running in a private network, you
-    can use [AWS PrivateLink](/ingest-data/network-security/privatelink/) to
-    connect Materialize to the database. For details, see [AWS PrivateLink](/ingest-data/network-security/privatelink/).
+  can use [AWS PrivateLink](/ingest-data/network-security/privatelink/) to
+  connect Materialize to the database. For details, see [AWS PrivateLink](/ingest-data/network-security/privatelink/).
 
 - **Use an SSH tunnel:** If your database is running in a private network, you
-    can use an SSH tunnel to connect Materialize to the database.
+  can use an SSH tunnel to connect Materialize to the database.
 
 {{< tabs >}}
 
@@ -124,10 +125,9 @@ to connect:
     ```
 
 1. [Add an inbound rule to your Aurora security group](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.RDSSecurityGroups.html)
-    for each IP address from the previous step.
+   for each IP address from the previous step.
 
     In each rule:
-
     - Set **Type** to **MySQL**.
     - Set **Source** to the IP address in CIDR notation.
 
@@ -154,18 +154,16 @@ see the [Terraform module repository](https://github.com/MaterializeInc/terrafor
     the network load balancer in the next step.
 
     To get the IP address of your database instance:
-
     1. In the AWS Management Console, select your database.
     1. Find your Aurora endpoint under **Connectivity & security**.
     1. Use the `dig` or `nslooklup` command
-    to find the IP address that the endpoint resolves to:
+       to find the IP address that the endpoint resolves to:
 
-       ```sh
-       dig +short <AURORA_ENDPOINT>
-       ```
+        ```sh
+        dig +short <AURORA_ENDPOINT>
+        ```
 
 1. [Create a dedicated target group for your Aurora instance](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html).
-
     - Choose the **IP addresses** type.
 
     - Set the protocol and port to **TCP** and **3306**.
@@ -176,16 +174,15 @@ see the [Terraform module repository](https://github.com/MaterializeInc/terrafor
       as the target.
 
     **Warning:** The IP address of your Aurora instance can change without
-      notice. For this reason, it's best to set up automation to regularly
-      check the IP of the instance and update your target group accordingly.
-      You can use a lambda function to automate this process - see
-      Materialize's [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py)
-      for an example. Another approach is to [configure an EC2 instance as an
-      RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/)
-      for your network load balancer.
+    notice. For this reason, it's best to set up automation to regularly
+    check the IP of the instance and update your target group accordingly.
+    You can use a lambda function to automate this process - see
+    Materialize's [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py)
+    for an example. Another approach is to [configure an EC2 instance as an
+    RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/)
+    for your network load balancer.
 
 1. [Create a network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html).
-
     - For **Network mapping**, choose the same VPC as your RDS instance and
       select all of the availability zones and subnets that you RDS instance is
       in.
@@ -202,7 +199,6 @@ see the [Terraform module repository](https://github.com/MaterializeInc/terrafor
     CIDR of the network load balancer. If you don't want to grant access to the
     entire VPC CIDR, you can add inbound rules for the private IP addresses of
     the load balancer subnets.
-
     - To find the VPC CIDR, go to the network load balancer and look
       under **Network mapping**.
 
@@ -212,7 +208,6 @@ see the [Terraform module repository](https://github.com/MaterializeInc/terrafor
       interface.
 
 1. [Create a VPC endpoint service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html).
-
     - For **Load balancer type**, choose **Network** and then select the network
       load balancer you created in the previous step.
 
@@ -220,9 +215,9 @@ see the [Terraform module repository](https://github.com/MaterializeInc/terrafor
       use this service name when connecting Materialize later.
 
     **Remarks** By disabling [Acceptance Required](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests),
-      while still strictly managing who can view your endpoint via IAM,
-      Materialze will be able to seamlessly recreate and migrate endpoints as
-      we work to stabilize this feature.
+    while still strictly managing who can view your endpoint via IAM,
+    Materialze will be able to seamlessly recreate and migrate endpoints as
+    we work to stabilize this feature.
 
 1. Go back to the target group you created for the network load balancer and
    make sure that the [health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)
@@ -244,8 +239,7 @@ configuration of resources for an SSH tunnel. For more details, see the
 {{</ note >}}
 
 1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
-    to serve as your SSH bastion host.
-
+   to serve as your SSH bastion host.
     - Make sure the instance is publicly accessible and in the same VPC as your
       Amazon Aurora MySQL instance.
 
@@ -253,30 +247,27 @@ configuration of resources for an SSH tunnel. For more details, see the
       connecting Materialize to your bastion host.
 
     **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses).
-      For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
-      to your bastion host.
+    For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
+    to your bastion host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
-
     1. In the [SQL Shell](/console/), or your preferred
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```mzsql
-       SELECT * FROM mz_egress_ips;
-       ```
+        ```mzsql
+        SELECT * FROM mz_egress_ips;
+        ```
 
     1. For each static egress IP, [add an inbound rule](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html)
        to your SSH bastion host's security group.
 
         In each rule:
-
         - Set **Type** to **MySQL**.
         - Set **Source** to the IP address in CIDR notation.
 
 1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.RDSSecurityGroups.html)
    to allow traffic from the SSH bastion host.
-
     - Set **Type** to **All TCP**.
     - Set **Source** to **Custom** and select the bastion host's security
       group.
@@ -297,10 +288,9 @@ file="shared-content/self-managed/configure-network-security-intro.md" %}}
 {{< tab "Allow Materialize IPs">}}
 
 1. [Add an inbound rule to your Aurora security group](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.RDSSecurityGroups.html)
-    to allow traffic from Materialize IPs.
+   to allow traffic from Materialize IPs.
 
     In each rule:
-
     - Set **Type** to **MySQL**.
     - Set **Source** to the IP address in CIDR notation.
 
@@ -319,8 +309,7 @@ configuration of resources for an SSH tunnel. For more details, see the
 {{</ note >}}
 
 1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
-    to serve as your SSH bastion host.
-
+   to serve as your SSH bastion host.
     - Make sure the instance is publicly accessible and in the same VPC as your
       Amazon Aurora MySQL instance.
 
@@ -328,14 +317,13 @@ configuration of resources for an SSH tunnel. For more details, see the
       connecting Materialize to your bastion host.
 
     **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses).
-      For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
-      to your bastion host.
+    For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
+    to your bastion host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
 1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.RDSSecurityGroups.html)
    to allow traffic from the SSH bastion host.
-
     - Set **Type** to **All TCP**.
     - Set **Source** to **Custom** and select the bastion host's security
       group.
@@ -381,7 +369,6 @@ your networking configuration.
 {{< /tab >}}
 
 {{< /tabs >}}
-
 
 ### 3. Start ingesting data
 

--- a/doc/user/content/ingest-data/mysql/amazon-rds.md
+++ b/doc/user/content/ingest-data/mysql/amazon-rds.md
@@ -399,11 +399,7 @@ your networking configuration.
 
 ### 3. Start ingesting data
 
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="ingest-data-step" %}}
 
 [//]: # "TODO(morsapaes) Replace these Step 6. and 7. with guidance using the
 new progress metrics in mz_source_statistics + console monitoring, when

--- a/doc/user/content/ingest-data/mysql/azure-db.md
+++ b/doc/user/content/ingest-data/mysql/azure-db.md
@@ -198,11 +198,7 @@ your networking configuration.
 
 ### 3. Start ingesting data
 
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="ingest-data-step" %}}
 
 ### 4. Monitor the ingestion status
 

--- a/doc/user/content/ingest-data/mysql/google-cloud-sql.md
+++ b/doc/user/content/ingest-data/mysql/google-cloud-sql.md
@@ -192,11 +192,7 @@ your networking configuration.
 
 ### 3. Start ingesting data
 
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="ingest-data-step" %}}
 
 ### 4. Monitor the ingestion status
 

--- a/doc/user/content/ingest-data/mysql/self-hosted.md
+++ b/doc/user/content/ingest-data/mysql/self-hosted.md
@@ -190,11 +190,7 @@ your networking configuration.
 
 ### 3. Start ingesting data
 
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="ingest-data-step" %}}
 
 ### 4. Monitor the ingestion status
 

--- a/doc/user/content/ingest-data/mysql/source-versioning.md
+++ b/doc/user/content/ingest-data/mysql/source-versioning.md
@@ -46,6 +46,8 @@ INSERT INTO t1 (a) VALUES (10);
 Configure your MySQL database for GTID-based binlog replication using the
 [configuration instructions for self-hosted MySQL](/ingest-data/mysql/self-hosted/#a-configure-mysql).
 
+In addition to the standard setup, in order to use the [`CREATE SOURCE` syntax](/sql/create-source/mysql-v2/) and use source versioning, you must also ensure that the MySQL system variable `binlog_row_metadata` is set to `FULL`, which will allow Materialize to access additional information about the schemas of the MySQL tables you want to replicate.
+
 ### Connect your source database to Materialize
 
 Create a connection to your MySQL database using the [`CREATE CONNECTION` syntax](/sql/create-connection/).

--- a/doc/user/content/ingest-data/mysql/source-versioning.md
+++ b/doc/user/content/ingest-data/mysql/source-versioning.md
@@ -14,8 +14,8 @@ menu:
 Changing column types is currently unsupported.
 {{< /note >}}
 
-Materialize allows you to handle certain types of upstream
-table schema changes seamlessly, specifically:
+Materialize allows you to handle certain types of upstream table schema changes
+seamlessly, specifically:
 
 - Adding a column in the upstream database.
 - Dropping a column in the upstream database.
@@ -25,15 +25,17 @@ This guide walks you through how to handle these changes without any downtime in
 ## Prerequisites
 
 Some familiarity with Materialize. If you've never used Materialize before,
-start with our [guide to getting started](/get-started/quickstart/) to learn
-how to connect a database to Materialize.
+start with our [guide to getting started](/get-started/quickstart/).
 
 ### Set up a MySQL database
 
-For this guide, setup a MySQL 8.0.1+ database. In your MySQL database, create a
-table `t1` and populate it:
+For this guide, set up a MySQL 8.0.1+ database. In your MySQL database, create a
+table `t1` in `mydb` and populate it:
 
 ```sql
+CREATE DATABASE mydb;
+USE mydb;
+
 CREATE TABLE t1 (
     a INT
 );
@@ -43,10 +45,11 @@ INSERT INTO t1 (a) VALUES (10);
 
 ### Configure your MySQL database
 
-Configure your MySQL database for GTID-based binlog replication using the
-[configuration instructions for self-hosted MySQL](/ingest-data/mysql/self-hosted/#a-configure-mysql).
+Configure your MySQL database for GTID-based binlog replication. You must set
+`binlog_row_metadata=FULL` to use the new [`CREATE
+SOURCE`](/sql/create-source/mysql-v2/) syntax.
 
-In addition to the standard setup, in order to use the [`CREATE SOURCE` syntax](/sql/create-source/mysql-v2/) and use source versioning, you must also ensure that the MySQL system variable `binlog_row_metadata` is set to `FULL`, which will allow Materialize to access additional information about the schemas of the MySQL tables you want to replicate.
+{{% include-headless "/headless/mysql-ingest-guides" %}}
 
 ### Connect your source database to Materialize
 
@@ -79,9 +82,7 @@ snapshot](/ingest-data/#snapshotting) of table `v1.t1` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. You can monitor progress for the snapshot
-operation on the overview page for the source in the Materialize console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -108,6 +109,11 @@ ALTER TABLE t1
 INSERT INTO t1 (a, b) VALUES (20, true);
 ```
 
+{{< note >}}
+In MySQL, `BOOL`/`BOOLEAN` is an alias for MySQL type `TINYINT(1)`. As such, the
+column `b` will be ingested as `smallint` in Materialize. See  [MySQL's data type documentation](https://dev.mysql.com/doc/refman/9.7/en/other-vendor-data-types.html).
+{{< /note >}}
+
 This operation has no immediate effect in Materialize. In Materialize:
 
 - The table `v1.t1` will continue to ingest only column `a`.
@@ -116,9 +122,9 @@ This operation has no immediate effect in Materialize. In Materialize:
 
 ### B. Incorporate the new column in Materialize
 
-Unlike SQL Server CDC, MySQL uses binlog-based replication, which automatically
-includes all columns. To incorporate the new column into Materialize, create a
-new `v2` schema and recreate the table in the new schema:
+MySQL uses binlog-based replication, which automatically includes all columns.
+To incorporate the new column into Materialize, create a new `v2` schema and
+recreate the table in the new schema:
 
 ```mzsql
 CREATE SCHEMA v2;
@@ -132,20 +138,18 @@ The [snapshotting](/ingest-data/#snapshotting) of table `v2.t1` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. You can monitor progress for the snapshot
-operation on the overview page for the source in the Materialize console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
 When `v2.t1` has finished snapshotting, create a new materialized view in the
-new schema. Since `v2.matview` references `v2.t1`, it can now reference column `b`:
+new schema. Since `v2.matview` references `v2.t1`, it can reference column `b`:
 
 ```mzsql {hl_lines="4"}
 CREATE MATERIALIZED VIEW v2.matview AS
     SELECT SUM(a)
     FROM v2.t1
-    WHERE b = true;
+    WHERE b = 1;
 ```
 
 ## Handle upstream column drop
@@ -165,9 +169,7 @@ CREATE TABLE v3.t1
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. You can monitor progress for the snapshot
-operation on the overview page for the source in the Materialize console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -181,7 +183,7 @@ ALTER TABLE t1 DROP COLUMN b;
 
 Dropping column `b` will have no effect on `v3.t1` in Materialize, provided
 you completed step A before dropping the column. However, the drop affects
-`v2.T` and `v2.matview` from our earlier examples. When the user attempts to
+`v2.t1` and `v2.matview` from our earlier examples. When you attempt to
 read from either, Materialize will report an error that the source table schema
 has been altered.
 

--- a/doc/user/content/ingest-data/mysql/source-versioning.md
+++ b/doc/user/content/ingest-data/mysql/source-versioning.md
@@ -9,7 +9,7 @@ menu:
         weight: 85
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 {{< note >}}
 Changing column types is currently unsupported.
 {{< /note >}}
@@ -30,7 +30,7 @@ how to connect a database to Materialize.
 
 ### Set up a MySQL database
 
-For this guide, setup a MySQL 5.7+ database. In your MySQL database, create a
+For this guide, setup a MySQL 8.0.1+ database. In your MySQL database, create a
 table `t1` and populate it:
 
 ```sql

--- a/doc/user/content/ingest-data/mysql/source-versioning.md
+++ b/doc/user/content/ingest-data/mysql/source-versioning.md
@@ -1,0 +1,193 @@
+---
+title: "Guide: Handle upstream schema changes with zero downtime"
+description: "How to add a column, or drop a column, from your source MySQL database, without any downtime in Materialize"
+
+menu:
+    main:
+        parent: "mysql"
+        identifier: "mysql-source-versioning"
+        weight: 85
+---
+
+{{< private-preview />}}
+{{< note >}}
+Changing column types is currently unsupported.
+{{< /note >}}
+
+Materialize allows you to handle certain types of upstream
+table schema changes seamlessly, specifically:
+
+- Adding a column in the upstream database.
+- Dropping a column in the upstream database.
+
+This guide walks you through how to handle these changes without any downtime in Materialize.
+
+## Prerequisites
+
+Some familiarity with Materialize. If you've never used Materialize before,
+start with our [guide to getting started](/get-started/quickstart/) to learn
+how to connect a database to Materialize.
+
+### Set up a MySQL database
+
+For this guide, setup a MySQL 5.7+ database. In your MySQL database, create a
+table `t1` and populate it:
+
+```sql
+CREATE TABLE t1 (
+    a INT
+);
+
+INSERT INTO t1 (a) VALUES (10);
+```
+
+### Configure your MySQL database
+
+Configure your MySQL database for GTID-based binlog replication using the
+[configuration instructions for self-hosted MySQL](/ingest-data/mysql/self-hosted/#a-configure-mysql).
+
+### Connect your source database to Materialize
+
+Create a connection to your MySQL database using the [`CREATE CONNECTION` syntax](/sql/create-connection/).
+
+## Create a source
+
+In Materialize, create a source using the [`CREATE SOURCE`
+syntax](/sql/create-source/mysql-v2/).
+
+```mzsql
+CREATE SOURCE my_source
+  FROM MYSQL CONNECTION mysql_connection;
+```
+
+## Create a table from the source
+
+To start ingesting specific tables from your source database, create a
+table in Materialize. We'll add it into the `v1` schema.
+
+```mzsql
+CREATE SCHEMA v1;
+
+CREATE TABLE v1.t1
+    FROM SOURCE my_source (REFERENCE mydb.t1);
+```
+
+Once you've created a table from source, the [initial
+snapshot](/ingest-data/#snapshotting) of table `v1.t1` will begin.
+
+{{< note >}}
+
+During the snapshotting, the data ingestion for the other tables associated with
+the source is temporarily blocked. You can monitor progress for the snapshot
+operation on the overview page for the source in the Materialize console.
+
+{{< /note >}}
+
+## Create a view on top of the table
+
+For this guide, add a materialized view `matview` (also in schema `v1`) that
+sums column `a` from table `t1`.
+
+```mzsql
+CREATE MATERIALIZED VIEW v1.matview AS
+    SELECT SUM(a) FROM v1.t1;
+```
+
+## Handle upstream column addition
+
+### A. Add a column in your upstream MySQL database
+
+In your upstream MySQL database, add a new column `b` to the table `t1`:
+
+```sql
+ALTER TABLE t1
+    ADD COLUMN b BOOLEAN DEFAULT false;
+
+INSERT INTO t1 (a, b) VALUES (20, true);
+```
+
+This operation has no immediate effect in Materialize. In Materialize:
+
+- The table `v1.t1` will continue to ingest only column `a`.
+- The materialized view `v1.matview` will continue to have access to column `a`
+  only.
+
+### B. Incorporate the new column in Materialize
+
+Unlike SQL Server CDC, MySQL uses binlog-based replication, which automatically
+includes all columns. To incorporate the new column into Materialize, create a
+new `v2` schema and recreate the table in the new schema:
+
+```mzsql
+CREATE SCHEMA v2;
+
+CREATE TABLE v2.t1
+    FROM SOURCE my_source (REFERENCE mydb.t1);
+```
+
+The [snapshotting](/ingest-data/#snapshotting) of table `v2.t1` will begin.
+`v2.t1` will include columns `a` and `b`.
+
+{{< note >}}
+
+During the snapshotting, the data ingestion for the other tables associated with
+the source is temporarily blocked. You can monitor progress for the snapshot
+operation on the overview page for the source in the Materialize console.
+
+{{< /note >}}
+
+When `v2.t1` has finished snapshotting, create a new materialized view in the
+new schema. Since `v2.matview` references `v2.t1`, it can now reference column `b`:
+
+```mzsql {hl_lines="4"}
+CREATE MATERIALIZED VIEW v2.matview AS
+    SELECT SUM(a)
+    FROM v2.t1
+    WHERE b = true;
+```
+
+## Handle upstream column drop
+
+### A. Exclude the column in Materialize
+
+To drop a column safely, first create a new schema in Materialize and recreate
+the table excluding the column you intend to drop. In this example, we'll drop
+column `b`.
+
+```mzsql
+CREATE SCHEMA v3;
+
+CREATE TABLE v3.t1
+    FROM SOURCE my_source (REFERENCE mydb.t1) WITH (EXCLUDE COLUMNS (b));
+```
+
+{{< note >}}
+
+During the snapshotting, the data ingestion for the other tables associated with
+the source is temporarily blocked. You can monitor progress for the snapshot
+operation on the overview page for the source in the Materialize console.
+
+{{< /note >}}
+
+### B. Drop the column in your upstream MySQL database
+
+In your upstream MySQL database, drop column `b` from table `t1`:
+
+```sql
+ALTER TABLE t1 DROP COLUMN b;
+```
+
+Dropping column `b` will have no effect on `v3.t1` in Materialize, provided
+you completed step A before dropping the column. However, the drop affects
+`v2.T` and `v2.matview` from our earlier examples. When the user attempts to
+read from either, Materialize will report an error that the source table schema
+has been altered.
+
+Once you have finished migrating any views and queries from `v2` to `v3`, you
+can clean up the old objects:
+
+```mzsql
+DROP TABLE v2.t1;
+DROP MATERIALIZED VIEW v2.matview;
+DROP SCHEMA v2;
+```

--- a/doc/user/content/ingest-data/postgres/_index.md
+++ b/doc/user/content/ingest-data/postgres/_index.md
@@ -42,7 +42,7 @@ common PostgreSQL hosted services.
 
 ## Integration guides
 
-The following integration guides are available:
+To help you get started, the following integration guides are available:
 
 {{% include-md file="shared-content/postgresql-ingest-data-guides.md" %}}
 

--- a/doc/user/content/ingest-data/postgres/source-versioning.md
+++ b/doc/user/content/ingest-data/postgres/source-versioning.md
@@ -27,8 +27,7 @@ This guide walks you through how to handle these changes without any downtime in
 ## Prerequisites
 
 Some familiarity with Materialize. If you've never used Materialize before,
-start with our [guide to getting started](/get-started/quickstart/) to learn
-how to connect a database to Materialize.
+start with our [guide to getting started](/get-started/quickstart/).
 
 ### Set up a PostgreSQL database
 
@@ -88,10 +87,7 @@ snapshot](/ingest-data/#snapshotting) of table `v1.T` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -140,10 +136,7 @@ The [snapshotting](/ingest-data/#snapshotting) of table `v2.T` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -175,10 +168,7 @@ CREATE TABLE v3.T
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 

--- a/doc/user/content/ingest-data/postgres/source-versioning.md
+++ b/doc/user/content/ingest-data/postgres/source-versioning.md
@@ -9,7 +9,7 @@ menu:
 
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 {{< note >}}
 - Changing column types is currently unsupported.
 {{% include-example file="examples/create_table/example_postgres_table"

--- a/doc/user/content/ingest-data/sql-server/source-versioning.md
+++ b/doc/user/content/ingest-data/sql-server/source-versioning.md
@@ -26,8 +26,7 @@ This guide walks you through how to handle these changes without any downtime in
 ## Prerequisites
 
 Some familiarity with Materialize. If you've never used Materialize before,
-start with our [guide to getting started](/get-started/quickstart/) to learn
-how to connect a database to Materialize.
+start with our [guide to getting started](/get-started/quickstart/).
 
 ### Set up a SQL Server database
 
@@ -78,10 +77,7 @@ snapshot](/ingest-data/#snapshotting) of table `v1.t1` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -178,10 +174,7 @@ The [snapshotting](/ingest-data/#snapshotting) of table `v2.t1` will begin.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 
@@ -213,10 +206,7 @@ CREATE TABLE v3.t1
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for the other tables associated with
-the source is temporarily blocked. As before, you can monitor progress for the
-snapshot operation on the overview page for the source in the Materialize
-console.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}
 

--- a/doc/user/content/ingest-data/sql-server/source-versioning.md
+++ b/doc/user/content/ingest-data/sql-server/source-versioning.md
@@ -10,7 +10,7 @@ menu:
 
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 {{< note >}}
 Changing column types is currently unsupported.
 {{< /note >}}

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -30,11 +30,18 @@ For details, see [CREATE SOURCE: PostgreSQL (New Syntax)](/sql/create-source/pos
 
 For details, see [CREATE SOURCE: PostgreSQL (Legacy)](/sql/create-source/postgres/).
 {{< /tab >}}
-{{< tab "MySQL" >}}
+{{< tab "MySQL (New)" >}}
 
 {{% include-example file="examples/create_source_mysql" example="syntax" %}}
 
-For details, see [CREATE SOURCE: MySQL](/sql/create-source/mysql/).
+For details, see [CREATE SOURCE: MySQL (New Syntax)](/sql/create-source/mysql-v2/).
+{{< /tab >}}
+
+{{< tab "MySQL (Legacy)" >}}
+
+{{% include-example file="examples/create_source_mysql_legacy" example="syntax" %}}
+
+For details, see [CREATE SOURCE: MySQL (Legacy)](/sql/create-source/mysql/).
 {{< /tab >}}
 
 {{< tab "SQL Server (New)" >}}

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -7,7 +7,7 @@ menu:
     parent: 'create-source'
     identifier: cs_kafka
     name: Kafka/Redpanda
-    weight: 20
+    weight: 10
 aliases:
     - /sql/create-source/avro-kafka
     - /sql/create-source/json-kafka

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -1,0 +1,293 @@
+---
+title: "CREATE SOURCE: MySQL (New Syntax)"
+description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
+pagerank: 40
+menu:
+  main:
+    parent: 'create-source'
+    identifier: cs_mysql-v2
+    name: MySQL (New Syntax)
+    weight: 21
+---
+
+{{< private-preview />}}
+
+{{< source-versioning-disambiguation is_new=true
+other_ref="[old reference page](/sql/create-source/mysql/)" include_blurb=true >}}
+
+## Prerequisites
+
+{{% create-source/intro %}}
+Materialize supports MySQL (5.7+) as a real-time data source. To connect to a
+MySQL database, you first need to tweak its configuration to enable
+[GTID-based binary log (binlog) replication](#change-data-capture) and set
+[`binlog_row_metadata=FULL`](#change-data-capture), and then
+[create a connection](#prerequisite-creating-a-connection-to-mysql) in
+Materialize that specifies access and authentication parameters.
+{{% /create-source/intro %}}
+
+## Syntax
+
+{{% include-syntax file="examples/create_source_mysql" example="syntax" %}}
+
+## Ingesting data
+
+After a source is created, you can create tables from the source referencing
+upstream MySQL tables that have GTID-based binlog replication enabled. You can
+create multiple tables that reference the same upstream table.
+
+See [`CREATE TABLE FROM SOURCE`](/sql/create-table/) for details.
+
+#### Handling table schema changes
+
+The use of `CREATE SOURCE` with the new [`CREATE TABLE FROM
+SOURCE`](/sql/create-table/) allows for the handling of certain upstream DDL
+changes without downtime.
+
+See [`CREATE TABLE FROM SOURCE`](/sql/create-table/#handling-table-schema-changes) for details.
+
+#### Supported types
+
+With the new syntax, after a MySQL source is created, you [`CREATE TABLE FROM
+SOURCE`](/sql/create-table/) to create a corresponding table in Materialize and
+start ingesting data.
+
+{{% include-from-yaml data="mysql_source_details"
+name="mysql-supported-types" %}}
+
+{{% include-from-yaml data="mysql_source_details"
+name="mysql-unsupported-types" %}}
+
+For more information, including strategies for handling unsupported types,
+see [`CREATE TABLE FROM SOURCE`](/sql/create-table/).
+
+#### Upstream table truncation restrictions
+
+{{% include-from-yaml data="mysql_source_details"
+name="mysql-truncation-restriction" %}}
+
+For additional considerations, see also [`CREATE TABLE`](/sql/create-table/).
+
+### Change data capture
+
+{{< note >}}
+For step-by-step instructions on enabling GTID-based binlog replication for your
+MySQL service, see the integration guides:
+[Amazon RDS](/ingest-data/mysql/amazon-rds/),
+[Amazon Aurora](/ingest-data/mysql/amazon-aurora/),
+[Azure DB](/ingest-data/mysql/azure-db/),
+[Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
+[Self-hosted](/ingest-data/mysql/self-hosted/).
+{{< /note >}}
+
+The source uses MySQL's binlog replication protocol to **continually ingest
+changes** resulting from `INSERT`, `UPDATE` and `DELETE` operations in the
+upstream database. This process is known as _change data capture_.
+
+The replication method used is based on [global transaction identifiers
+(GTIDs)](https://dev.mysql.com/doc/refman/8.0/en/replication-gtids.html), and
+guarantees **transactional consistency** — any operation inside a MySQL
+transaction is assigned the same timestamp in Materialize, which means that the
+source will never show partial results based on partially replicated
+transactions.
+
+Before creating a source in Materialize, you **must** configure the upstream
+MySQL database for GTID-based binlog replication:
+
+{{% mysql-direct/ingesting-data/mysql-configs %}}
+
+In addition, the new `CREATE TABLE FROM SOURCE` syntax requires full row
+metadata in the binlog. You must set the following system variable on the
+upstream MySQL server:
+
+```sql
+SET GLOBAL binlog_row_metadata = FULL;
+```
+
+If you're running MySQL using a managed service, additional configuration
+changes might be required. For step-by-step instructions on enabling GTID-based
+binlog replication for your MySQL service, see the integration guides.
+
+#### Binlog retention
+
+{{< warning >}}
+If Materialize tries to resume replication and finds GTID gaps due to missing
+binlog files, the source enters an errored state and you have to drop and
+recreate it.
+{{< /warning >}}
+
+By default, MySQL retains binlog files for **30 days** (i.e., 2592000 seconds)
+before automatically removing them. This is configurable via the
+[`binlog_expire_logs_seconds`](https://dev.mysql.com/doc/mysql-replication-excerpt/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds)
+system variable. We recommend using the default value for this configuration in
+order to not compromise Materialize's ability to resume replication in case of
+failures or restarts.
+
+In some MySQL managed services, binlog expiration can be overridden by a
+service-specific configuration parameter. It's important that you double-check
+if such a configuration exists, and ensure it's set to the maximum interval
+available.
+
+As an example, [Amazon RDS for MySQL](/ingest-data/mysql/amazon-rds/) has its
+own configuration parameter for binlog retention ([`binlog retention hours`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-stored-proc-configuring.html#mysql_rds_set_configuration-usage-notes.binlog-retention-hours))
+that overrides `binlog_expire_logs_seconds` and is set to `NULL` by default.
+
+### Monitoring source progress
+
+[//]: # "TODO(morsapaes) Replace this section with guidance using the new
+progress metrics in mz_source_statistics + console monitoring, when available
+(also for PostgreSQL)."
+
+By default, MySQL sources expose progress metadata as a subsource that you can
+use to monitor source **ingestion progress**. The name of the progress subsource
+can be specified when creating a source using the `EXPOSE PROGRESS AS` clause;
+otherwise, it will be named `<src_name>_progress`.
+
+The following metadata is available for each source as a progress subsource:
+
+Field              | Type                                                    | Details
+-------------------|---------------------------------------------------------|--------------
+`source_id_lower`  | [`uuid`](/sql/types/uuid/)                              | The lower-bound GTID `source_id` of the GTIDs covered by this range.
+`source_id_upper`  | [`uuid`](/sql/types/uuid/)                              | The upper-bound GTID `source_id` of the GTIDs covered by this range.
+`transaction_id`   | [`uint8`](/sql/types/uint/#uint8-info)                  | The `transaction_id` of the next GTID possible from the GTID `source_id`s covered by this range.
+
+And can be queried using:
+
+```mzsql
+SELECT transaction_id
+FROM <src_name>_progress;
+```
+
+Progress metadata is represented as a [GTID set](https://dev.mysql.com/doc/refman/8.0/en/replication-gtids-concepts.html)
+of future possible GTIDs, which is similar to the
+[`gtid_executed`](https://dev.mysql.com/doc/refman/8.0/en/replication-options-gtids.html#sysvar_gtid_executed)
+system variable on a MySQL replica. The reported `transaction_id` should
+increase as Materialize consumes **new** binlog records from the upstream MySQL
+database. For more details on monitoring source ingestion progress and debugging
+related issues, see [Troubleshooting](/ops/troubleshooting/).
+
+## Known limitations
+
+{{% include-headless "/headless/mysql-considerations" %}}
+
+## Example
+
+{{< important >}}
+Before creating a MySQL source, you must enable GTID-based binlog replication in
+the upstream database. For step-by-step instructions, see the integration guide
+for your MySQL service: [Amazon RDS](/ingest-data/mysql/amazon-rds/),
+[Amazon Aurora](/ingest-data/mysql/amazon-aurora/),
+[Azure DB](/ingest-data/mysql/azure-db/),
+[Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
+[Self-hosted](/ingest-data/mysql/self-hosted/).
+{{< /important >}}
+
+### Creating a source {#create-source-example}
+
+#### Prerequisite: Creating a connection to MySQL
+
+First, you must create a connection to your MySQL database. A connection
+describes how to connect and authenticate to an external system you want
+Materialize to read data from.
+
+Once created, a connection is **reusable** across multiple `CREATE SOURCE`
+statements. For more details on creating connections, check the
+[`CREATE CONNECTION`](/sql/create-connection/#mysql) documentation page.
+
+```mzsql
+CREATE SECRET mysqlpass AS '<MYSQL_PASSWORD>';
+
+CREATE CONNECTION mysql_connection TO MYSQL (
+    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
+    PORT 3306,
+    USER 'materialize',
+    PASSWORD SECRET mysqlpass
+);
+```
+
+If your MySQL server is not exposed to the public internet, you can [tunnel the
+connection](/sql/create-connection/#network-security-connections) through an
+AWS PrivateLink service (Materialize Cloud) or an SSH bastion host.
+
+{{< tabs tabID="1" >}}
+{{< tab "AWS PrivateLink (Materialize Cloud)">}}
+
+{{< include-md file="shared-content/aws-privatelink-cloud-only-note.md" >}}
+
+```mzsql
+CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
+   SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
+   AVAILABILITY ZONES ('use1-az1', 'use1-az4')
+);
+
+CREATE CONNECTION mysql_connection TO MYSQL (
+    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
+    PORT 3306,
+    USER 'root',
+    PASSWORD SECRET mysqlpass,
+    AWS PRIVATELINK privatelink_svc
+);
+```
+
+For step-by-step instructions on creating AWS PrivateLink connections and
+configuring an AWS PrivateLink service to accept connections from Materialize,
+check [this guide](/ops/network-security/privatelink/).
+
+{{< /tab >}}
+{{< tab "SSH tunnel">}}
+
+```mzsql
+CREATE CONNECTION ssh_connection TO SSH TUNNEL (
+    HOST 'bastion-host',
+    PORT 22,
+    USER 'materialize'
+);
+```
+
+```mzsql
+CREATE CONNECTION mysql_connection TO MYSQL (
+    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
+    SSH TUNNEL ssh_connection
+);
+```
+
+For step-by-step instructions on creating SSH tunnel connections and configuring
+an SSH bastion server to accept connections from Materialize, check
+[this guide](/ops/network-security/ssh-tunnel/).
+
+{{< /tab >}}
+{{< /tabs >}}
+
+#### Creating the source in Materialize
+
+You **must** enable GTID-based binlog replication before creating the source.
+See [Change data capture](#change-data-capture) for configuration details.
+
+Once replication is configured, create a `SOURCE` in Materialize:
+
+```mzsql
+CREATE SOURCE mz_source
+    FROM MYSQL CONNECTION mysql_connection;
+```
+
+After a source is created, you can create a table from the source, referencing
+specific upstream table(s).
+
+_Creates a table in Materialize from the upstream table `mydb.orders`_
+
+```mzsql
+CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
+```
+
+## Related pages
+
+- [`CREATE TABLE`](/sql/create-table/)
+- [`CREATE SECRET`](/sql/create-secret)
+- [`CREATE CONNECTION`](/sql/create-connection)
+- [`CREATE SOURCE`](../)
+- MySQL integration guides:
+  - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
+  - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
+  - [Azure DB](/ingest-data/mysql/azure-db/)
+  - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
+  - [Self-hosted](/ingest-data/mysql/self-hosted/)

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -71,6 +71,7 @@ For additional considerations, see also [`CREATE TABLE`](/sql/create-table/).
 ### Change data capture
 
 {{< note >}}
+
 For step-by-step instructions on enabling GTID-based binlog replication for your
 MySQL service, see the integration guides:
 [Amazon RDS](/ingest-data/mysql/amazon-rds/),

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -79,6 +79,7 @@ MySQL service, see the integration guides:
 [Azure DB](/ingest-data/mysql/azure-db/),
 [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
 [Self-hosted](/ingest-data/mysql/self-hosted/).
+
 {{< /note >}}
 
 The source uses MySQL's binlog replication protocol to **continually ingest
@@ -112,9 +113,11 @@ binlog replication for your MySQL service, see the integration guides.
 #### Binlog retention
 
 {{< warning >}}
+
 If Materialize tries to resume replication and finds GTID gaps due to missing
 binlog files, the source enters an errored state and you have to drop and
 recreate it.
+
 {{< /warning >}}
 
 By default, MySQL retains binlog files for **30 days** (i.e., 2592000 seconds)
@@ -174,6 +177,7 @@ related issues, see [Troubleshooting](/ops/troubleshooting/).
 ## Example
 
 {{< important >}}
+
 Before creating a MySQL source, you must enable GTID-based binlog replication in
 the upstream database. For step-by-step instructions, see the integration guide
 for your MySQL service: [Amazon RDS](/ingest-data/mysql/amazon-rds/),
@@ -181,6 +185,7 @@ for your MySQL service: [Amazon RDS](/ingest-data/mysql/amazon-rds/),
 [Azure DB](/ingest-data/mysql/azure-db/),
 [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
 [Self-hosted](/ingest-data/mysql/self-hosted/).
+
 {{< /important >}}
 
 ### Creating a source {#create-source-example}
@@ -279,6 +284,10 @@ _Creates a table in Materialize from the upstream table `mydb.orders`_
 ```mzsql
 CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
 ```
+
+### Modifying an existing source
+
+{{< include-md file="headless/alter-source-snapshot-blocking-behavior.md" >}}
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -171,10 +171,6 @@ system variable on a MySQL replica. The reported `transaction_id` should
 increase as Materialize consumes **new** binlog records from the upstream MySQL
 database. For more information, see [Troubleshooting](/ops/troubleshooting/).
 
-## Known limitations
-
-{{% include-headless "/headless/mysql-considerations" %}}
-
 ## Example
 
 {{< important >}}

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -10,7 +10,7 @@ menu:
     weight: 21
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{< source-versioning-disambiguation is_new=true
 other_ref="[old reference page](/sql/create-source/mysql/)" include_blurb=true >}}
@@ -18,7 +18,7 @@ other_ref="[old reference page](/sql/create-source/mysql/)" include_blurb=true >
 ## Prerequisites
 
 {{% create-source/intro %}}
-Materialize supports MySQL (5.7+) as a real-time data source. To connect to a
+Materialize supports MySQL (8.0.1+) as a real-time data source. To connect to a
 MySQL database, you first need to tweak its configuration to enable
 [GTID-based binary log (binlog) replication](#change-data-capture) and set
 [`binlog_row_metadata=FULL`](#change-data-capture), and then
@@ -38,7 +38,7 @@ create multiple tables that reference the same upstream table.
 
 See [`CREATE TABLE FROM SOURCE`](/sql/create-table/) for details.
 
-#### Handling table schema changes
+### Handling table schema changes
 
 The use of `CREATE SOURCE` with the new [`CREATE TABLE FROM
 SOURCE`](/sql/create-table/) allows for the handling of certain upstream DDL
@@ -46,7 +46,7 @@ changes without downtime.
 
 See [`CREATE TABLE FROM SOURCE`](/sql/create-table/#handling-table-schema-changes) for details.
 
-#### Supported types
+### Supported types
 
 With the new syntax, after a MySQL source is created, you [`CREATE TABLE FROM
 SOURCE`](/sql/create-table/) to create a corresponding table in Materialize and
@@ -61,7 +61,7 @@ name="mysql-unsupported-types" %}}
 For more information, including strategies for handling unsupported types,
 see [`CREATE TABLE FROM SOURCE`](/sql/create-table/).
 
-#### Upstream table truncation restrictions
+### Upstream table truncation restrictions
 
 {{% include-from-yaml data="mysql_source_details"
 name="mysql-truncation-restriction" %}}
@@ -106,9 +106,15 @@ upstream MySQL server:
 SET GLOBAL binlog_row_metadata = FULL;
 ```
 
+Note that `SET GLOBAL` does not persist across MySQL server restarts. To make
+the setting durable, use `SET PERSIST` (MySQL 8.0.11+) or set
+`binlog_row_metadata=FULL` in the server's configuration file. On managed
+services, set the variable through the service's parameter configuration
+instead.
+
 If you're running MySQL using a managed service, additional configuration
-changes might be required. For step-by-step instructions on enabling GTID-based
-binlog replication for your MySQL service, see the integration guides.
+changes might be required. To enable GTID-based binlog replication for your
+MySQL service, see the integration guides.
 
 #### Binlog retention
 
@@ -138,10 +144,6 @@ that overrides `binlog_expire_logs_seconds` and is set to `NULL` by default.
 
 ### Monitoring source progress
 
-[//]: # "TODO(morsapaes) Replace this section with guidance using the new
-progress metrics in mz_source_statistics + console monitoring, when available
-(also for PostgreSQL)."
-
 By default, MySQL sources expose progress metadata as a subsource that you can
 use to monitor source **ingestion progress**. The name of the progress subsource
 can be specified when creating a source using the `EXPOSE PROGRESS AS` clause;
@@ -167,8 +169,7 @@ of future possible GTIDs, which is similar to the
 [`gtid_executed`](https://dev.mysql.com/doc/refman/8.0/en/replication-options-gtids.html#sysvar_gtid_executed)
 system variable on a MySQL replica. The reported `transaction_id` should
 increase as Materialize consumes **new** binlog records from the upstream MySQL
-database. For more details on monitoring source ingestion progress and debugging
-related issues, see [Troubleshooting](/ops/troubleshooting/).
+database. For more information, see [Troubleshooting](/ops/troubleshooting/).
 
 ## Known limitations
 
@@ -197,8 +198,7 @@ describes how to connect and authenticate to an external system you want
 Materialize to read data from.
 
 Once created, a connection is **reusable** across multiple `CREATE SOURCE`
-statements. For more details on creating connections, check the
-[`CREATE CONNECTION`](/sql/create-connection/#mysql) documentation page.
+statements. For more information, see [`CREATE CONNECTION`](/sql/create-connection/#mysql).
 
 ```mzsql
 CREATE SECRET mysqlpass AS '<MYSQL_PASSWORD>';
@@ -235,9 +235,7 @@ CREATE CONNECTION mysql_connection TO MYSQL (
 );
 ```
 
-For step-by-step instructions on creating AWS PrivateLink connections and
-configuring an AWS PrivateLink service to accept connections from Materialize,
-check [this guide](/ops/network-security/privatelink/).
+For more information, see [this guide](/ops/network-security/privatelink/).
 
 {{< /tab >}}
 {{< tab "SSH tunnel">}}
@@ -257,9 +255,7 @@ CREATE CONNECTION mysql_connection TO MYSQL (
 );
 ```
 
-For step-by-step instructions on creating SSH tunnel connections and configuring
-an SSH bastion server to accept connections from Materialize, check
-[this guide](/ops/network-security/ssh-tunnel/).
+For more information, see [this guide](/ops/network-security/ssh-tunnel/).
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -3,11 +3,11 @@ title: "CREATE SOURCE: MySQL (New Syntax)"
 description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
 pagerank: 40
 menu:
-  main:
-    parent: 'create-source'
-    identifier: cs_mysql-v2
-    name: MySQL (New Syntax)
-    weight: 21
+    main:
+        parent: "create-source"
+        identifier: cs_mysql-v2
+        name: MySQL (New Syntax)
+        weight: 21
 ---
 
 {{< public-preview />}}
@@ -151,11 +151,11 @@ otherwise, it will be named `<src_name>_progress`.
 
 The following metadata is available for each source as a progress subsource:
 
-Field              | Type                                                    | Details
--------------------|---------------------------------------------------------|--------------
-`source_id_lower`  | [`uuid`](/sql/types/uuid/)                              | The lower-bound GTID `source_id` of the GTIDs covered by this range.
-`source_id_upper`  | [`uuid`](/sql/types/uuid/)                              | The upper-bound GTID `source_id` of the GTIDs covered by this range.
-`transaction_id`   | [`uint8`](/sql/types/uint/#uint8-info)                  | The `transaction_id` of the next GTID possible from the GTID `source_id`s covered by this range.
+| Field             | Type                                   | Details                                                                                          |
+| ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `source_id_lower` | [`uuid`](/sql/types/uuid/)             | The lower-bound GTID `source_id` of the GTIDs covered by this range.                             |
+| `source_id_upper` | [`uuid`](/sql/types/uuid/)             | The upper-bound GTID `source_id` of the GTIDs covered by this range.                             |
+| `transaction_id`  | [`uint8`](/sql/types/uint/#uint8-info) | The `transaction_id` of the next GTID possible from the GTID `source_id`s covered by this range. |
 
 And can be queried using:
 
@@ -277,10 +277,6 @@ _Creates a table in Materialize from the upstream table `mydb.orders`_
 CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
 ```
 
-### Modifying an existing source
-
-{{< include-md file="headless/alter-source-snapshot-blocking-behavior.md" >}}
-
 ## Related pages
 
 - [`CREATE TABLE`](/sql/create-table/)
@@ -288,8 +284,8 @@ CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
 - [`CREATE CONNECTION`](/sql/create-connection)
 - [`CREATE SOURCE`](../)
 - MySQL integration guides:
-  - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
-  - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
-  - [Azure DB](/ingest-data/mysql/azure-db/)
-  - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
-  - [Self-hosted](/ingest-data/mysql/self-hosted/)
+    - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
+    - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
+    - [Azure DB](/ingest-data/mysql/azure-db/)
+    - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
+    - [Self-hosted](/ingest-data/mysql/self-hosted/)

--- a/doc/user/content/sql/create-source/mysql-v2.md
+++ b/doc/user/content/sql/create-source/mysql-v2.md
@@ -7,7 +7,7 @@ menu:
         parent: "create-source"
         identifier: cs_mysql-v2
         name: MySQL (New Syntax)
-        weight: 21
+        weight: 15
 ---
 
 {{< public-preview />}}
@@ -15,16 +15,12 @@ menu:
 {{< source-versioning-disambiguation is_new=true
 other_ref="[old reference page](/sql/create-source/mysql/)" include_blurb=true >}}
 
+{{% create-source-intro external_source="MySQL" version="8.0.1+"
+create_table="/sql/create-table/" %}}
+
 ## Prerequisites
 
-{{% create-source/intro %}}
-Materialize supports MySQL (8.0.1+) as a real-time data source. To connect to a
-MySQL database, you first need to tweak its configuration to enable
-[GTID-based binary log (binlog) replication](#change-data-capture) and set
-[`binlog_row_metadata=FULL`](#change-data-capture), and then
-[create a connection](#prerequisite-creating-a-connection-to-mysql) in
-Materialize that specifies access and authentication parameters.
-{{% /create-source/intro %}}
+{{% include-from-yaml data="mysql_source_details" name="mysql-source-prereq" %}}
 
 ## Syntax
 
@@ -33,18 +29,21 @@ Materialize that specifies access and authentication parameters.
 ## Ingesting data
 
 After a source is created, you can create tables from the source referencing
-upstream MySQL tables that have GTID-based binlog replication enabled. You can
-create multiple tables that reference the same upstream table.
-
-See [`CREATE TABLE FROM SOURCE`](/sql/create-table/) for details.
+upstream MySQL tables that have [GTID-based binlog replication
+enabled](#change-data-capture) (Note: `binlog_row_metadata=FULL` is required to
+use the new syntax). You can create multiple tables that reference the same
+upstream table. See [`CREATE TABLE FROM SOURCE`](/sql/create-table/) for
+details.
 
 ### Handling table schema changes
 
 The use of `CREATE SOURCE` with the new [`CREATE TABLE FROM
 SOURCE`](/sql/create-table/) allows for the handling of certain upstream DDL
-changes without downtime.
+changes, specifically adding or dropping columns in the upstream tables, without
+downtime.
 
-See [`CREATE TABLE FROM SOURCE`](/sql/create-table/#handling-table-schema-changes) for details.
+See [Guide: Handle upstream schema
+changes](/ingest-data/mysql/source-versioning/) for details.
 
 ### Supported types
 
@@ -74,11 +73,7 @@ For additional considerations, see also [`CREATE TABLE`](/sql/create-table/).
 
 For step-by-step instructions on enabling GTID-based binlog replication for your
 MySQL service, see the integration guides:
-[Amazon RDS](/ingest-data/mysql/amazon-rds/),
-[Amazon Aurora](/ingest-data/mysql/amazon-aurora/),
-[Azure DB](/ingest-data/mysql/azure-db/),
-[Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
-[Self-hosted](/ingest-data/mysql/self-hosted/).
+{{% include-headless "headless/mysql-ingest-guides" %}}
 
 {{< /note >}}
 
@@ -98,19 +93,15 @@ MySQL database for GTID-based binlog replication:
 
 {{% mysql-direct/ingesting-data/mysql-configs %}}
 
-In addition, the new `CREATE TABLE FROM SOURCE` syntax requires full row
-metadata in the binlog. You must set the following system variable on the
-upstream MySQL server:
+{{< tip >}}
 
-```sql
-SET GLOBAL binlog_row_metadata = FULL;
-```
-
-Note that `SET GLOBAL` does not persist across MySQL server restarts. To make
+For `binlog_row_metadata`, using `SET GLOBAL binlog_row_metadata = FULL;` does
+not persist across MySQL server restarts. To make
 the setting durable, use `SET PERSIST` (MySQL 8.0.11+) or set
 `binlog_row_metadata=FULL` in the server's configuration file. On managed
 services, set the variable through the service's parameter configuration
 instead.
+{{< /tip >}}
 
 If you're running MySQL using a managed service, additional configuration
 changes might be required. To enable GTID-based binlog replication for your
@@ -175,107 +166,26 @@ database. For more information, see [Troubleshooting](/ops/troubleshooting/).
 
 {{< important >}}
 
-Before creating a MySQL source, you must enable GTID-based binlog replication in
-the upstream database. For step-by-step instructions, see the integration guide
-for your MySQL service: [Amazon RDS](/ingest-data/mysql/amazon-rds/),
-[Amazon Aurora](/ingest-data/mysql/amazon-aurora/),
-[Azure DB](/ingest-data/mysql/azure-db/),
-[Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/),
-[Self-hosted](/ingest-data/mysql/self-hosted/).
+Before creating a MySQL source, you must enable [GTID-based binary log (binlog)
+replication](#change-data-capture), including setting
+[`binlog_row_metadata=FULL`](#change-data-capture) to use the new syntax.
 
 {{< /important >}}
 
-### Creating a source {#create-source-example}
+### Prerequisites
 
-#### Prerequisite: Creating a connection to MySQL
+{{% include-from-yaml data="mysql_source_details" name="mysql-source-prereq" %}}
 
-First, you must create a connection to your MySQL database. A connection
-describes how to connect and authenticate to an external system you want
-Materialize to read data from.
+For details, see the [MySQL integration
+guides](/ingest-data/mysql/#integration-guides).
 
-Once created, a connection is **reusable** across multiple `CREATE SOURCE`
-statements. For more information, see [`CREATE CONNECTION`](/sql/create-connection/#mysql).
+### Create a source
 
-```mzsql
-CREATE SECRET mysqlpass AS '<MYSQL_PASSWORD>';
+{{% include-example file="examples/create_source_mysql"
+ example="create-source" %}}
 
-CREATE CONNECTION mysql_connection TO MYSQL (
-    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
-    PORT 3306,
-    USER 'materialize',
-    PASSWORD SECRET mysqlpass
-);
-```
-
-If your MySQL server is not exposed to the public internet, you can [tunnel the
-connection](/sql/create-connection/#network-security-connections) through an
-AWS PrivateLink service (Materialize Cloud) or an SSH bastion host.
-
-{{< tabs tabID="1" >}}
-{{< tab "AWS PrivateLink (Materialize Cloud)">}}
-
-{{< include-md file="shared-content/aws-privatelink-cloud-only-note.md" >}}
-
-```mzsql
-CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
-   SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
-   AVAILABILITY ZONES ('use1-az1', 'use1-az4')
-);
-
-CREATE CONNECTION mysql_connection TO MYSQL (
-    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
-    PORT 3306,
-    USER 'root',
-    PASSWORD SECRET mysqlpass,
-    AWS PRIVATELINK privatelink_svc
-);
-```
-
-For more information, see [this guide](/ops/network-security/privatelink/).
-
-{{< /tab >}}
-{{< tab "SSH tunnel">}}
-
-```mzsql
-CREATE CONNECTION ssh_connection TO SSH TUNNEL (
-    HOST 'bastion-host',
-    PORT 22,
-    USER 'materialize'
-);
-```
-
-```mzsql
-CREATE CONNECTION mysql_connection TO MYSQL (
-    HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
-    SSH TUNNEL ssh_connection
-);
-```
-
-For more information, see [this guide](/ops/network-security/ssh-tunnel/).
-
-{{< /tab >}}
-{{< /tabs >}}
-
-#### Creating the source in Materialize
-
-You **must** enable GTID-based binlog replication before creating the source.
-See [Change data capture](#change-data-capture) for configuration details.
-
-Once replication is configured, create a `SOURCE` in Materialize:
-
-```mzsql
-CREATE SOURCE mz_source
-    FROM MYSQL CONNECTION mysql_connection;
-```
-
-After a source is created, you can create a table from the source, referencing
-specific upstream table(s).
-
-_Creates a table in Materialize from the upstream table `mydb.orders`_
-
-```mzsql
-CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
-```
+{{% include-example file="examples/create_source_mysql"
+ example="create-table" %}}
 
 ## Related pages
 
@@ -283,9 +193,4 @@ CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
 - [`CREATE SECRET`](/sql/create-secret)
 - [`CREATE CONNECTION`](/sql/create-connection)
 - [`CREATE SOURCE`](../)
-- MySQL integration guides:
-    - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
-    - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
-    - [Azure DB](/ingest-data/mysql/azure-db/)
-    - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
-    - [Self-hosted](/ingest-data/mysql/self-hosted/)
+- [MySQL integration guides](/ingest-data/mysql/#integration-guides)

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -28,7 +28,7 @@ the MySQL source documentation and syntax **standardize on `schema`** as the
 preferred keyword.
 {{< /note >}}
 
-{{% include-syntax file="examples/create_source_mysql" example="syntax" %}}
+{{% include-syntax file="examples/create_source_mysql_legacy" example="syntax" %}}
 
 ### `CONNECTION` options
 

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -1,5 +1,5 @@
 ---
-title: "CREATE SOURCE: MySQL"
+title: "CREATE SOURCE: MySQL (Legacy syntax)"
 description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
 pagerank: 40
 menu:
@@ -7,16 +7,20 @@ menu:
         parent: "create-source"
         identifier: cs_mysql
         name: MySQL (Legacy Syntax)
-        weight: 20
+        weight: 16
 ---
 
-{{% create-source/intro %}}
-Materialize supports MySQL (5.7+) as a real-time data source. To connect to a
-MySQL database, you first need to tweak its configuration to enable
-[GTID-based binary log (binlog) replication](#change-data-capture), and then
-[create a connection](#creating-a-connection) in Materialize that specifies
+{{< source-versioning-disambiguation is_new=false
+other_ref="[new reference page](/sql/create-source/mysql-v2)"
+include_blurb=true >}}
+
+Creates a new source from MySQL. Materialize supports creating sources from
+MySQL (8.0.1+).
+
+To connect to a MySQL database, you first need to update its configuration to
+enable [GTID-based binary log (binlog) replication](#change-data-capture), and
+then [create a connection](#creating-a-connection) in Materialize that specifies
 access and authentication parameters.
-{{% /create-source/intro %}}
 
 {{< include-md file="shared-content/aws-privatelink-cloud-only-note.md" >}}
 

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -3,11 +3,11 @@ title: "CREATE SOURCE: MySQL"
 description: "Connecting Materialize to a MySQL database for Change Data Capture (CDC)."
 pagerank: 40
 menu:
-  main:
-    parent: 'create-source'
-    identifier: cs_mysql
-    name: MySQL
-    weight: 20
+    main:
+        parent: "create-source"
+        identifier: cs_mysql
+        name: MySQL (Legacy Syntax)
+        weight: 20
 ---
 
 {{% create-source/intro %}}
@@ -32,10 +32,10 @@ preferred keyword.
 
 ### `CONNECTION` options
 
-Field             | Value                           | Description
-------------------|---------------------------------|-------------------------------------
-`EXCLUDE COLUMNS` | A list of fully-qualified names | Exclude specific columns that cannot be decoded or should not be included in the subsources created in Materialize.
-`TEXT COLUMNS`    | A list of fully-qualified names | Decode data as `text` for specific columns that contain MySQL types that are [unsupported in Materialize](#supported-types).
+| Field             | Value                           | Description                                                                                                                  |
+| ----------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `EXCLUDE COLUMNS` | A list of fully-qualified names | Exclude specific columns that cannot be decoded or should not be included in the subsources created in Materialize.          |
+| `TEXT COLUMNS`    | A list of fully-qualified names | Decode data as `text` for specific columns that contain MySQL types that are [unsupported in Materialize](#supported-types). |
 
 ## Features
 
@@ -156,11 +156,11 @@ AS` clause; otherwise, it will be named `<src_name>_progress`.
 
 The following metadata is available for each source as a progress subsource:
 
-Field              | Type                                                    | Details
--------------------|---------------------------------------------------------|--------------
-`source_id_lower`  | [`uuid`](/sql/types/uuid/)  | The lower-bound GTID `source_id` of the GTIDs covered by this range.
-`source_id_upper`  | [`uuid`](/sql/types/uuid/)  | The upper-bound GTID `source_id` of the GTIDs covered by this range.
-`transaction_id`   | [`uint8`](/sql/types/uint/#uint8-info)                  | The `transaction_id` of the next GTID possible from the GTID `source_id`s covered by this range.
+| Field             | Type                                   | Details                                                                                          |
+| ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `source_id_lower` | [`uuid`](/sql/types/uuid/)             | The lower-bound GTID `source_id` of the GTIDs covered by this range.                             |
+| `source_id_upper` | [`uuid`](/sql/types/uuid/)             | The upper-bound GTID `source_id` of the GTIDs covered by this range.                             |
+| `transaction_id`  | [`uint8`](/sql/types/uint/#uint8-info) | The `transaction_id` of the next GTID possible from the GTID `source_id`s covered by this range. |
 
 And can be queried using:
 
@@ -242,6 +242,7 @@ check [this guide](/ops/network-security/privatelink/).
 
 {{< /tab >}}
 {{< tab "SSH tunnel">}}
+
 ```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST 'bastion-host',
@@ -345,8 +346,8 @@ ALTER SOURCE mz_source ADD SUBSOURCE table_1;
 - [`CREATE CONNECTION`](/sql/create-connection)
 - [`CREATE SOURCE`](../)
 - MySQL integration guides:
-  - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
-  - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
-  - [Azure DB](/ingest-data/mysql/azure-db/)
-  - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
-  - [Self-hosted](/ingest-data/mysql/self-hosted/)
+    - [Amazon RDS](/ingest-data/mysql/amazon-rds/)
+    - [Amazon Aurora](/ingest-data/mysql/amazon-aurora/)
+    - [Azure DB](/ingest-data/mysql/azure-db/)
+    - [Google Cloud SQL](/ingest-data/mysql/google-cloud-sql/)
+    - [Self-hosted](/ingest-data/mysql/self-hosted/)

--- a/doc/user/content/sql/create-source/postgres-v2.md
+++ b/doc/user/content/sql/create-source/postgres-v2.md
@@ -6,7 +6,7 @@ menu:
     parent: 'create-source'
     name: "PostgreSQL (New Syntax)"
     identifier: 'create-source-postgresql-v2'
-    weight: 22
+    weight: 20
 ---
 
 {{< private-preview />}}

--- a/doc/user/content/sql/create-source/sql-server-v2.md
+++ b/doc/user/content/sql/create-source/sql-server-v2.md
@@ -7,7 +7,7 @@ menu:
     parent: 'create-source'
     identifier: cs_sql-server-v2
     name: SQL Server (New Syntax)
-    weight: 24
+    weight: 30
 ---
 
 {{< private-preview />}}
@@ -15,16 +15,22 @@ menu:
 {{< source-versioning-disambiguation is_new=true
 other_ref="[old reference page](/sql/create-source/sql-server/)" include_blurb=true >}}
 
+{{% create-source-intro external_source="SQL Server" version="2016+"
+create_table="/sql/create-table/" %}}
+
 ## Prerequisites
 
-{{% create-source/intro %}}
-Materialize supports SQL Server (2016+) as a real-time data source. To connect to a
-SQL Server database, you first need to tweak its configuration to enable [Change Data
+To create a source from SQL Server (2016+), you must first:
+
+- Configure your SQL Server.
+  - Enable [Change Data
 Capture](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/enable-and-disable-change-data-capture-sql-server)
-and [`SNAPSHOT` transaction isolation](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/snapshot-isolation-in-sql-server)
-for the database that you would like to replicate. Then [create a connection](#prerequisite-creating-a-connection-to-sql-server)
-in Materialize that specifies access and authentication parameters.
-{{% /create-source/intro %}}
+and [`SNAPSHOT` transaction
+isolation](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/snapshot-isolation-in-sql-server)
+for the database that you would like to replicate.
+- [Create a connection to SQL
+  Server](#prerequisite-creating-a-connection-to-sql-server) in Materialize.
+  - The connection setup depends on your network security configuration.
 
 ## Syntax
 

--- a/doc/user/content/sql/create-source/sql-server.md
+++ b/doc/user/content/sql/create-source/sql-server.md
@@ -1,5 +1,5 @@
 ---
-title: "CREATE SOURCE: SQL Server"
+title: "CREATE SOURCE: SQL Server (Legacy Syntax)"
 description: "Connecting Materialize to a SQL Server database for Change Data Capture (CDC)."
 pagerank: 40
 menu:
@@ -7,8 +7,12 @@ menu:
     parent: 'create-source'
     identifier: cs_sql-server
     name: SQL Server (Legacy Syntax)
-    weight: 23
+    weight: 31
 ---
+
+{{< source-versioning-disambiguation is_new=false
+other_ref="[new reference page](/sql/create-source/sql-server-v2)"
+include_blurb=true >}}
 
 {{% create-source/intro %}}
 Materialize supports SQL Server (2016+) as a real-time data source. To connect to a

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -15,10 +15,13 @@ In Materialize, you can create:
 - Read-write tables. With read-write tables, users can read ([`SELECT`]) and
   write to the tables ([`INSERT`], [`UPDATE`], [`DELETE`]).
 
--  ***Private Preview***. Read-only tables from [PostgreSQL sources (new
-  syntax)](/sql/create-source/postgres-v2/). Users cannot be write ([`INSERT`],
-  [`UPDATE`], [`DELETE`]) to these tables. These tables are populated by [data
-  ingestion from a source](/ingest-data/postgres/). {{% include-example file="examples/create_table/example_postgres_table"
+- Read-only tables from sources that use the new syntax:
+  [PostgreSQL](/sql/create-source/postgres-v2/),
+  [MySQL](/sql/create-source/mysql-v2/), and
+  [SQL Server](/sql/create-source/sql-server-v2/). Users cannot write
+  ([`INSERT`], [`UPDATE`], [`DELETE`]) to these tables. These tables are
+  populated by [data ingestion from a
+  source](/ingest-data/). {{% include-example file="examples/create_table/example_postgres_table"
 example="syntax-version-requirement" %}}
 
 
@@ -46,7 +49,7 @@ example="syntax" %}}
 {{< tab "PostgreSQL source table" >}}
 ### PostgreSQL source table
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{< note >}}
 {{% include-example file="examples/create_table_postgres"
@@ -60,10 +63,24 @@ For an example, see [Create a table (PostgreSQL
 source)](/sql/create-table/#create-a-table-postgresql-source).
 
 {{< /tab >}}
+{{< tab "MySQL source table" >}}
+### MySQL source table
+
+{{< public-preview />}}
+
+{{< note >}}
+{{% include-example file="examples/create_table_mysql"
+example="syntax-version-requirement" %}}
+{{< /note >}}
+
+{{% include-syntax file="examples/create_table_mysql"
+example="syntax" %}}
+
+{{< /tab >}}
 {{< tab "SQL Server source table" >}}
 ### SQL Server source table
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{< note >}}
 {{% include-example file="examples/create_table_sql_server"
@@ -98,7 +115,7 @@ See also the known limitations for [`INSERT`](/sql/insert#known-limitations),
 
 ## Source-populated tables
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{< note >}}
 {{% include-example file="examples/create_table_postgres"
@@ -138,6 +155,14 @@ use within a [transaction block](/sql/begin/#ddl-only-transactions).
 {{% include-from-yaml data="postgres_source_details" name="postgres-unsupported-types" %}}
 
 {{< /tab >}}
+{{< tab "MySQL" >}}
+#### MySQL types
+
+{{% include-from-yaml data="mysql_source_details" name="mysql-supported-types" %}}
+
+{{% include-from-yaml data="mysql_source_details" name="mysql-unsupported-types" %}}
+
+{{< /tab >}}
 {{< tab "SQL Server" >}}
 #### SQL Server types
 
@@ -152,13 +177,15 @@ use within a [transaction block](/sql/begin/#ddl-only-transactions).
 
 ### Handling table schema changes
 
-The use of [`CREATE SOURCE`](/sql/create-source/postgres-v2/) with `CREATE
-TABLE FROM SOURCE` allows for the handling of the upstream DDL changes,
-specifically adding or dropping columns in the upstream tables, without
-downtime. For details, see:
+The use of `CREATE SOURCE` (new syntax) with `CREATE TABLE FROM SOURCE` allows
+for the handling of the upstream DDL changes, specifically adding or dropping
+columns in the upstream tables, without downtime. For details, see:
 
 - [PostgreSQL: Handling upstream schema changes with zero
 downtime](/ingest-data/postgres/source-versioning/)
+
+- [MySQL: Handling upstream schema changes with zero
+downtime](/ingest-data/mysql/source-versioning/)
 
 - [SQL Server: Handling upstream schema changes with zero
 downtime](/ingest-data/sql-server/source-versioning/)
@@ -205,7 +232,7 @@ Once a user-populated table is created, you can perform CRUD
 
 ### Create a table (PostgreSQL source)
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{< note >}}
 

--- a/doc/user/data/examples/create_source_mysql.yml
+++ b/doc/user/data/examples/create_source_mysql.yml
@@ -46,6 +46,18 @@
      the [connection to MySQL](/sql/create-connection/#mysql), you can create
      the source. In this example, assume the connection you created is named
      `mysql_connection`.
+  test_setup: |
+    $ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
+    $ mysql-execute name=mysql
+    DROP DATABASE IF EXISTS mydb;
+    CREATE DATABASE mydb;
+    USE mydb;
+    CREATE TABLE items (a INT);
+    CREATE TABLE orders (a INT);
+
+    > CREATE SECRET mysqlpass AS 'p@ssw0rd'
+    > CREATE CONNECTION mysql_connection TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
+
   code: |
      CREATE SOURCE mysql_source
      FROM MYSQL CONNECTION mysql_connection;

--- a/doc/user/data/examples/create_source_mysql.yml
+++ b/doc/user/data/examples/create_source_mysql.yml
@@ -1,51 +1,41 @@
 - name: "syntax"
+  description: |
+    To create a source from an external MySQL database:
+
   code: |
-    CREATE SOURCE [IF NOT EXISTS] <src_name>
+    CREATE SOURCE [IF NOT EXISTS] <source_name>
     [IN CLUSTER <cluster_name>]
-    FROM MYSQL CONNECTION <connection_name> [
-      (
-        [TEXT COLUMNS ( <col1> [, ...] ) ]
-        [, EXCLUDE COLUMNS ( <col1> [, ...] ) ]
-      )
-    ]
-    <FOR ALL TABLES | FOR SCHEMAS ( <schema1> [, ...] ) | FOR TABLES ( <table1> [AS <subsrc_name>] [, ...] )>
-    [EXPOSE PROGRESS AS <progress_subsource_name>]
-    [WITH (RETAIN HISTORY FOR <retention_period>)]
+    FROM MYSQL CONNECTION <connection_name>
+    ;
   syntax_elements:
-    - name: "`<src_name>`"
-      description: |
-        The name for the source.
     - name: "**IF NOT EXISTS**"
       description: |
-        Optional. If specified, do not throw an error if a source with the same name already exists. Instead, issue a notice and skip the source creation.
+        *Optional.* If specified, do not throw an error if a source with the same
+        name already exists. Instead, issue a notice and skip the source creation.
+
+    - name: "`<source_name>`"
+      description: |
+        The name of the source to create. Names for sources must follow the
+        [naming guidelines](/sql/identifiers/#naming-restrictions).
+
     - name: "**IN CLUSTER** `<cluster_name>`"
       description: |
-        Optional. The [cluster](/sql/create-cluster) to maintain this source.
-    - name: "**CONNECTION** `<connection_name>`"
-      description: |
-        The name of the MySQL connection to use in the source. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#mysql) documentation page.
-    - name: "**TEXT COLUMNS** ( `<col1>` [, ...] )"
-      description: |
-        Optional. Decode data as `text` for specific columns that contain MySQL types that are [unsupported in Materialize](#supported-types).
-    - name: "**EXCLUDE COLUMNS** ( `<col1>` [, ...] )"
-      description: |
-        Optional. Exclude specific columns that cannot be decoded or should not be included in the subsources created in Materialize.
-    - name: "**FOR** `<table_schema_specification>`"
-      description: |
-        Specifies which tables to create subsources for. The following `<table_schema_specification>`s are supported:
+        *Optional.* The [cluster](/sql/create-cluster) to maintain this source.
+        Otherwise, the source will be created in the active cluster.
 
-        | Option | Description |
-        |--------|-------------|
-        | `ALL TABLES` | Create subsources for all tables in all schemas upstream. The [`mysql` system schema](https://dev.mysql.com/doc/refman/8.3/en/system-schema.html) is ignored. |
-        | `SCHEMAS ( <schema1> [, ...] )` | Create subsources for specific schemas upstream. |
-        | `TABLES ( <table1> [AS <subsrc_name>] [, ...] )` | Create subsources for specific tables upstream. Requires fully-qualified table names (`<schema1>.<table1>`). |
-    - name: "**EXPOSE PROGRESS AS** `<progress_subsource_name>`"
-      description: |
-        Optional. The name of the progress collection for the source. If this is not specified, the progress collection will be named `<src_name>_progress`. For more information, see [Monitoring source progress](#monitoring-source-progress).
-    - name: "**WITH** (`<with_option>` [, ...])"
-      description: |
-        Optional. The following `<with_option>`s are supported:
+        {{< tip >}}
+        If possible, use a cluster dedicated just for sources. See also
+        [Operational guidelines](/manage/operational-guidelines/#sources).
+        {{< /tip >}}
 
-        | Option | Description |
-        |--------|-------------|
-        | `RETAIN HISTORY FOR <retention_period>` | ***Private preview.** This option has known performance or stability issues and is under active development.* Duration for which Materialize retains historical data, which is useful to implement [durable subscriptions](/transform-data/patterns/durable-subscriptions/#history-retention-period). Accepts positive [interval](/sql/types/interval/) values (e.g. `'1hr'`). Default: `1s`. |
+    - name: "`<connection_name>`"
+      description: |
+        The name of the MySQL connection to use for the source. For details
+        on creating connections, see [`CREATE
+        CONNECTION`](/sql/create-connection/#mysql).
+
+        A connection is **reusable** across multiple `CREATE SOURCE` statements.
+
+        To start ingesting data, create a [`CREATE TABLE FROM
+        SOURCE`](/sql/create-table/) statement for each upstream table to
+        replicate.

--- a/doc/user/data/examples/create_source_mysql.yml
+++ b/doc/user/data/examples/create_source_mysql.yml
@@ -39,3 +39,31 @@
         To start ingesting data, create a [`CREATE TABLE FROM
         SOURCE`](/sql/create-table/) statement for each upstream table to
         replicate.
+
+- name: "create-source"
+  description: |
+     Once you have configured the upstream MySQL, network security, and created
+     the [connection to MySQL](/sql/create-connection/#mysql), you can create
+     the source. In this example, assume the connection you created is named
+     `mysql_connection`.
+  code: |
+     CREATE SOURCE mysql_source
+     FROM MYSQL CONNECTION mysql_connection;
+
+  testable_results: false
+- name: "create-table"
+  description: |
+    After a source is created, you can [create a table from the
+    source](/sql/create-table/), referencing specific upstream table(s). Use a
+    [DDL transaction block](/sql/begin/#ddl-only-transactions) to create
+    multiple tables from the same source.
+  code: |
+    BEGIN;
+    CREATE TABLE items
+    FROM SOURCE mysql_source (REFERENCE mydb.items);
+
+    CREATE TABLE orders
+    FROM SOURCE mysql_source (REFERENCE mydb.orders);
+    COMMIT;
+
+  testable_results: false

--- a/doc/user/data/examples/create_source_mysql_legacy.yml
+++ b/doc/user/data/examples/create_source_mysql_legacy.yml
@@ -1,0 +1,51 @@
+- name: "syntax"
+  code: |
+    CREATE SOURCE [IF NOT EXISTS] <src_name>
+    [IN CLUSTER <cluster_name>]
+    FROM MYSQL CONNECTION <connection_name> [
+      (
+        [TEXT COLUMNS ( <col1> [, ...] ) ]
+        [, EXCLUDE COLUMNS ( <col1> [, ...] ) ]
+      )
+    ]
+    <FOR ALL TABLES | FOR SCHEMAS ( <schema1> [, ...] ) | FOR TABLES ( <table1> [AS <subsrc_name>] [, ...] )>
+    [EXPOSE PROGRESS AS <progress_subsource_name>]
+    [WITH (RETAIN HISTORY FOR <retention_period>)]
+  syntax_elements:
+    - name: "`<src_name>`"
+      description: |
+        The name for the source.
+    - name: "**IF NOT EXISTS**"
+      description: |
+        Optional. If specified, do not throw an error if a source with the same name already exists. Instead, issue a notice and skip the source creation.
+    - name: "**IN CLUSTER** `<cluster_name>`"
+      description: |
+        Optional. The [cluster](/sql/create-cluster) to maintain this source.
+    - name: "**CONNECTION** `<connection_name>`"
+      description: |
+        The name of the MySQL connection to use in the source. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#mysql) documentation page.
+    - name: "**TEXT COLUMNS** ( `<col1>` [, ...] )"
+      description: |
+        Optional. Decode data as `text` for specific columns that contain MySQL types that are [unsupported in Materialize](#supported-types).
+    - name: "**EXCLUDE COLUMNS** ( `<col1>` [, ...] )"
+      description: |
+        Optional. Exclude specific columns that cannot be decoded or should not be included in the subsources created in Materialize.
+    - name: "**FOR** `<table_schema_specification>`"
+      description: |
+        Specifies which tables to create subsources for. The following `<table_schema_specification>`s are supported:
+
+        | Option | Description |
+        |--------|-------------|
+        | `ALL TABLES` | Create subsources for all tables in all schemas upstream. The [`mysql` system schema](https://dev.mysql.com/doc/refman/8.3/en/system-schema.html) is ignored. |
+        | `SCHEMAS ( <schema1> [, ...] )` | Create subsources for specific schemas upstream. |
+        | `TABLES ( <table1> [AS <subsrc_name>] [, ...] )` | Create subsources for specific tables upstream. Requires fully-qualified table names (`<schema1>.<table1>`). |
+    - name: "**EXPOSE PROGRESS AS** `<progress_subsource_name>`"
+      description: |
+        Optional. The name of the progress collection for the source. If this is not specified, the progress collection will be named `<src_name>_progress`. For more information, see [Monitoring source progress](#monitoring-source-progress).
+    - name: "**WITH** (`<with_option>` [, ...])"
+      description: |
+        Optional. The following `<with_option>`s are supported:
+
+        | Option | Description |
+        |--------|-------------|
+        | `RETAIN HISTORY FOR <retention_period>` | ***Private preview.** This option has known performance or stability issues and is under active development.* Duration for which Materialize retains historical data, which is useful to implement [durable subscriptions](/transform-data/patterns/durable-subscriptions/#history-retention-period). Accepts positive [interval](/sql/types/interval/) values (e.g. `'1hr'`). Default: `1s`. |

--- a/doc/user/data/examples/create_table_mysql.yml
+++ b/doc/user/data/examples/create_table_mysql.yml
@@ -90,9 +90,6 @@
     {{< /note >}}
 
   test_setup: |
-    > CREATE SECRET mysqlpass AS 'p@ssw0rd'
-    > CREATE CONNECTION mysql_connection TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
-
     $ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
     $ mysql-execute name=mysql
     DROP DATABASE IF EXISTS mydb;
@@ -101,6 +98,8 @@
     CREATE TABLE items (a INT);
     CREATE TABLE orders (a INT);
 
+    > CREATE SECRET mysqlpass AS 'p@ssw0rd'
+    > CREATE CONNECTION mysql_connection TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
     > CREATE SOURCE mysql_source FROM MYSQL CONNECTION mysql_connection
 
   code: |

--- a/doc/user/data/examples/create_table_mysql.yml
+++ b/doc/user/data/examples/create_table_mysql.yml
@@ -1,0 +1,132 @@
+- name: "syntax"
+  description: |
+    To create a read-only table from a [source](/sql/create-source/) connected
+    (via native connector) to an external MySQL database:
+
+  code: |
+    CREATE TABLE [IF NOT EXISTS] <table_name> FROM SOURCE <source_name> (REFERENCE <upstream_schema>.<upstream_table>)
+    [WITH (
+        TEXT COLUMNS (<column_name> [, ...])
+      | EXCLUDE COLUMNS (<column_name> [, ...])
+      | PARTITION BY (<column_name> [, ...])
+      [, ...]
+    )]
+    ;
+  syntax_elements:
+    - name: "**IF NOT EXISTS**"
+      description: |
+        *Optional.* If specified, do not throw an error if the table with the same
+        name already exists. Instead, issue a notice and skip the table creation.
+
+        {{< include-md file="shared-content/create-table-if-not-exists-tip.md" >}}
+    - name: "`<table_name>`"
+      description: |
+
+        The name of the table to create. Names for tables must follow the [naming
+        guidelines](/sql/identifiers/#naming-restrictions).
+
+    - name: "`<source_name>`"
+      description: |
+
+        The name of the [source](/sql/create-source/) associated with the
+        reference object from which to create the table.
+
+    - name: "**(REFERENCE <upstream_schema>.<upstream_table>)**"
+      description: |
+
+        The fully-qualified name of the upstream MySQL table from which to create
+        the table. You can create multiple tables from the same upstream table.
+
+        To find the upstream tables available in your
+        [source](/sql/create-source/), you can use the following query,
+        substituting your source name for `<source_name>`:
+
+        <br>
+
+        ```mzsql
+        SELECT refs.*
+        FROM mz_internal.mz_source_references refs, mz_sources s
+        WHERE s.name = '<source_name>' -- substitute with your source name
+        AND refs.source_id = s.id;
+        ```
+
+    - name: "**WITH (<with_option>[,...])**"
+      description: |
+        The following `<with_option>`s are supported:
+
+        | Option | Description |
+        |--------|-------------|
+        | `TEXT COLUMNS (<column_name> [, ...])` | *Optional.* If specified, decode data as `text` for the listed column(s), such as for unsupported data types. See also [supported types](#supported-data-types). |
+        | `EXCLUDE COLUMNS (<column_name> [, ...])` | *Optional.* If specified, exclude the listed column(s) from the table, such as for unsupported data types. See also [supported types](#supported-data-types). |
+        | `PARTITION BY (<column_name> [, ...])` | {{< include-md file="shared-content/partition-by-option-description.md" >}} |
+  results: |
+    {{< include-md
+    file="shared-content/create-table-from-source-snapshotting.md"
+    >}}
+
+- name: "syntax-version-requirement"
+  description: |
+    You must be on **v26+** to use the new syntax.
+
+- name: "create-table"
+  description: |
+
+    To create new **read-only** tables from a source table, use the `CREATE
+    TABLE ... FROM SOURCE ... (REFERENCE <upstream_schema>.<upstream_table>)`
+    statement in a [DDL transaction
+    block](/sql/begin/#ddl-only-transactions). The following example creates
+    **read-only** tables `items` and `orders` from the MySQL source's
+    `mydb.items` and `mydb.orders` tables.
+
+    {{< note >}}
+
+    - Although the example creates the tables with the same names as the
+    upstream tables, the tables in Materialize can have names that differ from
+    the referenced table names.
+
+    - For supported MySQL data types, refer to [supported
+    types](/sql/create-table/#supported-data-types).
+
+    {{< /note >}}
+
+  code: |
+    /* This example assumes:
+      - In the upstream MySQL, you have configured:
+        - GTID-based binary log replication.
+        - `binlog_row_metadata = FULL`.
+        - A replication user and password with the appropriate access.
+      - In Materialize:
+        - You have created a secret for the MySQL password.
+        - You have defined the connection to the upstream MySQL.
+        - You have used the connection to create a source.
+
+       For example (substitute with your configuration):
+          CREATE SECRET mysqlpass AS '<replication user password>'; -- substitute
+          CREATE CONNECTION mysql_connection TO MYSQL (
+            HOST '<hostname>',          -- substitute
+            PORT 3306,
+            USER <replication user>,    -- substitute
+            PASSWORD SECRET mysqlpass
+            -- [, <network security configuration> ]
+          );
+
+          CREATE SOURCE mysql_source
+          FROM MYSQL CONNECTION mysql_connection;
+    */
+
+    BEGIN;
+    CREATE TABLE items
+    FROM SOURCE mysql_source (REFERENCE mydb.items)
+    ;
+    CREATE TABLE orders
+    FROM SOURCE mysql_source (REFERENCE mydb.orders)
+    ;
+    COMMIT;
+  results: |
+
+    {{< include-md
+    file="shared-content/create-table-from-source-snapshotting.md" >}}
+
+    {{< include-md file="shared-content/create-table-if-not-exists-tip.md" >}}
+
+  testable_results: false

--- a/doc/user/data/examples/create_table_mysql.yml
+++ b/doc/user/data/examples/create_table_mysql.yml
@@ -66,7 +66,7 @@
 
 - name: "syntax-version-requirement"
   description: |
-    You must be on **v26+** to use the new syntax.
+    You must be on **v26.25+** to use the new syntax.
 
 - name: "create-table"
   description: |

--- a/doc/user/data/examples/create_table_mysql.yml
+++ b/doc/user/data/examples/create_table_mysql.yml
@@ -89,6 +89,20 @@
 
     {{< /note >}}
 
+  test_setup: |
+    > CREATE SECRET mysqlpass AS 'p@ssw0rd'
+    > CREATE CONNECTION mysql_connection TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
+
+    $ mysql-connect name=mysql url=mysql://root@mysql password=p@ssw0rd
+    $ mysql-execute name=mysql
+    DROP DATABASE IF EXISTS mydb;
+    CREATE DATABASE mydb;
+    USE mydb;
+    CREATE TABLE items (a INT);
+    CREATE TABLE orders (a INT);
+
+    > CREATE SOURCE mysql_source FROM MYSQL CONNECTION mysql_connection
+
   code: |
     /* This example assumes:
       - In the upstream MySQL, you have configured:

--- a/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
+++ b/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
@@ -44,7 +44,7 @@
       FROM MYSQL CONNECTION mysql_connection;
 
     -- Step 2: Create tables from the source
-    CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
+    CREATE TABLE t FROM SOURCE mz_source (REFERENCE public.t);
 
   results: |
     - By default, the source will be created in the active cluster; to use a different cluster, use the `IN CLUSTER` clause.

--- a/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
+++ b/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
@@ -1,7 +1,7 @@
-- name: "create-source"
+- name: "create-source-legacy"
   description: |
     Once you have created the connection, you can use the connection in the
-    [`CREATE SOURCE`](/sql/create-source/) command to connect to your MySQL instance and start ingesting
+    [`CREATE SOURCE`](/sql/create-source/mysql/) command to connect to your MySQL instance and start ingesting
     data:
   test_setup: |
     > CREATE SECRET IF NOT EXISTS mysqlpass AS 'p@ssw0rd'
@@ -19,7 +19,7 @@
       FROM MYSQL CONNECTION mysql_connection
       FOR ALL TABLES;
 
-- name: "create-source-options"
+- name: "create-source-options-legacy"
   description: |
 
     - By default, the source will be created in the active cluster; to use a different cluster, use the `IN CLUSTER` clause.
@@ -28,7 +28,51 @@
 
     - To handle [unsupported data types](#supported-types), use the `TEXT COLUMNS` or `EXCLUDE COLUMNS` options.
 
+- name: "create-source"
+  description: |
+    Once you have created the connection, you can:
+    - use the connection in the [`CREATE SOURCE`](/sql/create-source/mysql-v2/)
+    command to connect to your MySQL instance, and
+    - use the source in [`CREATE TABLE FROM SOURCE`](/sql/create-table/) to
+    create tables in Materialize and start ingesting data:
+
+  test_setup: |
+    > DROP SOURCE mz_source CASCADE
+  code: |
+    -- Step 1: Create the source
+    CREATE SOURCE mz_source
+      FROM MYSQL CONNECTION mysql_connection;
+
+    -- Step 2: Create tables from the source
+    CREATE TABLE orders FROM SOURCE mz_source (REFERENCE mydb.orders);
+
+  results: |
+    - By default, the source will be created in the active cluster; to use a different cluster, use the `IN CLUSTER` clause.
+    - After creating the source, you can query `mz_internal.mz_source_references` to see all available tables.
+    - Create individual tables using [`CREATE TABLE <table_name> FROM SOURCE <source_name> (REFERENCE <upstream_table>)`](/sql/create-table/).
+    - To handle [unsupported data types](#supported-types), use `WITH (TEXT COLUMNS = [<column>])` or `WITH (EXCLUDE COLUMNS = [<column>])` in the [`CREATE TABLE`](/sql/create-table/) statement.
+  testable_results: false
+
 - name: "schema-changes"
   description: |
     After source creation, refer to [schema changes
     considerations](#schema-changes) for information on handling upstream schema changes.
+
+- name: "ingest-data-step"
+  description: |
+    {{< tabs >}}
+    {{< tab "New Syntax" >}}
+    #### New syntax
+
+    {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
+    {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+    {{< /tab >}}
+
+    {{< tab "Legacy Syntax" >}}
+    #### Legacy syntax
+
+    {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-legacy" %}}
+    {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options-legacy" %}}
+    {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
+    {{< /tab >}}
+    {{< /tabs >}}

--- a/doc/user/data/mysql_config_settings.yml
+++ b/doc/user/data/mysql_config_settings.yml
@@ -26,3 +26,7 @@ rows:
   - MySQL Configuration: "`replica_preserve_commit_order`"
     Value: "`ON`"
     Notes: "Only required when connecting Materialize to a read-replica."
+
+  - MySQL Configuration: "`binlog_row_metadata`"
+    Value: "`FULL`"
+    Notes: "Highly recommended, and required to use [`CREATE SOURCE` syntax](/sql/create-source/mysql-v2/)"

--- a/doc/user/data/mysql_config_settings.yml
+++ b/doc/user/data/mysql_config_settings.yml
@@ -7,13 +7,21 @@ rows:
     Value: "`ON`"
     Notes: ""
 
-  - MySQL Configuration: "`binlog_format`"
-    Value: "`ROW`"
-    Notes: "{{ $binlog_format_note }}"
-
   - MySQL Configuration: "`binlog_row_image`"
     Value: "`FULL`"
     Notes: ""
+
+  - MySQL Configuration: "`binlog_row_metadata`"
+    Value: "`FULL`"
+    Notes: |
+      - **Required** to use [`CREATE SOURCE` (New
+      syntax)](/sql/create-source/mysql-v2/).
+      - Highly recommended for use with the [`CREATE SOURCE` (Legacy
+      syntax)](/sql/create-source/mysql/).
+
+  - MySQL Configuration: "`binlog_format`"
+    Value: "`ROW`"
+    Notes: "{{ $binlog_format_note }}"
 
   - MySQL Configuration: "`gtid_mode`"
     Value: "`ON`"
@@ -26,7 +34,3 @@ rows:
   - MySQL Configuration: "`replica_preserve_commit_order`"
     Value: "`ON`"
     Notes: "Only required when connecting Materialize to a read-replica."
-
-  - MySQL Configuration: "`binlog_row_metadata`"
-    Value: "`FULL`"
-    Notes: "Highly recommended, and required to use [`CREATE SOURCE` syntax](/sql/create-source/mysql-v2/)"

--- a/doc/user/data/mysql_source_details.yml
+++ b/doc/user/data/mysql_source_details.yml
@@ -1,17 +1,18 @@
 - name: mysql-source-prereq
   content: |
-    To create a source from MySQL 5.7+, you must first:
-
+    To create a source from MySQL(8.0.1+), you must first:
     - **Configure upstream MySQL instance**
-      - Enable GTID-based binlog replication
-      - Create a replication user and password for Materialize to use to connect.
+      - Enable [GTID-based binary log(binlog)
+        replication](#change-data-capture). You **must** set
+        [`binlog_row_metadata=FULL`](#change-data-capture) to use the new
+        `CREATE SOURCE` syntax.
+      - Create a replication user and password for Materialize to use to
+        connect.
     - **Configure network security**
       - Ensure Materialize can connect to your MySQL instance.
     - **Create a connection to MySQL in Materialize**
-      - The connection setup depends on the network security configuration.
-
-    For details, see the [MySQL integration
-    guides](/ingest-data/mysql/#integration-guides).
+      - The [connection setup](/sql/create-connection/#mysql) depends on the
+        network security configuration.
 
 - name: mysql-supported-types
   content: |

--- a/doc/user/layouts/shortcodes/create-source-intro.html
+++ b/doc/user/layouts/shortcodes/create-source-intro.html
@@ -5,6 +5,6 @@
 
 Creates a new source from {{ $external_source }}. {{ if $version }} Materialize
 supports creating sources from {{ $external_source }} version {{ $version }}. {{
-end }} Once a new source is created, you can {{ $create_table }} from the source
+end }} Once a new source is created, you can {{ $create_table }}
 to create the corresponding tables in Materialize and start the data ingestion
 process.

--- a/doc/user/layouts/shortcodes/ingest-data/mysql-native-support.md
+++ b/doc/user/layouts/shortcodes/ingest-data/mysql-native-support.md
@@ -1,1 +1,0 @@
-<ul><li>[Amazon Aurora for MySQL](/ingest-data/mysql/amazon-aurora/)</li><li>[Amazon RDS for MySQL](/ingest-data/mysql/amazon-rds/)</li><li>[Azure DB for MySQL](/ingest-data/mysql/azure-db/)</li><li>[Google Cloud SQL for MySQL](/ingest-data/mysql/google-cloud-sql/)</li><li>[Self-hosted MySQL](/ingest-data/mysql/self-hosted/)</li></ul>

--- a/doc/user/layouts/shortcodes/mysql-direct/before-you-begin.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/before-you-begin.html
@@ -1,6 +1,5 @@
-- Make sure you are running MySQL 5.7 or higher. Materialize uses
-  [GTID-based binary log (binlog) replication](/sql/create-source/mysql/#change-data-capture),
-  which is not available in older versions of MySQL.
+- Make sure you are running MySQL 8.0.1+ with support for [GTID-based binary log
+(binlog) replication](#1-enable-gtid-based-binlog-replication).
 
 - Ensure you have access to your MySQL instance via the [`mysql` client](https://dev.mysql.com/doc/refman/8.0/en/mysql.html),
   or your preferred SQL client.

--- a/doc/user/shared-content/create-table-from-source-snapshotting.md
+++ b/doc/user/shared-content/create-table-from-source-snapshotting.md
@@ -5,9 +5,6 @@ timestamp), you are not able to query the table until snapshotting is complete.
 
 {{< note >}}
 
-During the snapshotting, the data ingestion for
-the existing tables for the same source is temporarily blocked. As such, if
-possible, you can resize the cluster to speed up the snapshotting process and
-once the process finishes, resize the cluster for steady-state.
+{{% include-headless "/headless/source-versioning-snapshotting-note" %}}
 
 {{< /note >}}


### PR DESCRIPTION
Adds docs outlining how to use the new `CREATE TABLE FROM SOURCE` syntax for MySQL sources to enable source versioning, and re-adds the `source-versioning.md` mysql doc that was previously reverted
