### PR TITLE
mysql: log row shape on decoding error

### DIFF
--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -10,7 +10,6 @@
 use std::fmt::Write;
 use std::str::FromStr;
 
-use itertools::{EitherOrBoth, Itertools};
 use mysql_common::value::convert::from_value_opt;
 use mysql_common::{Row as MySqlRow, Value};
 
@@ -43,50 +42,39 @@ pub fn pack_mysql_row(
         .columns_ref()
         .first()
         .is_some_and(|col| col.name_ref().starts_with(b"@"));
-    // Wire indices of `row` to decode, in iteration order. Keeping indices
-    // (rather than moving values out via `row.unwrap()`) lets us describe the
-    // row's shape on a decode error without paying the allocation cost on the
-    // happy path.
-    let active_indices: Vec<usize> = if fallback_names {
-        (0..row.len()).collect()
-    } else {
-        row.columns_ref()
-            .iter()
-            .enumerate()
-            .filter(|(_, col)| {
-                table_desc
-                    .columns
-                    .iter()
-                    .any(|c| c.name.as_str() == col.name_str())
-            })
-            .map(|(i, _)| i)
-            .collect()
-    };
 
-    for pair in table_desc.columns.iter().zip_longest(&active_indices) {
-        let (col_desc, wire_idx) = match pair {
-            EitherOrBoth::Both(col_desc, &idx) => (col_desc, idx),
-            EitherOrBoth::Left(col_desc) => {
+    // For each column in `table_desc` (in descriptor order), resolve its wire
+    // index. Non-fallback rows are matched by name so a reordered upstream
+    // still decodes correctly; fallback rows have no names and are matched
+    // positionally. A `None` here means the upstream row is missing this
+    // column and is only tolerated for ignored columns.
+    for (i, col_desc) in table_desc.columns.iter().enumerate() {
+        let wire_idx = if fallback_names {
+            (i < row.len()).then_some(i)
+        } else {
+            row.columns_ref()
+                .iter()
+                .position(|wc| wc.name_str() == col_desc.name.as_str())
+        };
+        if col_desc.column_type.is_none() {
+            // This column is ignored, so don't decode it.
+            continue;
+        }
+        let wire_idx = match wire_idx {
+            Some(idx) => idx,
+            None => {
                 return Err(decode_error(
-                    "extra column description",
+                    "upstream row is missing column",
                     col_desc,
                     table_desc,
                     gtid_set,
                     &row,
                 ));
             }
-            EitherOrBoth::Right(_) => {
-                // If there are extra columns on the upstream table we can safely ignore them
-                break;
-            }
         };
-        if col_desc.column_type.is_none() {
-            // This column is ignored, so don't decode it.
-            continue;
-        }
         let value = row
             .as_ref(wire_idx)
-            .expect("active_indices is within row bounds")
+            .expect("wire_idx resolved from row")
             .clone();
         if let Err(err) = pack_val_as_datum(value, col_desc, &mut packer) {
             return Err(decode_error(

--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -64,7 +64,7 @@ pub fn pack_mysql_row(
             Some(idx) => idx,
             None => {
                 return Err(decode_error(
-                    "upstream row is missing column",
+                    "extra column description",
                     col_desc,
                     table_desc,
                     gtid_set,

--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::Write;
 use std::str::FromStr;
 
 use itertools::{EitherOrBoth, Itertools};
@@ -28,6 +29,7 @@ pub fn pack_mysql_row(
     row_container: &mut Row,
     row: MySqlRow,
     table_desc: &MySqlTableDesc,
+    gtid_set: Option<&str>,
 ) -> Result<Row, MySqlError> {
     let mut packer = row_container.packer();
 
@@ -37,12 +39,16 @@ pub fn pack_mysql_row(
     // This is a fallback for MySQL servers that do not have `binlog_row_metadata` set to
     // `FULL`. If the first column name does not begin with '@', then we can assume that
     // full metadata is available and we can match columns by name.
-    let row_values: Vec<Value> = if row
+    let fallback_names = row
         .columns_ref()
         .first()
-        .is_some_and(|col| col.name_ref().starts_with(b"@"))
-    {
-        row.unwrap()
+        .is_some_and(|col| col.name_ref().starts_with(b"@"));
+    // Wire indices of `row` to decode, in iteration order. Keeping indices
+    // (rather than moving values out via `row.unwrap()`) lets us describe the
+    // row's shape on a decode error without paying the allocation cost on the
+    // happy path.
+    let active_indices: Vec<usize> = if fallback_names {
+        (0..row.len()).collect()
     } else {
         row.columns_ref()
             .iter()
@@ -51,35 +57,23 @@ pub fn pack_mysql_row(
                 table_desc
                     .columns
                     .iter()
-                    .filter(|col| col.column_type.is_some())
                     .any(|c| c.name.as_str() == col.name_str())
             })
-            .map(|(i, _)| {
-                row.as_ref(i)
-                    .expect("Can't unwrap row if some of columns was taken")
-                    .clone()
-            })
+            .map(|(i, _)| i)
             .collect()
     };
 
-    for values in table_desc
-        .columns
-        .iter()
-        .filter(|col| col.column_type.is_some())
-        .zip_longest(row_values)
-    {
-        let (col_desc, value) = match values {
-            EitherOrBoth::Both(col_desc, value) => (col_desc, value),
+    for pair in table_desc.columns.iter().zip_longest(&active_indices) {
+        let (col_desc, wire_idx) = match pair {
+            EitherOrBoth::Both(col_desc, &idx) => (col_desc, idx),
             EitherOrBoth::Left(col_desc) => {
-                tracing::error!(
-                    "mysql: extra column description {col_desc:?} for table {}",
-                    table_desc.name
-                );
-                Err(MySqlError::ValueDecodeError {
-                    column_name: col_desc.name.clone(),
-                    qualified_table_name: format!("{}.{}", table_desc.schema_name, table_desc.name),
-                    error: "extra column description".to_string(),
-                })?
+                return Err(decode_error(
+                    "extra column description",
+                    col_desc,
+                    table_desc,
+                    gtid_set,
+                    &row,
+                ));
             }
             EitherOrBoth::Right(_) => {
                 // If there are extra columns on the upstream table we can safely ignore them
@@ -90,17 +84,121 @@ pub fn pack_mysql_row(
             // This column is ignored, so don't decode it.
             continue;
         }
-        match pack_val_as_datum(value, col_desc, &mut packer) {
-            Err(err) => Err(MySqlError::ValueDecodeError {
-                column_name: col_desc.name.clone(),
-                qualified_table_name: format!("{}.{}", table_desc.schema_name, table_desc.name),
-                error: err.to_string(),
-            })?,
-            Ok(()) => (),
-        };
+        let value = row
+            .as_ref(wire_idx)
+            .expect("active_indices is within row bounds")
+            .clone();
+        if let Err(err) = pack_val_as_datum(value, col_desc, &mut packer) {
+            return Err(decode_error(
+                &err.to_string(),
+                col_desc,
+                table_desc,
+                gtid_set,
+                &row,
+            ));
+        }
     }
 
     Ok(row_container.clone())
+}
+
+/// Build a `ValueDecodeError`, logging the schema, table, column, source
+/// gtid_set (if any), and a shape description of `row` at the same time.
+/// The shape string is only built here — pack_mysql_row's happy path does no
+/// per-row allocation beyond what decoding requires.
+fn decode_error(
+    err_msg: &str,
+    col_desc: &MySqlColumnDesc,
+    table_desc: &MySqlTableDesc,
+    gtid_set: Option<&str>,
+    row: &MySqlRow,
+) -> MySqlError {
+    let row_shape = describe_row_shape(row, table_desc);
+    tracing::warn!(
+        "mysql decode error for `{}`.`{}` column `{}`: {}; gtid_set={:?}; row_shape={}",
+        table_desc.schema_name,
+        table_desc.name,
+        col_desc.name,
+        err_msg,
+        gtid_set,
+        row_shape,
+    );
+    MySqlError::ValueDecodeError {
+        column_name: col_desc.name.clone(),
+        qualified_table_name: format!("{}.{}", table_desc.schema_name, table_desc.name),
+        error: err_msg.to_string(),
+    }
+}
+
+/// Describes the structural shape of a row without revealing any data values.
+/// Iterates every wire column. For each, emits the wire name, the binlog
+/// wire type, the character-set id (or `binary`), a classification relative
+/// to `table_desc` (`expected=<scalar>` for active columns, `ignored` for
+/// columns excluded from the source, `extra` for upstream columns with no
+/// descriptor entry), and a value disposition (`null` or `bytes(len=N)` /
+/// primitive kind). Intended for diagnostic logging on decode errors: MySQL
+/// serializes CHAR, VARCHAR, TEXT, JSON, BLOB, etc. all as `Value::Bytes`,
+/// so the wire type tag and the expected scalar type are what distinguish
+/// them.
+fn describe_row_shape(row: &MySqlRow, table_desc: &MySqlTableDesc) -> String {
+    // Binlogs without full row metadata use positional "@N" names, so we
+    // have to match by wire position rather than by name.
+    let fallback_names = row
+        .columns_ref()
+        .first()
+        .is_some_and(|col| col.name_ref().starts_with(b"@"));
+
+    let mut out = String::new();
+    out.push('[');
+    for (i, wire_col) in row.columns_ref().iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let wire_name = wire_col.name_str();
+        let cs = wire_col.character_set();
+        // 63 = binary collation (binary/blob columns).
+        let cs_str = if cs == 63 {
+            "binary".to_string()
+        } else {
+            format!("charset={cs}")
+        };
+        let wire_type = format!("{:?}", wire_col.column_type());
+
+        let matched_col = if fallback_names {
+            table_desc.columns.get(i)
+        } else {
+            table_desc
+                .columns
+                .iter()
+                .find(|c| c.name.as_str() == wire_name)
+        };
+        let match_info = match matched_col {
+            Some(col) => match &col.column_type {
+                Some(ct) => format!("expected={:?}", ct.scalar_type),
+                None => "ignored".to_string(),
+            },
+            None => "extra".to_string(),
+        };
+
+        let val_desc = match row.as_ref(i) {
+            None => "absent".to_string(),
+            Some(Value::NULL) => "null".to_string(),
+            Some(Value::Bytes(b)) => format!("bytes(len={})", b.len()),
+            Some(Value::Int(_)) => "int".to_string(),
+            Some(Value::UInt(_)) => "uint".to_string(),
+            Some(Value::Float(_)) => "float".to_string(),
+            Some(Value::Double(_)) => "double".to_string(),
+            Some(Value::Date(..)) => "date".to_string(),
+            Some(Value::Time(..)) => "time".to_string(),
+        };
+
+        let _ = write!(
+            out,
+            "{{name={wire_name}, wire={wire_type}, {cs_str}, {match_info}, val={val_desc}}}"
+        );
+    }
+    out.push(']');
+    out
 }
 
 // TODO(guswynn|roshan): This function has various `.to_string()` and `format!` calls that should

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -7,12 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Write;
-
 use maplit::btreemap;
-use mysql_common::Value;
 use mysql_common::binlog::events::{QueryEvent, RowsEventData};
-use mz_mysql_util::{MySqlError, MySqlTableDesc, pack_mysql_row};
+use mz_mysql_util::{MySqlError, pack_mysql_row};
 use mz_ore::iter::IteratorExt;
 use mz_repr::{Diff, Row};
 use mz_storage_types::errors::DataflowError;
@@ -301,30 +298,23 @@ pub(super) async fn handle_rows_event(
             before_row.map(|r| (r, Diff::MINUS_ONE)),
             after_row.map(|r| (r, Diff::ONE)),
         ];
+        let gtid_str = format!("{new_gtid:?}");
         for (binlog_row, diff) in updates.into_iter().flatten() {
             let row = mysql_async::Row::try_from(binlog_row)?;
             for (output, row_val) in outputs.iter().repeat_clone(row) {
-                let row_shape = describe_row_shape(&row_val, &output.desc);
-                let event = match pack_mysql_row(&mut final_row, row_val, &output.desc) {
-                    Ok(row) => Ok(SourceMessage {
-                        key: Row::default(),
-                        value: row,
-                        metadata: Row::default(),
-                    }),
-                    // Produce a DefiniteError in the stream for any rows that fail to decode
-                    Err(err @ MySqlError::ValueDecodeError { .. }) => {
-                        tracing::warn!(
-                            %id,
-                            "timely-{worker_id} decode error for {table:?} \
-                             output={} gtid={new_gtid:?}: {err}; row shape: {row_shape}",
-                            output.output_index,
-                        );
-                        Err(DataflowError::from(DefiniteError::ValueDecodeError(
-                            err.to_string(),
-                        )))
-                    }
-                    Err(err) => Err(err)?,
-                };
+                let event =
+                    match pack_mysql_row(&mut final_row, row_val, &output.desc, Some(&gtid_str)) {
+                        Ok(row) => Ok(SourceMessage {
+                            key: Row::default(),
+                            value: row,
+                            metadata: Row::default(),
+                        }),
+                        // Produce a DefiniteError in the stream for any rows that fail to decode
+                        Err(err @ MySqlError::ValueDecodeError { .. }) => Err(DataflowError::from(
+                            DefiniteError::ValueDecodeError(err.to_string()),
+                        )),
+                        Err(err) => Err(err)?,
+                    };
 
                 let data = (output.output_index, event);
 
@@ -373,58 +363,4 @@ pub(super) async fn handle_rows_event(
     );
 
     Ok(())
-}
-
-/// Describes the structural shape of a row without revealing any data values.
-/// Emits per-column ordinal, the binlog wire type, the expected Materialize
-/// scalar type from the table descriptor, the character-set id (or `binary`),
-/// and a value disposition (`null` or `bytes(len=N)` / primitive kind).
-/// Intended for diagnostic logging on decode errors: MySQL serializes CHAR,
-/// VARCHAR, TEXT, JSON, BLOB, etc. all as `Value::Bytes`, so the wire type
-/// tag and the expected scalar type are what distinguish them.
-fn describe_row_shape(row: &mysql_async::Row, desc: &MySqlTableDesc) -> String {
-    let mut out = String::new();
-    out.push('[');
-    for i in 0..row.len() {
-        if i > 0 {
-            out.push_str(", ");
-        }
-        let (wire_type, charset) = match row.columns_ref().get(i) {
-            Some(c) => {
-                let cs = c.character_set();
-                // 63 = binary collation (binary/blob columns).
-                let cs_str = if cs == 63 {
-                    "binary".to_string()
-                } else {
-                    format!("charset={cs}")
-                };
-                (format!("{:?}", c.column_type()), cs_str)
-            }
-            None => ("?".to_string(), "charset=?".to_string()),
-        };
-        let expected = match desc.columns.get(i) {
-            Some(col) => match &col.column_type {
-                Some(ct) => format!("{:?}", ct.scalar_type),
-                None => "ignored".to_string(),
-            },
-            None => "?".to_string(),
-        };
-        let val_desc = match row.as_ref(i) {
-            None => "absent".to_string(),
-            Some(Value::NULL) => "null".to_string(),
-            Some(Value::Bytes(b)) => format!("bytes(len={})", b.len()),
-            Some(Value::Int(_)) => "int".to_string(),
-            Some(Value::UInt(_)) => "uint".to_string(),
-            Some(Value::Float(_)) => "float".to_string(),
-            Some(Value::Double(_)) => "double".to_string(),
-            Some(Value::Date(..)) => "date".to_string(),
-            Some(Value::Time(..)) => "time".to_string(),
-        };
-        let _ = write!(
-            out,
-            "{{ord={i}, wire={wire_type}, {charset}, expected={expected}, val={val_desc}}}"
-        );
-    }
-    out.push(']');
-    out
 }

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -7,9 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::Write;
+
 use maplit::btreemap;
+use mysql_common::Value;
 use mysql_common::binlog::events::{QueryEvent, RowsEventData};
-use mz_mysql_util::{MySqlError, pack_mysql_row};
+use mz_mysql_util::{MySqlError, MySqlTableDesc, pack_mysql_row};
 use mz_ore::iter::IteratorExt;
 use mz_repr::{Diff, Row};
 use mz_storage_types::errors::DataflowError;
@@ -301,6 +304,7 @@ pub(super) async fn handle_rows_event(
         for (binlog_row, diff) in updates.into_iter().flatten() {
             let row = mysql_async::Row::try_from(binlog_row)?;
             for (output, row_val) in outputs.iter().repeat_clone(row) {
+                let row_shape = describe_row_shape(&row_val, &output.desc);
                 let event = match pack_mysql_row(&mut final_row, row_val, &output.desc) {
                     Ok(row) => Ok(SourceMessage {
                         key: Row::default(),
@@ -308,9 +312,17 @@ pub(super) async fn handle_rows_event(
                         metadata: Row::default(),
                     }),
                     // Produce a DefiniteError in the stream for any rows that fail to decode
-                    Err(err @ MySqlError::ValueDecodeError { .. }) => Err(DataflowError::from(
-                        DefiniteError::ValueDecodeError(err.to_string()),
-                    )),
+                    Err(err @ MySqlError::ValueDecodeError { .. }) => {
+                        tracing::warn!(
+                            %id,
+                            "timely-{worker_id} decode error for {table:?} \
+                             output={} gtid={new_gtid:?}: {err}; row shape: {row_shape}",
+                            output.output_index,
+                        );
+                        Err(DataflowError::from(DefiniteError::ValueDecodeError(
+                            err.to_string(),
+                        )))
+                    }
                     Err(err) => Err(err)?,
                 };
 
@@ -361,4 +373,58 @@ pub(super) async fn handle_rows_event(
     );
 
     Ok(())
+}
+
+/// Describes the structural shape of a row without revealing any data values.
+/// Emits per-column ordinal, the binlog wire type, the expected Materialize
+/// scalar type from the table descriptor, the character-set id (or `binary`),
+/// and a value disposition (`null` or `bytes(len=N)` / primitive kind).
+/// Intended for diagnostic logging on decode errors: MySQL serializes CHAR,
+/// VARCHAR, TEXT, JSON, BLOB, etc. all as `Value::Bytes`, so the wire type
+/// tag and the expected scalar type are what distinguish them.
+fn describe_row_shape(row: &mysql_async::Row, desc: &MySqlTableDesc) -> String {
+    let mut out = String::new();
+    out.push('[');
+    for i in 0..row.len() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let (wire_type, charset) = match row.columns_ref().get(i) {
+            Some(c) => {
+                let cs = c.character_set();
+                // 63 = binary collation (binary/blob columns).
+                let cs_str = if cs == 63 {
+                    "binary".to_string()
+                } else {
+                    format!("charset={cs}")
+                };
+                (format!("{:?}", c.column_type()), cs_str)
+            }
+            None => ("?".to_string(), "charset=?".to_string()),
+        };
+        let expected = match desc.columns.get(i) {
+            Some(col) => match &col.column_type {
+                Some(ct) => format!("{:?}", ct.scalar_type),
+                None => "ignored".to_string(),
+            },
+            None => "?".to_string(),
+        };
+        let val_desc = match row.as_ref(i) {
+            None => "absent".to_string(),
+            Some(Value::NULL) => "null".to_string(),
+            Some(Value::Bytes(b)) => format!("bytes(len={})", b.len()),
+            Some(Value::Int(_)) => "int".to_string(),
+            Some(Value::UInt(_)) => "uint".to_string(),
+            Some(Value::Float(_)) => "float".to_string(),
+            Some(Value::Double(_)) => "double".to_string(),
+            Some(Value::Date(..)) => "date".to_string(),
+            Some(Value::Time(..)) => "time".to_string(),
+        };
+        let _ = write!(
+            out,
+            "{{ord={i}, wire={wire_type}, {charset}, expected={expected}, val={val_desc}}}"
+        );
+    }
+    out.push(']');
+    out
 }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -420,21 +420,21 @@ pub(crate) fn render<'scope>(
                         let row: MySqlRow = row;
                         snapshot_staged += 1;
                         for (output, row_val) in outputs.iter().repeat_clone(row) {
-                            let event = match pack_mysql_row(&mut final_row, row_val, &output.desc)
-                            {
-                                Ok(row) => Ok(SourceMessage {
-                                    key: Row::default(),
-                                    value: row,
-                                    metadata: Row::default(),
-                                }),
-                                // Produce a DefiniteError in the stream for any rows that fail to decode
-                                Err(err @ MySqlError::ValueDecodeError { .. }) => {
-                                    Err(DataflowError::from(DefiniteError::ValueDecodeError(
-                                        err.to_string(),
-                                    )))
-                                }
-                                Err(err) => Err(err)?,
-                            };
+                            let event =
+                                match pack_mysql_row(&mut final_row, row_val, &output.desc, None) {
+                                    Ok(row) => Ok(SourceMessage {
+                                        key: Row::default(),
+                                        value: row,
+                                        metadata: Row::default(),
+                                    }),
+                                    // Produce a DefiniteError in the stream for any rows that fail to decode
+                                    Err(err @ MySqlError::ValueDecodeError { .. }) => {
+                                        Err(DataflowError::from(DefiniteError::ValueDecodeError(
+                                            err.to_string(),
+                                        )))
+                                    }
+                                    Err(err) => Err(err)?,
+                                };
                             raw_handle
                                 .give_fueled(
                                     &data_cap_set[0],


### PR DESCRIPTION
If MySQL fails to decode a binlog row, it unfortunately doesn't provide much information. This adds additional logging that provide the row shape information for debugging.

In pushing this further down into `pack_mysql_row`, I did some additional refactoring.

Sample output:
```
WARN timely{name="storage" worker_id=0}: mz_mysql_util::decoding: mysql decode error for `public`.`decode_err` column `f2`: Couldn't convert the value `Time("'029:59:59'")` to a desired type; gtid_set=Some("Partitioned((Interval { lower: 693e00a9-3dce-11f1-9e2c-ca0de7a4a79f, upper: 693e00a9-3dce-11f1-9e2c-ca0de7a4a79f }, Active(11)))"); row_shape=[{name=f1, wire=MYSQL_TYPE_LONG, charset=0, expected=Int32, val=int}, {name=f2, wire=MYSQL_TYPE_TIME2, charset=0, expected=Time, val=time}]
```