### PR TITLE
`repeat_row`: Make subquery guard aware of negative diffs

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -22,7 +22,7 @@ use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 
 use mz_ore::str::separated;
-use mz_ore::{soft_assert_eq_no_log, soft_assert_or_log};
+use mz_ore::{soft_assert_eq_no_log, soft_assert_or_log, soft_panic_or_log};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
@@ -3560,10 +3560,19 @@ impl TableFunc {
                 // We error if the count is not one,
                 // and produce no rows if equal to one.
                 let count = datums[0].unwrap_int64();
-                if count != 1 {
-                    Err(EvalError::MultipleRowsFromSubquery)
-                } else {
+                if count == 1 {
                     Ok(Box::new([].into_iter()))
+                } else if count > 1 {
+                    Err(EvalError::MultipleRowsFromSubquery)
+                } else if count < 0 {
+                    Err(EvalError::NegativeRowsFromSubquery)
+                } else {
+                    // This shouldn't happen because this is not an SQL `count` but an MIR `count`,
+                    // which produces no output on 0 input rows.
+                    soft_panic_or_log!("subquery counting unexpectedly produced 0");
+                    Err(EvalError::Internal(
+                        "subquery counting unexpectedly produced 0".into(),
+                    ))
                 }
             }
             TableFunc::Repeat => Ok(Box::new(repeat(datums[0]).into_iter())),

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -164,5 +164,6 @@ message ProtoEvalError {
     google.protobuf.Empty key_cannot_be_null = 80;
     string invalid_catalog_json = 81;
     string redact_error = 82;
+    google.protobuf.Empty negative_rows_from_subquery = 83;
   }
 }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2683,6 +2683,7 @@ pub enum EvalError {
     OutOfDomain(DomainLimit, DomainLimit, Box<str>),
     ComplexOutOfRange(Box<str>),
     MultipleRowsFromSubquery,
+    NegativeRowsFromSubquery,
     Undefined(Box<str>),
     LikePatternTooLong,
     LikeEscapeTooLong,
@@ -2867,6 +2868,9 @@ impl fmt::Display for EvalError {
             }
             EvalError::MultipleRowsFromSubquery => {
                 write!(f, "more than one record produced in subquery")
+            }
+            EvalError::NegativeRowsFromSubquery => {
+                write!(f, "negative number of rows produced in subquery")
             }
             EvalError::Undefined(s) => {
                 write!(f, "{} is undefined", s)
@@ -3148,6 +3152,7 @@ impl RustType<ProtoEvalError> for EvalError {
             }),
             EvalError::ComplexOutOfRange(v) => ComplexOutOfRange(v.into_proto()),
             EvalError::MultipleRowsFromSubquery => MultipleRowsFromSubquery(()),
+            EvalError::NegativeRowsFromSubquery => NegativeRowsFromSubquery(()),
             EvalError::Undefined(v) => Undefined(v.into_proto()),
             EvalError::LikePatternTooLong => LikePatternTooLong(()),
             EvalError::LikeEscapeTooLong => LikeEscapeTooLong(()),
@@ -3282,6 +3287,7 @@ impl RustType<ProtoEvalError> for EvalError {
                 )),
                 ComplexOutOfRange(v) => Ok(EvalError::ComplexOutOfRange(v.into())),
                 MultipleRowsFromSubquery(()) => Ok(EvalError::MultipleRowsFromSubquery),
+                NegativeRowsFromSubquery(()) => Ok(EvalError::NegativeRowsFromSubquery),
                 Undefined(v) => Ok(EvalError::Undefined(v.into())),
                 LikePatternTooLong(()) => Ok(EvalError::LikePatternTooLong),
                 LikeEscapeTooLong(()) => Ok(EvalError::LikeEscapeTooLong),

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -652,6 +652,7 @@ mod columnation {
                         | e @ EvalError::KeyCannotBeNull
                         | e @ EvalError::UnterminatedLikeEscapeSequence
                         | e @ EvalError::MultipleRowsFromSubquery
+                        | e @ EvalError::NegativeRowsFromSubquery
                         | e @ EvalError::LikePatternTooLong
                         | e @ EvalError::LikeEscapeTooLong
                         | e @ EvalError::MultidimensionalArrayRemovalNotSupported


### PR DESCRIPTION
This is the 4. PR in the `repeat_row` productionization work stream. Resolve SQL-164.

This resolves https://github.com/MaterializeInc/materialize/pull/32978#discussion_r2200866973. It was not important originally, but now that we are productionizing `repeat_row`, the original error message would become confusing: it would say that "more than one record produced in subquery", when in fact there was a negative number of rows.

I didn't add a test, because I wasn't able to find a query where this error deterministically happens. If I just naively put a `repeat_row(-1)` inside a subquery, then sometimes this error happens, but sometimes a `Distinct` gives the negative accumulation error message.