### PR TITLE
console: Add user profile hook to show OIDC User details

### DIFF
--- a/console/src/api/materialize/useCurrentUser.ts
+++ b/console/src/api/materialize/useCurrentUser.ts
@@ -1,0 +1,54 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { QueryKey, useQuery } from "@tanstack/react-query";
+import { sql } from "kysely";
+
+import { buildRegionQueryKey } from "~/api/buildQueryKeySchema";
+
+import { queryBuilder } from "./db";
+import { executeSqlV2 } from "./executeSqlV2";
+
+export const currentUserQueryKeys = {
+  all: () => buildRegionQueryKey("currentUser"),
+};
+
+function buildCurrentUserQuery() {
+  return queryBuilder.selectNoFrom(sql<string>`current_user`.as("currentUser"));
+}
+
+async function fetchCurrentUser({
+  queryKey,
+  requestOptions,
+}: {
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) {
+  return executeSqlV2({
+    queries: buildCurrentUserQuery().compile(),
+    queryKey,
+    requestOptions,
+  });
+}
+
+/** Fetches the SQL role the connected session is acting as. */
+export default function useCurrentUser() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: currentUserQueryKeys.all(),
+    queryFn: ({ queryKey, signal }) =>
+      fetchCurrentUser({ queryKey, requestOptions: { signal } }),
+    staleTime: Infinity,
+  });
+
+  return {
+    results: data?.rows[0]?.currentUser,
+    isLoading,
+    error,
+  };
+}

--- a/console/src/hooks/useSelfManagedProfile.ts
+++ b/console/src/hooks/useSelfManagedProfile.ts
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import useCurrentUser from "~/api/materialize/useCurrentUser";
+import { useAuth } from "~/external-library-wrappers/oidc";
+
+export interface SelfManagedProfile {
+  name: string | undefined;
+  email: string | undefined;
+  picture: string | undefined;
+  /** The SQL role (`current_user`) — authoritative for what Materialize sees. */
+  sqlRole: string | undefined;
+  isLoading: boolean;
+}
+
+/** Unified identity for self-managed UI: OIDC claims when present, with the
+ * SQL role as the authoritative fallback. */
+export const useSelfManagedProfile = (): SelfManagedProfile => {
+  const auth = useAuth();
+  const profile = auth?.user?.profile;
+  const { results: sqlRole, isLoading } = useCurrentUser();
+
+  const oidcName = typeof profile?.name === "string" ? profile.name : undefined;
+  const oidcEmail =
+    typeof profile?.email === "string" ? profile.email : undefined;
+  const oidcPicture =
+    typeof profile?.picture === "string" ? profile.picture : undefined;
+
+  return {
+    name: oidcName ?? sqlRole,
+    email: oidcEmail,
+    picture: oidcPicture,
+    sqlRole,
+    isLoading,
+  };
+};

--- a/console/src/layouts/PageFooter.tsx
+++ b/console/src/layouts/PageFooter.tsx
@@ -17,6 +17,7 @@ import { MaterializeTheme } from "~/theme";
 
 import {
   ConsoleImageTag,
+  CurrentUserTag,
   EnvironmentdImageRefTag,
   HelmChartVersionTag,
 } from "./footerTagComponents";
@@ -91,6 +92,7 @@ export const AuthenticatedPageFooter = ({ children, ...props }: StackProps) => {
       <ConsoleImageTag />
       <EnvironmentdImageRefTag />
       <HelmChartVersionTag />
+      <CurrentUserTag />
       {children}
     </PageFooterContainer>
   );

