### PR TITLE
feature-benchmark: Make `ExactlyOnce` scenario more stable

### DIFF
--- a/misc/python/materialize/feature_benchmark/filter.py
+++ b/misc/python/materialize/feature_benchmark/filter.py
@@ -42,11 +42,15 @@ class NoFilter(Filter):
 
 
 class FilterFirst(Filter):
+    def __init__(self, count: int = 1) -> None:
+        super().__init__()
+        self._count = count
+
     def filter(self, measurement: Measurement) -> bool:
         self._data.append(measurement.value)
 
-        if len(self._data) == 1:
-            print("Discarding first measurement.")
+        if len(self._data) <= self._count:
+            print(f"Discarding warmup measurement {len(self._data)}/{self._count}.")
             return True
         else:
             return False

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -1326,8 +1326,15 @@ class ExactlyOnce(Sink):
 
     FIXED_SCALE = True  # TODO: Remove when database-issues#8705 is fixed
 
+    def __init__(
+        self, scale: float, mz_version: MzVersion, default_size: int, seed: int
+    ) -> None:
+        super().__init__(scale, mz_version, default_size, seed)
+        self._instance_id = uuid.uuid4().hex[:8]
+        self._benchmark_iter = 0
+
     def version(self) -> ScenarioVersion:
-        return ScenarioVersion.create(1, 1, 0)
+        return ScenarioVersion.create(1, 2, 0)
 
     def shared(self) -> Action:
         return TdAction(self.keyschema() + self.schema() + f"""
@@ -1361,19 +1368,30 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keysch
 {self.n()}
 """)
 
-    def benchmark(self) -> MeasurementSource:
-        return Td(f"""
+    def before(self) -> Action:
+        self._benchmark_iter += 1
+        self._topic = f"sink-output-{self._instance_id}-{self._benchmark_iter}"
+        return TdAction(f"""
 > DROP SINK IF EXISTS sink1;
 > DROP SOURCE IF EXISTS sink1_check CASCADE;
-  /* A */
+> DROP CLUSTER IF EXISTS sink_cluster CASCADE;
 
-> DROP CLUSTER IF EXISTS sink_cluster CASCADE
 > CREATE CLUSTER sink_cluster SIZE 'scale={self._default_size},workers=1', REPLICATION FACTOR 1;
+
+$ kafka-create-topic topic={self._topic}
+""")
+
+    def benchmark(self) -> MeasurementSource:
+        topic = self._topic
+        return Td(f"""
+> SELECT 1
+  /* A */
+1
 
 > CREATE SINK sink1
   IN CLUSTER sink_cluster
   FROM source1_tbl
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-{topic}-${{testdrive.seed}}')
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
@@ -1384,9 +1402,9 @@ $ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true await
 
 > CREATE SOURCE sink1_check
   IN CLUSTER source_cluster
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}');
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-{topic}-${{testdrive.seed}}');
 
-> CREATE TABLE sink1_check_tbl FROM SOURCE sink1_check (REFERENCE "testdrive-sink-output-${{testdrive.seed}}")
+> CREATE TABLE sink1_check_tbl FROM SOURCE sink1_check (REFERENCE "testdrive-{topic}-${{testdrive.seed}}")
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT;

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -119,11 +119,12 @@ FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.5.0"
 
 
 def make_filter(args: argparse.Namespace) -> Filter:
-    # Discard the first run unless a small --max-runs limit is explicitly set
+    # Discard the first few runs to allow for JVM/cache warmup (Kafka, Schema Registry)
+    # unless a small --max-runs limit is explicitly set
     if args.max_measurements <= 5:
         return NoFilter()
     else:
-        return FilterFirst()
+        return FilterFirst(count=3)
 
 
 def make_termination_conditions(args: argparse.Namespace) -> list[TerminationCondition]:


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/C08A7H11KP0/p1776725737014279

Test run: https://buildkite.com/materialize/nightly/builds/16153#019dadbc-6e50-43e5-8f23-b5e722f31aae

It's still not as reliable as I want it to be, but way better than before.
Before:
```
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
--------------------------------------------------------------------------------------------------------------------------------------------------------
ExactlyOnce                         | wallclock       |           4.098 |          16.244 |   s    |    10%     |      no       | better:  4.0 times faster
ExactlyOnce                         | memory_mz       |        3154.121 |        3945.324 |   MB   |    20%     |      no       | better: 20.1% less
ExactlyOnce                         | memory_clusterd |         119.711 |         266.188 |   MB   |    50%     |      no       | better:  2.2 times less
```
After:
```
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
--------------------------------------------------------------------------------------------------------------------------------------------------------
ExactlyOnce                         | wallclock       |           5.606 |           6.002 |   s    |    10%     |      no       | better:  6.6% faster
ExactlyOnce                         | memory_mz       |        3329.906 |        3356.672 |   MB   |    20%     |      no       | better:  0.8% less
ExactlyOnce                         | memory_clusterd |         182.832 |         150.965 |   MB   |    50%     |      no       | worse:  21.1% more
```