--- a/console/src/layouts/ProfileDropdown.tsx
+++ b/console/src/layouts/ProfileDropdown.tsx
@@ -17,6 +17,7 @@ import {
   MenuGroup,
   MenuItem,
   MenuList,
+  Spinner,
   Tag,
   Text,
   useBreakpointValue,
@@ -40,12 +41,61 @@ import {
 } from "~/external-library-wrappers/frontegg";
 import { useAuth } from "~/external-library-wrappers/oidc";
 import { AUTH_ROUTES } from "~/fronteggRoutes";
+import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import { NAV_HORIZONTAL_SPACING, NAV_HOVER_STYLES } from "~/layouts/constants";
 import docUrls from "~/mz-doc-urls.json";
 import { MaterializeTheme } from "~/theme";
 
-const UserInfoMenuItem = () => {
+const UserInfoHeaderBlock = ({
+  name,
+  email,
+  sqlRole,
+}: {
+  name?: string;
+  email?: string;
+  sqlRole?: string;
+}) => {
   const { colors } = useTheme<MaterializeTheme>();
+  if (!name && !email && !sqlRole) return null;
+  return (
+    <VStack px="3" pt="3" pb="2" align="left" lineHeight="1.3" spacing="0">
+      {name && <Text fontWeight="semibold">{name}</Text>}
+      {email && (
+        <Text mt="1" fontSize="xs" color={colors.foreground.secondary}>
+          {email}
+        </Text>
+      )}
+      {sqlRole && (
+        <Text mt="1" fontSize="xs" color={colors.foreground.secondary}>
+          SQL role: {sqlRole}
+        </Text>
+      )}
+    </VStack>
+  );
+};
+
+const SelfManagedUserInfoMenuItem = () => {
+  const { name, email, sqlRole, isLoading } = useSelfManagedProfile();
+  if (isLoading && !name && !email && !sqlRole) {
+    return (
+      <>
+        <HStack px="3" pt="3" pb="2">
+          <Spinner size="sm" />
+        </HStack>
+        <MenuDivider />
+      </>
+    );
+  }
+  if (!name && !email && !sqlRole) return null;
+  return (
+    <>
+      <UserInfoHeaderBlock name={name} email={email} sqlRole={sqlRole} />
+      <MenuDivider />
+    </>
+  );
+};
+
+const UserInfoMenuItem = () => {
   return (
     <AppConfigSwitch
       cloudConfigElement={({ runtimeConfig }) => {
@@ -53,19 +103,7 @@ const UserInfoMenuItem = () => {
         const { user, auth, authActions } = runtimeConfig;
         return (
           <>
-            <VStack
-              px="3"
-              pt="3"
-              pb="2"
-              align="left"
-              lineHeight="1.3"
-              spacing="0"
-            >
-              <Text fontWeight="semibold">{user?.name}</Text>
-              <Text mt="1" fontSize="xs" color={colors.foreground.secondary}>
-                {user?.email}
-              </Text>
-            </VStack>
+            <UserInfoHeaderBlock name={user?.name} email={user?.email} />
             <MenuDivider />
             <OrganizationMenuGroup
               user={user}
@@ -75,6 +113,10 @@ const UserInfoMenuItem = () => {
             <MenuDivider />
           </>
         );
+      }}
+      selfManagedConfigElement={({ appConfig }) => {
+        if (appConfig.authMode === "None") return null;
+        return <SelfManagedUserInfoMenuItem />;
       }}
     />
   );
@@ -91,6 +133,16 @@ const PricingMenuItem = () => (
     Pricing
   </MenuItem>
 );
+
+const SelfManagedMenuButtonLabel = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const { name } = useSelfManagedProfile();
+  return (
+    <Text textStyle="text-ui-med" color={colors.foreground.primary}>
+      {name ?? "Settings"}
+    </Text>
+  );
+};
 
 const OidcSignOutMenuItem = () => {
   const auth = useAuth();
@@ -156,6 +208,11 @@ const DefaultAvatar = () => {
   return <ChakraAvatar size="xs" />;
 };
 
+const SelfManagedAvatar = () => {
+  const { name, picture } = useSelfManagedProfile();
+  return <ChakraAvatar size="xs" src={picture} name={name} />;
+};
+
 const Avatar = () => {
   return (
     <AppConfigSwitch
@@ -172,8 +229,9 @@ const Avatar = () => {
           />
         );
       }}
-      selfManagedConfigElement={() => {
-        return <DefaultAvatar />;
+      selfManagedConfigElement={({ appConfig }) => {
+        if (appConfig.authMode === "None") return <DefaultAvatar />;
+        return <SelfManagedAvatar />;
       }}
     />
   );
@@ -254,14 +312,19 @@ const ProfileDropdown = ({
                     </>
                   );
                 }}
-                selfManagedConfigElement={
-                  <Text
-                    textStyle="text-ui-med"
-                    color={colors.foreground.primary}
-                  >
-                    Settings
-                  </Text>
-                }
+                selfManagedConfigElement={({ appConfig }) => {
+                  if (appConfig.authMode === "None") {
+                    return (
+                      <Text
+                        textStyle="text-ui-med"
+                        color={colors.foreground.primary}
+                      >
+                        Settings
+                      </Text>
+                    );
+                  }
+                  return <SelfManagedMenuButtonLabel />;
+                }}
               />
             </VStack>
           )}

--- a/console/src/layouts/footerTagComponents.tsx
+++ b/console/src/layouts/footerTagComponents.tsx
@@ -12,6 +12,7 @@ import { useAtom } from "jotai";
 import * as React from "react";
 
 import { useMaybeCurrentOrganizationId } from "~/api/auth";
+import useCurrentUser from "~/api/materialize/useCurrentUser";
 import { CopyButton } from "~/components/copyableComponents";
 import { AppConfigSwitch } from "~/config/AppConfigSwitch";
 import { currentEnvironmentState } from "~/store/environments";
@@ -139,6 +140,28 @@ export const HelmChartVersionTag = () => {
   return (
     <AppConfigSwitch
       selfManagedConfigElement={() => <HelmChartVersionTagContent />}
+    />
+  );
+};
+
+const CurrentUserTagContent = () => {
+  const { results: currentUser } = useCurrentUser();
+
+  if (!currentUser) return <LoadingVersionTag />;
+
+  return (
+    <VersionTag
+      label={`User ${currentUser}`}
+      contents={currentUser}
+      title="Copy username"
+    />
+  );
+};
+
+export const CurrentUserTag = () => {
+  return (
+    <AppConfigSwitch
+      selfManagedConfigElement={() => <CurrentUserTagContent />}
     />
   );
 };


### PR DESCRIPTION


### Motivation
We need to show user details when the user is logged in using SSO. Currently using the sql to fetch user information but I also added the hook to fetch any information from OIDC profile and use sql as the fallback if necessary if no claims are set.  Fixes: [CNS-58](https://linear.app/materializeinc/issue/CNS-58/display-user-id-access-in-console-for-oidc)


### Description
- Introduced `useCurrentUser` hook to fetch the SQL role of the connected session.
- Added `useOidcProfile` hook to extract and type OIDC user profile claims.
- Created `useUserProfile` hook to unify user identity from OIDC and SQL role.
- Implemented `CurrentUserTag` component to display the current user in the footer.
- Enhanced `PageFooter` to include the `CurrentUserTag` for better user visibility.

### Verification
<img width="1226" height="718" alt="image" src="https://github.com/user-attachments/assets/29f408e4-5304-48e7-b717-38afb67526a8" />
<img width="2078" height="524" alt="image" src="https://github.com/user-attachments/assets/ceb662ce-0389-43a1-b571-68395ac43798" />

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
